### PR TITLE
fix(macOS): 使用项目内 Vite 完成打包

### DIFF
--- a/pinvou3-app/src-tauri/tauri.conf.json
+++ b/pinvou3-app/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "identifier": "com.pinvou.pinvou3",
   "build": {
     "beforeDevCommand": "vite",
-    "beforeBuildCommand": "node scripts/tauri/require-wrapper.js build && npm run validate:pet-assets -- --release && vite build",
+    "beforeBuildCommand": "node scripts/tauri/require-wrapper.js build && npm run validate:pet-assets -- --release && npm run build:ui",
     "beforeBundleCommand": "node scripts/tauri/require-wrapper.js bundle",
     "devUrl": "http://127.0.0.1:1420",
     "frontendDist": "../dist"

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -51,6 +51,16 @@ assert.deepEqual(
 const linux = composeEffectiveConfig([platformConfigPath("linux")]).effectiveConfig;
 assert.deepEqual(linux.bundle.targets, ["deb"]);
 assert.match(linux.build.beforeBuildCommand, /require-wrapper\.js build/);
+assert.match(
+  linux.build.beforeBuildCommand,
+  /npm run build:ui/,
+  "release build must resolve Vite from the repository dependencies",
+);
+assert.doesNotMatch(
+  linux.build.beforeBuildCommand,
+  /&&\s+vite build/,
+  "release build must not rely on a globally installed Vite binary",
+);
 assert.match(linux.build.beforeBundleCommand, /require-wrapper\.js bundle/);
 assert.ok(linux.bundle.resources["resources/common/web-template/"]);
 assert.equal(linux.bundle.resources["resources/platforms/linux/asr/"], "runtime/asr");


### PR DESCRIPTION
## 改了什么

- 将 Tauri `beforeBuildCommand` 中的裸 `vite build` 改为 `npm run build:ui`。
- 增加配置契约测试，确保发布构建不会依赖全局安装的 Vite。

## 改动原因

公开仓库首轮 macOS 打包中，`npm ci` 已安装仓库依赖，但 Tauri 通过普通 shell 执行裸 `vite`，不会自动解析 `node_modules/.bin`，最终报错 `vite: command not found`。

## 影响面

仅影响 Tauri 发布构建前的前端构建命令。开发模式、应用运行逻辑、签名策略和其他平台配置不变。Linux/Windows 同样会使用仓库锁定的 Vite，结果更可复现。

## 验证

- `npm run test:tauri-effective-config` 通过。
- `npm run build:ui` 使用 Vite 8.1.4 构建成功。
- `./scripts/fork-guard.sh --fast` 通过。
- `git diff --check` 通过。