### PR TITLE
chore(fork): 固定 CodeWhale 公开基线

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -140,7 +140,6 @@ jobs:
               - 'pinvou3-app/src-tauri/config/**'
               - 'pinvou3-app/src-tauri/packaging/**'
               - 'remote-control-relay/**'
-              - 'scripts/deploy-remote-relay.sh'
               - 'scripts/run-user-journey-tests.sh'
               - 'scripts/mcp-server-contract-smoke.py'
               - 'pinvou3-app/package.json'
@@ -152,8 +151,6 @@ jobs:
               - '.github/workflows/pr-check.yml'
             relay:
               - 'remote-control-relay/**'
-              - 'scripts/deploy-remote-relay.sh'
-              - 'scripts/deploy-remote-relay-test.sh'
               - '.github/workflows/pr-check.yml'
 
   fast-gate:
@@ -174,6 +171,9 @@ jobs:
         run: |
           base_ref="${BASE_REF#refs/heads/}"
           python3 scripts/architecture-guard.py --base-ref "origin/$base_ref"
+
+      - name: 公开底座 gitlink 可达性
+        run: ./scripts/verify-public-submodule.sh
 
       - name: 初始化公共底座 submodule
         run: git submodule update --init --recursive -- CodeWhale
@@ -286,11 +286,8 @@ jobs:
       - name: 安装 relay 依赖
         run: npm --prefix remote-control-relay ci --prefer-offline --no-audit
 
-      - name: Relay 与部署脚本回归
-        run: |
-          bash -n scripts/deploy-remote-relay.sh
-          bash -n scripts/deploy-remote-relay-test.sh
-          npm --prefix remote-control-relay test
+      - name: Relay 回归
+        run: npm --prefix remote-control-relay test
 
   rust-test:
     name: rust-test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "CodeWhale"]
 	path = CodeWhale
 	url = https://github.com/Pinvou/CodeWhale.git
-	branch = pinvou3-clean

--- a/docs/fork-modifications.en.md
+++ b/docs/fork-modifications.en.md
@@ -1,0 +1,71 @@
+# CodeWhale Fork Inventory
+
+> This is the public English summary of Pinvou Agent's CodeWhale delta.
+> The detailed Chinese inventory and [`fork-policy.md`](fork-policy.md) remain the maintainer source of truth.
+
+## Current baseline
+
+| Item | Value |
+|---|---|
+| Upstream | `Hmbown/CodeWhale` tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
+| Public release | `Pinvou/CodeWhale` tag `pinvou-v0.9.0-r1` |
+| Pinned commit | `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e` |
+| Maintenance branch | `pinvou3-clean` |
+| Organization | 6 long-lived product themes, 3 maintenance/fix commits, and 3 public baseline/security commits |
+| Diff from upstream tag | 3,878 insertions, 550 deletions, 57 files |
+
+The delta exceeds the 1,500-line soft limit and has therefore received a mandatory boundary review. The retained code owns behavior that cannot be reconstructed safely in the desktop wrapper: task persistence, workflow completion, prompt-source sealing, and engine-level safety. Shell rendering and platform-specific desktop behavior remain in the parent repository and do not add fork drift.
+
+## Long-lived themes
+
+### T1 — Host library facade
+
+Exposes the upstream bin-first crate as a library for the desktop host. It exports existing engine modules and does not reimplement them.
+
+### T2 — Tool surface and execution safety
+
+Defines the Pinvou tool surface, write-size limits, truncated-argument guidance, wildcard tool restrictions, and fail-closed handling for dangerous commands and required approvals. Result-oriented golden and safety tests protect the behavior.
+
+### T3 — Sealed prompts and one context source
+
+Lets the app own the static prompt composer, accepts only explicitly injected project instructions, loads Skills from the Pinvou runtime bundle, filters disabled Skills, and keeps internal reminders out of the working set.
+
+### T4 — Scheduled execution and history lifecycle
+
+Keeps a stable conversation identity for each automation, persists run links, anchors hourly schedules, skips offline misfires, prevents overlapping runs, and deletes only terminal task history and its artifacts.
+
+### T5 — Host orchestration and workflow completion
+
+Adds host-provided tools and hard allowlists across execution modes, structured subagent outputs, safe declared file persistence, authoritative completion/failure envelopes, bulk cancellation, and cancellable OAuth login.
+
+### T6 — Host routing and shared automation APIs
+
+Exposes an opaque runtime route receipt, explicit route limits, and shared reconciliation APIs so the host can use one consistent routing and automation model without duplicating engine internals.
+
+## Public baseline maintenance
+
+The three commits above the product baseline add:
+
+- a full-history Gitleaks workflow and two exact allowlist entries for public upstream test fixtures;
+- `PINVOU_FORK.md` and the README fork notice;
+- removal of one internal project-name comment without changing behavior.
+
+They do not introduce a seventh product theme.
+
+## Verification
+
+The released CodeWhale baseline passed:
+
+- full-history Gitleaks across 5,448 commits with zero reported leaks;
+- `cargo check --workspace --all-targets --locked`;
+- `forkguard_` regression tests;
+- formatting, DCO, required gate, and CodeQL checks.
+
+The parent repository additionally verifies that:
+
+- `.gitmodules` uses `https://github.com/Pinvou/CodeWhale.git`;
+- no floating submodule branch is configured;
+- the gitlink commit is publicly reachable;
+- `pinvou-v0.9.0-r1^{}` equals the pinned gitlink.
+
+For any future gitlink or fork-behavior change, update this inventory, the Chinese source-of-truth inventory, fingerprints, and result-oriented tests in the same PR.

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -2,15 +2,17 @@
 
 > 本文是 pinvou3 对 CodeWhale 底座 fork 的单一现状清单。
 > 基线、主题边界、守护指纹和每次 sync 结论都以本文与 `docs/fork-policy.md` 为准。
+> English: [`docs/fork-modifications.en.md`](fork-modifications.en.md)
 
 ## 0. 当前状态（2026-07-24 · v0.9.0）
 
 | 项 | 当前值 |
 |---|---|
 | 上游基线 | tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
-| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `b2e3a83bf74f` |
-| 组织方式 | **6 个长期主题 commit + 3 个维护/修复 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
-| drift | 对 `v0.9.0`：**+3771 / -550，54 文件** |
+| 公开固定基线 | tag `pinvou-v0.9.0-r1`，commit `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e` |
+| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `070f4413eeb0` |
+| 组织方式 | **6 个长期主题 commit + 3 个维护/修复 commit + 3 个公开基线/安全维护 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
+| drift | 对 `v0.9.0`：**+3878 / -550，57 文件** |
 | 守护 | `scripts/fork-guard.sh`：v0.9 主题指纹 + 宿主 ShellManager 观察器与生命周期指纹 + submodule/app `forkguard_` 行为测试 |
 | app 状态 | `pinvou3-tauri` 主库编译通过，lib test target 可完整编译；macOS 适配保留在父仓平台抽象中，不增加 fork drift |
 
@@ -107,6 +109,14 @@
   - 公开 `reconcile_run_statuses_shared`，宿主不再持 automation mutex 等待 task-manager I/O。
 - **为什么单列**：这是可上游化的宿主 API 面，与 pinvou3 私有产品逻辑解耦；后续最优先提上游。
 
+### 公开基线与安全维护（不新增产品主题）
+
+- `3e8e6e7f chore(security): 配置 fork 全历史密钥扫描`
+- `23d4c9b5 docs(fork): 记录 Pinvou 公开基线`
+- `070f4413 chore(fork): 清理内部项目注释`
+
+这三个提交只增加公开 fork 的说明、全历史 Gitleaks 门禁与精确测试夹具白名单，并移除一处内部项目代号注释；不改变 T1–T6 的产品行为。父仓只固定到稳定标签 `pinvou-v0.9.0-r1`，不跟随维护分支漂移。
+
 ### T7 macOS 平台目标支持 (2026-07)
 
 **不在 fork 内做任何改动** —— fork 已通过 `crates/tui/Cargo.toml:112` 声明
@@ -186,6 +196,13 @@ diff /tmp/pre-sync-prompt.txt /tmp/post-sync-prompt.txt
 本地 `/tmp` 空间不足时，显式把 `TMPDIR` 和 `CARGO_TARGET_DIR` 指到项目盘；不要用清理用户目录解决构建问题。
 
 ## 5. Sync 历史
+
+### v0.9.0 公开固定基线（2026-07-24）
+
+- 在 `Pinvou/CodeWhale` 保留上游完整 MIT 历史与作者归属，并发布不可变标签 `pinvou-v0.9.0-r1`。
+- 对 5,448 个历史 commit 执行 Gitleaks；只精确放行两个上游公开测试夹具，扫描结果为 0 个泄漏。
+- GitHub CI 已通过全 workspace/all-targets 编译、`forkguard_` 回归、格式、DCO、Gitleaks 与 CodeQL。
+- 父仓 gitlink 固定到标签解引用 commit；`.gitmodules` 不再跟随 `pinvou3-clean` 浮动分支。
 
 ### v0.9.0 clean re-fork（2026-07-17）
 

--- a/docs/fork-policy.en.md
+++ b/docs/fork-policy.en.md
@@ -1,0 +1,85 @@
+# CodeWhale Fork Maintenance Policy
+
+> Last updated: 2026-07-24
+> Released baseline: `pinvou-v0.9.0-r1@070f4413`
+> Detailed inventory: [`fork-modifications.en.md`](fork-modifications.en.md)
+
+## 1. Baseline and ownership
+
+- Upstream: [`Hmbown/CodeWhale`](https://github.com/Hmbown/CodeWhale), tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f`.
+- Public fork: [`Pinvou/CodeWhale`](https://github.com/Pinvou/CodeWhale).
+- Maintenance branch: `pinvou3-clean`, currently at `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e`.
+- Pinvou Agent pins the immutable tag `pinvou-v0.9.0-r1`, which dereferences to that commit.
+- `.gitmodules` intentionally has no `branch` entry. A parent-repository checkout must never move merely because the maintenance branch moved.
+
+The fork is maintained as six long-lived themes:
+
+1. host library facade;
+2. tool surface, file-write limits, and execution safety;
+3. sealed prompts and a single context/Skill source;
+4. scheduled execution and task-history lifecycle;
+5. host orchestration, workflow completion gates, and cancellable login;
+6. host routing, budgets, and shared automation APIs.
+
+The exact files, commits, rationale, drift, and tests are recorded in [`fork-modifications.en.md`](fork-modifications.en.md).
+
+## 2. Where a change belongs
+
+Use the narrowest layer that can own the behavior:
+
+| Need | Location |
+|---|---|
+| Desktop UI, Tauri bridge, or runtime configuration | `pinvou3-app/` |
+| Model guidance or a domain workflow | bundle instructions or `SKILL.md` |
+| Independent external integration | MCP server or connector |
+| Reusable CodeWhale bug fix or API | a clean branch from the latest upstream `main`, then an upstream PR |
+| Pinvou-specific behavior that must be atomic with engine, subagent, or task lifecycle | the nearest existing fork theme |
+
+Create a new fork theme only when the change has a genuinely independent state, verification, and rollback boundary.
+
+## 3. Same-PR requirements
+
+A parent-repository PR that changes fork-specific behavior or the CodeWhale gitlink must also update:
+
+1. `docs/fork-modifications.md` and its English counterpart when public guidance changes;
+2. the relevant fixed-string fingerprint in `scripts/fork-guard.sh`;
+3. at least one result-oriented `forkguard_*` test, unless the PR documents a platform-only substitute;
+4. any intentionally invalidated upstream test with an explicit `#[ignore = "pinvou3 fork(...)"]`.
+
+Before opening the PR, run:
+
+```bash
+./scripts/verify-public-submodule.sh
+./scripts/fork-guard.sh --fast
+```
+
+Documentation, fingerprints, tests, and the patch must travel in the same PR.
+
+## 4. Upstream synchronization
+
+Before syncing:
+
+```bash
+git -C CodeWhale fetch upstream --tags
+git -C CodeWhale branch backup/pre-vX-sync <current-fork-head>
+git -C CodeWhale diff --shortstat <current-release-tag>..<current-fork-head>
+./scripts/fork-guard.sh --fast
+```
+
+Prefer a clean re-fork from an upstream release tag when crossing a major version, when core engine/prompt/automation code was reorganized, when conflict volume is high, or when old drift has already exceeded the soft limit.
+
+Classify every old patch as one of:
+
+- already provided upstream;
+- movable to the app, a Skill, or an MCP server;
+- still required in one of the six fork themes.
+
+After the sync, run the fork guard, CodeWhale library and `forkguard_` tests, parent app checks, and a before/after static system-prompt diff. The full commands remain in the Chinese policy, which is the maintainer source of truth.
+
+## 5. Release and integrity rules
+
+- Preserve upstream MIT licensing and author attribution.
+- Create a new immutable Pinvou tag for every reviewed public baseline; never move or reuse a released tag.
+- The tag target, public maintenance branch, and parent gitlink must identify the same reachable commit at release time.
+- CI verifies the public URL, tag target, gitlink reachability, and absence of a floating `.gitmodules` branch.
+- Never force-push a shared release baseline without explicit authorization.

--- a/docs/fork-policy.md
+++ b/docs/fork-policy.md
@@ -1,12 +1,15 @@
 # pinvou3 对 CodeWhale 底座的 fork 维护策略
 
-> 最后更新：2026-07-23（上游基线 `v0.9.0@d167c07c9`）
+> 最后更新：2026-07-24（公开发布基线 `pinvou-v0.9.0-r1@070f4413`）
 > 配套：`docs/fork-modifications.md`、`scripts/fork-guard.sh`、`docs/底座升级验收清单.md`
+> English: [`docs/fork-policy.en.md`](fork-policy.en.md)
 
 ## 0. 当前基线与组织方式
 
 - 上游：`Hmbown/CodeWhale` tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f`。
-- 生产 fork 分支：`pinvou3-clean`，当前 head `c32bb73f4605`。
+- 公开 fork：`https://github.com/Pinvou/CodeWhale`。
+- 维护分支：`pinvou3-clean`，当前 head `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e`。
+- 父仓固定标签：`pinvou-v0.9.0-r1`，解引用后必须是上述 commit；`.gitmodules` 不配置浮动 `branch`。
 - fork 不再按历史 C1–C12 / W1–W13 批量编号维护，当前只保留 **6 个长期主题**：
 
   1. 宿主 library facade
@@ -36,7 +39,7 @@ Engine、ToolRegistry、SSE、Session、SkillRegistry、Commands、MCP client、
 - 总 drift 软上限：1500 行。
 - 单文件 fork-distinct 改动软上限：200 行。
 - 超过不是自动拒绝，但必须在 `fork-modifications.md` 记录：为什么不能放 app/skill/MCP、哪些已 harvest、后续减量顺序。
-- 当前 v0.9.0 re-fork 为 `+3668/-558，53 文件`，已经完成强制评估；结论见修改清单 §0。
+- 当前公开基线相对 v0.9.0 为 `+3878/-550，57 文件`，已经完成强制评估；结论见修改清单 §0。
 
 ### 1.3 主题提交
 
@@ -147,6 +150,6 @@ diff /tmp/pre-sync-prompt.txt /tmp/post-sync-prompt.txt
 
 1. submodule 先形成干净的主题 commit，并完成底座测试。
 2. 父仓同一 PR 更新 gitlink、app 适配、Cargo.lock、两份文档和 guard。
-3. fork 远端分支与父仓 gitlink 必须指向同一个可达 commit。
+3. fork 稳定标签、远端维护分支与父仓 gitlink 必须指向同一个公开可达 commit；父仓不得通过 `.gitmodules branch` 跟随浮动分支。
 4. 未明确授权时，不直接 force-push 共享 main；先在同步分支交付验证结果。
 5. 合入后删除临时 worktree/branch 属单独清理动作，不与 sync 默认捆绑。

--- a/docs/remote-control-phase1-architecture.md
+++ b/docs/remote-control-phase1-architecture.md
@@ -58,9 +58,9 @@ Web 构建以 `/pinvou3/remote/` 为默认 base path。Relay 对 HTML 禁止缓�
 要求重新验证，对带 hash 的静态资源使用 immutable 缓存，因此替换 Web dist 后浏览器可在
 下次加载获得新版本，而不受已安装桌面版本的 UI 资源约束。
 
-正式部署由 `scripts/deploy-remote-relay.sh` 完成：脚本以生产 base path 重建 WebUI，整体上传
-`web/dist`，备份当前 Relay 与完整 dist 后再替换，并在服务/公网验证失败时回滚。为避免误操作，
-必须显式设置 `PINVOU_CONFIRM_PRODUCTION_DEPLOY=1`；脚本不会修改 Nginx 配置。
+公开仓库不分发 Pinvou 官方环境的部署脚本、服务器地址或基础设施配置。自行部署 Relay 时，应
+按目标环境独立配置进程托管、反向代理、TLS、备份、健康检查与失败回滚；不要把生产凭据或
+服务端配置提交到公开仓库。
 
 ## 4. 持久访问链接
 

--- a/scripts/fork-guard.sh
+++ b/scripts/fork-guard.sh
@@ -62,6 +62,7 @@ fingerprints=(
   "T6|automation reconcile shared API    |CodeWhale/crates/tui/src/automation_manager.rs|pub async fn reconcile_run_statuses_shared("
 
   "CI|公开 fork 全目标编译门禁           |CodeWhale/.github/workflows/pinvou-fork-ci.yml|cargo check --workspace --all-targets --locked"
+  "CI|父仓固定公开 CodeWhale 标签         |scripts/verify-public-submodule.sh|PINVOU_CODEWHALE_TAG=\"pinvou-v0.9.0-r1\""
 
   "APP|消息携带 resolved route            |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|resolve_runtime_route_for_model"
   "APP|部署级 route profile               |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|fn route_limits_for_model("

--- a/scripts/verify-public-submodule.sh
+++ b/scripts/verify-public-submodule.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PINVOU_CODEWHALE_PATH="CodeWhale"
+PINVOU_CODEWHALE_URL="https://github.com/Pinvou/CodeWhale.git"
+PINVOU_CODEWHALE_TAG="pinvou-v0.9.0-r1"
+
+actual_path="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.path)"
+actual_url="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.url)"
+
+if [[ "$actual_path" != "$PINVOU_CODEWHALE_PATH" ]]; then
+  echo "错误：CodeWhale submodule path 应为 $PINVOU_CODEWHALE_PATH，实际为 $actual_path" >&2
+  exit 1
+fi
+
+if [[ "$actual_url" != "$PINVOU_CODEWHALE_URL" ]]; then
+  echo "错误：CodeWhale submodule 必须使用公开 URL $PINVOU_CODEWHALE_URL" >&2
+  exit 1
+fi
+
+if git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.branch >/dev/null; then
+  echo "错误：.gitmodules 不得配置浮动的 submodule.CodeWhale.branch" >&2
+  exit 1
+fi
+
+gitlink="$(
+  git -C "$REPO" ls-files --stage -- "$PINVOU_CODEWHALE_PATH" |
+    awk '$1 == "160000" { print $2 }'
+)"
+
+if [[ ! "$gitlink" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "错误：无法从索引读取唯一的 CodeWhale gitlink commit" >&2
+  exit 1
+fi
+
+remote_refs="$(git ls-remote "$PINVOU_CODEWHALE_URL")"
+tag_target="$(
+  printf '%s\n' "$remote_refs" |
+    awk -v ref="refs/tags/${PINVOU_CODEWHALE_TAG}^{}" '$2 == ref { print $1 }'
+)"
+
+if [[ "$tag_target" != "$gitlink" ]]; then
+  echo "错误：${PINVOU_CODEWHALE_TAG} 解引用为 ${tag_target:-<不存在>}，父仓 gitlink 为 $gitlink" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$remote_refs" | awk -v sha="$gitlink" '$1 == sha { found = 1 } END { exit !found }'; then
+  echo "错误：父仓 gitlink $gitlink 无法从公开 CodeWhale refs 到达" >&2
+  exit 1
+fi
+
+echo "公开 CodeWhale 基线校验通过：${PINVOU_CODEWHALE_TAG} -> $gitlink"


### PR DESCRIPTION
## 概述

将公开父仓的 CodeWhale submodule 固定到已验证的不可变标签 `pinvou-v0.9.0-r1`，并补齐面向国际开发者的 fork 维护说明与公开可达性门禁。

## 背景

公开仓库不能依赖浮动 submodule 分支，否则维护分支更新会让源码基线、审计结论和发布构建失去一一对应关系。本次把父仓 gitlink、公开标签和远端可达 commit 固定为同一基线；同时修正公开迁移后 CI 和架构文档仍引用已裁剪内部部署脚本的问题。

## 变更

- 将 `CodeWhale` gitlink 更新到 `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e`，对应 `pinvou-v0.9.0-r1`。
- 删除 `.gitmodules` 中的 `branch = pinvou3-clean`，避免递归克隆跟随浮动分支。
- 增加中英文 fork 策略和修改清单，记录六个长期主题、公开基线、drift、同步与上游贡献规则。
- 增加 `scripts/verify-public-submodule.sh`，校验公开 URL、标签解引用、gitlink 可达性和无浮动 branch，并接入 `fast-gate`。
- 同步更新 fork 指纹与修改清单，满足 gitlink 变更的同 PR 约束。
- 移除公开 CI 和架构文档中对未公开内部部署脚本的失效引用；Relay 功能测试继续保留。

## 验证

- `./scripts/verify-public-submodule.sh`
- `./scripts/fork-guard.sh --fast`
- `./scripts/ci-fork-link-check.sh origin/main`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`（20 项通过）
- `npm --prefix remote-control-relay test`（23 项通过）
- `bash -n scripts/verify-public-submodule.sh scripts/fork-guard.sh scripts/ci-fork-link-check.sh`
- `git diff --check`
- Gitleaks 8.30.1 工作树扫描：0 个泄漏

## 备注

本 PR 不改变 CodeWhale 产品功能；CodeWhale 基线自身的全目标编译、`forkguard_`、DCO、Gitleaks 和 CodeQL 已在公开 fork PR 中通过。macOS 打包验证按当前分工由团队另行完成，不作为本 PR 的等待项。
