### PR TITLE
fix: 统一侧边栏定时任务记录样式

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 [Website](https://pinvou.com/) · [CodeWhale engine](https://github.com/Pinvou/CodeWhale) · [Security](SECURITY.md) · [MIT License](LICENSE)
 
-![Pinvou Agent desktop workspace](docs/assets/screenshots/home.webp)
+<video src="docs/assets/videos/feature-update-2026-07-17-2026-07-23.mp4" controls width="100%" poster="docs/assets/screenshots/home.webp">
+  Pinvou Agent desktop feature update video
+</video>
 
 Pinvou Agent brings models, tools, personal knowledge, specialist personas, and reusable workflows into one desktop workspace. It is designed for work that should end with a result—not just another chat response.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,9 @@
 
 Pinvou Agent 不只是一个聊天界面。它把模型、工具、个人知识、专家角色和工作流放进同一个桌面应用，让 AI 从“回答问题”进一步走到“完成任务”。模型既可以运行在本地，也可以接入 OpenAI-compatible 服务；工具与连接器按需启用。
 
-![Pinvou Agent 主界面](docs/assets/screenshots/home.webp)
+<video src="docs/assets/videos/feature-update-2026-07-17-2026-07-23.mp4" controls width="100%" poster="docs/assets/screenshots/home.webp">
+  Pinvou Agent 新增功能介绍视频
+</video>
 
 ## 能做什么
 

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -856,21 +856,12 @@ function defaultModelPresetForCapabilities(capabilities) {
           return {
             id: run.sessionId,
             title,
-            subtitle: `${scheduledRunLabel(run.status)} · ${formatSessionDate(run.scheduledFor || run.createdAt, language)}`,
-            date: '',
+            date: formatSessionDate(run.scheduledFor || run.createdAt, language),
             updatedAt: run.createdAt || run.scheduledFor || '',
             pinned: !!run.pinned,
             pinnedAt: run.pinnedAt || '',
             working: run.status === 'running' || run.status === 'queued',
-            leadingIcon: (
-              <span className="relative inline-flex h-5 w-5 items-center justify-center">
-                <Clock size={16} />
-                {run.unread && (
-                  <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2"
-                    style={{ background: '#0B57D0', borderColor: activeTheme === 'dark' ? '#1E1F20' : '#F0F4F9' }} />
-                )}
-              </span>
-            ),
+            unread: !!run.unread,
             testId: 'scheduled-run-sidebar-item',
             menuTestId: 'scheduled-run-sidebar-menu',
             scheduledRun: run,
@@ -888,16 +879,8 @@ function defaultModelPresetForCapabilities(capabilities) {
           : chat.title;
         return Object.assign({}, chat, {
           title,
-          subtitle: `${scheduledRunLabel(run.status)} · ${formatSessionDate(run.scheduledFor || run.createdAt, language)}`,
-          leadingIcon: (
-            <span className="relative inline-flex h-5 w-5 items-center justify-center">
-              <Clock size={16} />
-              {run.unread && (
-                <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2"
-                  style={{ background: '#0B57D0', borderColor: activeTheme === 'dark' ? '#1E1F20' : '#F0F4F9' }} />
-              )}
-            </span>
-          ),
+          date: chat.date || formatSessionDate(run.scheduledFor || run.createdAt, language),
+          unread: !!run.unread,
           testId: 'scheduled-run-sidebar-item',
           menuTestId: 'scheduled-run-sidebar-menu',
           scheduledRun: run,
@@ -1019,16 +1002,6 @@ function defaultModelPresetForCapabilities(capabilities) {
         if (window.matchMedia && window.matchMedia('(max-width: 639px)').matches) {
           setIsSidebarOpen(false);
         }
-      }
-
-      function scheduledRunLabel(value) {
-        return ({
-          queued: '等待中',
-          running: '运行中',
-          completed: '已完成',
-          failed: '失败',
-          canceled: '已取消',
-        }[value] || value || '未知');
       }
 
       async function handleOpenScheduledRunShortcut(run) {

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -327,6 +327,11 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
           </span>
           {chat.working && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-current opacity-70 animate-pulse" title={t.riGenerating}></span>}
           {chat.skill && <span className="text-[11px] shrink-0 opacity-70 mr-1" title={chat.skill}>🧭</span>}
+          {chat.unread && (
+            <span data-testid="scheduled-run-sidebar-unread" aria-label="定时任务运行有未查看的对话"
+              className="mr-1 h-2 w-2 shrink-0 rounded-full group-hover:hidden"
+              style={{ background: '#0B57D0' }} />
+          )}
           {confirming ? (
             <div className="flex items-center gap-0.5 shrink-0" onClick={e => e.stopPropagation()}>
               <span className={`text-[11px] mr-0.5 ${isDark ? 'text-[#F28B82]' : 'text-[#C5221F]'}`}>{t.riDelQ}</span>


### PR DESCRIPTION
## 概述
统一侧边栏任务列表中定时任务运行记录的展示样式，让它和普通任务保持同一行布局。

## 背景
定时任务运行记录此前额外展示时钟图标和第二行状态/时间信息，在合并后的任务列表里高度与信息结构都不同，视觉上和普通任务不一致。

## 变更
- 将定时任务运行记录改为复用普通任务的一行标题与右侧日期展示。
- 保留运行中状态点和未读提示点，避免丢失状态反馈。
- 清理不再使用的定时运行状态标签函数。

## 验证
- `npm run test:scheduled`
- `npm run check:architecture`（仅既有大文件 advisory warning，无新增架构债）
- `npm run lint:ui`
- `npm run dev` 启动桌面应用，确认 Tauri 初始化完成并进入 `bridge:init_done`

## 影响面
影响侧边栏“任务列表”中的定时任务运行记录展示；不涉及定时任务详情页、任务执行、后端调度或 CodeWhale fork。潜在风险是未读提示位置变化，已保留独立未读点以降低风险。
