### PR TITLE
docs: add Pinvou Agent feature video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 [Website](https://pinvou.com/) · [CodeWhale engine](https://github.com/Pinvou/CodeWhale) · [Security](SECURITY.md) · [MIT License](LICENSE)
 
-![Pinvou Agent desktop workspace](docs/assets/screenshots/home.webp)
+<video src="docs/assets/videos/feature-update-2026-07-17-2026-07-23.mp4" controls width="100%" poster="docs/assets/screenshots/home.webp">
+  Pinvou Agent desktop feature update video
+</video>
 
 Pinvou Agent brings models, tools, personal knowledge, specialist personas, and reusable workflows into one desktop workspace. It is designed for work that should end with a result—not just another chat response.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,9 @@
 
 Pinvou Agent 不只是一个聊天界面。它把模型、工具、个人知识、专家角色和工作流放进同一个桌面应用，让 AI 从“回答问题”进一步走到“完成任务”。模型既可以运行在本地，也可以接入 OpenAI-compatible 服务；工具与连接器按需启用。
 
-![Pinvou Agent 主界面](docs/assets/screenshots/home.webp)
+<video src="docs/assets/videos/feature-update-2026-07-17-2026-07-23.mp4" controls width="100%" poster="docs/assets/screenshots/home.webp">
+  Pinvou Agent 新增功能介绍视频
+</video>
 
 ## 能做什么
 


### PR DESCRIPTION
## Summary
- Add the 2026-07-17 to 2026-07-23 feature update video under docs/assets/videos.
- Replace the top README screenshot in both English and Chinese READMEs with an embedded video using the existing home screenshot as the poster.

## Validation
- Verified the PR branch diff only includes README.md, README.zh-CN.md, and the new MP4 asset.

## Note
- GitHub accepted the 59.44 MB MP4, but warned that it exceeds the recommended 50 MB file size.