### PR TITLE
fix: 升级 DOMPurify 至 3.4.12

### DIFF
--- a/pinvou3-app/package-lock.json
+++ b/pinvou3-app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pinvou3-app",
       "version": "0.6.4",
       "dependencies": {
-        "dompurify": "^3.4.2",
+        "dompurify": "^3.4.12",
         "marked": "^13.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1052,9 +1052,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -67,7 +67,7 @@
     "vite": "^8.1.4"
   },
   "dependencies": {
-    "dompurify": "^3.4.2",
+    "dompurify": "^3.4.12",
     "marked": "^13.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## 改了什么

- 将 `pinvou3-app` 的 DOMPurify 从 3.4.2 升级到 3.4.12。
- 重新应用已关闭 Dependabot PR #1 的同等安全补丁，仅修改依赖清单和锁文件。

## 改动原因

公开仓重写历史后，旧 Dependabot 分支已删除，GitHub 不允许重新打开原 PR。本 PR 在当前 `main` 上重建该更新，用于修复当前 DOMPurify 安全告警。

## 影响面

- 影响前端 HTML 清理依赖版本。
- 不修改业务逻辑、应用配置或运行时数据。
- 潜在风险集中在依赖升级兼容性，交由现有 CI 验证。