### PR TITLE
fix: 移除未使用且存在漏洞的 React Router 依赖

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
+++ b/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "chart.js": "^4.4.7",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -812,15 +811,6 @@
       "resolved": "https://registry.npmmirror.com/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmmirror.com/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1756,38 +1746,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/rollup": {

--- a/pinvou3-app/src-tauri/resources/common/web-template/package.json
+++ b/pinvou3-app/src-tauri/resources/common/web-template/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "chart.js": "^4.4.7",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/pinvou3-app/src-tauri/resources/common/web-template/src/App.jsx
+++ b/pinvou3-app/src-tauri/resources/common/web-template/src/App.jsx
@@ -1,11 +1,5 @@
-import { HashRouter, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+
 export default function App() {
-  return (
-    <HashRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-      </Routes>
-    </HashRouter>
-  )
+  return <Home />
 }


### PR DESCRIPTION
## 改了什么

- 移除 `web-template` 未实际需要的 `react-router-dom`、`react-router` 与 `@remix-run/router` 依赖。
- 模板当前只有一个 `/` 页面，改为直接渲染 `Home`，现有界面行为不变。

## 改动原因

已关闭的 Dependabot PR #2 原计划从 6.30.4 升级到 7.18.1，但该版本后来新增高危告警 GHSA-qwww-vcr4-c8h2，直接复用会引入新的高危漏洞；真正安全的 8.3.0 又要求 React 19.2.7 和 Node 22.22.0。当前模板不需要路由能力，因此移除依赖比跨两次主版本升级更稳妥。

## 影响面

- 影响 `web-template` 的启动入口与依赖清单。
- 当前单页模板行为不变；未来新增多页面路由时需要重新选择路由方案。
- 本地已通过 `npm ci` 和 `npm run build`；现有 CI 会继续验证。