### PR TITLE
fix: 升级 tar 至 0.4.46

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -8164,9 +8164,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## 改了什么

- 将 `Cargo.lock` 中的 `tar` 从 0.4.45 升级到 0.4.46。
- 重新应用已关闭 Dependabot PR #5 的同等安全补丁，仅修改 Rust 锁文件。

## 改动原因

公开仓重写历史后，旧 Dependabot 分支已删除，GitHub 不允许重新打开原 PR。本 PR 在当前 `main` 上重建该更新，修复 GHSA-3pv8-6f4r-ffg2。

## 影响面

- 影响 Rust 归档处理依赖版本。
- 不修改业务源码、应用配置或运行时数据。
- 潜在风险集中在依赖升级兼容性，交由现有 CI 验证。