### PR TITLE
fix: 升级 web-template 的 PostCSS 至 8.5.23

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
+++ b/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
@@ -1646,9 +1646,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1715,7 +1715,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## 改了什么

- 将 `web-template/package-lock.json` 中的 PostCSS 从 8.5.15 升级到 8.5.23。
- 同步升级 PostCSS 要求的 nanoid 补丁版本。
- 仅修改该模板的锁文件。

## 改动原因

修复高危漏洞 GHSA-r28c-9q8g-f849。Dependabot PR #21 只更新了根应用的锁文件，没有覆盖 `web-template` 的独立依赖树。

## 影响面

- 影响 web-template 的前端构建依赖。
- 不修改模板业务源码或运行时配置。
- 本地已通过 `npm ci` 和 `npm run build`。