### PR TITLE
fix: 统一侧边栏定时任务记录样式

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -626,21 +626,12 @@ function defaultModelPresetForCapabilities(capabilities) {
           return {
             id: run.sessionId,
             title,
-            subtitle: `${scheduledRunLabel(run.status)} · ${formatSessionDate(run.scheduledFor || run.createdAt, language)}`,
-            date: '',
+            date: formatSessionDate(run.scheduledFor || run.createdAt, language),
             updatedAt: run.createdAt || run.scheduledFor || '',
             pinned: !!run.pinned,
             pinnedAt: run.pinnedAt || '',
             working: run.status === 'running' || run.status === 'queued',
-            leadingIcon: (
-              <span className="relative inline-flex h-5 w-5 items-center justify-center">
-                <Clock size={16} />
-                {run.unread && (
-                  <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2"
-                    style={{ background: '#0B57D0', borderColor: activeTheme === 'dark' ? '#1E1F20' : '#F0F4F9' }} />
-                )}
-              </span>
-            ),
+            unread: !!run.unread,
             testId: 'scheduled-run-sidebar-item',
             menuTestId: 'scheduled-run-sidebar-menu',
             scheduledRun: run,
@@ -658,16 +649,8 @@ function defaultModelPresetForCapabilities(capabilities) {
           : chat.title;
         return Object.assign({}, chat, {
           title,
-          subtitle: `${scheduledRunLabel(run.status)} · ${formatSessionDate(run.scheduledFor || run.createdAt, language)}`,
-          leadingIcon: (
-            <span className="relative inline-flex h-5 w-5 items-center justify-center">
-              <Clock size={16} />
-              {run.unread && (
-                <span className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full border-2"
-                  style={{ background: '#0B57D0', borderColor: activeTheme === 'dark' ? '#1E1F20' : '#F0F4F9' }} />
-              )}
-            </span>
-          ),
+          date: chat.date || formatSessionDate(run.scheduledFor || run.createdAt, language),
+          unread: !!run.unread,
           testId: 'scheduled-run-sidebar-item',
           menuTestId: 'scheduled-run-sidebar-menu',
           scheduledRun: run,
@@ -789,16 +772,6 @@ function defaultModelPresetForCapabilities(capabilities) {
         if (window.matchMedia && window.matchMedia('(max-width: 639px)').matches) {
           setIsSidebarOpen(false);
         }
-      }
-
-      function scheduledRunLabel(value) {
-        return ({
-          queued: '等待中',
-          running: '运行中',
-          completed: '已完成',
-          failed: '失败',
-          canceled: '已取消',
-        }[value] || value || '未知');
       }
 
       async function handleOpenScheduledRunShortcut(run) {

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -327,6 +327,11 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
           </span>
           {chat.working && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-current opacity-70 animate-pulse" title={t.riGenerating}></span>}
           {chat.skill && <span className="text-[11px] shrink-0 opacity-70 mr-1" title={chat.skill}>🧭</span>}
+          {chat.unread && (
+            <span data-testid="scheduled-run-sidebar-unread" aria-label="定时任务运行有未查看的对话"
+              className="mr-1 h-2 w-2 shrink-0 rounded-full group-hover:hidden"
+              style={{ background: '#0B57D0' }} />
+          )}
           {confirming ? (
             <div className="flex items-center gap-0.5 shrink-0" onClick={e => e.stopPropagation()}>
               <span className={`text-[11px] mr-0.5 ${isDark ? 'text-[#F28B82]' : 'text-[#C5221F]'}`}>{t.riDelQ}</span>


### PR DESCRIPTION
## 改了什么

- 迁移原 PR #15 的定时任务侧边栏样式修复。
- 统一定时任务记录与普通会话记录的图标、布局和选中态。
- 保留原作者提交与 `Signed-off-by`。

## 改动原因

公开仓库重建历史后，原 PR #15 无法直接重新打开；本 PR 基于已合入 #25 的最新 `main` 重新迁移干净提交。

## 影响面

- 仅影响侧边栏定时任务记录的展示与交互样式。
- 不包含 #13/#14 的 README 和约 59 MB 视频文件。
- 不涉及 Rust、凭据、服务地址、部署配置或第三方资源。
- 与开放 PR #23 都修改 `pinvou3-app/src/app/main.jsx`，后合入的一方可能需要解决文本冲突。

## 验证

- `npm run test:scheduled`
- `npm run lint:ui -- --quiet`
- `npm run build:ui`
- `npm run test:webui`（25 条完整 WebUI 旅程通过）

迁移自 #15；#13 的重复代码统一由本 PR 承接。