### PR TITLE
docs(install): vLLM 启动示例补工具调用必需参数

### DIFF
--- a/pinvou3-app/INSTALL.md
+++ b/pinvou3-app/INSTALL.md
@@ -38,8 +38,9 @@ vllm serve /opt/models/qwen3.6-35b-a3b-fp8 \
 ```
 
 关键约束：
+- Qwen3.6 官方建议使用 `vllm>=0.19.0`；旧版本可能不支持对应模型或无法识别下述 parser 参数，遇到未注册错误时请先升级 vLLM。
 - `--served-model-name` **推荐** 设为 `qwen36_35b_256k`（或至少包含 `_256k`），底座据此派生 256K 上下文窗口与 compaction 阈值。
-- `--enable-auto-tool-choice --tool-call-parser qwen3_coder` **必须**带上：缺了 vLLM 不会把模型输出解析成标准 `tool_calls`，工具调用会直接失效或漂移。注意 Qwen3.6 的 tool-call parser 名是 `qwen3_coder`（Qwen2.5/Qwen3 时代是 `hermes`；`qwen3` 是 `--reasoning-parser` 的注册名，写给 `--tool-call-parser` 会因未注册而 KeyError 启动失败），升级模型时按模型卡核对。
+- `--enable-auto-tool-choice --tool-call-parser qwen3_coder` **必须**带上：缺了 vLLM 不会把模型输出解析成标准 `tool_calls`，工具调用会直接失效或漂移。注意 Qwen3.6 的 tool-call parser 名是 `qwen3_coder`；其他模型可能使用 `hermes` 等不同 parser，升级或更换模型时必须按对应模型卡核对。`qwen3` 是 `--reasoning-parser` 的注册名，写给 `--tool-call-parser` 会因未注册而启动失败。
 - `--reasoning-parser qwen3` 建议按官方模型卡带上，由服务端把 thinking 内容解析到独立字段；缺省时 `<think>` 内容可能泄漏进正文。它与客户端 `DEEPSEEK_REASONING_EFFORT=off` 不冲突：后者控制是否请求/展示推理，前者保证服务端输出结构干净。
 - 若使用其他模型名（如 `Qwen2.5-72B-Instruct`），底座也能识别 Qwen 系列并派生 128K 窗口；如仍想获得 256K 阈值，请在模型名中附加 `_256k` 后缀。
 - 若 vLLM 绑在其他端口（如 `8080`），见下节「自定义后端地址」。

--- a/pinvou3-app/INSTALL.md
+++ b/pinvou3-app/INSTALL.md
@@ -31,11 +31,16 @@ vllm serve /opt/models/qwen3.6-35b-a3b-fp8 \
   --served-model-name qwen36_35b_256k \
   --max-model-len 262144 \
   --tensor-parallel-size 1 \
-  --gpu-memory-utilization 0.95
+  --gpu-memory-utilization 0.95 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --reasoning-parser qwen3
 ```
 
 关键约束：
 - `--served-model-name` **推荐** 设为 `qwen36_35b_256k`（或至少包含 `_256k`），底座据此派生 256K 上下文窗口与 compaction 阈值。
+- `--enable-auto-tool-choice --tool-call-parser qwen3_coder` **必须**带上：缺了 vLLM 不会把模型输出解析成标准 `tool_calls`，工具调用会直接失效或漂移。注意 Qwen3.6 的 tool-call parser 名是 `qwen3_coder`（Qwen2.5/Qwen3 时代是 `hermes`；`qwen3` 是 `--reasoning-parser` 的注册名，写给 `--tool-call-parser` 会因未注册而 KeyError 启动失败），升级模型时按模型卡核对。
+- `--reasoning-parser qwen3` 建议按官方模型卡带上，由服务端把 thinking 内容解析到独立字段；缺省时 `<think>` 内容可能泄漏进正文。它与客户端 `DEEPSEEK_REASONING_EFFORT=off` 不冲突：后者控制是否请求/展示推理，前者保证服务端输出结构干净。
 - 若使用其他模型名（如 `Qwen2.5-72B-Instruct`），底座也能识别 Qwen 系列并派生 128K 窗口；如仍想获得 256K 阈值，请在模型名中附加 `_256k` 后缀。
 - 若 vLLM 绑在其他端口（如 `8080`），见下节「自定义后端地址」。
 


### PR DESCRIPTION
## 概述

`pinvou3-app/INSTALL.md` 的 `vllm serve` 示例补齐工具调用必需参数 `--enable-auto-tool-choice --tool-call-parser qwen3_coder`，并按 Qwen3.6 官方模型卡补上 `--reasoning-parser qwen3`，避免按文档启动后工具调用失效。

## 背景

此前安装文档的 vLLM 启动示例完全缺少工具调用相关参数：缺 `--enable-auto-tool-choice` 时 vLLM 不会启用工具调用解析，缺 `--tool-call-parser` 时模型输出不会被解析成标准 `tool_calls`，工具调用会直接失效或漂移。依据 Qwen3.6 模型卡与 vLLM 官方文档，Qwen3.6 的 tool-call parser 名为 `qwen3_coder`（Qwen2.5/Qwen3 时代为 `hermes`）；`qwen3` 是 `--reasoning-parser` 的注册名，误写给 `--tool-call-parser` 会因未注册而 KeyError 启动失败。模型卡的工具调用命令同时带 `--reasoning-parser qwen3`，缺省时 thinking 内容可能泄漏进正文。

## 变更

- 启动示例补 `--enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3`。
- 关键约束新增两条说明：tool-call parser 名随模型代际变化（升级模型时按模型卡核对）、`qwen3` 误用于 `--tool-call-parser` 的后果；`--reasoning-parser qwen3` 与客户端 `DEEPSEEK_REASONING_EFFORT=off` 不冲突（前者保证服务端输出结构干净，后者控制客户端是否请求/展示推理）。

## 验证

- 纯文档变更，人工审阅内容；对照 Qwen3.6 官方模型卡与 vLLM 文档核实 `--tool-call-parser qwen3_coder` 与 `--reasoning-parser qwen3` 写法。
- 确认文中引用的 `DEEPSEEK_REASONING_EFFORT` 环境变量在本仓库代码中实际存在。
