### PR TITLE
refactor(rust): 清理 clippy 告警

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -193,7 +193,8 @@ device_query = "2"
 # 有欠账的 lint/group 显式 allow 并注明欠账规模,由清理 PR(#35 及后续)消化后逐个启用。
 # CI(pr-check.yml rust-lint job)直接跑 `cargo clippy --lib --no-deps`(无 continue-on-error),
 # deny 命中即 fail;allow 的欠账 lint 被静默,不产生告警噪声。
-# 实测基线(rust 1.97.1,2026-07-27):clippy::all 组 54 处欠账,rustc 默认 lint 113 处。
+# 实测基线(rust 1.97.1,2026-07-28):应用 crate 的 clippy::all 组 20 处欠账
+# (不含 CodeWhale),rustc 默认 lint 既有基线为 113 处。
 # =============================================================================
 [lints.rust]
 # —— 零欠账,deny 硬门禁(实测 0 违规)——
@@ -220,7 +221,7 @@ private_interfaces = "allow"
 
 [lints.clippy]
 # —— all / pedantic 组有历史欠账,整组 allow(priority=-1 保证下方具体 lint 的 deny 生效)——
-# all 组(correctness+suspicious+style+complexity+perf)实测 54 处欠账;
+# all 组(correctness+suspicious+style+complexity+perf)应用 crate 实测 20 处欠账;
 # pedantic 组欠账更多(原方案全量 warn 实测近 2000 条告警,等于无门禁)。
 # 欠账由清理 PR(#35 及后续)消化后,再整组或逐 lint 升 deny。
 all = { level = "allow", priority = -1 }

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -504,7 +504,7 @@ pub async fn list_deliverables(project_dir: String) -> Result<serde_json::Value,
                             .and_then(|r| r.strip_suffix(".md"))
                             .and_then(|n| n.parse::<u32>().ok())
                         {
-                            if best.as_ref().map_or(true, |(s, _)| seq > *s) {
+                            if best.as_ref().is_none_or(|(s, _)| seq > *s) {
                                 best = Some((seq, path));
                             }
                         }

--- a/pinvou3-app/src-tauri/src/app/commands/attachments.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/attachments.rs
@@ -149,6 +149,7 @@ pub(super) fn stage_image_in_workspace(
 
 /// Copy a remote-control upload into the session workspace before the
 /// temporary upload directory is removed.
+#[allow(dead_code)]
 pub(crate) fn stage_remote_attachment_source(
     src: &str,
     basename: &str,

--- a/pinvou3-app/src-tauri/src/app/commands/chat.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/chat.rs
@@ -31,7 +31,7 @@ pub async fn chat(
     app: AppHandle,
 ) -> Result<(), String> {
     let trimmed = message.trim();
-    if trimmed.is_empty() && attachments.as_ref().map_or(true, |a| a.is_empty()) {
+    if trimmed.is_empty() && attachments.as_ref().is_none_or(|a| a.is_empty()) {
         return Err("empty message".to_string());
     }
     // 多 session 并发:消息显式路由到指定 session(前端传 session_id);兼容旧前端时
@@ -70,7 +70,7 @@ pub(crate) async fn chat_with_reservation(
     store: &SessionStore,
     app: &AppHandle,
 ) -> Result<(), String> {
-    if message.trim().is_empty() && attachments.as_ref().map_or(true, |a| a.is_empty()) {
+    if message.trim().is_empty() && attachments.as_ref().is_none_or(|a| a.is_empty()) {
         return Err("empty message".to_string());
     }
     let chat_started_at = std::time::Instant::now();

--- a/pinvou3-app/src-tauri/src/app/commands/files.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/files.rs
@@ -41,11 +41,7 @@ pub async fn verify_upload(upload_id: String) -> Result<VerifyUploadOutput, Stri
     let file_path = match std::fs::read_dir(&upload_dir).ok().and_then(|entries| {
         entries
             .filter_map(|entry| entry.ok())
-            .find(|entry| {
-                entry
-                    .file_type()
-                    .is_ok_and(|kind| kind.is_file())
-            })
+            .find(|entry| entry.file_type().is_ok_and(|kind| kind.is_file()))
             .map(|entry| entry.path())
     }) {
         Some(path) => path,

--- a/pinvou3-app/src-tauri/src/app/commands/files.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/files.rs
@@ -41,13 +41,11 @@ pub async fn verify_upload(upload_id: String) -> Result<VerifyUploadOutput, Stri
     let file_path = match std::fs::read_dir(&upload_dir).ok().and_then(|entries| {
         entries
             .filter_map(|entry| entry.ok())
-            .filter(|entry| {
+            .find(|entry| {
                 entry
                     .file_type()
-                    .map(|kind| kind.is_file())
-                    .unwrap_or(false)
+                    .is_ok_and(|kind| kind.is_file())
             })
-            .next()
             .map(|entry| entry.path())
     }) {
         Some(path) => path,

--- a/pinvou3-app/src-tauri/src/app/commands/interaction.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/interaction.rs
@@ -32,9 +32,6 @@ pub async fn get_mode_state(
 
 // ===================== 卡片池: 专家面具 =====================
 
-/// 列出全部专家卡的**摘要**（不含 body，~200 卡）。前端进卡片池拉一次缓存。
-/// Side B: body 太大（~6K 字/张），不随 list 下发，加持/详情时按需取。
-
 /// 用户在 composer chip 选 Plan：设 mode=Plan。
 /// 下一条 chat 消息带 mode=Plan 发送，底座自动切只读工具集 + ReadOnly sandbox。
 #[tauri::command]

--- a/pinvou3-app/src-tauri/src/app/commands/monitor.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/monitor.rs
@@ -102,7 +102,7 @@ fn normalize_local_vllm_base_url(raw: &str) -> Option<String> {
         return None;
     }
     let port: u16 = port.parse().ok()?;
-    if !matches!(port, 8000 | 8001 | 8002 | 11434 | 1234) {
+    if !matches!(port, 8000..=8002 | 11434 | 1234) {
         return None;
     }
     Some(format!("http://{host}:{port}/v1"))

--- a/pinvou3-app/src-tauri/src/app/commands/personas.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/personas.rs
@@ -171,7 +171,7 @@ pub(super) fn merge_resolutions(
                 None => continue,
             };
             for (j, ni) in new_items.iter_mut().enumerate() {
-                if ni.get("resolution").map_or(false, |v| !v.is_null()) {
+                if ni.get("resolution").is_some_and(|v| !v.is_null()) {
                     continue; // new 已带裁决，尊重 new（含 Boss 改裁决/取消）
                 }
                 if let Some(old_res) = old_items.get(j).and_then(|x| x.get("resolution")) {

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -73,7 +73,7 @@ pub async fn list_sessions(
             && !store.is_hidden(&m.id)
             && store
                 .active_skill(&m.id)
-                .map_or(true, |b| b.project_dir.is_none())
+                .is_none_or(|b| b.project_dir.is_none())
     });
     Ok(metas
         .into_iter()
@@ -102,7 +102,7 @@ pub async fn list_archived_sessions(
         store.is_hidden(&m.id)
             && store
                 .active_skill(&m.id)
-                .map_or(true, |b| b.project_dir.is_none())
+                .is_none_or(|b| b.project_dir.is_none())
     });
     metas.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     Ok(metas

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1,3 +1,6 @@
+// 本文件为命令层测试,借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;跨 await 持有无竞争者,不会死锁。
+#![allow(clippy::await_holding_lock)]
+
 use super::prelude::*;
 use super::{
     artifacts::*, attachments::*, files::*, interaction::*, knowledge::*, marketplace::*,

--- a/pinvou3-app/src-tauri/src/app/commands/workflows.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/workflows.rs
@@ -1364,7 +1364,7 @@ pub async fn find_resumable_run(
         let mtime = std::fs::metadata(&progress)
             .and_then(|md| md.modified())
             .unwrap_or(std::time::UNIX_EPOCH);
-        if best.as_ref().map_or(true, |(bt, _, _, _)| mtime > *bt) {
+        if best.as_ref().is_none_or(|(bt, _, _, _)| mtime > *bt) {
             best = Some((mtime, m.id.clone(), pd.clone(), scenario));
         }
     }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -5,7 +5,7 @@
 //!     [`EngineConfig`] / [`DtConfig`]，然后 `spawn_engine`，存到 Tauri State
 //!  2. 后台 task 持续读 `EngineHandle::rx_event`，转译成 Tauri 事件
 //!     （`chat:delta` / `chat:tool_start` / `chat:tool_end` / `chat:done`
-//!      / `chat:plan_ready`）
+//!     / `chat:plan_ready`）
 //!  3. 暴露 `send_user_message()` 给 [`commands::chat`] 调用
 //!
 //! 所有配置决策（model / paths / locale / allow_shell ...）都在 bridge 里，
@@ -1025,7 +1025,7 @@ impl AppEngine {
                 reservation.mark_submitted();
                 Ok(())
             }
-            Err(error) => Err(error.into()),
+            Err(error) => Err(error),
         }
     }
 
@@ -1152,6 +1152,7 @@ fn format_instructions(sources: &[deepseek_tui::prompts::InstructionSource]) -> 
 /// 底座两层 plan 结构：
 ///   - `update_plan`         → strategy 层（`plan_snapshot`）
 ///   - `checklist_write` / `todo_write` → leaf task 层（`todos_snapshot`）
+///
 /// 任一调过 + plan_phase=Planning → TurnComplete 时 emit `chat:plan_ready`。
 /// 参考底座 `tui/ui.rs:1072-1085` 的 `plan_tool_used_in_turn` 判据 +
 /// `prompts/modes/plan.md` "Use update_plan ... and checklist_write ..." 双工具引导。
@@ -2804,8 +2805,8 @@ fn apply_scheduled_turn_policy(
     };
 
     *mode = profile.execution_mode().to_app_mode();
-    *route = Box::new(resolved_route);
-    *compaction = Box::new(compaction_config);
+    **route = resolved_route;
+    **compaction = compaction_config;
     *auto_model = false;
     *allow_shell = profile.allow_shell;
     *trust_mode = profile.trust_mode;
@@ -2823,7 +2824,7 @@ fn scheduled_tool_should_auto_approve(
     profile: Option<&ScheduledRunProfile>,
     approval_force_prompt: bool,
 ) -> bool {
-    profile.map_or(true, |profile| {
+    profile.is_none_or(|profile| {
         profile.auto_approve && !approval_force_prompt
     })
 }
@@ -3447,6 +3448,8 @@ mod scheduled_turn_tests {
 }
 
 #[cfg(test)]
+// 测试借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;单线程测试内跨 await 持有无竞争者,不会死锁。
+#[allow(clippy::await_holding_lock)]
 mod live_tests {
     use super::*;
     use crate::core::mode_state::SerializableMode;

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -2824,9 +2824,7 @@ fn scheduled_tool_should_auto_approve(
     profile: Option<&ScheduledRunProfile>,
     approval_force_prompt: bool,
 ) -> bool {
-    profile.is_none_or(|profile| {
-        profile.auto_approve && !approval_force_prompt
-    })
+    profile.is_none_or(|profile| profile.auto_approve && !approval_force_prompt)
 }
 
 #[cfg(test)]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -651,9 +651,7 @@ impl EnginePool {
         let persona_reminder = active_card
             .as_ref()
             .map(crate::features::personas::equip_anchor);
-        let restrict_tools = active_card
-            .as_ref()
-            .is_some_and(|c| c.conversational_only);
+        let restrict_tools = active_card.as_ref().is_some_and(|c| c.conversational_only);
         let restrict_tools = restrict_tools || restrict_tools_for_turn;
         self.get_or_spawn(session_id)
             .await?

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -170,6 +170,8 @@ where
     store.delete_scheduled_run(session_id, expected_task_id)
 }
 
+/// EnginePool 预备 API(含测试覆盖,待 Tauri command 层接入);在 lib 生产视角下为 dead code。
+#[allow(dead_code)]
 async fn delete_chat_session_with_gate<F, Fut, G>(
     turn_locks: &SessionTurnLocks,
     store: &SessionStore,
@@ -246,6 +248,7 @@ pub struct EnginePool {
 
 impl EnginePool {
     /// boot bridge(一次)并建空池。不预热任何 engine(lazy)。
+    #[allow(dead_code)]
     pub fn new(app: AppHandle, store: SessionStore) -> Result<Self> {
         Self::new_with_dependencies(
             app,
@@ -438,6 +441,7 @@ impl EnginePool {
     /// Delete an ordinary chat under the exact turn gate used by lazy spawn
     /// and send. No queued sender can slip between engine reclaim, disk delete,
     /// and lifecycle cleanup to resurrect the session.
+    #[allow(dead_code)]
     pub(crate) async fn delete_chat_session(&self, session_id: &str) -> Result<()> {
         delete_chat_session_with_gate(
             &self.turn_locks,
@@ -579,6 +583,7 @@ impl EnginePool {
     }
 
     /// 发用户消息给指定 session 的 engine(没起则 lazy spawn)。
+    #[allow(dead_code)]
     pub async fn send_user_message(
         &self,
         session_id: &str,
@@ -648,7 +653,7 @@ impl EnginePool {
             .map(crate::features::personas::equip_anchor);
         let restrict_tools = active_card
             .as_ref()
-            .map_or(false, |c| c.conversational_only);
+            .is_some_and(|c| c.conversational_only);
         let restrict_tools = restrict_tools || restrict_tools_for_turn;
         self.get_or_spawn(session_id)
             .await?
@@ -1025,6 +1030,8 @@ fn resolve_spawn_model(
 }
 
 #[cfg(test)]
+// 测试借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;单线程测试内跨 await 持有无竞争者,不会死锁。
+#[allow(clippy::await_holding_lock)]
 mod scheduled_model_tests {
     use super::{
         delete_chat_session_with_gate, delete_scheduled_run_with_gate,

--- a/pinvou3-app/src-tauri/src/features/assistant/harness.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/harness.rs
@@ -21,7 +21,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::platform::paths;
 
@@ -42,7 +42,10 @@ fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
 }
 
 // ── 调度器 JSON 结构 ──
-
+// 这些 struct 镜像 Python scheduler.py 产出的 JSON schema;部分字段(all_actionable、
+// failed_roles、output_path)由 Python 端产出但 Rust 当前未读取,保留是为了显式记录
+// 契约,避免日后 Python 改字段时 Rust 端无感知。
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct SchedulerDecision {
     pub action: String,
@@ -64,6 +67,7 @@ pub struct SchedulerDecision {
 }
 
 /// [per_page] scheduler 展开的单页任务（scheduler.py build_tasks_for 产出）。
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct SchedulerTask {
     pub page: u32,
@@ -107,16 +111,6 @@ struct GateFinding {
     /// 由 find_rollback_rule 显式告警兜底，不静默猜。
     #[serde(default)]
     violation_type: String,
-}
-
-// ── 事件结构 ──
-
-#[derive(Debug, Clone, Serialize)]
-pub struct AgentStateEvent {
-    pub role_id: String,
-    pub role_name: String,
-    pub status: String,
-    pub message: String,
 }
 
 // ── Harness 返回值 ──
@@ -527,7 +521,7 @@ pub fn find_project_dir(workspace: &Path) -> Option<PathBuf> {
                 continue;
             }
             if p.file_name()
-                .map_or(false, |n| n.to_string_lossy().starts_with('.'))
+                .is_some_and(|n| n.to_string_lossy().starts_with('.'))
             {
                 continue;
             }
@@ -748,10 +742,8 @@ fn materialize_dispatch_graph(project: &Path) -> Result<(), String> {
         return Err(format!("dispatch_graph.py not found: {}", script.display()));
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = vec![
-        script.to_string_lossy().to_string(),
-        project.to_string_lossy().to_string(),
-    ];
+    let args = [script.to_string_lossy().to_string(),
+        project.to_string_lossy().to_string()];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     run_python(&arg_refs, scripts_dir).map(|_| ())
 }
@@ -920,10 +912,8 @@ fn run_warmup(project: &Path) -> Result<serde_json::Value, String> {
         return Err(format!("warmup_check.py not found: {}", script.display()));
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = vec![
-        script.to_string_lossy().to_string(),
-        project.to_string_lossy().to_string(),
-    ];
+    let args = [script.to_string_lossy().to_string(),
+        project.to_string_lossy().to_string()];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     match run_python_with_timeout(&arg_refs, scripts_dir, WARMUP_TIMEOUT_SECS) {
         Ok(stdout) => match serde_json::from_str(&stdout) {
@@ -1110,6 +1100,9 @@ fn workflow_failure_reason_for_project(project: &Path) -> Option<String> {
     })
 }
 
+/// 公开入口版本(预留 API,待 command 层接入);当前生产路径直接调
+/// workflow_failure_reason_for_project。保留 pub(crate) 签名以便未来暴露。
+#[allow(dead_code)]
 pub(crate) fn workflow_failure_reason(workspace: &Path) -> Option<String> {
     workflow_failure_reason_for_project(&find_project_dir(workspace)?)
 }
@@ -1134,12 +1127,10 @@ fn run_gate_runner(project: &Path) -> Result<GateResult, String> {
         });
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = vec![
-        script.to_string_lossy().to_string(),
+    let args = [script.to_string_lossy().to_string(),
         deck_dir.to_string_lossy().to_string(),
         "--layer".to_string(),
-        "1".to_string(),
-    ];
+        "1".to_string()];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let out = run_python(&arg_refs, scripts_dir)?;
     serde_json::from_str(&out).map_err(|e| format!("parse gate_runner: {e}"))
@@ -1154,11 +1145,9 @@ fn run_deliverable_check(project: &Path, role_id: &str) -> Result<GateResult, St
         });
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = vec![
-        script.to_string_lossy().to_string(),
+    let args = [script.to_string_lossy().to_string(),
         project.to_string_lossy().to_string(),
-        role_id.to_string(),
-    ];
+        role_id.to_string()];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let out = run_python(&arg_refs, scripts_dir)?;
     let v: serde_json::Value =
@@ -1550,15 +1539,6 @@ pub fn approve_gate(workspace: &Path, role_id: &str) -> HarnessAction {
 /// 语义对齐 gate local fail：--fail 计次 → 耗尽则 Blocked，否则带失败原因重派同角色。
 pub fn agent_failed(workspace: &Path, role_id: &str, error: &str) -> HarnessAction {
     agent_failed_impl(workspace, role_id, None, error)
-}
-
-pub(crate) fn agent_failed_for_agent(
-    workspace: &Path,
-    role_id: &str,
-    agent_id: &str,
-    error: &str,
-) -> HarnessAction {
-    agent_failed_impl(workspace, role_id, Some(agent_id), error)
 }
 
 fn agent_failed_impl(
@@ -2611,7 +2591,7 @@ fn dispatch_or_wait(decision: SchedulerDecision, project: &Path, scenario: &str)
             let no_upstream = read_role_def(&role_id)
                 .get("depends_on")
                 .and_then(|v| v.as_array())
-                .map_or(false, |a| a.is_empty());
+                .is_some_and(|a| a.is_empty());
             let addendum = if no_upstream {
                 let user_req = read_user_request(project);
                 if user_req.trim().is_empty() {

--- a/pinvou3-app/src-tauri/src/features/assistant/harness.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/harness.rs
@@ -742,8 +742,10 @@ fn materialize_dispatch_graph(project: &Path) -> Result<(), String> {
         return Err(format!("dispatch_graph.py not found: {}", script.display()));
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = [script.to_string_lossy().to_string(),
-        project.to_string_lossy().to_string()];
+    let args = [
+        script.to_string_lossy().to_string(),
+        project.to_string_lossy().to_string(),
+    ];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     run_python(&arg_refs, scripts_dir).map(|_| ())
 }
@@ -912,8 +914,10 @@ fn run_warmup(project: &Path) -> Result<serde_json::Value, String> {
         return Err(format!("warmup_check.py not found: {}", script.display()));
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = [script.to_string_lossy().to_string(),
-        project.to_string_lossy().to_string()];
+    let args = [
+        script.to_string_lossy().to_string(),
+        project.to_string_lossy().to_string(),
+    ];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     match run_python_with_timeout(&arg_refs, scripts_dir, WARMUP_TIMEOUT_SECS) {
         Ok(stdout) => match serde_json::from_str(&stdout) {
@@ -1127,10 +1131,12 @@ fn run_gate_runner(project: &Path) -> Result<GateResult, String> {
         });
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = [script.to_string_lossy().to_string(),
+    let args = [
+        script.to_string_lossy().to_string(),
         deck_dir.to_string_lossy().to_string(),
         "--layer".to_string(),
-        "1".to_string()];
+        "1".to_string(),
+    ];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let out = run_python(&arg_refs, scripts_dir)?;
     serde_json::from_str(&out).map_err(|e| format!("parse gate_runner: {e}"))
@@ -1145,9 +1151,11 @@ fn run_deliverable_check(project: &Path, role_id: &str) -> Result<GateResult, St
         });
     }
     let scripts_dir = script.parent().unwrap_or(project);
-    let args = [script.to_string_lossy().to_string(),
+    let args = [
+        script.to_string_lossy().to_string(),
         project.to_string_lossy().to_string(),
-        role_id.to_string()];
+        role_id.to_string(),
+    ];
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let out = run_python(&arg_refs, scripts_dir)?;
     let v: serde_json::Value =

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -1255,6 +1255,8 @@ fn reminder_for(mode: AppMode) -> Option<&'static str> {
 }
 
 #[cfg(test)]
+// 测试借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;单线程测试内跨 await 持有无竞争者,不会死锁。
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
 
@@ -2305,7 +2307,7 @@ mod tests {
         assert!(
             !prompt.contains(session_id),
             "workspace 路径(含 session_id)必须移出静态 system → turn_meta, 实际仍含: {}",
-            &prompt.chars().take(200).collect::<String>()
+            prompt.chars().take(200).collect::<String>()
         );
     }
 

--- a/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
@@ -17,6 +17,9 @@ pub enum AgentBackend {
     CodexAcp,
 }
 
+// parse/as_str 是 backend 字符串表示(序列化契约)的公开解析入口,当前仅测试
+// 引用;保留以固定别名契约,后续接入后端切换时由业务代码消费。
+#[allow(dead_code)]
 impl AgentBackend {
     pub fn parse(value: Option<&str>) -> Result<Self> {
         match value.unwrap_or("deepseek") {
@@ -134,6 +137,9 @@ impl SessionAgentStore {
             .unwrap_or_default()
     }
 
+    /// 显式切换会话后端。当前后端由 set_codex_workspace / set_acp_session 隐式
+    /// 设置,前端尚未暴露切换入口;保留该 API 供后续后端切换功能使用。
+    #[allow(dead_code)]
     pub fn set_backend(&self, session_id: &str, backend: AgentBackend) -> Result<()> {
         {
             let mut records = self.records.write();

--- a/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
@@ -191,8 +191,14 @@ pub fn drain_for_url<R: std::io::Read + Send + 'static>(
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         for line in BufReader::new(r).lines() {
-            // 跳过读取失败的行(坏行不中断日志排空,连接器只需首个 URL)。
-            let Ok(line) = line else { continue };
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    // 管道读取错误通常不可恢复；继续迭代可能反复返回 Err 并空转。
+                    log::warn!("[{}] 授权输出读取失败，停止排空：{error}", ctx.cli_bin);
+                    break;
+                }
+            };
             if let Some(u) = ctx.extract_url(&line) {
                 let _ = tx.send(u);
             }
@@ -327,6 +333,7 @@ pub async fn refresh_connector_auth_gates() -> Result<ConnectorAuthGateRefresh, 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Error, Read};
 
     const TEST_CTX: CliCtx = CliCtx {
         cli_bin: "test-cli",
@@ -353,6 +360,27 @@ mod tests {
     #[test]
     fn extract_url_none_without_url() {
         assert_eq!(TEST_CTX.extract_url("纯文本,没有链接"), None);
+    }
+
+    struct ReadErrorThenPanic {
+        failed: bool,
+    }
+
+    impl Read for ReadErrorThenPanic {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.failed {
+                panic!("读取错误后不应继续轮询同一管道");
+            }
+            self.failed = true;
+            Err(Error::other("test read failure"))
+        }
+    }
+
+    #[test]
+    fn drain_for_url_stops_after_read_error() {
+        let (tx, _rx) = mpsc::channel();
+        let handle = drain_for_url(TEST_CTX, ReadErrorThenPanic { failed: false }, tx);
+        assert!(handle.join().is_ok(), "读取错误后应退出排空线程");
     }
 
     /// 本地生成二维码:任意 URL 都能出码(不依赖各 CLI 的 qrcode 子命令),

--- a/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
@@ -190,7 +190,9 @@ pub fn drain_for_url<R: std::io::Read + Send + 'static>(
     tx: mpsc::Sender<String>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        for line in BufReader::new(r).lines().flatten() {
+        for line in BufReader::new(r).lines() {
+            // 跳过读取失败的行(坏行不中断日志排空,连接器只需首个 URL)。
+            let Ok(line) = line else { continue };
             if let Some(u) = ctx.extract_url(&line) {
                 let _ = tx.send(u);
             }

--- a/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
@@ -75,7 +75,7 @@ fn extract_user_code(line: &str) -> Option<String> {
         return None;
     }
     line.split(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
-        .filter(|s| {
+        .rfind(|s| {
             let len = s.len();
             (6..=32).contains(&len)
                 && s.chars()
@@ -83,7 +83,6 @@ fn extract_user_code(line: &str) -> Option<String> {
                 && s.chars()
                     .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '-')
         })
-        .last()
         .map(|s| s.to_string())
 }
 
@@ -148,7 +147,9 @@ fn drain_for_auth_event<R: std::io::Read + Send + 'static>(
     tx: mpsc::Sender<AuthEvent>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        for line in std::io::BufRead::lines(std::io::BufReader::new(r)).flatten() {
+        for line in std::io::BufRead::lines(std::io::BufReader::new(r)) {
+            // 跳过读取失败的行(坏行不中断认证事件排空)。
+            let Ok(line) = line else { continue };
             if let Some(safe_line) = safe_auth_log_line(&line) {
                 let _ = tx.send(AuthEvent::Line(safe_line));
             }

--- a/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
@@ -148,8 +148,14 @@ fn drain_for_auth_event<R: std::io::Read + Send + 'static>(
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         for line in std::io::BufRead::lines(std::io::BufReader::new(r)) {
-            // 跳过读取失败的行(坏行不中断认证事件排空)。
-            let Ok(line) = line else { continue };
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    // 管道读取错误通常不可恢复；继续迭代可能反复返回 Err 并空转。
+                    log::warn!("[dingtalk] 授权输出读取失败，停止排空：{error}");
+                    break;
+                }
+            };
             if let Some(safe_line) = safe_auth_log_line(&line) {
                 let _ = tx.send(AuthEvent::Line(safe_line));
             }

--- a/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
@@ -38,7 +38,7 @@ fn parse_tmeet_version(s: &str) -> Option<(u64, u64, u64)> {
         .char_indices()
         .find(|(_, c)| c.is_ascii_digit() || *c == 'v')?
         .0;
-    let version = tail[start..].trim_start_matches(|c| c == 'v' || c == 'V');
+    let version = tail[start..].trim_start_matches(['v', 'V']);
     let mut nums = version
         .split(|c: char| !c.is_ascii_digit())
         .filter(|p| !p.is_empty())
@@ -218,7 +218,15 @@ fn drain_for_auth_url<R: std::io::Read + Send + 'static>(
     tx: mpsc::Sender<(Option<String>, Option<String>)>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        for line in std::io::BufRead::lines(std::io::BufReader::new(r)).flatten() {
+        for line in std::io::BufRead::lines(std::io::BufReader::new(r)) {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    // 管道读取错误通常不可恢复；继续迭代可能反复返回 Err 并空转。
+                    log::warn!("[tmeet] 授权输出读取失败，停止排空：{error}");
+                    break;
+                }
+            };
             let safe = safe_auth_log_line(&line);
             let url = TMEET_CTX.extract_url(&line);
             let _ = tx.send((url, safe));

--- a/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
@@ -1679,7 +1679,10 @@ fn clean_msg_text(value: &str) -> String {
 
 fn decode_msg_html_payload(value: &str) -> String {
     let value = clean_msg_text(value);
-    if value.len() < 8 || !value.len().is_multiple_of(2) || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if value.len() < 8
+        || !value.len().is_multiple_of(2)
+        || !value.bytes().all(|b| b.is_ascii_hexdigit())
+    {
         return value;
     }
     let mut bytes = Vec::with_capacity(value.len() / 2);

--- a/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
@@ -1679,7 +1679,7 @@ fn clean_msg_text(value: &str) -> String {
 
 fn decode_msg_html_payload(value: &str) -> String {
     let value = clean_msg_text(value);
-    if value.len() < 8 || value.len() % 2 != 0 || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
+    if value.len() < 8 || !value.len().is_multiple_of(2) || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
         return value;
     }
     let mut bytes = Vec::with_capacity(value.len() / 2);
@@ -2050,7 +2050,7 @@ fn detect_utf16(bytes: &[u8]) -> Option<(Utf16Endian, usize)> {
     if bytes.starts_with(&[0xFE, 0xFF]) {
         return Some((Utf16Endian::Big, 2));
     }
-    if bytes.len() < 4 || bytes.len() % 2 != 0 {
+    if bytes.len() < 4 || !bytes.len().is_multiple_of(2) {
         return None;
     }
 
@@ -2087,7 +2087,7 @@ fn decode_utf16(
         Utf16Endian::Little => "UTF-16 LE",
         Utf16Endian::Big => "UTF-16 BE",
     };
-    if payload.len() % 2 != 0 {
+    if !payload.len().is_multiple_of(2) {
         return (
             None,
             Some(format!("检测到 {label} 编码,但文件字节数不完整,未读取内容")),
@@ -3113,8 +3113,8 @@ mod tests {
         ];
 
         println!(
-            "\n{:<14} {:<12} {:<5} {:>6}  {}",
-            "文件", "kind", "md", "tokens", "warning / 内容预览"
+            "\n{:<14} {:<12} {:<5} {:>6}  warning / 内容预览",
+            "文件", "kind", "md", "tokens",
         );
         println!("{}", "-".repeat(100));
         let mut failures = Vec::new();

--- a/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
@@ -134,7 +134,7 @@ fn handle_event(app: &AppHandle, ev: &Event, root: &Path) {
             "event": event_type,
         });
         let _ = app.emit("artifact:disk", payload.clone());
-        crate::platform::app_events::forward_app_event(&app, "artifact:disk", payload);
+        crate::platform::app_events::forward_app_event(app, "artifact:disk", payload);
     }
 }
 

--- a/pinvou3-app/src-tauri/src/features/knowledge/l1.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/l1.rs
@@ -498,7 +498,7 @@ impl L1Store {
             let rows = stmt.query_map(params![collection_id, m, lim as i64], map)?;
             rows.collect()
         } else {
-            let like = format!("%{}%", q.replace('%', "").replace('_', ""));
+            let like = format!("%{}%", q.replace(['%', '_'], ""));
             let mut stmt = c.prepare(
                 "SELECT d.id,k.text,0.0 AS score,d.name,d.path,k.ord \
                  FROM chunks k JOIN documents d ON d.id=k.document_id \

--- a/pinvou3-app/src-tauri/src/features/knowledge/scanner.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/scanner.rs
@@ -50,7 +50,7 @@ pub fn scan(
         // 增量：mtime + size 都没变 → 跳过（省去 upsert 写入 + FTS 触发器开销）。
         if let Some(&(mt, sz)) = existing.get(&rec.path) {
             if mt == rec.mtime && sz == rec.size {
-                if walked % 5000 == 0 {
+                if walked.is_multiple_of(5000) {
                     on_progress(walked);
                 }
                 continue;
@@ -62,7 +62,7 @@ pub fn scan(
             buf.clear();
             std::thread::sleep(Duration::from_millis(THROTTLE_MS));
         }
-        if walked % 5000 == 0 {
+        if walked.is_multiple_of(5000) {
             on_progress(walked);
         }
     }

--- a/pinvou3-app/src-tauri/src/features/knowledge/store.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/store.rs
@@ -467,7 +467,7 @@ impl Store {
 /// 但调用处 SQL 未加 `ESCAPE '\'`，所以仅做最朴素处理——把已有反斜杠也保留。
 /// v0 文件名含 `%`/`_` 的子串搜索可能略宽，可接受；FTS5 路径(≥3 字符)才是主路径。
 fn escape_like(s: &str) -> String {
-    s.replace('%', "").replace('_', "")
+    s.replace(['%', '_'], "")
 }
 
 #[cfg(test)]

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -451,6 +451,12 @@ pub struct MarketplaceManager<S: CredentialStore = SystemCredentialStore> {
     credential_store: S,
 }
 
+impl Default for MarketplaceManager<SystemCredentialStore> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MarketplaceManager<SystemCredentialStore> {
     pub fn new() -> Self {
         Self::with_store(SystemCredentialStore::new())
@@ -1351,6 +1357,8 @@ fn default_mcp_json() -> serde_json::Value {
 }
 
 #[cfg(test)]
+// 测试借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;单线程测试内跨 await 持有无竞争者,不会死锁。
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
     use crate::platform::credential_store::{CredentialStore, MemoryCredentialStore};
@@ -1685,7 +1693,7 @@ mod tests {
         };
         let response = format!(
             "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.as_bytes().len()
+            body.len()
         );
         stream.write_all(response.as_bytes()).await
     }

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -846,7 +846,7 @@ fn clean_memory_label(value: &str) -> Option<String> {
                     '“' | '”' | '‘' | '’' | '《' | '》' | '「' | '」' | '：' | ':'
                 )
         })
-        .trim_end_matches(|c| matches!(c, '吧' | '呗' | '哦' | '哈' | '啦' | '呀'))
+        .trim_end_matches(['吧', '呗', '哦', '哈', '啦', '呀'])
         .trim();
     let cleaned = clean_text(cleaned, 24);
     if cleaned.is_empty() || cleaned.chars().count() > 12 {
@@ -2580,7 +2580,7 @@ fn discover_turn_suggestions(user: &str) -> Vec<MemorySuggestion> {
     }
 
     let clauses: Vec<String> = text
-        .split(|c| matches!(c, '。' | '！' | '？' | '；' | ';' | '\n'))
+        .split(['。', '！', '？', '；', ';', '\n'])
         .map(|s| clean_text(s, 160))
         .filter(|s| !s.is_empty())
         .collect();
@@ -3238,7 +3238,7 @@ fn active_recent_work(items: &[RecentWorkItem], now: DateTime<Utc>) -> Vec<&Rece
 }
 
 fn recent_work_is_expired(item: &RecentWorkItem, now: DateTime<Utc>) -> bool {
-    if parse_time(&item.expires_at).map_or(false, |expires_at| expires_at <= now) {
+    if parse_time(&item.expires_at).is_some_and(|expires_at| expires_at <= now) {
         return true;
     }
     parse_time(&item.last_hit)

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
@@ -2848,7 +2848,7 @@ fn canonicalize_json(value: &Value) -> Value {
         Value::Array(values) => Value::Array(values.iter().map(canonicalize_json).collect()),
         Value::Object(values) => {
             let mut entries = values.iter().collect::<Vec<_>>();
-            entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_unstable_by_key(|(left, _)| *left);
             Value::Object(
                 entries
                     .into_iter()

--- a/pinvou3-app/src-tauri/src/features/remote_control/relay_client.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/relay_client.rs
@@ -889,9 +889,7 @@ mod tests {
             sender
                 .try_send(RelayOutbound::Message(json!(index)))
                 .unwrap();
-            let frame = match receiver.try_recv().unwrap() {
-                QueuedOutbound::Message(frame) => frame,
-            };
+            let QueuedOutbound::Message(frame) = receiver.try_recv().unwrap();
             pending_bytes += frame.text.len();
             push_pending(&mut pending, frame);
         }
@@ -920,9 +918,7 @@ mod tests {
         );
 
         for expected in MAX_PENDING_MESSAGES..(MAX_PENDING_MESSAGES + OUTBOUND_CHANNEL_CAPACITY) {
-            let frame = match receiver.try_recv().unwrap() {
-                QueuedOutbound::Message(frame) => frame,
-            };
+            let QueuedOutbound::Message(frame) = receiver.try_recv().unwrap();
             assert_eq!(frame.text, expected.to_string());
         }
         assert!(matches!(
@@ -970,9 +966,7 @@ mod tests {
         sender
             .try_send(RelayOutbound::Message(value.clone()))
             .unwrap();
-        let frame = match receiver.try_recv().unwrap() {
-            QueuedOutbound::Message(frame) => frame,
-        };
+        let QueuedOutbound::Message(frame) = receiver.try_recv().unwrap();
         let mut pending = VecDeque::new();
         push_pending(&mut pending, frame);
         assert_eq!(sender.byte_budget.available_permits(), budget - bytes);
@@ -1063,26 +1057,20 @@ mod tests {
             assert_eq!(latest["lease_id"], "C");
         }
 
-        let blocker = match receiver.recv().await.unwrap() {
-            QueuedOutbound::Message(frame) => frame,
-        };
+        let QueuedOutbound::Message(blocker) = receiver.recv().await.unwrap();
         assert_eq!(
             serde_json::from_str::<Value>(&blocker.text).unwrap()["kind"],
             "blocker"
         );
         drop(blocker);
 
-        let first = match receiver.recv().await.unwrap() {
-            QueuedOutbound::Message(frame) => frame,
-        };
+        let QueuedOutbound::Message(first) = receiver.recv().await.unwrap();
         assert_eq!(
             serde_json::from_str::<Value>(&first.text).unwrap()["lease_id"],
             "A"
         );
         drop(first);
-        let latest = match receiver.recv().await.unwrap() {
-            QueuedOutbound::Message(frame) => frame,
-        };
+        let QueuedOutbound::Message(latest) = receiver.recv().await.unwrap();
         assert_eq!(
             serde_json::from_str::<Value>(&latest.text).unwrap()["lease_id"],
             "C"

--- a/pinvou3-app/src-tauri/src/features/review/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/review/mod.rs
@@ -341,7 +341,7 @@ fn ledger_from_entries(
         r.get("verdict").and_then(Value::as_str).is_some()
             || r.get("issues")
                 .and_then(Value::as_array)
-                .map_or(false, |a| !a.is_empty())
+                .is_some_and(|a| !a.is_empty())
     })?;
     let latest_pos = latest.get("pos").and_then(Value::as_u64).unwrap_or(0);
     let passed = latest
@@ -366,7 +366,7 @@ fn ledger_from_entries(
         if rv
             .get("issues")
             .and_then(Value::as_array)
-            .map_or(true, |a| a.is_empty())
+            .is_none_or(|a| a.is_empty())
         {
             return None;
         }
@@ -583,6 +583,7 @@ fn review_reasoning_dialect(
     }
 }
 
+#[allow(clippy::if_same_then_else)]
 fn review_reasoning_dialect_from_base_url(base_url: &str, model: &str) -> ReviewReasoningDialect {
     let normalized = base_url
         .trim()

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -689,8 +689,7 @@ impl Pinvou3Bundle {
                 "args": [present_server.to_string_lossy()]
             }),
         );
-        let json = serde_json::to_string_pretty(&mcp)
-            .map_err(std::io::Error::other)?;
+        let json = serde_json::to_string_pretty(&mcp).map_err(std::io::Error::other)?;
         std::fs::write(&self.mcp_json, json)
     }
 
@@ -728,8 +727,7 @@ impl Pinvou3Bundle {
             }
         }
         if changed {
-            let json = serde_json::to_string_pretty(&mcp)
-                .map_err(std::io::Error::other)?;
+            let json = serde_json::to_string_pretty(&mcp).map_err(std::io::Error::other)?;
             std::fs::write(&self.mcp_json, json)?;
         }
         Ok(())

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -205,18 +205,6 @@ pub fn install_prompt_overrides() {
     }));
 }
 
-/// 内置 MCP 默认配置:注册 present_artifact server(成品卡)。`{{PINVOU3_PRESENT_SERVER}}`
-/// 占位符在 `ensure_extracted` 写出时被替换成解包后的 server 脚本绝对路径(常量无法
-/// 编译期拿到 `~/.pinvou3/bundle/` 运行时路径,同 INSTRUCTIONS_MD 的 `{{PINVOU3_WORKSPACE}}`)。
-/// server key `pinvou3` + tool `present_artifact` → 底座透传给前端的工具名是
-/// `mcp_pinvou3_present_artifact`(底座 `mcp.rs:all_tools` 格式 `mcp_{server}_{tool}`)。
-/// **server 名特意取 `pinvou3`(=产品名)而非 `pinvou`**:Qwen3.6 上下文里 `pinvou3`
-/// (产品名 + 满屏 `.pinvou3/` 工作目录路径)无处不在、`pinvou` 仅工具引导一处出现,
-/// 采样必把 server 名漂成 `pinvou3` → 旧名 `pinvou` 稳定复现 `Failed to find MCP
-/// server: pinvou3`。对齐产品名消除「差一个 3」的撞脸。改名安全:instructions.md 引导名
-/// 与前端 `isPresentArtifactTool` 的 `endsWith("present_artifact")` 后缀匹配都不破。
-pub const DEFAULT_MCP_JSON: &str = "{\n  \"servers\": {\n    \"pinvou3\": {\n      \"command\": \"python3\",\n      \"args\": [\"{{PINVOU3_PRESENT_SERVER}}\"]\n    }\n  }\n}\n";
-
 /// present_artifact MCP server 脚本(零依赖 python stdio),编译期内嵌,解包到
 /// `~/.pinvou3/bundle/mcp-servers/`。底座按 mcp.json 用 `python3 <path>` 拉起它。
 pub const PRESENT_ARTIFACT_SERVER_PY: &str =
@@ -491,7 +479,8 @@ impl Pinvou3Bundle {
     /// 不能删除所有未知目录:未来/本地可能有自定义 MCP 工具。这里只精确处理曾经内置、
     /// 现在源码资源已经移除的 marketplace 工具。
     fn cleanup_removed_marketplace_tools(&self) -> std::io::Result<()> {
-        for tool_id in ["data_analysis"] {
+        {
+            let tool_id = "data_analysis";
             let _ = crate::features::marketplace::MarketplaceManager::new().uninstall(tool_id);
 
             let mut disabled = crate::features::marketplace::load_disabled_connectors();
@@ -701,7 +690,7 @@ impl Pinvou3Bundle {
             }),
         );
         let json = serde_json::to_string_pretty(&mcp)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            .map_err(std::io::Error::other)?;
         std::fs::write(&self.mcp_json, json)
     }
 
@@ -740,7 +729,7 @@ impl Pinvou3Bundle {
         }
         if changed {
             let json = serde_json::to_string_pretty(&mcp)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                .map_err(std::io::Error::other)?;
             std::fs::write(&self.mcp_json, json)?;
         }
         Ok(())

--- a/pinvou3-app/src-tauri/src/features/scheduled/tasks.rs
+++ b/pinvou3-app/src-tauri/src/features/scheduled/tasks.rs
@@ -2184,6 +2184,8 @@ pub fn scheduled_task_chat_prompt() -> Result<String, String> {
 }
 
 #[cfg(test)]
+// 测试借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;单线程测试内跨 await 持有无竞争者,不会死锁。
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
 

--- a/pinvou3-app/src-tauri/src/features/updater/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/updater/mod.rs
@@ -81,6 +81,9 @@ pub struct PlatformAsset {
 pub enum DownloadUpdateResult {
     #[allow(dead_code)]
     Path(String),
+    // Prepared 为平台更新流程的预留变体,当前各平台实现均不构造,
+    // 故在 lib 视角下被误报为 dead code;保留以备后续平台接入。
+    #[allow(dead_code)]
     Prepared(PreparedUpdate),
 }
 

--- a/pinvou3-app/src-tauri/src/features/voice/platform/macos.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/platform/macos.rs
@@ -14,6 +14,10 @@ pub fn engine_binary_name() -> &'static str {
     "pinvou-asr"
 }
 
+/// 平台 ASR 引擎完整性契约:macOS 二期未打包 ASR 引擎,恒为完整。
+/// 该函数与 linux/windows 同名实现构成跨平台接口,仅被 voice_asr 内部调用;
+/// macOS 用 Speech 框架不走该路径,故在此目标下为间接死代码。
+#[allow(dead_code)]
 pub fn bundled_engine_intact(_path: &Path, _bundled_dir: Option<&Path>) -> bool {
     // macOS 二期没有打包 ASR 引擎。
     true

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -2,6 +2,12 @@
 //!
 //! Platform runtime policy is owned by the sibling `platform` module. This module keeps
 //! platform-neutral status, transcription, model download, and Tauri command glue.
+//!
+//! 其中 model_available、download_current_model、transcribe、sha256_file、
+//! model_file_verified 等函数仅被 `platform/{windows,linux}.rs` 调用;macOS 用系统
+//! Speech 框架(见 `platform/voice_asr_speech.rs`),不引用这些函数。因此它们在 macOS
+//! 编译目标下被 clippy 误报为 dead code,但删除会破坏 Windows/Linux 构建。
+#![allow(dead_code)]
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/pinvou3-app/src-tauri/src/features/workflow/workflow_registry.rs
+++ b/pinvou3-app/src-tauri/src/features/workflow/workflow_registry.rs
@@ -10,6 +10,8 @@ pub struct WorkflowInfo {
     pub name: Option<String>,
     pub enabled: bool,
     pub scenarios: Vec<String>,
+    // dir 记录 workflow 所在目录,当前 Rust 路径不读取(改由 id 推导),保留以备调试/定位。
+    #[allow(dead_code)]
     pub dir: PathBuf,
     pub ui: serde_json::Value,
 }

--- a/pinvou3-app/src-tauri/src/platform/capabilities.rs
+++ b/pinvou3-app/src-tauri/src/platform/capabilities.rs
@@ -29,10 +29,14 @@ pub(crate) const fn is_windows() -> bool {
     cfg!(target_os = "windows")
 }
 
+// is_linux / is_unix 仅被测试或条件编译分支引用,在 lib 视角下被误报为 dead code。
+// 保留它们作为 cfg! 的语义化别名,提升条件分支可读性(与 is_windows 对称)。
+#[allow(dead_code)]
 pub(crate) const fn is_linux() -> bool {
     cfg!(target_os = "linux")
 }
 
+#[allow(dead_code)]
 pub(crate) const fn is_unix() -> bool {
     cfg!(unix)
 }

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -51,7 +51,9 @@ impl CredentialReference {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum CredentialState {
+    #[default]
     Missing,
     Configured,
     EnvOverride,
@@ -59,11 +61,6 @@ pub enum CredentialState {
     Unavailable,
 }
 
-impl Default for CredentialState {
-    fn default() -> Self {
-        Self::Missing
-    }
-}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -61,7 +61,6 @@ pub enum CredentialState {
     Unavailable,
 }
 
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialEditAction {

--- a/pinvou3-app/src-tauri/src/platform/os/macos/macos_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/macos/macos_path.rs
@@ -11,10 +11,6 @@ pub fn platform_compat_path(value: &str) -> PathBuf {
     PathBuf::from(value)
 }
 
-pub fn pdf_tool_path(command: &str) -> PathBuf {
-    PathBuf::from(command)
-}
-
 pub fn pandoc_tool_path() -> PathBuf {
     PathBuf::from("pandoc")
 }

--- a/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
@@ -55,7 +55,8 @@ pub fn command_exists(command: &str) -> bool {
     }
     // cask 类 GUI 应用(如 LibreOffice)装在 /Applications/*.app/Contents/MacOS/,
     // 不在 Homebrew bin 目录,也不在 GUI 进程 PATH 内 → 依赖体检系统性误报缺失。
-    for cask_dir in ["/Applications/LibreOffice.app/Contents/MacOS"] {
+    {
+        let cask_dir = "/Applications/LibreOffice.app/Contents/MacOS";
         let path = Path::new(cask_dir).join(command);
         if path.is_file() && is_executable(&path) {
             return true;
@@ -132,30 +133,10 @@ pub fn libreoffice_missing_message() -> &'static str {
     "需要 LibreOffice。可通过 Homebrew 安装（brew install --cask libreoffice），或从 https://www.libreoffice.org/download 下载。"
 }
 
-pub fn sevenzip_missing_message() -> &'static str {
-    "压缩包解析需要 7-Zip。可通过 Homebrew 安装（brew install p7zip），或从 https://www.7-zip.org 下载。"
-}
-
-pub fn python3_missing_message() -> &'static str {
-    "邮件解析需要 python3。macOS 自带 python3（需安装 Xcode Command Line Tools：xcode-select --install）；如仍缺失可从 https://www.python.org/downloads 下载。"
-}
-
-pub fn msgconvert_missing_message() -> &'static str {
-    ".msg 邮件解析需要 msgconvert（Perl 模块 Email::Outlook::Message）。Homebrew 无对应 formula，请运行：sudo cpan -i Email::Outlook::Message，或改用其他工具转换 .msg 文件。"
-}
-
-pub fn libreoffice_dependency_packages() -> &'static str {
-    "libreoffice"
-}
-
-pub fn sevenzip_dependency_packages() -> &'static str {
-    "p7zip"
-}
-
 pub fn email_dependency_packages() -> &'static str {
     // msgconvert 需要 Perl 模块 Email::Outlook::Message，Homebrew 无对应 formula，
     // 无法一键安装。返回空串 → check_dependencies 的 apt 字段为空 → 前端不显示
-    // 「一键安装」按钮，用户按 msgconvert_missing_message 的指引手动安装。
+    // 「一键安装」按钮，用户需自行通过 `sudo cpan -i Email::Outlook::Message` 安装。
     ""
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -1,3 +1,11 @@
+//! 不支持平台(linux/macos/windows 之外)的契约存根。
+//!
+//! 这些函数构成跨平台 OS trait 的「不支持」分支:当某能力在当前平台未实现时返回
+//! Err/None/false。它们在具体平台编译目标下会被 `macos`/`linux`/`windows` 模块的同名
+//! 实现通过 glob re-export 阴影,因此 clippy 在某平台下会误报为 dead code,但删除会
+//! 破坏其它平台的 `pub use` 解析。整文件豁免 dead_code。
+#![allow(dead_code)]
+
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;

--- a/pinvou3-app/src-tauri/src/platform/prefs.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs.rs
@@ -14,33 +14,29 @@ use crate::platform::credential_store::{
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum Theme {
+    #[default]
     Genesis,
     LiquidLight,
     LiquidDark,
 }
-impl Default for Theme {
-    fn default() -> Self {
-        Theme::Genesis
-    }
-}
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
+#[derive(Default)]
 pub enum ColorScheme {
     Light,
     Dark,
+    #[default]
     System,
-}
-impl Default for ColorScheme {
-    fn default() -> Self {
-        ColorScheme::System
-    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Default)]
 pub enum Language {
     #[serde(rename = "zh-Hans")]
+    #[default]
     ZhHans,
     #[serde(rename = "en")]
     En,
@@ -48,11 +44,6 @@ pub enum Language {
     /// LLM 回复语言链路零改动。
     #[serde(rename = "ja")]
     Ja,
-}
-impl Default for Language {
-    fn default() -> Self {
-        Language::ZhHans
-    }
 }
 impl Language {
     pub fn locale_tag(self) -> &'static str {
@@ -245,17 +236,14 @@ impl ModelPreset {
 ///   自带额度,key 必填(留空底座直接报 "requires API key")。
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum SearchProvider {
+    #[default]
     Bing,
     Metaso,
     Bocha,
     Baidu,
     Tavily,
-}
-impl Default for SearchProvider {
-    fn default() -> Self {
-        SearchProvider::Bing
-    }
 }
 
 impl SearchProvider {

--- a/pinvou3-app/src-tauri/src/platform/prefs.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs.rs
@@ -32,8 +32,7 @@ pub enum ColorScheme {
     System,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum Language {
     #[serde(rename = "zh-Hans")]
     #[default]

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 pub(crate) struct HiddenCommand;
 
 impl HiddenCommand {
+    #[allow(clippy::new_ret_no_self)]
     pub(crate) fn new<S: AsRef<OsStr>>(program: S) -> Command {
         let mut command = Command::new(program);
         hide_std_console(&mut command);
@@ -96,9 +97,15 @@ fn subprocess_output_detail(stdout: &[u8], stderr: &[u8]) -> String {
     detail.chars().take(4000).collect()
 }
 
+// HiddenTokioCommand 为 Windows 隐藏控制台窗口的异步子进程创建预留,当前各平台
+// 均未接入调用方,故在 lib 视角下被误报为 dead code;new 返回 Command 而非 Self
+// 是有意设计(构造器语义)。
+#[allow(dead_code)]
 pub(crate) struct HiddenTokioCommand;
 
 impl HiddenTokioCommand {
+    #[allow(dead_code)]
+    #[allow(clippy::new_ret_no_self)]
     pub(crate) fn new<S: AsRef<OsStr>>(program: S) -> tokio::process::Command {
         let mut command = tokio::process::Command::new(program);
         hide_tokio_console(&mut command);
@@ -124,4 +131,5 @@ pub(crate) fn hide_tokio_console(command: &mut tokio::process::Command) {
 }
 
 #[cfg(not(target_os = "windows"))]
+#[allow(dead_code)]
 pub(crate) fn hide_tokio_console(_command: &mut tokio::process::Command) {}

--- a/pinvou3-app/src-tauri/tests/compaction_probe.rs
+++ b/pinvou3-app/src-tauri/tests/compaction_probe.rs
@@ -3,6 +3,7 @@
 //! 背景见 docs/context-compaction-设计.md §6。两条线用不同的尺:
 //!   - T(should_compact):对「可摘要子集」用 raw 尺(bytes÷4,无放大)
 //!   - E(emergency):对「全量」用 conservative 尺(raw×1.5 + system÷3 + framing)
+//!
 //! 本 harness 程序化对拍两把尺,定 T 公式常数 k/S/R/framing,不依赖真机/vLLM。
 //!
 //! 跑法:


### PR DESCRIPTION
## 概述

系统性清理 `pinvou3-app/src-tauri` 的 clippy 告警，修复清理过程中发现的授权输出读取问题，并建立可逐步收紧的 lint 门禁基线。

## 背景

Rust 代码仍有历史 lint 欠账，无法直接把全部 clippy 规则升级为硬门禁。本 PR 先清理可安全修复的告警，对必须保留的兼容代码做精确说明，同时把已清零的高价值规则设为 `deny`，防止回流。

## 变更

- 等价简化 `map_or`、手写 `Default`、端口匹配、排序、冗余借用及未使用变量等写法，保持现有业务行为。
- 删除确认无引用的死代码；对平台存根、条件编译代码及测试锁等必要例外添加精确 lint 说明。
- 为已清零的高价值规则启用 `deny`，保留仍有历史欠账的 lint，并把应用 crate 的 `clippy::all` 实测基线更新为 20 条（不含 CodeWhale）。
- 修正 `connector_cli`、钉钉和腾讯会议授权输出排空：底层读取失败时记录日志并退出线程，避免错误源持续返回 `Err` 时空转。
- 新增读取错误回归测试，确保排空线程不会在同一错误管道上继续轮询。
- 保持 CodeWhale fork 不变。

## 验证

- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo clippy --lib --no-deps`
- `cargo clippy --lib --no-deps -- -W clippy::all`：应用 crate 剩余 20 条历史告警
- `cargo test drain_for_url_stops_after_read_error -- --test-threads=1`：通过
- `python3 scripts/architecture-guard.py`：通过
- `./scripts/fork-guard.sh --fast`：通过

## 备注

- 已基于当前 `origin/main`（`ff7bff12`）完成 rebase。
- CodeWhale 构建仍输出 22 条既有 rustc warning，不属于本 PR 改动。
