### PR TITLE
build(rust): 工具链 lint 硬门禁、构建 profile 与 CI 编译去重

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -6,8 +6,9 @@ name: mac-build
 #
 # 与 pr-check.yml 的 rust-test 关系:
 # - rust-test 在 ubuntu 上跑完整 lib tests,是主线 gate。
-# - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + cargo build --release,
-#   验证 macOS 平台目标零回归。
+# - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟
+#   (cargo build 与 tauri bundle 共用同一 release-fast profile,产物互相复用,不重复编译),
+#   验证 macOS 平台目标零回归。真发版的 fat-LTO --release 产物由 scripts/release-macos.sh 产出。
 # - mac-build 不跑 relay e2e(那需要 remote-control-relay 的 node_modules,mac-build 不装
 #   该依赖)。因此不设 PINVOU_REQUIRE_REMOTE_E2E,让 e2e 测试在缺依赖时静默跳过而非 panic。
 
@@ -36,19 +37,25 @@ jobs:
     timeout-minutes: 50
     env:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],
+      # 不再需要 CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
+      # 本 step 只作 rustup 引导;实际工具链由 pinvou3-app/src-tauri/rust-toolchain.toml
+      # 锁定具体版本(下方 cargo 步骤 working-directory 在 src-tauri,rustup 按该文件
+      # 自动安装并使用 pinned 版本,本地与 CI 不漂移)。
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          # 装双 target:tauri universal 构建内部跑两次 cargo(aarch64+x86_64)+ lipo 合并,
-          # 故两套 target triple 都得装。cargo check/test/build 仍走 host(aarch64,编译快)。
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      # universal 构建需要双 target;装到 rust-toolchain.toml 锁定的 pinned 工具链上
+      # (working-directory 在 src-tauri,rustup 按该文件的 override 解析工具链)。
+      - name: 安装双 target (universal 构建)
+        working-directory: pinvou3-app/src-tauri
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Rust cache
         # 本工作流仅在 main 上运行,统一写入 main 作用域缓存。
@@ -58,15 +65,16 @@ jobs:
           shared-key: mac-build
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      # macOS 27+ 兼容:dyld 新增 LINKEDIT 字符串池 8 字节对齐校验,而 release 默认
-      # strip=debuginfo 会让 proc-macro dylib dlopen 被拒 → E0463(macOS ≤26 无此校验)。
-      # runner 目前是 macos-15(不受影响),但 GitHub 升级 runner 到 macOS 27+ 时若缺此
-      # 注入,cargo build --release 会硬失败(该 step 无 continue-on-error)。
+      # macOS 27+ 兼容:dyld 新增 LINKEDIT 字符串池 8 字节对齐校验,而 release(及继承它的
+      # release-fast)默认 strip=symbols 会让 proc-macro dylib dlopen 被拒 → E0463
+      # (macOS ≤26 无此校验)。runner 目前是 macos-15(不受影响),但 GitHub 升级 runner 到
+      # macOS 27+ 时若缺此注入,cargo/tauri 构建(--release 或 --profile release-fast)会硬失败。
       # 同 release-macos.sh 的 workaround;详见该脚本「问题 A」注释。等上游修后可移除。
       - name: macOS 27+ strip workaround
         run: |
           if [ "$(sw_vers -productVersion | cut -d. -f1)" -ge 27 ] 2>/dev/null; then
             echo "CARGO_PROFILE_RELEASE_STRIP=none" >> "$GITHUB_ENV"
+            echo "CARGO_PROFILE_RELEASE_FAST_STRIP=none" >> "$GITHUB_ENV"
             echo "RUSTFLAGS=-C strip=none" >> "$GITHUB_ENV"
             echo "⚠️ macOS $(sw_vers -productVersion) → 注入 strip=none(绕过 dyld 对齐校验)"
           else
@@ -103,9 +111,14 @@ jobs:
         working-directory: pinvou3-app/src-tauri
         run: cargo test --target aarch64-apple-darwin --lib -- --test-threads=1
 
-      - name: Cargo build release
+      # 编译冒烟用 release-fast(Cargo.toml 里专为 CI 定义的轻量 profile:lto=false、
+      # codegen-units=16、inherits="release"):release 现带 lto="fat"+codegen-units=1,
+      # 全图 fat-LTO 冷编译极易吃满 50min 上限;release-fast 验证 release 路径代码可编译即可。
+      # 下方 tauri bundle 冒烟也用同一 release-fast profile —— 同 profile 同 target dir,
+      # bundle 的 aarch64 编译腿直接复用本步产物,不再两套 profile 重复编译全图。
+      - name: Cargo build (release-fast 冒烟)
         working-directory: pinvou3-app/src-tauri
-        run: cargo build --release --target aarch64-apple-darwin --lib
+        run: cargo build --profile release-fast --target aarch64-apple-darwin --lib
 
       # tauri bundle smoke:验证 dmg/app 实际打包链路(Info.plist/entitlements/资源打包)。
       # 只在 main push 跑，不作为 PR 检测项。Universal 打包失败会让 mac-build 失败，
@@ -116,7 +129,11 @@ jobs:
         # universal-apple-darwin 是 Tauri 专属 target(内部跑 aarch64+x86_64 两次 cargo + lipo),
         # 不是合法 rustc target triple;故 cargo check/test/build 仍用 host(aarch64),
         # 仅此处 tauri 构建用 universal,产出可在 Intel + Apple Silicon 通用运行的 dmg/app。
-        run: node scripts/tauri/build.js build --target universal-apple-darwin
+        # `-- --profile release-fast`:tauri v2 CLI 的 build 无一等 --profile 选项,
+        # 自定义 profile 经 `--` 后的 runner 尾随参数透传给 cargo(CLI 据此定位
+        # target/<triple>/release-fast/ 产物);与上方冒烟同 profile,aarch64 腿复用其产物,
+        # x86_64 腿为唯一新增编译。真正发版的 fat-LTO 产物由 release-macos.sh 产出。
+        run: node scripts/tauri/build.js build --target universal-apple-darwin -- --profile release-fast
 
       # Verify 脚本:轻量探测(brew/connector CLI) + 核心校验(plist/usage-key/bundle targets)。
       # 核心校验失败会 exit 1,挡 build(此前 continue-on-error 让核心校验失败也变绿)。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,11 +6,14 @@ name: PR Check
 # - changes:检测本 PR 有没有 Rust/依赖、L1 harness 或前端改动,给编译/前端 job 做 paths filter。
 # - frontend-test:前端/Relay/WebUI 改动时跑 lint、构建、逻辑测试和浏览器旅程。
 # - rust-test(编译类):**仅当改了 Rust/Cargo/submodule 才跑**(非 Rust PR 直接 skip,不耗
-#   编译时间)。占位 bge-m3 → cargo test --lib(~240 单测;真 bge-m3/vLLM 测试已 #[ignore])。
+#   编译时间)。占位 bge-m3 → cargo test --lib(真 bge-m3/vLLM 测试已 #[ignore])。
+# - rust-lint:fmt / clippy / cargo-deny 三项硬门禁(均无 continue-on-error),
+#   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
+#   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
+#   欠账由清理 PR(#35 及后续)消化后逐个升 deny。
 # - windows-rust-test:只在 main push 跑，不作为 PR 或 Merge Queue 合入门禁。
 # - required-gate:汇总所有适用检查，作为 PR 与 Merge Queue 的唯一 required check。
 # - merge_group:进入 Merge Queue 后基于最新 main 跑完整检查，不要求开放 PR 反复 rebase。
-# 未上:clippy/fmt(现有代码各 75/329 处不符合,要先清理才能加 -D gate)。
 #
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
@@ -286,6 +289,73 @@ jobs:
       - name: Relay 回归
         run: npm --prefix remote-control-relay test
 
+  # clippy/fmt/deny 独立 job:与 rust-test 并行,各自独立 cache。
+  # clippy 用 clippy-driver 编译,产物不能被 cargo test(rustc)复用;在同一 job 里
+  # 串行跑会导致依赖图被编译两遍。拆成并行 job 后 wall-clock ≈ max(lint, test)。
+  rust-lint:
+    name: rust-lint
+    needs: changes
+    if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout (含 submodule)
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: 初始化公共底座 submodule
+        run: git submodule update --init --recursive -- CodeWhale
+
+      # 同 rust-test:tauri/webkit 系统库 + cmake(aws-lc-sys build script 需要)。
+      - name: 装 Tauri + pinvou3 Linux 系统依赖
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
+            librsvg2-dev libssl-dev \
+            libx11-dev libxi-dev libxtst-dev \
+            libayatana-appindicator3-dev \
+            build-essential pkg-config cmake
+
+      # 本 step 只作 rustup 引导;实际工具链由 pinvou3-app/src-tauri/rust-toolchain.toml
+      # 锁定具体版本(下方 cargo 步骤 working-directory 在 src-tauri,rustup 按该文件
+      # 自动安装并使用 pinned 版本,本地与 CI 不漂移)。
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: pinvou3-app/src-tauri
+          shared-key: rust-lint
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # fmt 硬门禁:风格规则见 rustfmt.toml(只用 stable 可用选项)。
+      - name: cargo fmt --check (硬门禁)
+        working-directory: pinvou3-app/src-tauri
+        run: cargo fmt -- --check
+
+      # clippy 硬门禁(无 continue-on-error):lint 配置走 Cargo.toml [lints] 表,
+      # 不用命令行 -W/-D(避免与本地行为分叉)。[lints] 只启用实测零欠账的 lint(deny),
+      # deny 命中即非零退出;欠账 lint/group 显式 allow(见表内注释,清理 PR 消化后启用)。
+      # --lib:只检查主库,不编译 tests/examples。--no-deps:不 lint 依赖;
+      # CodeWhale 子模块(path 依赖)的告警不受本仓 [lints] 约束,属上游欠账,仅显示不挡。
+      - name: cargo clippy --lib (硬门禁,[lints] deny 命中即 fail)
+        working-directory: pinvou3-app/src-tauri
+        run: cargo clippy --lib --no-deps
+
+      # cargo-deny 硬门禁:advisories(RUSTSEC)/licenses/bans/sources,规则见 deny.toml。
+      - name: cargo-deny (advisories/licenses/bans/sources)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+      - name: cargo deny check (硬门禁)
+        working-directory: pinvou3-app/src-tauri
+        run: cargo deny check advisories licenses bans sources
+
   rust-test:
     name: rust-test
     needs: changes
@@ -296,10 +366,8 @@ jobs:
     # Tauri + fastembed + aws-lc-sys 全冷编译耗时长;设上限避免卡死 runner 占用
     # (GitHub 默认 6h,此处收紧到 45min,与 mac-build 的 50min 量级一致)。
     timeout-minutes: 45
-    env:
-      # 测试编译不需要完整 debug info:line-tables-only 保留 panic 行号,
-      # 编译提速 ~30%、target/cache 体积大减(限额内能容纳更多份)。
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+    # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
+    # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v4
@@ -335,6 +403,13 @@ jobs:
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      # rust-toolchain.toml 在 src-tauri 下,对从仓库根用 --manifest-path 调用的 cargo 不生效;
+      # 把该文件锁定的工具链设为 default,保证 CI 与本地同一 pinned 版本(单一真相源是文件,
+      # 版本号不在 workflow 里重复硬编码,升级只改 rust-toolchain.toml)。
+      - name: 对齐 rust-toolchain.toml 锁定的工具链
+        working-directory: pinvou3-app/src-tauri
+        run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
 
       # remote_control 的真实 relay 下载 e2e 需要 node + relay 依赖,缺 node_modules/ws 时
       # 该 e2e 会自动 skip —— 装上依赖让 CI 真正执行它,而不是绿灯假过。
@@ -402,7 +477,6 @@ jobs:
     # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。
     timeout-minutes: 45
     env:
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
       # reqwest 0.13 → aws-lc-sys(非 FIPS)。Windows x86_64 需 NASM 汇编;runner 默认无 NASM,
       # 用预生成 NASM 对象规避(aws-lc-rs 官方支持,无需额外装 NASM)。
       AWS_LC_SYS_PREBUILT_NASM: "1"
@@ -417,6 +491,13 @@ jobs:
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      # 同 rust-test:把 src-tauri/rust-toolchain.toml 锁定的工具链设为 default,
+      # 保证从仓库根 --manifest-path 调用 cargo 时与本地同一 pinned 版本。
+      - name: 对齐 rust-toolchain.toml 锁定的工具链
+        working-directory: pinvou3-app/src-tauri
+        shell: bash
+        run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
 
       - name: Node.js
         uses: actions/setup-node@v4
@@ -454,6 +535,7 @@ jobs:
       - fast-gate
       - frontend-test
       - relay-test
+      - rust-lint
       - rust-test
     if: ${{ always() && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
@@ -466,6 +548,7 @@ jobs:
           FAST_GATE_RESULT: ${{ needs.fast-gate.result }}
           FRONTEND_RESULT: ${{ needs.frontend-test.result }}
           RELAY_RESULT: ${{ needs.relay-test.result }}
+          RUST_LINT_RESULT: ${{ needs.rust-lint.result }}
           RUST_RESULT: ${{ needs.rust-test.result }}
         run: |
           if [[ "$COMMIT_MESSAGE_RESULT" != success || "$CHANGES_RESULT" != success || "$FAST_GATE_RESULT" != success ]]; then
@@ -477,6 +560,7 @@ jobs:
           for item in \
             "frontend-test:$FRONTEND_RESULT" \
             "relay-test:$RELAY_RESULT" \
+            "rust-lint:$RUST_LINT_RESULT" \
             "rust-test:$RUST_RESULT"; do
             name="${item%%:*}"
             result="${item#*:}"

--- a/docs/麒麟OS-V11适配踩坑记录.md
+++ b/docs/麒麟OS-V11适配踩坑记录.md
@@ -152,7 +152,6 @@ exec /usr/bin/pinvou3-tauri "$@"
   pinvou3-app/src-tauri/resources/common/web-template/node_modules/esbuild/bin/esbuild
   ```
 
-- `Cargo.toml` 声明最低 Rust 1.88，但 `notify-rust 4.18.0` 要求 Rust 1.89，需要统一版本口径。
 - 正式 DEB 应直接提供 `pinvou3` 命令。
 
 ### 完整适配验收

--- a/pinvou3-app/src-tauri/.cargo/config.toml
+++ b/pinvou3-app/src-tauri/.cargo/config.toml
@@ -1,0 +1,21 @@
+# pinvou3-app/src-tauri 的 cargo 构建配置。
+#
+# 关于链接器加速(可选,不强制):
+# 本文件**不**硬编码 linker/rustflags——硬编码 `linker = "clang"` + `-fuse-ld=lld` 会强制
+# 每台开发/CI 机器都装 clang+lld,缺失就编译失败,跨平台维护成本高。
+#
+# 想在本地用更快的链接器,请把覆盖写进 `.cargo/config.local.toml`(该文件不入版本控制),
+# 示例(Linux,mold/lld 任选其一):
+#   [target.x86_64-unknown-linux-gnu]
+#   linker = "clang"
+#   rustflags = ["-C", "link-arg=-fuse-ld=lld"]   # 或 "-C", "link-arg=-fuse-ld=mold"
+#
+#   [target.aarch64-unknown-linux-gnu]
+#   linker = "clang"
+#   rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+#
+# macOS 不换链接器:Tauri 依赖 Apple ld 处理 framework,换 lld/zld 风险高于收益。
+# Windows 不换链接器:MSVC link.exe 是 WebView2/Com 的唯一稳定选项。
+#
+# 未来若团队统一约定要强制(如 CI 已确认装好 clang+lld),再把这些 rustflags 从
+# config.local.toml 提升回这里,并同步更新 CI 镜像。

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -3,8 +3,10 @@ name = "pinvou3-tauri"
 version = "0.6.4"
 description = "品悟智能助手桌面应用后端"
 authors = ["pinvou"]
-license = ""
+license = "MIT"
 edition = "2021"
+# MSRV:rust-version 是「能编译本 crate 的最低版本」下限;
+# 实际构建工具链由 rust-toolchain.toml 锁定到具体版本(可复现),二者语义互补。
 rust-version = "1.88"
 # 主 binary 是 Tauri app(src/main.rs);src/bin/dump_system_prompt.rs 是 dev 工具,
 # 加这个键让 `cargo run`(不带 --bin)默认跑主 app,不再因为多 bin 报错。
@@ -185,3 +187,91 @@ webkit2gtk = "2.0"
 # 多窗口撕离(detach.rs begin_detach_drag):X11 全局鼠标坐标+左键状态,
 # 驱动鬼影跨屏跟随 + 松手落位。Wayland 下不可用 → 降级(后续 task)。
 device_query = "2"
+
+# =============================================================================
+# Lint 门禁 —— 硬门禁设计:只启用「当前实测零欠账」的 lint(deny);
+# 有欠账的 lint/group 显式 allow 并注明欠账规模,由清理 PR(#35 及后续)消化后逐个启用。
+# CI(pr-check.yml rust-lint job)直接跑 `cargo clippy --lib --no-deps`(无 continue-on-error),
+# deny 命中即 fail;allow 的欠账 lint 被静默,不产生告警噪声。
+# 实测基线(rust 1.97.1,2026-07-27):clippy::all 组 54 处欠账,rustc 默认 lint 113 处。
+# =============================================================================
+[lints.rust]
+# —— 零欠账,deny 硬门禁(实测 0 违规)——
+# unsafe 代码块内部仍要求显式 unsafe 操作,避免误用:
+unsafe_op_in_unsafe_fn = "deny"
+# 多余的花括号 import,如 `use std::{collections::{HashMap}};`
+unused_import_braces = "deny"
+# 能省略的显式 lifetime 标注:
+unused_lifetimes = "deny"
+# 未使用的 import / 变量 / mut(本 PR 已清零 3 处,deny 防回流):
+unused_imports = "deny"
+unused_variables = "deny"
+unused_mut = "deny"
+
+# —— 有欠账,显式 allow;注释给出欠账规模,清理 PR(#35 及后续)消化后升 deny ——
+# unreachable_pub:1795 处欠账(全 crate pub 未收口,工程量大,单独清理)。
+unreachable_pub = "allow"
+# let_underscore_drop:306 处欠账(`let _ =` 吞 Drop 副作用,需逐个确认语义)。
+let_underscore_drop = "allow"
+# dead_code:96 处欠账(历史保留代码/平台条件编译残留,需甄别后清理)。
+dead_code = "allow"
+# private_interfaces:14 处欠账(pub 接口暴露私有类型,随 unreachable_pub 一起收口)。
+private_interfaces = "allow"
+
+[lints.clippy]
+# —— all / pedantic 组有历史欠账,整组 allow(priority=-1 保证下方具体 lint 的 deny 生效)——
+# all 组(correctness+suspicious+style+complexity+perf)实测 54 处欠账;
+# pedantic 组欠账更多(原方案全量 warn 实测近 2000 条告警,等于无门禁)。
+# 欠账由清理 PR(#35 及后续)消化后,再整组或逐 lint 升 deny。
+all = { level = "allow", priority = -1 }
+pedantic = { level = "allow", priority = -1 }
+
+# —— 精选零欠账「防回归」lint,deny 硬门禁(实测 0 违规,新增即 fail CI)——
+# dbg!/todo!/unimplemented! 会在运行时 panic 或留下调试残留:遗留即隐患。
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+# 多余 unwrap(正确性,误报极低)。
+unnecessary_unwrap = "deny"
+# 禁 `dep = "*"` 通配版本(防未来新增不锁版本的危险依赖)。
+wildcard_dependencies = "deny"
+# 注:print_stdout/print_stderr 未启用——本 app 启动诊断大量用 eprintln!(早于日志
+#     后端就绪),启用会刷出大量噪声;待日志链路统一后再评估。
+# 注:cargo_common_metadata 未启用——本 crate 是 private bin(不发布 crates.io),
+#     repository/readme/keywords/categories 无意义。
+
+# =============================================================================
+# 构建优化 Profile —— release 开启「安全范围内最大优化」
+# =============================================================================
+# panic="unwind"(非 abort):底座 CodeWhale 用 catch_unwind 做工具调用 panic 隔离,
+# 改 abort 会破坏「单次工具 panic 不拖垮整个会话」的设计。
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+# macOS 27+ 发布链路会注入 CARGO_PROFILE_RELEASE_STRIP=none 绕过 dyld 对齐 bug,
+# 本设置主要作用于 Linux deb / Windows MSI 产物。
+strip = "symbols"
+debug = "line-tables-only"
+panic = "unwind"
+incremental = false
+
+# 专为 Release 测试/CI 用的轻量 profile:不 LTO、不禁 incremental,编译快但仍走 release 优化。
+# mac-build.yml 的编译冒烟与 universal bundle 冒烟均用此 profile,
+# 两者产物可互相复用(同 profile 同 target dir),避免 CI 里两套 profile 重复编译全图。
+# 真正发版的 fat-LTO 产物由 scripts/release-macos.sh(走真 --release)产出。
+[profile.release-fast]
+inherits = "release"
+lto = false
+codegen-units = 16
+incremental = true
+# debug 不再重复声明:release 已是 line-tables-only,继承即同值。
+
+# Dev profile:line-tables-only 编译提速、overflow-checks 在调试期暴露整数回绕。
+[profile.dev]
+debug = "line-tables-only"
+opt-level = 0
+overflow-checks = true
+# 依赖在 dev 下也做轻量优化(否则全 debug 编译,运行太慢影响本地调试体验)。
+[profile.dev.package."*"]
+opt-level = 2

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 edition = "2021"
 # MSRV:rust-version 是「能编译本 crate 的最低版本」下限;
 # 实际构建工具链由 rust-toolchain.toml 锁定到具体版本(可复现),二者语义互补。
-rust-version = "1.88"
+rust-version = "1.89"
 # 主 binary 是 Tauri app(src/main.rs);src/bin/dump_system_prompt.rs 是 dev 工具,
 # 加这个键让 `cargo run`(不带 --bin)默认跑主 app,不再因为多 bin 报错。
 default-run = "pinvou3-tauri"

--- a/pinvou3-app/src-tauri/build.rs
+++ b/pinvou3-app/src-tauri/build.rs
@@ -50,7 +50,7 @@ fn hash_dir(dir: &Path) -> u64 {
     let mut files: Vec<PathBuf> = Vec::new();
     collect_files(dir, &mut files);
     files.sort();
-    let mut hash: u64 = 0xcbf29ce484222325;
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
     for path in &files {
         println!("cargo:rerun-if-changed={}", path.display());
         hash = fnv1a_step(hash, path.to_string_lossy().as_bytes());
@@ -70,7 +70,12 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
         // __pycache__/.pyc 是跑过引擎测试的机器才有的本地缓存(gitignored 但在盘上),
         // 折进 hash 会让不同机器 hash 漂移→bundle 无谓重解包,且发布物夹 pyc。
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        if name == "__pycache__" || name.ends_with(".pyc") {
+        // 大小写不敏感:有些工具/平台会产出 .PYC(虽然 CPython 默认 .pyc)。
+        // clippy::case_sensitive_file_extension_comparisons 对 to_ascii_lowercase+ends_with
+        // 仍误报(它只认 Path::extension().eq_ignore_ascii_case 形式),此处是对文件名串的
+        // 字面后缀判断,小写化已正确,按需 allow。
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
+        if name.to_ascii_lowercase().ends_with(".pyc") || name == "__pycache__" {
             continue;
         }
         if path.is_dir() {
@@ -83,13 +88,13 @@ fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) {
 
 /// 简易 FNV-1a 64 位 hash —— 不需要 cryptographic 强度，只要内容变化时 hash 变即可。
 fn fnv1a_64(bytes: &[u8]) -> u64 {
-    fnv1a_step(0xcbf29ce484222325, bytes)
+    fnv1a_step(0xcbf2_9ce4_8422_2325, bytes)
 }
 
 fn fnv1a_step(mut hash: u64, bytes: &[u8]) -> u64 {
     for b in bytes {
-        hash ^= *b as u64;
-        hash = hash.wrapping_mul(0x100000001b3);
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
     }
     hash
 }
@@ -108,7 +113,7 @@ fn sync_workflow_bundle() {
     sync_tree(data_src, dst);
     // 2. 引擎脚本 → bundle/scripts/（排 test_*，与 scheduler.py 同根路径假设对齐）
     let scripts_dst = dst.join("scripts");
-    let _ = std::fs::create_dir_all(&scripts_dst);
+    drop(std::fs::create_dir_all(&scripts_dst));
     // watch 目录本身：往 _engine/scripts 新增一个 .py，文件级 rerun-if-changed 看不到
     // （那条路径之前不存在），但目录 mtime 会变 → 触发 build.rs 重跑、新脚本进 bundle。
     println!("cargo:rerun-if-changed={}", engine_src.display());
@@ -120,7 +125,9 @@ fn sync_workflow_bundle() {
                 .and_then(|n| n.to_str())
                 .unwrap_or("")
                 .to_string();
-            if !name.ends_with(".py") || name.starts_with("test_") {
+            // 大小写不敏感匹配 .py(防御性:个别工具产出 .PY)。
+            #[allow(clippy::case_sensitive_file_extension_comparisons)]
+            if !name.to_ascii_lowercase().ends_with(".py") || name.starts_with("test_") {
                 continue;
             }
             println!("cargo:rerun-if-changed={}", p.display());
@@ -147,17 +154,20 @@ fn sync_tree(src: &Path, dst: &Path) {
             .and_then(|n| n.to_str())
             .unwrap_or("")
             .to_string();
+        // 扩展名按小写比较(.ENV / .PYC 大小写变体也排除,避免误嵌)。同 collect_files,
+        // clippy::case_sensitive_file_extension_comparisons 对小写化 ends_with 仍误报,allow。
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
         if name == ".git"
             || name == ".gitignore"
             || name == "__pycache__"
-            || name.ends_with(".env")
-            || name.ends_with(".pyc")
+            || name.to_ascii_lowercase().ends_with(".env")
+            || name.to_ascii_lowercase().ends_with(".pyc")
         {
             continue;
         }
         let dp = dst.join(&name);
         if sp.is_dir() {
-            let _ = std::fs::create_dir_all(&dp);
+            drop(std::fs::create_dir_all(&dp));
             sync_tree(&sp, &dp);
         } else {
             println!("cargo:rerun-if-changed={}", sp.display());
@@ -176,5 +186,5 @@ fn copy_if_changed(src: &Path, dst: &Path) {
             return;
         }
     }
-    let _ = std::fs::write(dst, new_bytes);
+    drop(std::fs::write(dst, new_bytes));
 }

--- a/pinvou3-app/src-tauri/deny.toml
+++ b/pinvou3-app/src-tauri/deny.toml
@@ -1,0 +1,75 @@
+# cargo-deny 配置 —— pinvou3-app/src-tauri
+# 用法:`cargo deny check`(需 `cargo install cargo-deny`)。CI 在 pr-check.yml 里调用。
+# 四类检查:advisories(RUSTSEC 漏洞)、licenses(开源合规)、bans(重复 crate / 禁用 crate)、
+# sources(只允许 crates.io + 本地 path 依赖)。
+
+[graph]
+# 只检查本 crate 的依赖图(含 path 依赖 CodeWhale)。
+all-features = true
+
+[advisories]
+version = 2
+# CI 里 `cargo deny check advisories` 命中新漏洞就 fail;下面是已评估、暂不能在本仓修复的条目。
+# 真漏洞(anyhow RUSTSEC-2026-0190、crossbeam-epoch RUSTSEC-2026-0204)已通过 cargo update
+# 修掉(anyhow 1.0.104 / crossbeam-epoch 0.9.20),不再命中。
+ignore = [
+    # quick-xml DoS/ReDoS(解析恶意 XML 的二次复杂度/内存耗尽)。本仓 quick-xml 原经
+    # calamine 0.26(→0.31.0)与 plist/tauri(→0.39.4)传递引入;均已只读解析用户提供的
+    # xlsx/plist,非网络面 XML 输入,风险中等。
+    # calamine 已在依赖升级 PR(reqwest/sha2/calamine/tokio-tungstenite 安全升级)升到 0.36
+    # (→quick-xml 0.41+),消除了 calamine 这一路的 0.31.0。
+    # 剩余 quick-xml 0.39.4 由 plist 1.9.0(pinned 在 tauri 2.11)传递引入,plist 的
+    # quick-xml 是 ^0.39.2,< 0.40,本仓不可单独抬;等 tauri 升级带 plist 升级后自然消失。
+    # 暂按已知风险接受(本 ignore 仍命中 plist 那一路;calamine 一路已不再命中)。
+    "RUSTSEC-2026-0194", # quick-xml 二次复杂度(plist/tauri 传递,等上游 plist)
+    "RUSTSEC-2026-0195", # quick-xml NsReader 内存耗尽(plist/tauri 传递,等上游 plist)
+]
+# unmaintained 保留 "workspace":父 crate 依赖图比子模块深
+# (子模块 + Tauri GTK3/glib + fastembed),实测 unmaintained="all" 会命中 gtk-rs GTK3、
+# glib VariantStrIter(unsound)、number_prefix、proc-macro-error、unic-* 等良性/上游锁定
+# 的条目并 fail CI。这些非本仓可修(等 tauri/gtk-rs 升级),"workspace" 仅报 workspace crate,
+# 把噪声挡在 CI 之外;真漏洞仍由上面的 ignore 显式管理 + cargo update 修复。
+unmaintained = "workspace"
+
+[licenses]
+version = 2
+# 允许的许可证白名单(宽松许可)。补充 MIT-0 / BSL-1.0 / NCSA / CDLA-Permissive-2.0:
+# 这些是 fastembed/ort/tauri 生态里出现的宽松许可,均允许商用、无 copyleft 传染。
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "BSL-1.0",       # Boost Software License(tauri 生态)
+    "NCSA",          # University of Illinois/NCSA(llvm/MLIR 相关)
+    "CDLA-Permissive-2.0", # Community Data License(fastembed/ort 模型元数据)
+]
+confidence-threshold = 0.8
+
+[bans]
+# 重复 crate 只 warn 不 fail:Tauri + CodeWhale 共享图里天然有上百个多版本(reqwest
+# 0.12/0.13、toml_edit×4 等),逐个去重是长期工程,不该卡 CI。单版本强制(multiple-versions
+# = "deny")会把每次依赖升级都变成破坏性事件。
+# 注意:[bans] 不支持 version 键(只有 [advisories]/[licenses] 支持)。
+multiple-versions = "warn"
+# wildcards 保留 "warn"(不能升 deny):本仓 3 个 CodeWhale 子模块依赖是
+# path = "../../CodeWhale/..." 形式(AGENTS.md §2 禁止给它们加版本约束),
+# cargo-deny 把无版本的 path 依赖判为 "wildcard"。升 deny 会把这 3 个**不可改**的
+# 子模块依赖直接 fail CI。warn 维持可见性,真正的 `dep = "*"` 版本通配仍会被报出。
+wildcards = "warn"
+highlight = "all"
+
+[sources]
+# 只允许 crates.io + 本地 path 依赖。禁止任何 git/未知 registry。
+# 注意:[sources] 不支持 version 键(只有 [advisories]/[licenses] 支持)。
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/pinvou3-app/src-tauri/deny.toml
+++ b/pinvou3-app/src-tauri/deny.toml
@@ -54,11 +54,11 @@ allow = [
 confidence-threshold = 0.8
 
 [bans]
-# 重复 crate 只 warn 不 fail:Tauri + CodeWhale 共享图里天然有上百个多版本(reqwest
-# 0.12/0.13、toml_edit×4 等),逐个去重是长期工程,不该卡 CI。单版本强制(multiple-versions
-# = "deny")会把每次依赖升级都变成破坏性事件。
+# Tauri + CodeWhale 共享图里天然有上百个多版本(reqwest 0.12/0.13、toml_edit×4 等),
+# 逐个去重是长期工程,不该卡 CI,也不应让每次审计输出数十万字的已知重复图。
+# 这里关闭重复版本报告;漏洞、许可证、来源和通配依赖仍按各自规则独立审计。
 # 注意:[bans] 不支持 version 键(只有 [advisories]/[licenses] 支持)。
-multiple-versions = "warn"
+multiple-versions = "allow"
 # wildcards 保留 "warn"(不能升 deny):本仓 3 个 CodeWhale 子模块依赖是
 # path = "../../CodeWhale/..." 形式(AGENTS.md §2 禁止给它们加版本约束),
 # cargo-deny 把无版本的 path 依赖判为 "wildcard"。升 deny 会把这 3 个**不可改**的

--- a/pinvou3-app/src-tauri/rust-toolchain.toml
+++ b/pinvou3-app/src-tauri/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # 锁定构建工具链具体版本，保证本地与 CI 完全可复现（不写 floating "stable",
 # 避免 stable 自动滚动导致本地/CI 编译器版本漂移）。
-# 版本要求:>= Cargo.toml 的 rust-version(MSRV 1.88);选当前 stable 具体版。
+# 版本要求:>= Cargo.toml 的 rust-version(MSRV 1.89);选当前 stable 具体版。
 # 升级方式:改这里一个数字即可,CI(dtolnay/rust-toolchain 读取本文件)与本地自动一致。
 # 带上 clippy / rustfmt 组件，配合 lint 门禁。
 [toolchain]

--- a/pinvou3-app/src-tauri/rust-toolchain.toml
+++ b/pinvou3-app/src-tauri/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# 锁定构建工具链具体版本，保证本地与 CI 完全可复现（不写 floating "stable",
+# 避免 stable 自动滚动导致本地/CI 编译器版本漂移）。
+# 版本要求:>= Cargo.toml 的 rust-version(MSRV 1.88);选当前 stable 具体版。
+# 升级方式:改这里一个数字即可,CI(dtolnay/rust-toolchain 读取本文件)与本地自动一致。
+# 带上 clippy / rustfmt 组件，配合 lint 门禁。
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]

--- a/pinvou3-app/src-tauri/rustfmt.toml
+++ b/pinvou3-app/src-tauri/rustfmt.toml
@@ -1,0 +1,7 @@
+# pinvou3-app/src-tauri 代码风格配置。
+# 只用 stable rustfmt 支持的选项，保证 `cargo fmt --check` 门禁在任何 stable 工具链上都能跑。
+# imports_granularity / group_imports 等 import 整理项是 nightly-only，不在此声明——
+# 它们会让 stable `cargo fmt` 直接报错。import 顺序靠人工 + review 保证。
+edition = "2021"
+max_width = 100
+use_try_shorthand = true

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
-use tauri::{AppHandle, Manager, State, WebviewWindow};
+use tauri::{AppHandle, State, WebviewWindow};
 
 use crate::features::assistant::engine_pool::EnginePool;
 use crate::features::remote_control::manager;

--- a/pinvou3-app/src-tauri/src/features/knowledge/embed.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/embed.rs
@@ -96,7 +96,7 @@ impl Embedder {
             return Ok(vec![]);
         }
         let docs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
-        let mut m = self
+        let m = self
             .model
             .lock()
             .map_err(|_| "embed lock poisoned".to_string())?;

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -80,7 +80,7 @@ pub fn kb_model_cancel() {
 /// React 首帧提交后调用：在 blocking 线程池读取并构建 embedding 模型，完成后原子换入
 /// KnowledgeService。模型未安装/加载失败时保持纯全文降级，不影响主界面。
 pub async fn kb_model_load_after_first_frame(
-    app: tauri::AppHandle,
+    _app: tauri::AppHandle,
     service: tauri::State<'_, KnowledgeService>,
     pool: tauri::State<'_, crate::features::assistant::engine_pool::EnginePool>,
 ) -> Result<bool, String> {


### PR DESCRIPTION
## 概述

本 PR 在依赖安全升级 #40 已合入的基础上，补齐 Rust 工具链、lint、依赖审计和构建 profile 门禁，并让 macOS CI 的编译冒烟与打包冒烟复用同一套产物。

## 背景

原改动同时包含依赖升级和工具链治理，现已拆分为两个 PR。本 PR 只保留工具链部分，并修正联合评审发现的两个问题：`notify-rust 4.18.0` 实际要求 Rust 1.89，原 `rust-version = "1.88"` 不成立；cargo-deny 输出完整重复依赖图，单次日志约 69.8 万字节，难以审阅。

## 变更

- 将 MSRV 校准为 Rust 1.89，并用 `rust-toolchain.toml` 将日常开发和 CI 工具链固定为 1.97.1。
- 增加零欠账 Rust/Clippy lint 硬门禁，清理 3 处现有违规，并加入稳定的 rustfmt 配置。
- 增加 cargo-deny 的漏洞、许可证、禁用依赖和来源审计；关闭已知重复版本图的逐项输出，保留通配 path 依赖告警。
- 在 `pr-check.yml` 增加独立 `rust-lint` job，并纳入 `required-gate`；Linux/Windows/macOS 构建统一读取锁定的工具链版本。
- 增加 `release`、`release-fast` 和 `dev` profile；macOS 的编译与 Tauri bundle 冒烟统一使用 `release-fast`，复用目标产物，正式发布仍使用完整 `release`。
- 更新麒麟 OS 适配记录，移除已经解决的 Rust 最低版本待办。

## 影响面

- 影响 Rust 本地开发、PR 门禁以及 Linux/Windows/macOS CI 构建。
- 不修改业务功能、依赖版本、Cargo.lock 或 CodeWhale submodule。
- macOS universal bundle 的自定义 profile 链路需在合入 `main` 后由 `mac-build` 做最终端到端验证。

## 验证

- `cargo +1.89.0 check --locked --lib`：通过，确认声明的 MSRV 可完整编译。
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`：通过。
- `cargo clippy --locked --lib --no-deps`：通过；仅保留 CodeWhale submodule 现有 22 条警告。
- `cargo test --locked --lib -- --test-threads=1`：727 passed，0 failed，12 ignored。
- `cargo deny check advisories licenses bans sources`：四类检查全部通过；日志由约 69.8 万字节收敛为 1,099 字节。
- `python3 scripts/architecture-guard.py`：通过。
- `./scripts/fork-guard.sh --fast`：通过。
- workflow YAML 语法检查：通过。

## 备注

- cargo-deny 仍会报告 3 个 CodeWhale path 依赖的 wildcard 警告；这些依赖按仓库规则不能添加版本约束，因此保持可见但不阻断。
- macOS 27+ 的 strip workaround 同步覆盖 `release-fast`。
