### PR TITLE
fix(readme): 补充首页视频入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@
 
 [Website](https://pinvou.com/) · [CodeWhale engine](https://github.com/Pinvou/CodeWhale) · [Security](SECURITY.md) · [MIT License](LICENSE)
 
-![Pinvou Agent desktop workspace](docs/assets/screenshots/home.webp)
+<p align="center">
+  <a href="https://pinvou.com/assets/videos/pinvou-agent-feature-update-2026-07.mp4">
+    <img src="docs/assets/screenshots/home.webp" alt="Watch the 90-second Pinvou Agent feature demo">
+  </a>
+</p>
+<p align="center">
+  <a href="https://pinvou.com/assets/videos/pinvou-agent-feature-update-2026-07.mp4"><strong>▶ Watch the 90-second feature demo (Chinese)</strong></a>
+</p>
 
 Pinvou Agent brings models, tools, personal knowledge, specialist personas, and reusable workflows into one desktop workspace. It is designed for work that should end with a result—not just another chat response.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,9 +6,14 @@
 
 Pinvou Agent 不只是一个聊天界面。它把模型、工具、个人知识、专家角色和工作流放进同一个桌面应用，让 AI 从“回答问题”进一步走到“完成任务”。模型既可以运行在本地，也可以接入 OpenAI-compatible 服务；工具与连接器按需启用。
 
-![Pinvou Agent 主界面](docs/assets/screenshots/home.webp)
-
-[▶ 观看 90 秒功能演示：7 月 17—23 日功能更新](https://pinvou.com/assets/videos/pinvou-agent-feature-update-2026-07.mp4)
+<p align="center">
+  <a href="https://pinvou.com/assets/videos/pinvou-agent-feature-update-2026-07.mp4">
+    <img src="docs/assets/screenshots/home.webp" alt="观看 Pinvou Agent 90 秒功能演示">
+  </a>
+</p>
+<p align="center">
+  <a href="https://pinvou.com/assets/videos/pinvou-agent-feature-update-2026-07.mp4"><strong>▶ 观看 90 秒功能演示：7 月 17—23 日功能更新</strong></a>
+</p>
 
 ## 能做什么
 


### PR DESCRIPTION
## 概述
修正仓库默认首页看不到功能演示入口的问题，在中英文 README 首屏提供可点击的视频封面和醒目的播放链接。

## 背景
此前只在中文 README 增加了普通文字链接，而 GitHub 仓库首页默认展示英文 README。进一步验证发现 GitHub Markdown 会过滤外链 video 标签，因此无法在 README 内直接播放 MP4，需要使用 GitHub 可稳定渲染的链接封面方案。

## 变更
- 将中英文 README 的主界面截图改为可点击的视频封面。
- 在封面下方增加居中的播放入口。
- 英文首页明确标注当前演示视频为中文版。
- 继续使用官网托管视频，不向公开仓库加入 MP4 二进制。

## 验证
- git diff --check
- 使用 GitHub Markdown API 渲染中英文 README，确认图片、视频链接和播放文案均被保留
- 官网视频返回 HTTP 200，Range 请求返回 HTTP 206

## 备注
GitHub Markdown 会将 video 标签渲染为空内容，因此本 PR 使用可点击封面跳转播放，这是 README 中稳定可见的实现。