### PR TITLE
fix(deps): 依赖安全升级(reqwest 0.13 / sha2 0.11 / calamine 0.36 / tokio-tungstenite 0.30)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -293,7 +293,9 @@ jobs:
     # changes 在 push 时被 skip,需 !cancelled() 才能让本 job 不被连带 skip。
     if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Tauri + fastembed + aws-lc-sys 全冷编译耗时长;设上限避免卡死 runner 占用
+    # (GitHub 默认 6h,此处收紧到 45min,与 mac-build 的 50min 量级一致)。
+    timeout-minutes: 45
     env:
       # 测试编译不需要完整 debug info:line-tables-only 保留 panic 行号,
       # 编译提速 ~30%、target/cache 体积大减(限额内能容纳更多份)。
@@ -309,6 +311,7 @@ jobs:
 
       # pinvou3 编译链接的系统库(本地 pkg-config 实测:gtk/webkit/soup/rsvg/openssl/
       # X11×3/appindicator)。ubuntu runner 默认没装,否则 glib-sys 等 build script 失败。
+      # cmake:reqwest 0.13 的 rustls 改用 aws-lc-rs,其 build script 需 cmake + C 编译器。
       - name: 装 Tauri + pinvou3 Linux 系统依赖
         run: |
           sudo apt-get update
@@ -317,7 +320,7 @@ jobs:
             librsvg2-dev libssl-dev \
             libx11-dev libxi-dev libxtst-dev \
             libayatana-appindicator3-dev \
-            build-essential pkg-config
+            build-essential pkg-config cmake
 
       # bge-m3 是 gitignored 大资源(559M),CI 干净 checkout 没有它,而 tauri_build::build()
       # 会校验 tauri.conf resources 路径存在。单测用 mem()=embedder None、不加载真模型,真
@@ -396,9 +399,13 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
-    timeout-minutes: 40
+    # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。
+    timeout-minutes: 45
     env:
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      # reqwest 0.13 → aws-lc-sys(非 FIPS)。Windows x86_64 需 NASM 汇编;runner 默认无 NASM,
+      # 用预生成 NASM 对象规避(aws-lc-rs 官方支持,无需额外装 NASM)。
+      AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -561,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +632,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1023,17 +1056,19 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.26.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138646b9af2c5d7f1804ea4bf93afc597737d2bd4f7341d67c48b03316976eb1"
+checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
 dependencies = [
+ "atoi_simd",
  "byteorder",
  "codepage",
  "encoding_rs",
+ "fast-float2",
  "log",
- "quick-xml 0.31.0",
+ "quick-xml 0.41.0",
  "serde",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1276,6 +1311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1717,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1953,6 +1997,12 @@ dependencies = [
  "sha2 0.10.9",
  "zeroize",
 ]
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "debugserver-types"
@@ -2603,6 +2653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastembed"
 version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,6 +2779,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2824,6 +2881,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -5948,11 +6011,12 @@ dependencies = [
  "parking_lot",
  "qrcode",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rusqlite",
+ "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tar",
  "tauri",
  "tauri-build",
@@ -5969,7 +6033,7 @@ dependencies = [
  "webview2-com",
  "windows 0.61.3",
  "windows-sys 0.61.2",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -6259,20 +6323,20 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
- "encoding_rs",
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 
@@ -6302,6 +6366,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -6797,7 +6862,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6858,6 +6922,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -7134,6 +7199,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7198,6 +7264,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7698,6 +7765,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8982,9 +9060,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -9324,22 +9402,20 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9350,6 +9426,12 @@ checksum = "fa10c302f5a53b7ad27fd42a3996e23d096ba39b5b8dd6d9e683a05b01bee749"
 dependencies = [
  "pom",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -10962,7 +11044,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tracing",
  "uds_windows",
@@ -11168,6 +11250,26 @@ dependencies = [
  "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -73,12 +73,22 @@ codewhale-secrets = { path = "../../CodeWhale/crates/secrets" }
 codewhale-config = { path = "../../CodeWhale/crates/config" }
 
 # Monitor 用：vLLM HTTP probe（/v1/models + Prometheus /metrics）
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking", "stream"] }
+# 0.13 与 CodeWhale 子模块对齐；feature `rustls`(0.13 改名,自带 aws-lc-rs)。
+# aws-lc-rs 构建需 cmake,CI 已加安装步骤。
+# 注意:oauth2(经 reqwest 0.12 传递)会把 rustls 0.23 的 `ring` feature 也拉进图,
+# 使 rustls 同时启用 aws-lc-rs + ring。tokio-tungstenite 的无参 ClientConfig::builder()
+# 在两 provider 共存时会 panic,故需在启动时显式 install_default(见 lib.rs)。
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "blocking", "stream", "query"] }
 wait-timeout = "0.2"
 
-# Updater 用：下载 deb 的 sha256 校验；Windows OTA 包使用 zip + MD5；
-# 产物卡封面也会读 .pptx(zip)里的 docProps/thumbnail.jpeg。
-sha2 = "0.10"
+# rustls 直依赖:仅为在启动时调 aws_lc_rs::default_provider().install_default()
+# 选定进程级 CryptoProvider(见上方 panic 根因)。只声明 aws-lc-rs;ring 由传递依赖启用。
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+
+# Updater 用：sha256 校验；Windows OTA 包使用 MD5；产物卡封面读 .pptx 里的 thumbnail。
+# 0.11 与 CodeWhale 子模块对齐。digest 的 Output 不实现 LowerHex,统一用 hex_lower 编码
+# (见 src/platform/encoding.rs)。
+sha2 = "0.11"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 md5 = "0.7"
 flate2 = "1"
@@ -105,10 +115,10 @@ walkdir = "2"
 
 # 本地 embedding（L1 语义检索）：fastembed-rs 进程内 ONNX 推理（CPU EP），**不依赖 vLLM**。
 # 模型(bge-m3 ONNX)用户本地下载，UserDefinedEmbeddingModel 从目录加载，不走 HF 自动下载。
-# 电子表格解析（file_ingest 用）：纯 Rust 读 xlsx/xls/ods 的**全部工作表**。
-# 旧实现走 LibreOffice CSV 只导「活动工作表」，多 sheet 文件会丢 90% 内容（实测散热
-# 报告 4 sheet 只抽到首页 418 字）；calamine 直接按 reader 嗅探格式、逐 sheet 逐行读。
-calamine = "0.26"
+# 电子表格解析（file_ingest 用）：读 xlsx/xls/ods 的全部工作表。
+# 0.36 拉入 quick-xml 0.41+,修 RUSTSEC-2026-0194/0195 ReDoS。
+# 剩余 quick-xml 0.39.4 由 plist/tauri 传递,等上游。
+calamine = "0.36"
 # 文本附件编码兜底：把国内常见 GBK / GB18030 文件真正转成 UTF-8，
 # 避免 `from_utf8_lossy` 把中文正文替换成一串 U+FFFD。
 encoding_rs = "0.8"
@@ -117,7 +127,8 @@ encoding_rs = "0.8"
 # 纯 Rust,不依赖各 CLI 自带的 qrcode 子命令(wecom-cli 就没有)。关默认的 image 渲染器
 # (省掉 image crate 依赖),只用 svg 渲染器。
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+# 0.30:Message::Text 的 String→Utf8Bytes、Ping/Pong 的 Vec→Bytes,relay_client.rs 已适配。
+tokio-tungstenite = { version = "0.30", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 rand = "0.9"
 base64 = "0.22"

--- a/pinvou3-app/src-tauri/src/app/commands/files.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/files.rs
@@ -73,7 +73,7 @@ pub async fn verify_upload(upload_id: String) -> Result<VerifyUploadOutput, Stri
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
     Ok(VerifyUploadOutput {
-        sha256: format!("{:x}", hasher.finalize()),
+        sha256: crate::platform::encoding::hex_lower(&hasher.finalize()),
         byte_size: bytes.len() as u64,
     })
 }

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -523,7 +523,8 @@ async fn verify_upload_returns_sha256_when_e2e_enabled_and_not_leak_path() {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(data);
-    assert_eq!(output.sha256, format!("{:x}", hasher.finalize()));
+    let expected = crate::platform::encoding::hex_lower(&hasher.finalize());
+    assert_eq!(output.sha256, expected);
     assert_eq!(output.byte_size, data.len() as u64);
 }
 

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -685,7 +685,7 @@ fn fingerprint(path: &Path, include_hash: bool) -> Result<Option<FileFingerprint
             }
             digest.update(&buffer[..read]);
         }
-        Some(format!("{:x}", digest.finalize()))
+        Some(crate::platform::encoding::hex_lower(&digest.finalize()))
     } else {
         None
     };

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -263,11 +263,7 @@ fn sha256_file(path: &Path) -> Result<String, String> {
         hasher.update(&buf[..n]);
     }
     let digest = hasher.finalize();
-    let mut s = String::with_capacity(digest.len() * 2);
-    for b in digest.iter() {
-        s.push_str(&format!("{b:02x}"));
-    }
-    Ok(s)
+    Ok(crate::platform::encoding::hex_lower(&digest))
 }
 
 fn extract_targz(targz: &Path, dest: &Path) -> Result<(), String> {

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
@@ -2769,12 +2769,7 @@ fn rpc_fingerprint(command: &str, args: &Value) -> Result<String, String> {
     let encoded = serde_json::to_vec(&(command, canonical))
         .map_err(|error| format!("serialize Web RPC fingerprint: {error}"))?;
     let digest = Sha256::digest(encoded);
-    let mut fingerprint = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(fingerprint, "{byte:02x}");
-    }
-    Ok(fingerprint)
+    Ok(crate::platform::encoding::hex_lower(&digest))
 }
 
 fn canonicalize_json(value: &Value) -> Value {

--- a/pinvou3-app/src-tauri/src/features/remote_control/relay_client.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/relay_client.rs
@@ -376,7 +376,7 @@ async fn run_revocation_loop(
 
         let (mut write, mut read) = ws.split();
         let revoke = revoke_message_parts(&endpoint_id, &desktop_secret);
-        if let Err(error) = write.send(Message::Text(revoke.to_string())).await {
+        if let Err(error) = write.send(Message::Text(revoke.to_string().into())).await {
             if tx_in
                 .send(RelayInbound::Connection {
                     endpoint_id: endpoint_id.clone(),
@@ -418,7 +418,7 @@ async fn run_revocation_loop(
                                 Ok(value) => {
                                     let terminal = terminal_message(&value, &endpoint_id);
                                     drop(value);
-                                    if tx_in.send(RelayInbound::Message(text)).await.is_err() {
+                                    if tx_in.send(RelayInbound::Message(text.to_string())).await.is_err() {
                                         return;
                                     }
                                     if terminal.is_some() {
@@ -562,7 +562,7 @@ async fn run_loop(
         let register_result = tokio::select! {
             biased;
             _ = shutdown.cancelled() => return,
-            result = write.send(Message::Text(register.to_string())) => result,
+            result = write.send(Message::Text(register.to_string().into())) => result,
         };
         if let Err(error) = register_result {
             if !send_inbound_until_shutdown(
@@ -601,7 +601,7 @@ async fn run_loop(
             let send_result = tokio::select! {
                 biased;
                 _ = shutdown.cancelled() => return,
-                result = write.send(Message::Text(frame.text.clone())) => result,
+                result = write.send(Message::Text(frame.text.clone().into())) => result,
             };
             if let Err(error) = send_result {
                 push_pending_front(&mut pending, frame);
@@ -642,7 +642,7 @@ async fn run_loop(
                             let send_result = tokio::select! {
                                 biased;
                                 _ = shutdown.cancelled() => return,
-                                result = write.send(Message::Text(frame.text.clone())) => result,
+                                result = write.send(Message::Text(frame.text.clone().into())) => result,
                             };
                             if let Err(error) = send_result {
                                 push_pending_front(&mut pending, frame);
@@ -677,7 +677,7 @@ async fn run_loop(
                                     drop(value);
                                     if !send_inbound_until_shutdown(
                                         &tx_in,
-                                        RelayInbound::Message(text),
+                                        RelayInbound::Message(text.to_string()),
                                         &shutdown,
                                     ).await {
                                         return;
@@ -710,7 +710,7 @@ async fn run_loop(
                     let ping_result = tokio::select! {
                         biased;
                         _ = shutdown.cancelled() => return,
-                        result = write.send(Message::Ping(Vec::new())) => result,
+                        result = write.send(Message::Ping(Vec::<u8>::new().into())) => result,
                     };
                     if ping_result.is_err() { break; }
                 }

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -1906,7 +1906,9 @@ fn generate_session_id() -> String {
 /// edit that was based on the same messages.
 pub fn transcript_revision(messages: &[Message]) -> Result<String> {
     let encoded = serde_json::to_vec(messages).context("serialize transcript for revision")?;
-    Ok(format!("{:x}", Sha256::digest(encoded)))
+    Ok(crate::platform::encoding::hex_lower(&Sha256::digest(
+        encoded,
+    )))
 }
 
 fn looks_like_truncating_overwrite(existing: &[Message], incoming: &[Message]) -> bool {

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -412,11 +412,7 @@ fn sha256_file(path: &Path) -> Result<String, String> {
         hasher.update(&buf[..n]);
     }
     let digest = hasher.finalize();
-    let mut out = String::with_capacity(digest.len() * 2);
-    for b in digest {
-        out.push_str(&format!("{b:02x}"));
-    }
-    Ok(out)
+    Ok(crate::platform::encoding::hex_lower(&digest))
 }
 
 /// 转码到 16k 单声道 → 调 sense-voice-main → 清洗输出。供 transcribe_voice_audio 调用。

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -152,8 +152,25 @@ fn ensure_release_env() {
     }
 }
 
+/// 进程级选定并安装 rustls 的 CryptoProvider(aws-lc-rs)。
+///
+/// 幂等:`install_default` 返回 `Err` 表示已装过(本次或之前的 reqwest/tungstenite 调用),
+/// 用 `drop` 吞掉即可,不会二次注册。装在 `run()` 最前,保证后续 reqwest / relay 的
+/// `connect_async` 都用已确定的 provider,避开「aws-lc-rs + ring 同时启用时无参
+/// ClientConfig::builder().expect() panic」(见 Cargo.toml rustls 注释)。
+fn install_rustls_provider() {
+    drop(rustls::crypto::aws_lc_rs::default_provider().install_default());
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // 必须最先执行:进程级选定 rustls CryptoProvider。
+    // 见 Cargo.toml 的 rustls/reqwest 注释——reqwest 0.13 自带 aws-lc-rs 但只「借用」
+    // provider,不写入默认槽;而 oauth2(经 reqwest 0.12)把 rustls 0.23 的 `ring` feature
+    // 也拉进图,使 rustls 同时启用 aws-lc-rs + ring 两个 provider。tokio-tungstenite 0.30
+    // 的 TLS 连接器走无参 ClientConfig::builder(),两 provider 共存时会 panic。此处选定
+    // aws-lc-rs(FIPS 可候选、性能优于 ring),在任何 TLS 连接之前装好。
+    install_rustls_provider();
     ensure_release_env();
     startup::init();
     startup::mark("environment:ready");

--- a/pinvou3-app/src-tauri/src/platform/encoding.rs
+++ b/pinvou3-app/src-tauri/src/platform/encoding.rs
@@ -53,11 +53,11 @@ mod tests {
     }
 
     #[test]
-    fn capacity_is_exact_no_excess() {
-        // 预分配 2*n 容量 + 逐字节写,结果长度应恰好等于容量(无 realloc)。
+    fn output_length_is_two_chars_per_byte() {
+        // 每个字节固定编码为两个十六进制字符。
+        // String 只保证容量不小于预分配值，不能把“容量恰好相等”当成跨平台契约。
         let s = hex_lower(&[0xab; 32]);
         assert_eq!(s.len(), 64);
-        assert_eq!(s.capacity(), 64);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/platform/encoding.rs
+++ b/pinvou3-app/src-tauri/src/platform/encoding.rs
@@ -1,0 +1,71 @@
+//! 小型字节编码工具。
+//!
+//! 历史上散落在 sessions / remote_control / voice / knowledge / app commands 等处的
+//! sha256 → 十六进制编码,sha2 0.10 时多用 `format!("{:x}", hasher.finalize())`
+//! (依赖 GenericArray 的 LowerHex impl),其余是手写 `for` 循环配 `write!`/`push_str`,
+//! 风格不一、每处重复一遍。sha2 0.11 的 `Output`(GenericArray)不实现 LowerHex,
+//! 前一种写法编译不过。集中到本函数既消除重复,又便于将来统一换实现(如换更快的查表法)。
+
+/// 把字节切片编码为小写十六进制字符串。
+///
+/// 用 `write!` 逐字节写进预分配 `String`(容量恰好 2× 字节长度),避免 `.map().collect()`
+/// 每字节分配一个临时 `String`。与 `hex::encode` 等价但无需新增直接依赖。
+pub(crate) fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 2);
+    // write! 到 String 永不失败(fmt::Error 仅出现在写入失败时,String 无 IO 失败)。
+    for b in bytes {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        assert_eq!(hex_lower(&[]), "");
+    }
+
+    #[test]
+    fn known_vectors() {
+        assert_eq!(hex_lower(&[0x00]), "00");
+        assert_eq!(hex_lower(&[0x0f, 0x10, 0xff]), "0f10ff");
+        // SHA-256("") = e3b0c442...(前 16 字节)
+        assert_eq!(
+            &hex_lower(&[
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24,
+            ])[..],
+            "e3b0c44298fc1c149afbf4c8996fb924"
+        );
+        // 完整 32 字节(64 hex 字符):SHA-256("abc")——覆盖全 digest 长度的截断/边界。
+        assert_eq!(
+            &hex_lower(&[
+                0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
+                0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
+                0xf2, 0x00, 0x15, 0xad,
+            ])[..],
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn capacity_is_exact_no_excess() {
+        // 预分配 2*n 容量 + 逐字节写,结果长度应恰好等于容量(无 realloc)。
+        let s = hex_lower(&[0xab; 32]);
+        assert_eq!(s.len(), 64);
+        assert_eq!(s.capacity(), 64);
+    }
+
+    #[test]
+    fn lowercase_only() {
+        let s = hex_lower(&[0xfa, 0xbc]);
+        assert_eq!(s, "fabc");
+        assert!(s
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+    }
+}

--- a/pinvou3-app/src-tauri/src/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/mod.rs
@@ -2,6 +2,7 @@ pub mod app_events;
 pub(crate) mod capabilities;
 pub mod connector_state;
 pub mod credential_store;
+pub(crate) mod encoding;
 pub(crate) mod filesystem;
 pub(crate) mod notifications;
 pub(crate) mod os;


### PR DESCRIPTION
## 概述

按 PR #37 评审意见,将「依赖安全升级」从工具链/lint/CI 改造中拆出单独成 PR:升级 reqwest、sha2、calamine、tokio-tungstenite 等存在安全通告或重大版本落后的依赖,并完成全部源码适配。

## 背景

PR #37 评审(h3c-hexin)要求将依赖安全升级与 lint/release/CI 改造拆成两个 PR。本 PR 为其中的依赖安全升级部分,基于最新 main(82944b9)手工合并,保留 main 已合入的 ACP 依赖(agent-client-protocol、tokio-util/compat、wait-timeout、reqwest 的 stream feature);rust-version = "1.88" MSRV、license、[lints]、[profile] 等工具链内容不在本 PR,由后续工具链 PR 携带。

## 变更

- reqwest 0.12 → 0.13:feature `rustls-tls` 改名 `rustls`,与 main 的 `stream` 取并集并加 `query`;新增 rustls 直依赖(0.23, 仅 aws-lc-rs),并在 `run()` 最前 `install_rustls_provider()` 显式选定进程级 CryptoProvider——oauth2 传递依赖会把 rustls 的 ring feature 也拉进图,两 provider 共存时 tungstenite 无参 TLS builder 会 panic;此处用 `drop(...)` 替代 `let _ = ...`,不触发 let_underscore_drop。
- sha2 0.10 → 0.11:digest Output 不再实现 LowerHex,新增 `src/platform/encoding.rs` 的 `hex_lower` 统一十六进制编码,适配 files/tests/model_download/remote_control manager/sessions/voice_asr,以及 main 新增的 codex_acp/workspace.rs(pr241 分支尚无该文件,本 PR 手工适配)。
- calamine 0.26 → 0.36:拉入 quick-xml 0.41,修 RUSTSEC-2026-0194/0195 ReDoS(剩余 quick-xml 0.39.4 由 plist/tauri 传递,等上游)。
- tokio-tungstenite 0.24 → 0.30:适配 Message::Text 的 String→Utf8Bytes、Ping/Pong 的 Vec→Bytes(relay_client.rs)。
- Cargo.lock 重新解析:anyhow、crossbeam-epoch 一并升级到 RUSTSEC 修复版本。
- CI(pr-check.yml)仅加新依赖必需位:rust-test apt 加 cmake(aws-lc-sys 构建需要)、timeout 30→45min;windows-rust-test 加 AWS_LC_SYS_PREBUILT_NASM=1(预生成 NASM 对象,免装 NASM)、timeout 40→45min。不含 rust-lint job 等工具链改造。

## 验证

- `cargo check --lib`:通过,91 个警告(均为历史欠账,本 PR 未新增 lint 门禁)。
- `cargo test --lib -- --test-threads=1`:729 passed / 0 failed / 12 ignored(macOS 本地)。
- `cargo fmt -- --check`:通过(默认 rustfmt 规则)。
- `python3 scripts/architecture-guard.py`:通过。
- `./scripts/fork-guard.sh --fast`:通过(指纹层全过)。

## 备注

- 影响面需重点回归:远控 WebSocket 链路(tokio-tungstenite 0.24→0.30,relay_client 连接/收发/心跳)与 Excel 解析(calamine 0.26→0.36,file_ingest 多 sheet 抽取)。
- aws-lc-rs 首次冷编译显著增加 CI 时长,已同步放宽 rust-test / windows-rust-test timeout。
- 后续工具链 PR(rust-toolchain 锁定、零欠账 lint 门禁、release 去重)建议以本分支为 base。