### PR TITLE
fix(rust): 修复 Windows lint 门禁失败

### DIFF
--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -935,6 +935,7 @@ mod blocklist_contract {
 
 #[cfg(test)]
 mod web_template_seed {
+    #[cfg(unix)]
     use std::fs;
     use std::path::PathBuf;
 

--- a/pinvou3-app/src-tauri/src/platform/os/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/mod.rs
@@ -35,6 +35,3 @@ pub use interface::{
     super_permission_is_enabled, super_permission_turn_reminder, system_default_open_supported,
     user_home_dir, validate_upload_location,
 };
-
-#[cfg(target_os = "windows")]
-pub use interface::bios_serial_number;


### PR DESCRIPTION
## 概述

修复 Rust 未使用导入硬门禁在 Windows 全目标检查中暴露的两处平台条件编译问题，恢复 Windows CI。

## 背景

PR #37 启用 `unused_imports = "deny"` 后，合入主线的 Windows 全目标检查发现一个未使用的 Windows 重导出，以及一个仅 Unix 测试使用但未按平台限定的导入。

## 变更

- 移除未被调用的 Windows BIOS 序列号重导出，保留实际使用的底层实现。
- 将 Web 模板测试中的 `std::fs` 导入限定为 Unix，与测试条件保持一致。

## 验证

- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --locked --all-targets`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `git diff --check`

## 备注

仅调整编译期导入范围，不改变运行时行为。