### PR TITLE
fix(rust): 修复 Windows lint 门禁 unused import 失败

### DIFF
--- a/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
@@ -12,8 +12,6 @@ pub use permission::{
     disable_super_permission, enable_super_permission, super_permission_is_enabled,
     super_permission_turn_reminder,
 };
-#[cfg(target_os = "windows")]
-pub use system::bios_serial_number;
 pub use system::{
     archive_dependency_packages, archive_tool_exists, archive_tool_path, command_exists,
     email_dependency_packages, email_tool_exists, libreoffice_missing_message,


### PR DESCRIPTION
## 概述

移除 `pinvou3-app/src-tauri/src/platform/os/interface/mod.rs` 中未使用的 `bios_serial_number` 再导出，修复 main 分支 `windows-rust-test` 任务因 `unused_imports = "deny"` 硬门禁报错而失败的问题。

## 背景

main 最新一次 push 的 PR Check 中 `windows-rust-test` 失败，报错 `error: unused import: system::bios_serial_number`（`interface/mod.rs:16`）。原因是 #44 修复 Windows lint 门禁时删除了 `os/mod.rs` 外层的 `bios_serial_number` 再导出，导致 interface 内层这个再导出失去所有引用方；而 `windows-rust-test` 仅在 main push 时运行，#44 合入后那次运行被并发取消，问题直到下一次 main push 才暴露。经全仓库检索，`bios_serial_number` 当前无任何调用方。

## 变更

- 删除 `pinvou3-app/src-tauri/src/platform/os/interface/mod.rs` 中 `#[cfg(target_os = "windows")] pub use system::bios_serial_number;`（2 行），处理方式与 #44 一致。
- 已逐一核对 `windows/mod.rs` 其余 50+ 个再导出在 crate 内均有引用方，无其他同类隐患。

## 验证

- `cargo check --lib`（macOS）通过，仅存量 allow 级警告。
- `python3 scripts/architecture-guard.py` 通过。
- Windows 目标编译由 CI `windows-rust-test` 最终确认。

## 备注

- `interface/system.rs` 中的 `bios_serial_number` 包装函数及其 Windows 实现链（`windows_system.rs`）此后仅余 dead_code 级警告（该 lint 当前为 allow，属已登记欠账），本次按最小改动原则未一并清理；如需彻底移除该功能残留可另行处理。