### PR TITLE
ci(rust): 接入 sccache 消除仓库内 crate 每轮重编译

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,6 +27,8 @@ name: PR Check
 #   mtime,cargo 按 mtime 判 dirty,CodeWhale path 依赖 + 主 crate 每轮必重编(~5min)。
 #   sccache 按内容哈希缓存编译产物(GHA cache 后端,scoping 与 actions/cache 一致),
 #   仓库内 crate 源码不变即全命中;main push 恒跑 rust-test 同时充当 sccache 暖源。
+#   PR/merge queue 侧 SCCACHE_GHA_RW_MODE=READ_ONLY(对齐 rust-cache save-if 仅 main),
+#   只读暖 cache,不向共享 10GB 配额写入。
 
 on:
   pull_request:
@@ -340,6 +342,8 @@ jobs:
       # sccache 按内容哈希缓存编译产物,解决 checkout 刷新 mtime 导致仓库内 crate 每轮重编。
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
+      # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v4
@@ -418,6 +422,8 @@ jobs:
       # 同 rust-lint:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
+      # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
@@ -541,6 +547,8 @@ jobs:
       # 同 rust-test:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
+      # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,6 +23,10 @@ name: PR Check
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
+# - sccache(2026-07 补充):rust-cache 只罩第三方依赖;checkout 会刷新仓库内源文件
+#   mtime,cargo 按 mtime 判 dirty,CodeWhale path 依赖 + 主 crate 每轮必重编(~5min)。
+#   sccache 按内容哈希缓存编译产物(GHA cache 后端,scoping 与 actions/cache 一致),
+#   仓库内 crate 源码不变即全命中;main push 恒跑 rust-test 同时充当 sccache 暖源。
 
 on:
   pull_request:
@@ -332,6 +336,10 @@ jobs:
     if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      # sccache 按内容哈希缓存编译产物,解决 checkout 刷新 mtime 导致仓库内 crate 每轮重编。
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v4
@@ -367,6 +375,12 @@ jobs:
           shared-key: rust-lint
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
+      - name: sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.16.0
+
       # fmt 硬门禁:风格规则见 rustfmt.toml(只用 stable 可用选项)。
       - name: cargo fmt --check (硬门禁)
         working-directory: pinvou3-app/src-tauri
@@ -400,6 +414,10 @@ jobs:
     # Tauri + fastembed + aws-lc-sys 全冷编译耗时长;设上限避免卡死 runner 占用
     # (GitHub 默认 6h,此处收紧到 45min,与 mac-build 的 50min 量级一致)。
     timeout-minutes: 45
+    env:
+      # 同 rust-lint:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
@@ -472,6 +490,12 @@ jobs:
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
+      - name: sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.16.0
+
       # 保留 --test-threads=1:虽已把 env 写测试收敛到 crate 级唯一锁
       # (bridge::paths::tests::ENV_LOCK),但进程级 env 对未持锁的读取者仍全局可见，
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
@@ -514,6 +538,9 @@ jobs:
       # reqwest 0.13 → aws-lc-sys(非 FIPS)。Windows x86_64 需 NASM 汇编;runner 默认无 NASM,
       # 用预生成 NASM 对象规避(aws-lc-rs 官方支持,无需额外装 NASM)。
       AWS_LC_SYS_PREBUILT_NASM: "1"
+      # 同 rust-test:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -549,6 +576,12 @@ jobs:
           workspaces: pinvou3-app/src-tauri
           shared-key: windows-rust-test
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
+      - name: sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.16.0
 
       - name: Windows 架构与 Tauri 资源契约
         run: |

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,6 +29,7 @@ name: PR Check
 #   仓库内 crate 源码不变即全命中;main push 恒跑 rust-test 同时充当 sccache 暖源。
 #   PR/merge queue 侧 SCCACHE_GHA_RW_MODE=READ_ONLY(对齐 rust-cache save-if 仅 main),
 #   只读暖 cache,不向共享 10GB 配额写入。
+#   接入范围仅 rust-test / windows-rust-test;rust-lint 不接入(见该 job 注释)。
 
 on:
   pull_request:
@@ -332,18 +333,14 @@ jobs:
   # clippy/fmt/deny 独立 job:与 rust-test 并行,各自独立 cache。
   # clippy 用 clippy-driver 编译,产物不能被 cargo test(rustc)复用;在同一 job 里
   # 串行跑会导致依赖图被编译两遍。拆成并行 job 后 wall-clock ≈ max(lint, test)。
+  # 不接入 sccache:clippy 产物与 test 不通用,接入会使 sccache 写入量翻倍,
+  # 而本 job 仅 ~2-3min、收益过小,权衡 10GB 配额压力后不接入(#47 评审结论)。
   rust-lint:
     name: rust-lint
     needs: changes
     if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      # sccache 按内容哈希缓存编译产物,解决 checkout 刷新 mtime 导致仓库内 crate 每轮重编。
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: "true"
-      # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v4
@@ -378,12 +375,6 @@ jobs:
           workspaces: pinvou3-app/src-tauri
           shared-key: rust-lint
           save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
-      - name: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-        with:
-          version: v0.16.0
 
       # fmt 硬门禁:风格规则见 rustfmt.toml(只用 stable 可用选项)。
       - name: cargo fmt --check (硬门禁)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -414,7 +414,8 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
+      # 【临时】稳态 A/B 实验:本分支强制 READ_WRITE,实验结束后还原。
+      SCCACHE_GHA_RW_MODE: READ_WRITE
     # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
@@ -483,9 +484,10 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           # 稳定 key 前缀(跨 PR/push 一致);restore 按前缀回退,lock 变了也增量。
-          shared-key: rust-test
-          # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # 【临时】稳态 A/B 实验:独立 shared-key + 本分支可写,避免与 main 既有
+          # key 冲突写不进;实验结束后还原为 rust-test + 仅 main 保存。
+          shared-key: rust-test-steady
+          save-if: true
 
       # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
       - name: sccache
@@ -526,7 +528,8 @@ jobs:
   windows-rust-test:
     name: windows-rust-test
     # 跨平台构建不作为 PR 检测项；合入 main 后再做 Windows 原生验证。
-    if: ${{ github.event_name == 'push' }}
+    # 【临时】稳态 A/B 实验:允许 PR 触发以验证 windows sccache 接入,实验结束后还原。
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。
@@ -539,7 +542,8 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
+      # 【临时】稳态 A/B 实验:本分支强制 READ_WRITE,实验结束后还原。
+      SCCACHE_GHA_RW_MODE: READ_WRITE
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -573,8 +577,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: pinvou3-app/src-tauri
-          shared-key: windows-rust-test
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # 【临时】稳态 A/B 实验:独立 shared-key + 本分支可写;实验结束后还原为
+          # windows-rust-test + 仅 main 保存。
+          shared-key: windows-rust-test-steady
+          save-if: true
 
       # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
       - name: sccache

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -414,8 +414,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
-      # 【临时】稳态 A/B 实验:本分支强制 READ_WRITE,实验结束后还原。
-      SCCACHE_GHA_RW_MODE: READ_WRITE
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
@@ -484,10 +483,9 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           # 稳定 key 前缀(跨 PR/push 一致);restore 按前缀回退,lock 变了也增量。
-          # 【临时】稳态 A/B 实验:独立 shared-key + 本分支可写,避免与 main 既有
-          # key 冲突写不进;实验结束后还原为 rust-test + 仅 main 保存。
-          shared-key: rust-test-steady
-          save-if: true
+          shared-key: rust-test
+          # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
       - name: sccache
@@ -528,8 +526,7 @@ jobs:
   windows-rust-test:
     name: windows-rust-test
     # 跨平台构建不作为 PR 检测项；合入 main 后再做 Windows 原生验证。
-    # 【临时】稳态 A/B 实验:允许 PR 触发以验证 windows sccache 接入,实验结束后还原。
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。
@@ -542,8 +539,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
-      # 【临时】稳态 A/B 实验:本分支强制 READ_WRITE,实验结束后还原。
-      SCCACHE_GHA_RW_MODE: READ_WRITE
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -577,10 +573,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: pinvou3-app/src-tauri
-          # 【临时】稳态 A/B 实验:独立 shared-key + 本分支可写;实验结束后还原为
-          # windows-rust-test + 仅 main 保存。
-          shared-key: windows-rust-test-steady
-          save-if: true
+          shared-key: windows-rust-test
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # 装在 cargo 步骤之前即可;post 阶段自动输出 show-stats 命中率。
       - name: sccache


### PR DESCRIPTION
## 概述

rust-test / windows-rust-test 两个 job 接入 sccache(GHA cache 后端),按内容哈希缓存编译产物,消除仓库内 crate 在 CI 上的每轮全量重编译。**稳态 A/B 实测:rust-test 7m05s~8m11s → 2m24s;windows-rust-test 冷跑 17m55s → 稳态 4m36s。**

## 背景

现有 Swatinem/rust-cache 只能罩住第三方依赖(实测 1.3GB cache full match 命中):actions/checkout 会把仓库内所有源文件 mtime 刷成当前时间,而 cargo 的增量指纹基于 mtime 比对,导致 CodeWhale path 依赖(11 个 crate)与 pinvou3-tauri 主 crate 每轮必判 dirty 重编。实测基线 rust-test 7m28s 中 cargo test 占 5m09s,其中编译 5m07s、730 个测试实际只运行 1.6s —— 时间几乎全花在可避免的仓库内重编译上。

## 变更

- rust-test / windows-rust-test 增加 job 级 env:`RUSTC_WRAPPER=sccache`、`SCCACHE_GHA_ENABLED=true`,并新增 `mozilla-actions/sccache-action@v0.0.10` 步骤(锁定 sccache v0.16.0,post 阶段自动输出命中率统计)。
- `SCCACHE_GHA_RW_MODE` 按事件区分:仅 main push 读写(暖源),pull_request / merge_group 只读,对齐 rust-cache `save-if` 仅 main 的 10GB 配额保护策略。
- **rust-lint 不接入**(评审意见):clippy 产物与 test 不通用,接入会使 sccache 写入量翻倍,而该 job 仅 ~2min、收益过小。
- 既有 rust-cache 保留不动:rust-cache 的 key 环境哈希包含 `RUSTC_WRAPPER`,合入后 main 会自动另存新 key,旧格式缓存不会被误用。
- 文件头部 Cache 策略注释同步更新。

## 验证

**稳态 A/B(同 SHA 重跑,rust-cache 指纹对齐 + sccache 暖,与评审引用基线同条件):**

| job | 基线(无 sccache) | 本方案稳态 | 关键数据 |
|---|---|---|---|
| rust-test | 7m05s ~ 8m11s | **2m24s** | cargo test 编译段 5m07s → 41.25s;仓库内 crate 11/11 命中(100%);730 测试全过 |
| windows-rust-test | 全冷 17m55s(仅编译段) | **4m36s** | 全目标检查 17m55s → 1m23s;sccache 21/21 命中(100%) |
| rust-lint | 2m02s ~ 3m18s | 2m13s(未接入 sccache) | 移除 sccache 后无回归 |

Windows 三轮递进验证:冷跑 17m55s(0% 命中,1489 对象成功写入)→ sccache 暖跑 11m32s(87.45% 命中)→ 双暖稳态 4m36s(100% 命中),确认 sccache-action 在 windows-latest 可用、与 AWS_LC_SYS_PREBUILT_NASM 兼容。

**一次性切换成本(如实说明):**`RUSTC_WRAPPER` 变化使既有 rust-cache 产物指纹失效,合入后 main 首轮 rust-test 需全量编译一遍(约 19min)并同时存出新格式 rust-cache 与 sccache 条目,此后进入上表稳态。

## 备注

- 缓存配额:仓库 10GB 限额当前已用 ~9.9GB,sccache GHA 后端每 job 每轮写入数百至上千个小对象,会加速 LRU 流转;已观察到两份 linux release 缓存被驱逐。建议另行清理 release 冗余缓存(约 6GB,多为子集重复)腾出额度,本 PR 不含该清理。
- sccache 命中路径按对象逐个走网络读取(均值 ~0.2s/个):稳态下第三方依赖由 rust-cache 整包恢复、仅仓库内 ~12 个 crate 过 sccache,读取开销可忽略;仅当 rust-cache 也失效(如 lockfile 大改)时才会退化为全图读取(~5-6min),仍优于全冷编译。
- windows-rust-test 仍只在 main push 触发(维持既有设计);本 PR 已用临时放开触发的方式完成 Windows 侧真实验证,正式配置未变。