### PR TITLE
fix(sidebar): 修复会话置顶失效与对话管理页选中态残留

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -2751,7 +2751,8 @@ function workspaceDisplayName(path) {
           );
         }
         // 与左侧任务列表同款行项目:置顶/重命名/删除/收纳/打开文件夹/右键菜单;
-        // 定时任务运行项点按进入运行会话(与侧栏一致)
+        // 定时任务运行项点按进入运行会话(与侧栏一致)。
+        // 管理页只是会话清单,不高亮当前会话(active 恒 false),避免打开过的对话残留"选中"背景。
         const route = sessionRoute(chat);
         return (
           <RecentItem
@@ -2759,11 +2760,7 @@ function workspaceDisplayName(path) {
             chat={chat}
             theme={theme}
             t={t}
-            active={route === 'codex'
-              ? chat.id === activeCodexId
-              : route === 'scheduled'
-                ? chat.id === activeScheduledId
-                : chat.id === activeId}
+            active={false}
             personaTarget={false}
             onSelect={route === 'codex'
               ? () => onOpenCodex && onOpenCodex(chat.id)

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -777,7 +777,7 @@ function workspaceDisplayName(path) {
 
       const [justInstalledTool, setJustInstalledTool] = useState(null);
       const [taskListFilter, setTaskListFilter] = useState('all');
-      const [taskListSort, setTaskListSort] = useState('recent');
+      const [taskListSort, setTaskListSort] = useState('pinned_first');
       const [taskFilterOpen, setTaskFilterOpen] = useState(false);
       const taskFilterRef = useRef(null);
       // 日期组展开状态:未点过的组按默认值走(今天展开、以往折叠),点过后记住用户选择
@@ -848,11 +848,17 @@ function workspaceDisplayName(path) {
 
       // 任务列表按日期堆叠:今天默认展开、以往默认折叠;组内顺序沿用上面的筛选+排序结果,
       // 组间按日期倒序,无时间戳的落 'unknown' 组沉底。
+      // 「置顶优先」排序下置顶项提升到所有日期组之上,否则旧会话会埋进默认折叠的以往分组,
+      // 只剩置顶标志、没有置顶效果。
       const todayDateKey = localDateKey(Date.now());
+      const sidebarPinnedHoisted = taskListSort === 'pinned_first'
+        ? sidebarTaskHistory.filter(chat => !!chat.pinned)
+        : [];
       const sidebarTaskGroups = [];
       {
         const byDate = new Map();
         sidebarTaskHistory.forEach(chat => {
+          if (sidebarPinnedHoisted.length && chat.pinned) return;
           const key = localDateKey(chat.updatedAt || chat.pinnedAt);
           if (!byDate.has(key)) byDate.set(key, []);
           byDate.get(key).push(chat);
@@ -1905,7 +1911,14 @@ function workspaceDisplayName(path) {
                           </div>
                         )}
                       </div>
-                    ) : sidebarTaskGroups.length > 0 ? sidebarTaskGroups.map((group) => {
+                    ) : (sidebarPinnedHoisted.length > 0 || sidebarTaskGroups.length > 0) ? (
+                      <>
+                        {sidebarPinnedHoisted.length > 0 && (
+                          <div className="space-y-0.5">
+                            {sidebarPinnedHoisted.map(renderSidebarTaskItem)}
+                          </div>
+                        )}
+                        {sidebarTaskGroups.map((group) => {
                       const isOpen = dateGroupOpen[group.key] ?? (group.key === todayDateKey);
                       return (
                         <div key={group.key}>
@@ -1924,7 +1937,9 @@ function workspaceDisplayName(path) {
                           )}
                         </div>
                       );
-                    }) : (
+                        })}
+                      </>
+                    ) : (
                       <div className={`px-3 py-3 text-[13px] ${activeTheme === 'dark' ? 'text-[#9AA0A6]' : 'text-[#8A8F94]'}`}>
                         {t.sidebarTaskEmpty || '暂无任务'}
                       </div>

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -212,8 +212,8 @@ try {
     'Codex sessions must share the global recent-session list');
   assert.ok(main.includes("taskKind: 'codex'") && main.includes("testId: 'codex-sidebar-item'"),
     'global sessions must visually identify Codex records');
-  assert.ok(main.includes("useState('recent')"),
-    'work and code sessions must be mixed by recent update time by default');
+  assert.ok(main.includes("useState('pinned_first')"),
+    'pinned sessions float first by default; unpinned work and code sessions still mix by recent update time');
   assert.ok(main.includes("{ id: 'code', label: t.sidebarTaskFilterCode || '代码' }")
     && main.includes("if (taskListFilter === 'code') return chat.taskKind === 'codex';")
     && i18n.includes("sidebarTaskFilterCode: '代码'")

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -49,7 +49,10 @@ function injectSource() {
     const ZOMBIE={session_id:'s-zombie',project_dir:'/x/wf',scenario:'sansheng_liubu'};
     const WF_STATE={project_dir:'/x/wf',scenario:'sansheng_liubu',all_completed:false,roles:{taizi:{name:'太子',status:'running'},zhongshu:{name:'中书',status:'pending'}}};
     const WF_TEMPLATE={id:'sansheng-liubu',name:'三省六部帮你办',enabled:true,scenarios:['sansheng_liubu'],ui:{header:'🏛️ 三省六部帮你办',template:{title:'🏛️ 三省六部帮你办',badge:'11 agent',desc:'太子接旨 → 中书省起草 → 门下省审议 → 尚书省派单 → 六部并行办差 → 回奏呈报。'},agentDefs:[{id:'taizi',name:'太子',color:'#C9A227'},{id:'zhongshu',name:'中书省',color:'#4285F4'}],lanes:[{lane:0,title:'接旨',agents:['taizi']},{lane:1,title:'起草',agents:['zhongshu']}]}};
-    let SESSIONS=[{id:'s1',title:'第三季度财报分析',created_at:Date.now()-1000,updated_at:Date.now()}];
+    let SESSIONS=[
+      {id:'s-pinned-old',title:'置顶旧会话',created_at:'2026-06-01T08:00:00Z',updated_at:'2026-06-01T08:00:00Z',pinned:true,pinned_at:'2026-07-20T08:00:00Z'},
+      {id:'s1',title:'第三季度财报分析',created_at:Date.now()-1000,updated_at:Date.now()}
+    ];
     let CODEX_SESSIONS=[{id:'codex-1',title:'Codex回归会话',created_at:new Date(Date.now()-1000).toISOString(),updated_at:new Date().toISOString(),workspace_kind:'temporary',workspace_path:''}];
     let ARCHIVED_SESSIONS=[];
     window.__SHELL_JOBS__=[{
@@ -235,6 +238,25 @@ async function expand(page) {
   rec('①a 侧边栏任务合并为单一任务列表',
     sidebarTaskShell.hasTaskList && !sidebarTaskShell.hasPinnedGroup && !sidebarTaskShell.hasRegularGroup && sidebarTaskShell.hasFilterButton,
     JSON.stringify(sidebarTaskShell));
+  const pinnedSidebarState = await page.evaluate(() => {
+    const visible = (node) => {
+      const rect = node.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+    const pinnedRows = [...document.querySelectorAll('[data-testid="regular-sidebar-item"]')]
+      .filter(node => (node.textContent || '').includes('置顶旧会话') && node.getBoundingClientRect().left < 330 && visible(node));
+    const todayLabel = [...document.querySelectorAll('span')]
+      .find(node => /^今天 \(\d+\)$/.test((node.textContent || '').trim()) && node.getBoundingClientRect().left < 330 && visible(node));
+    const pinnedRow = pinnedRows[0];
+    return {
+      count: pinnedRows.length,
+      beforeToday: !!(pinnedRow && todayLabel && pinnedRow.getBoundingClientRect().top < todayLabel.getBoundingClientRect().top),
+      pinVisible: !!(pinnedRow && [...pinnedRow.querySelectorAll('svg')].some(icon => icon.classList.contains('rotate-45'))),
+    };
+  });
+  rec('①a-1 默认置顶会话跨日期分组上浮且不重复',
+    pinnedSidebarState.count === 1 && pinnedSidebarState.beforeToday && pinnedSidebarState.pinVisible,
+    JSON.stringify(pinnedSidebarState));
   await page.click('[data-testid="sidebar-task-filter"]'); await sleep(200);
   const sidebarTaskFilterMenu = await page.evaluate(() => {
     const menu = document.querySelector('[data-testid="sidebar-task-filter-menu"]');
@@ -250,14 +272,14 @@ async function expand(page) {
       hasRegularChat: text.includes('普通会话'),
     };
   });
-  rec('①a-1 任务筛选弹层只保留有效筛选与排序项',
+  rec('①a-2 任务筛选弹层只保留有效筛选与排序项',
     sidebarTaskFilterMenu.exists && sidebarTaskFilterMenu.hasAll && sidebarTaskFilterMenu.hasPinned &&
     sidebarTaskFilterMenu.hasScheduled && sidebarTaskFilterMenu.hasPinnedFirst && sidebarTaskFilterMenu.hasRecent &&
     !sidebarTaskFilterMenu.hasCurrentChat && !sidebarTaskFilterMenu.hasRegularChat,
     JSON.stringify(sidebarTaskFilterMenu));
   await page.keyboard.press('Escape'); await sleep(200);
 
-  // ①a-2 对话管理页必须按 Codex 会话类型路由，不能误走普通聊天 switchToSession。
+  // ①a-3 对话管理页必须按 Codex 会话类型路由，不能误走普通聊天 switchToSession。
   await clickText(page, '查看全部'); await sleep(500);
   const codexManagedOpen = await page.evaluate(() => {
     const label = [...document.querySelectorAll('span')]
@@ -272,11 +294,23 @@ async function expand(page) {
     view: document.querySelector('[data-testid="app-root"]')?.getAttribute('data-current-view'),
     activeId: localStorage.getItem('pinvou_codex_active_session'),
   }));
-  rec('①a-2 对话管理页正确打开 Codex 会话',
+  rec('①a-3 对话管理页正确打开 Codex 会话',
     codexManagedOpen.found && codexManagedState.view === 'codex' && codexManagedState.activeId === 'codex-1',
     JSON.stringify({ ...codexManagedOpen, ...codexManagedState }));
 
   await clickText(page, '查看全部'); await sleep(400);
+  const managedActiveState = await page.evaluate(() => {
+    const label = [...document.querySelectorAll('span')]
+      .find(node => (node.textContent || '').trim() === 'Codex回归会话' && node.getBoundingClientRect().left > 300);
+    const row = label && label.closest('div[class*="cursor-pointer"]');
+    return {
+      found: !!row,
+      activeClass: !!(row && (row.classList.contains('bg-[#333537]') || row.classList.contains('bg-[#E1E5EA]'))),
+    };
+  });
+  rec('①a-4 对话管理页不残留当前会话选中背景',
+    managedActiveState.found && !managedActiveState.activeClass,
+    JSON.stringify(managedActiveState));
   await clickText(page, '批量管理'); await sleep(200);
   await page.evaluate(() => {
     const label = [...document.querySelectorAll('span')]
@@ -289,7 +323,7 @@ async function expand(page) {
     archived: document.body.innerText.includes('已收纳到【对话管理-已收纳】'),
     activeId: localStorage.getItem('pinvou_codex_active_session'),
   }));
-  rec('①a-3 批量收纳 Codex 会话等待后端成功并清除激活态',
+  rec('①a-5 批量收纳 Codex 会话等待后端成功并清除激活态',
     codexBatchArchive.invoked && codexBatchArchive.archived && codexBatchArchive.activeId === null,
     JSON.stringify(codexBatchArchive));
   await page.evaluate(() => document.querySelector('button[aria-label="取消"]')?.click());


### PR DESCRIPTION
## 概述

修复左侧侧边栏会话列表置顶失效（只显示置顶标志、不触发置顶行为），以及对话管理页已打开会话残留选中背景的问题。

## 背景

- 置顶失效由两处问题叠加：`604e63f2`（接入 ACP 代码会话）将侧边栏默认排序从「置顶优先」误改为「最近更新」，默认排序完全忽略 pinned 标志；`0e3d9afe` 引入的日期分组（默认开启）又把置顶项留在各自日期组内，旧会话会埋进默认折叠的以往分组，即使手动选「置顶优先」也看不到置顶效果。
- 对话管理页（SearchView）复用侧栏 `RecentItem` 行组件时把「当前激活会话」的 `active` 高亮一并传入，导致打开过的对话在管理页残留深色选中背景。

## 变更

- `pinvou3-app/src/app/main.jsx`：侧边栏默认排序恢复为「置顶优先」（与开源基线 `e34024e6` 一致）。
- `pinvou3-app/src/app/main.jsx`：日期分组模式下、「置顶优先」排序时，置顶项提升到所有日期组之上渲染，不再计入日期分组；不新增分组标题，保持「单一任务列表」设计。
- `pinvou3-app/src/app/main.jsx`：对话管理页 `renderChatRow` 中 `RecentItem` 的 `active` 改为恒 `false`，侧栏高亮逻辑不受影响。

## 验证

- `npx eslint src/app/main.jsx` 通过。
- `npx vite build` 构建通过。
- `node tests/scheduled_tasks_unit.js`、`node tests/scheduled_tasks_smoke.js` 通过。
- `node tests/ui_smoke.js` ALL 36 PASS（首轮出现 2 例 headless Chrome 时序抖动失败，重跑两轮均全过）。
- `python scripts/architecture-guard.py` 通过。

## 备注

- 用户手动切换排序为「最近更新」时，列表保持纯时间序，置顶项不再提升（符合排序菜单语义）。