### PR TITLE
fix(codex): 启用 Windows ACP 兼容

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -26,7 +26,7 @@
     "test:diff-ui": "node tests/diff_viewer_ui_smoke.mjs",
     "test:marketplace-oauth": "node tests/marketplace_oauth_logic.test.js",
     "test:composer-tools": "node tests/composer_tool_menu_logic.test.js",
-    "test:codex-acp": "node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
+    "test:codex-acp": "node tests/codex_acp_windows_contract.test.js && node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
     "test:session-management": "node tests/session_management_logic.test.mjs",
     "test:chat-input-limit": "node tests/chat_input_limit_logic.test.js",
     "test:voice-input": "node tests/voice_input_error_logic.test.js",

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -1234,7 +1234,9 @@ impl AcpPool {
         if let Some(path) = self.bundled_node.as_ref().filter(|path| path.is_file()) {
             return Some(path.clone());
         }
-        if adapter.extension().and_then(|value| value.to_str()) == Some("js") {
+        if crate::platform::capabilities::is_windows()
+            || adapter.extension().and_then(|value| value.to_str()) == Some("js")
+        {
             return find_in_path(if crate::platform::capabilities::is_windows() {
                 "node.exe"
             } else {
@@ -1452,15 +1454,17 @@ fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
         let mut command = Command::new(node);
         command.arg(adapter);
         Ok(command)
+    } else if is_windows_cmd(adapter) {
+        let mut command = Command::new("cmd");
+        command.args(["/D", "/S", "/C"]).arg(adapter);
+        Ok(command)
     } else {
         Ok(Command::new(adapter))
     }
 }
 
 fn codex_login_command(codex: &Path) -> Command {
-    if crate::platform::capabilities::is_windows()
-        && codex.extension().and_then(|value| value.to_str()) == Some("cmd")
-    {
+    if is_windows_cmd(codex) {
         let mut command = Command::new("cmd");
         command.args(["/D", "/S", "/C"]).arg(codex).arg("login");
         command
@@ -1469,6 +1473,11 @@ fn codex_login_command(codex: &Path) -> Command {
         command.arg("login");
         command
     }
+}
+
+fn is_windows_cmd(path: &Path) -> bool {
+    crate::platform::capabilities::is_windows()
+        && path.extension().and_then(|value| value.to_str()) == Some("cmd")
 }
 
 async fn capture_login_output<R>(reader: R, login_url: Arc<parking_lot::RwLock<Option<String>>>)

--- a/pinvou3-app/src-tauri/src/platform/capabilities.rs
+++ b/pinvou3-app/src-tauri/src/platform/capabilities.rs
@@ -17,7 +17,7 @@ pub(crate) const fn current() -> DesktopCapabilities {
         uses_bundled_dependency_installer: cfg!(target_os = "windows"),
         task_completion_notifications_default: !cfg!(target_os = "linux"),
         local_vllm_supported: cfg!(target_os = "linux"),
-        codex_acp_supported: cfg!(target_os = "linux"),
+        codex_acp_supported: cfg!(any(target_os = "linux", target_os = "windows")),
     }
 }
 
@@ -46,6 +46,10 @@ mod tests {
         assert_eq!(
             capabilities.task_completion_notifications_default,
             !is_linux()
+        );
+        assert_eq!(
+            capabilities.codex_acp_supported,
+            cfg!(any(target_os = "linux", target_os = "windows"))
         );
     }
 }

--- a/pinvou3-app/tests/codex_acp_windows_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_windows_contract.test.js
@@ -1,0 +1,60 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const appRoot = path.resolve(__dirname, "..");
+const runtime = fs.readFileSync(
+  path.join(appRoot, "src-tauri", "src", "features", "codex_acp", "mod.rs"),
+  "utf8",
+);
+const capabilities = fs.readFileSync(
+  path.join(appRoot, "src-tauri", "src", "platform", "capabilities.rs"),
+  "utf8",
+);
+const build = fs.readFileSync(path.join(appRoot, "scripts", "tauri", "build.js"), "utf8");
+const windowsConfig = JSON.parse(
+  fs.readFileSync(
+    path.join(appRoot, "src-tauri", "config", "platforms", "windows", "tauri.conf.json"),
+    "utf8",
+  ),
+);
+
+assert.match(
+  capabilities,
+  /codex_acp_supported:\s*cfg!\(any\(target_os = "linux", target_os = "windows"\)\)/,
+  "Codex ACP must be advertised on Linux and Windows only",
+);
+
+assert.match(
+  runtime,
+  /crate::platform::capabilities::is_windows\(\)\s*\|\|\s*adapter\.extension\(\)/,
+  "Windows ACP status must require node.exe even when the adapter is a .cmd shim",
+);
+
+assert.ok(
+  runtime.includes("fn is_windows_cmd(path: &Path) -> bool")
+    && runtime.includes("} else if is_windows_cmd(adapter) {")
+    && runtime.includes('command.args(["/D", "/S", "/C"]).arg(adapter);'),
+  "Windows codex-acp.cmd adapters must be launched through cmd /D /S /C",
+);
+
+assert.ok(
+  runtime.includes("fn codex_login_command(codex: &Path) -> Command")
+    && runtime.includes("if is_windows_cmd(codex)")
+    && runtime.includes('command.args(["/D", "/S", "/C"]).arg(codex).arg("login");'),
+  "Windows codex.cmd login must keep using cmd /D /S /C",
+);
+
+assert.equal(
+  build.includes('if (platform !== "linux") return;'),
+  true,
+  "packaged Codex Bridge preparation is still Linux-only until Windows runtime assets exist",
+);
+
+assert.deepEqual(
+  Object.keys(windowsConfig.bundle.resources || {}),
+  [],
+  "Windows must not package a missing codex-bridge resource mapping",
+);
+
+console.log("codex_acp_windows_contract: ok");


### PR DESCRIPTION
## 概述
启用 Windows 平台的 Codex ACP 入口，并补齐 Windows 下 npm `.cmd` shim 的启动路径处理，使 Windows 可以通过系统或托管路径解析到 ACP adapter 后正常启动。

## 背景
原能力开关只在 Linux 暴露 Codex ACP，且 adapter 启动逻辑只对 `.js` 入口走 Node 包装；Windows 上常见的 `codex-acp.cmd` shim 直接作为进程启动存在兼容风险。

## 变更
- 将 `codex_acp_supported` 扩展为 Linux 和 Windows。
- Windows 下解析 ACP adapter 时要求能找到 `node.exe`，避免状态检查漏掉 Node 依赖。
- 为 `codex-acp.cmd` 和 `codex.cmd login` 统一使用 `cmd /D /S /C` 启动。
- 新增 Codex ACP Windows 合同测试，并纳入 `npm run test:codex-acp`。

## 验证
- `python scripts/architecture-guard.py`
- `npm run test:codex-acp`
- `npm run test:tauri-effective-config`
- `npm run test:tauri-layout`

## 备注
- 本机 Windows Rust 全图编译检查 `cargo check --lib --no-default-features` 首次依赖编译超过 15 分钟未完成，已停止残留进程；完整 Rust 门禁以 GitHub CI 结果为准。