### PR TITLE
fix(bridge): 修正内部 envelope 后缀判断逻辑

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1094,7 +1094,7 @@
     return textParts.filter(function (text) {
       var trimmed = text.trim();
       return !(
-        (trimmed.indexOf("<turn_meta>") === 0 && trimmed.lastIndexOf("</turn_meta>") === trimmed.length - "</turn_meta>".length) ||
+        (trimmed.indexOf("<turn_meta>") === 0 && trimmed.endsWith("</turn_meta>")) ||
         trimmed === "<turn_meta_unchanged />"
       );
     }).map(function (text) {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -2674,7 +2674,7 @@
     return textParts.filter(function (text) {
       var trimmed = text.trim();
       return !(
-        (trimmed.indexOf("<turn_meta>") === 0 && trimmed.lastIndexOf("</turn_meta>") === trimmed.length - "</turn_meta>".length) ||
+        (trimmed.indexOf("<turn_meta>") === 0 && trimmed.endsWith("</turn_meta>")) ||
         trimmed === "<turn_meta_unchanged />"
       );
     }).map(function (text) {


### PR DESCRIPTION
## 概述

修复 CodeQL `js/incorrect-suffix-check` 告警（#3、#4，同一根因）：`userMessageDisplayText` 判断 `</turn_meta>` 后缀的方式存在边界错误，改用 `endsWith`。

## 背景

GitHub Code Scanning 报出 `pinvou3-app/src/platform/tauri/bridge.js:1097` 与 `pinvou3-app/src/platform/web/bridge.js:2677` 两处 `js/incorrect-suffix-check`（high）。原判断：

```js
trimmed.lastIndexOf("</turn_meta>") === trimmed.length - "</turn_meta>".length
```

当 `trimmed` 恰为 `"<turn_meta>"`（11 字符）时，`length - 12 === -1` 且 `lastIndexOf` 未命中也返回 `-1`，等式成立，一条普通消息会被误判为内部 envelope 而在展示层被隐藏。告警属实（逻辑缺陷，安全影响有限）。

## 变更

- `pinvou3-app/src/platform/tauri/bridge.js`、`pinvou3-app/src/platform/web/bridge.js`：后缀判断改为 `trimmed.endsWith("</turn_meta>")`，两份拷贝同步修复。

## 验证

- 用 node 对修复前后判定式做对照：仅 `"<turn_meta>"` 这一误判用例行为改变，其余用例（完整 envelope、前缀不匹配、普通文本）结果一致。
- `node --check` 两个文件语法通过；`python3 scripts/architecture-guard.py` 通过。