### PR TITLE
feat(model): 增加运行时凭据扩展接口

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/settings.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/settings.rs
@@ -271,13 +271,16 @@ pub async fn reveal_model_api_key(id: String) -> Result<Option<String>, String> 
 
 /// 增或改一条模型(按 id)。前端负责生成稳定 id。
 #[tauri::command]
-pub async fn save_model(model: SavedModel) -> Result<(), String> {
+pub async fn save_model(model: SavedModel, pool: State<'_, EnginePool>) -> Result<(), String> {
+    let model_id = model.id.clone();
     let mut prefs = UserPrefs::load();
     let old = prefs.model_by_id(&model.id).cloned();
     let model = apply_model_credential(model, old.as_ref())
         .map_err(|e| sanitize_command_error("save_model", e))?;
     prefs.upsert_model(model);
-    prefs.save().map_err(|e| format!("save_model: {e:?}"))
+    prefs.save().map_err(|e| format!("save_model: {e:?}"))?;
+    pool.mark_model_updated(&model_id);
+    Ok(())
 }
 
 /// 删一条模型。至少保留一条;删到当前 active 会自动回退列表首条。

--- a/pinvou3-app/src-tauri/src/app/commands/settings.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/settings.rs
@@ -124,6 +124,8 @@ pub struct EffectiveModelConfig {
     pub provider_kind: Option<String>,
     pub vendor: Option<String>,
     pub endpoint_mode: Option<String>,
+    pub credential_mode: crate::features::assistant::runtime_model::ModelCredentialMode,
+    pub requires_user_api_key: bool,
     /// 被环境变量覆盖的字段名列表（如 `["model", "base_url"]`）。
     /// 空列表表示全部走 settings.json，用户修改会生效。
     pub env_overrides: Vec<String>,
@@ -171,6 +173,9 @@ pub async fn get_effective_model_config(
         .map(|model| model.preset)
         .unwrap_or_default()
         .as_str();
+    let credential_mode = pool.credential_mode_for(effective.as_ref(), bridge.api_key_required());
+    let requires_user_api_key = credential_mode
+        == crate::features::assistant::runtime_model::ModelCredentialMode::UserManaged;
     Ok(EffectiveModelConfig {
         preset: preset.to_string(),
         model: bridge.model(),
@@ -196,6 +201,8 @@ pub async fn get_effective_model_config(
         endpoint_mode: effective
             .as_ref()
             .and_then(|model| model.endpoint_mode.clone()),
+        credential_mode,
+        requires_user_api_key,
         env_overrides,
     })
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -13,9 +13,9 @@
 //! 池本身是 Tauri State;`commands.rs` 里的 chat / cancel / submit_user_input 等都带
 //! `session_id` 路由到对应 engine。
 //!
-//! 并发说明:`entries` 用 `tokio::Mutex`,`get_or_spawn` 全程持锁(spawn 很快,只建
-//! channel + spawn task,无网络),从根上避免「同 session 并发 spawn 两个 engine」的
-//! TOCTOU。不同 session 的发送只在各自首次 spawn 的瞬间串行,spawn 完即各自并发跑。
+//! 并发说明:运行时模型准备可能访问外部凭据服务,不能占用全局 `entries` 锁。每个
+//! session 先通过独立 runtime lock 串行准备/比较/rebuild,再短暂持有 `entries` 完成
+//! 本地 spawn,从根上避免同 session 双引擎,也不让慢凭据服务阻塞其他 session。
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -42,6 +42,10 @@ use crate::features::assistant::engine::{
     AppEngine, EngineTurnSignal, TranscriptOperation, TurnLifecycle, TurnReservation,
 };
 use crate::features::assistant::platform::bridge::Pinvou3Bridge;
+use crate::features::assistant::runtime_model::{
+    ModelCredentialMode, PassthroughRuntimeModelProvider, PreparedRuntimeModel,
+    RuntimeModelProvider, RuntimeModelRequest,
+};
 use crate::features::sessions::{transcript_revision, ScheduledRunProfile, SessionStore};
 use crate::platform::prefs::{SavedModel, UserPrefs};
 
@@ -214,6 +218,8 @@ struct EngineEntry {
     engine: AppEngine,
     /// 该 engine 的 event forwarder,evict 时 abort,避免僵尸 task 继续 emit。
     forwarder: JoinHandle<()>,
+    /// 创建该 engine 时实际使用的运行时模型和非敏感凭据版本。
+    runtime_model: PreparedRuntimeModel,
 }
 
 pub type EngineToolFactory =
@@ -234,6 +240,7 @@ fn should_sync_session(_is_scheduled: bool, _has_messages: bool) -> bool {
 #[derive(Clone)]
 pub struct EnginePool {
     entries: Arc<Mutex<HashMap<String, EngineEntry>>>,
+    runtime_model_locks: SessionTurnLocks,
     turn_locks: SessionTurnLocks,
     turn_lifecycles: SessionTurnLifecycles,
     shell_managers: SessionShellManagers,
@@ -241,6 +248,7 @@ pub struct EnginePool {
     store: SessionStore,
     tool_factory: EngineToolFactory,
     tool_policy: ToolPolicy,
+    runtime_model_provider: Arc<dyn RuntimeModelProvider>,
     /// 所有 session 共享一份已 boot 的 bridge(boot 会写盘 / 设 env,只能一次)。
     /// commands 读 model / workspace 也走这里。
     pub bridge: Pinvou3Bridge,
@@ -264,9 +272,26 @@ impl EnginePool {
         tool_factory: EngineToolFactory,
         tool_policy: ToolPolicy,
     ) -> Result<Self> {
+        Self::new_with_runtime_model_provider(
+            app,
+            store,
+            tool_factory,
+            tool_policy,
+            Arc::new(PassthroughRuntimeModelProvider),
+        )
+    }
+
+    pub fn new_with_runtime_model_provider(
+        app: AppHandle,
+        store: SessionStore,
+        tool_factory: EngineToolFactory,
+        tool_policy: ToolPolicy,
+        runtime_model_provider: Arc<dyn RuntimeModelProvider>,
+    ) -> Result<Self> {
         let bridge = Pinvou3Bridge::boot()?;
         Ok(Self {
             entries: Arc::new(Mutex::new(HashMap::new())),
+            runtime_model_locks: SessionTurnLocks::default(),
             turn_locks: SessionTurnLocks::default(),
             turn_lifecycles: SessionTurnLifecycles::default(),
             shell_managers: SessionShellManagers::default(),
@@ -274,8 +299,23 @@ impl EnginePool {
             store,
             tool_factory,
             tool_policy,
+            runtime_model_provider,
             bridge,
         })
+    }
+
+    pub(crate) fn credential_mode_for(
+        &self,
+        model: Option<&SavedModel>,
+        user_api_key_required: bool,
+    ) -> ModelCredentialMode {
+        match model {
+            Some(model) => self
+                .runtime_model_provider
+                .credential_mode(model, user_api_key_required),
+            None if user_api_key_required => ModelCredentialMode::UserManaged,
+            None => ModelCredentialMode::None,
+        }
     }
 
     pub fn compute_disallowed_tools(&self) -> Vec<String> {
@@ -288,12 +328,75 @@ impl EnginePool {
         tools
     }
 
-    /// 为 spawn 构造该 session 的 bridge:从 disk 读最新 prefs(模型列表/默认可能刚被
-    /// GUI 改过),再按该 session 的显式 model_id 注入 session_model(没绑定则回退全局
-    /// active)。绑定指向已删模型时 `model_by_id` 返回 None,自然回退 active。
-    /// 这是「热切换不重启」的落点:改模型只写 disk + evict,下次 spawn 经此读到新配置。
+    /// 为独立调用构造该 session 的 bridge。与 EnginePool lazy spawn 共用同一套
+    /// runtime provider，保证检阅等旁路入口也不会绕过运行时凭据准备。
     pub(crate) async fn fresh_bridge_for(&self, session_id: &str) -> Result<Pinvou3Bridge> {
         self.fresh_bridge_for_policy(session_id, false).await
+    }
+
+    async fn prepare_runtime_model(
+        &self,
+        session_id: &str,
+        scheduled_unattended: bool,
+    ) -> Result<(Pinvou3Bridge, PreparedRuntimeModel, bool)> {
+        let mut bridge = self.bridge.clone();
+        bridge.prefs = UserPrefs::load();
+        let scheduled_profile = self.store.scheduled_profile(session_id);
+        let interactive_model_override = self.store.session_model_override(session_id);
+        let pins_scheduled_model = scheduled_profile.is_some()
+            && (scheduled_unattended || interactive_model_override.is_none());
+        bridge.session_model = resolve_spawn_model(
+            &bridge.prefs.advanced.saved_models,
+            scheduled_profile.as_ref(),
+            interactive_model_override.as_deref(),
+            scheduled_unattended,
+        )?;
+        let selected = bridge
+            .effective_model_owned()
+            .context("No effective model is available for runtime preparation")?;
+        let selected_id = selected.id.clone();
+        let prepared = self
+            .runtime_model_provider
+            .prepare(RuntimeModelRequest {
+                session_id: session_id.to_string(),
+                model: selected,
+                scheduled_unattended,
+            })
+            .await?;
+        if prepared.model.id != selected_id {
+            bail!(
+                "Runtime model provider changed model identity from '{}' to '{}'",
+                selected_id,
+                prepared.model.id
+            );
+        }
+        Ok((bridge, prepared, pins_scheduled_model))
+    }
+
+    async fn finalize_runtime_bridge(
+        &self,
+        mut bridge: Pinvou3Bridge,
+        prepared: &PreparedRuntimeModel,
+        pins_scheduled_model: bool,
+    ) -> Pinvou3Bridge {
+        bridge.session_model = Some(prepared.model.clone());
+        // 本地 vLLM:发请求的 model 名以 vLLM 实际 served name 为准(探测 /v1/models),
+        // 免去写死 qwen36_35b_256k 与 --served-model-name 不一致的 model_not_found。
+        // 探测失败(vLLM 没起)保持配置值;云端 provider 不探测。
+        if bridge.provider() == "vllm" {
+            let (served, max_len) =
+                crate::features::monitor::probe_vllm_model_info(&bridge.base_url()).await;
+            if let Some(served) = served.filter(|_| !pins_scheduled_model) {
+                if let Some(mut model) = bridge.effective_model_owned() {
+                    if model.model != served {
+                        model.model = served;
+                        bridge.session_model = Some(model);
+                    }
+                }
+            }
+            bridge.probed_context_tokens = max_len;
+        }
+        bridge
     }
 
     async fn fresh_bridge_for_policy(
@@ -301,37 +404,12 @@ impl EnginePool {
         session_id: &str,
         scheduled_unattended: bool,
     ) -> Result<Pinvou3Bridge> {
-        let mut b = self.bridge.clone();
-        b.prefs = UserPrefs::load();
-        let scheduled_profile = self.store.scheduled_profile(session_id);
-        let interactive_model_override = self.store.session_model_override(session_id);
-        let pins_scheduled_model = scheduled_profile.is_some()
-            && (scheduled_unattended || interactive_model_override.is_none());
-        b.session_model = resolve_spawn_model(
-            &b.prefs.advanced.saved_models,
-            scheduled_profile.as_ref(),
-            interactive_model_override.as_deref(),
-            scheduled_unattended,
-        )?;
-        // 本地 vLLM:发请求的 model 名以 vLLM 实际 served name 为准(探测 /v1/models),
-        // 免去写死 qwen36_35b_256k 与 --served-model-name 不一致的 model_not_found。
-        // 探测失败(vLLM 没起)保持配置值;云端 provider 不探测。
-        if b.provider() == "vllm" {
-            let (served, max_len) =
-                crate::features::monitor::probe_vllm_model_info(&b.base_url()).await;
-            if let Some(served) = served.filter(|_| !pins_scheduled_model) {
-                if let Some(mut m) = b.effective_model_owned() {
-                    if m.model != served {
-                        m.model = served;
-                        b.session_model = Some(m);
-                    }
-                }
-            }
-            // 窗口探测:填给 bridge,build_engine_config 据此填 active_route_limits.context_tokens
-            // + 按真实窗口推导压缩阈值。探测失败保持 None → 名字 hint 老路。
-            b.probed_context_tokens = max_len;
-        }
-        Ok(b)
+        let (bridge, prepared, pins_scheduled_model) = self
+            .prepare_runtime_model(session_id, scheduled_unattended)
+            .await?;
+        Ok(self
+            .finalize_runtime_bridge(bridge, &prepared, pins_scheduled_model)
+            .await)
     }
 
     /// 取该 session 的 engine,没有就 spawn 一个。spawn 后若该 session 有磁盘历史
@@ -349,16 +427,29 @@ impl EnginePool {
         session_id: &str,
         scheduled_unattended: bool,
     ) -> Result<AppEngine> {
-        let mut entries = self.entries.lock().await;
-        if let Some(entry) = entries.get(session_id) {
-            return Ok(entry.engine.clone());
+        let runtime_lock = self.runtime_model_locks.for_session(session_id).await;
+        let _runtime = runtime_lock.lock().await;
+        let (bridge, prepared, pins_scheduled_model) = self
+            .prepare_runtime_model(session_id, scheduled_unattended)
+            .await?;
+
+        let stale = {
+            let mut entries = self.entries.lock().await;
+            if let Some(entry) = entries.get(session_id) {
+                if !prepared.requires_rebuild_from(&entry.runtime_model) {
+                    return Ok(entry.engine.clone());
+                }
+            }
+            entries.remove(session_id)
+        };
+        if let Some(entry) = stale {
+            self.reclaim_engine_entry(session_id, entry).await;
         }
 
         let is_scheduled = self.store.scheduled_profile(session_id).is_some();
-
         let bridge = self
-            .fresh_bridge_for_policy(session_id, scheduled_unattended)
-            .await?;
+            .finalize_runtime_bridge(bridge, &prepared, pins_scheduled_model)
+            .await;
         let shell_workspace = self
             .store
             .scheduled_profile(session_id)
@@ -410,11 +501,12 @@ impl EnginePool {
             }
         }
 
-        entries.insert(
+        self.entries.lock().await.insert(
             session_id.to_string(),
             EngineEntry {
                 engine: engine.clone(),
                 forwarder,
+                runtime_model: prepared,
             },
         );
         Ok(engine)
@@ -476,32 +568,40 @@ impl EnginePool {
         result
     }
 
+    async fn reclaim_engine_entry(&self, session_id: &str, entry: EngineEntry) {
+        // Stop the producer before admission fallback awaits disk I/O.
+        // An in-flight SessionUpdated save is serialized with the fallback
+        // by SessionStore's mutation gate; no later delta/tool event can
+        // overtake the authoritative transcript_committed + done pair.
+        let EngineEntry {
+            engine, forwarder, ..
+        } = entry;
+        let reclaimed = quiesce_engine_before_reclaim(
+            || engine.cancel_current(),
+            || async move {
+                forwarder.abort();
+                let _ = forwarder.await;
+            },
+            || engine.finish_reclaimed_turn(&self.app, &self.store, session_id),
+        )
+        .await;
+        if reclaimed {
+            log::warn!(
+                "[engine_pool] emitted interrupted terminal before reclaim sid={}",
+                session_id
+            );
+            crate::features::assistant::timing::finish_turn(session_id, "Interrupted", None);
+        }
+        if let Err(e) = engine.handle.send(Op::Shutdown).await {
+            eprintln!("[engine_pool] shutdown {session_id} failed: {e:?}");
+        }
+    }
+
     async fn evict_locked(&self, session_id: &str) {
+        let runtime_lock = self.runtime_model_locks.for_session(session_id).await;
+        let _runtime = runtime_lock.lock().await;
         if let Some(entry) = self.entries.lock().await.remove(session_id) {
-            // Stop the producer before admission fallback awaits disk I/O.
-            // An in-flight SessionUpdated save is serialized with the fallback
-            // by SessionStore's mutation gate; no later delta/tool event can
-            // overtake the authoritative transcript_committed + done pair.
-            let EngineEntry { engine, forwarder } = entry;
-            let reclaimed = quiesce_engine_before_reclaim(
-                || engine.cancel_current(),
-                || async move {
-                    forwarder.abort();
-                    let _ = forwarder.await;
-                },
-                || engine.finish_reclaimed_turn(&self.app, &self.store, session_id),
-            )
-            .await;
-            if reclaimed {
-                log::warn!(
-                    "[engine_pool] emitted interrupted terminal before reclaim sid={}",
-                    session_id
-                );
-                crate::features::assistant::timing::finish_turn(session_id, "Interrupted", None);
-            }
-            if let Err(e) = engine.handle.send(Op::Shutdown).await {
-                eprintln!("[engine_pool] shutdown {session_id} failed: {e:?}");
-            }
+            self.reclaim_engine_entry(session_id, entry).await;
         } else if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
             // A caller can reserve before lazy spawn. Reclaim that Reserved
             // phase without fabricating chat:done; the guard's eventual send

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -218,8 +218,45 @@ struct EngineEntry {
     engine: AppEngine,
     /// 该 engine 的 event forwarder,evict 时 abort,避免僵尸 task 继续 emit。
     forwarder: JoinHandle<()>,
-    /// 创建该 engine 时实际使用的运行时模型和非敏感凭据版本。
-    runtime_model: PreparedRuntimeModel,
+    /// 创建该 engine 时实际使用的运行时模型、提供器版本和本地模型修订号。
+    runtime_model: PreparedRuntimeState,
+}
+
+#[derive(Clone, Default)]
+struct ModelUpdateRevisions {
+    revisions: Arc<SyncMutex<HashMap<String, u64>>>,
+}
+
+impl ModelUpdateRevisions {
+    fn current(&self, model_id: &str) -> u64 {
+        self.revisions.lock().get(model_id).copied().unwrap_or(0)
+    }
+
+    fn bump(&self, model_id: &str) -> u64 {
+        let mut revisions = self.revisions.lock();
+        let revision = revisions.entry(model_id.to_string()).or_default();
+        *revision = revision.saturating_add(1);
+        *revision
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct PreparedRuntimeState {
+    prepared: PreparedRuntimeModel,
+    model_update_revision: u64,
+}
+
+impl PreparedRuntimeState {
+    fn new(prepared: PreparedRuntimeModel, model_update_revision: u64) -> Self {
+        Self {
+            prepared,
+            model_update_revision,
+        }
+    }
+
+    fn requires_rebuild_from(&self, previous: &Self) -> bool {
+        self != previous
+    }
 }
 
 pub type EngineToolFactory =
@@ -241,6 +278,7 @@ fn should_sync_session(_is_scheduled: bool, _has_messages: bool) -> bool {
 pub struct EnginePool {
     entries: Arc<Mutex<HashMap<String, EngineEntry>>>,
     runtime_model_locks: SessionTurnLocks,
+    model_update_revisions: ModelUpdateRevisions,
     turn_locks: SessionTurnLocks,
     turn_lifecycles: SessionTurnLifecycles,
     shell_managers: SessionShellManagers,
@@ -292,6 +330,7 @@ impl EnginePool {
         Ok(Self {
             entries: Arc::new(Mutex::new(HashMap::new())),
             runtime_model_locks: SessionTurnLocks::default(),
+            model_update_revisions: ModelUpdateRevisions::default(),
             turn_locks: SessionTurnLocks::default(),
             turn_lifecycles: SessionTurnLifecycles::default(),
             shell_managers: SessionShellManagers::default(),
@@ -316,6 +355,12 @@ impl EnginePool {
             None if user_api_key_required => ModelCredentialMode::UserManaged,
             None => ModelCredentialMode::None,
         }
+    }
+
+    /// 模型配置或用户托管凭据保存成功后调用。只递增非敏感内存修订号；
+    /// 已在生成的引擎不被立即打断，下次 turn 会在发送前安全回收并重建。
+    pub(crate) fn mark_model_updated(&self, model_id: &str) {
+        self.model_update_revisions.bump(model_id);
     }
 
     pub fn compute_disallowed_tools(&self) -> Vec<String> {
@@ -380,6 +425,7 @@ impl EnginePool {
         pins_scheduled_model: bool,
     ) -> Pinvou3Bridge {
         bridge.session_model = Some(prepared.model.clone());
+        bridge.runtime_model_credential = prepared.credential.clone();
         // 本地 vLLM:发请求的 model 名以 vLLM 实际 served name 为准(探测 /v1/models),
         // 免去写死 qwen36_35b_256k 与 --served-model-name 不一致的 model_not_found。
         // 探测失败(vLLM 没起)保持配置值;云端 provider 不探测。
@@ -432,6 +478,8 @@ impl EnginePool {
         let (bridge, prepared, pins_scheduled_model) = self
             .prepare_runtime_model(session_id, scheduled_unattended)
             .await?;
+        let model_update_revision = self.model_update_revisions.current(&prepared.model.id);
+        let prepared = PreparedRuntimeState::new(prepared, model_update_revision);
 
         let stale = {
             let mut entries = self.entries.lock().await;
@@ -448,7 +496,7 @@ impl EnginePool {
 
         let is_scheduled = self.store.scheduled_profile(session_id).is_some();
         let bridge = self
-            .finalize_runtime_bridge(bridge, &prepared, pins_scheduled_model)
+            .finalize_runtime_bridge(bridge, &prepared.prepared, pins_scheduled_model)
             .await;
         let shell_workspace = self
             .store
@@ -1134,9 +1182,11 @@ mod scheduled_model_tests {
     use super::{
         delete_chat_session_with_gate, delete_scheduled_run_with_gate,
         quiesce_engine_before_reclaim, resolve_scheduled_model, resolve_spawn_model,
-        scheduled_profile_after_turn_gate, should_sync_session, ScheduledUnattendedGuard,
-        SessionShellManagers, SessionTurnLifecycles, SessionTurnLocks,
+        scheduled_profile_after_turn_gate, should_sync_session, ModelUpdateRevisions,
+        PreparedRuntimeState, ScheduledUnattendedGuard, SessionShellManagers,
+        SessionTurnLifecycles, SessionTurnLocks,
     };
+    use crate::features::assistant::runtime_model::PreparedRuntimeModel;
     use crate::features::sessions::{ScheduledRunMode, ScheduledRunProfile, SessionStore};
     use crate::platform::credential_store::{CredentialEditAction, CredentialState};
     use crate::platform::prefs::{ModelPreset, SavedModel};
@@ -1259,6 +1309,31 @@ mod scheduled_model_tests {
         );
         managers.remove("session-1");
         assert!(managers.get("session-1").is_none());
+    }
+
+    #[test]
+    fn saved_model_update_revision_forces_next_turn_rebuild() {
+        let revisions = ModelUpdateRevisions::default();
+        let prepared = PreparedRuntimeModel::unchanged(model("model-1", "wire-model"));
+        let previous = PreparedRuntimeState::new(prepared.clone(), revisions.current("model-1"));
+
+        revisions.bump("model-1");
+        let after_save = PreparedRuntimeState::new(prepared, revisions.current("model-1"));
+
+        assert!(after_save.requires_rebuild_from(&previous));
+    }
+
+    #[tokio::test]
+    async fn runtime_preparation_locks_are_isolated_between_sessions() {
+        let locks = SessionTurnLocks::default();
+        let first = locks.for_session("session-1").await;
+        let second = locks.for_session("session-2").await;
+        assert!(!Arc::ptr_eq(&first, &second));
+
+        let _first_guard = first.lock().await;
+        let _second_guard = tokio::time::timeout(std::time::Duration::from_secs(1), second.lock())
+            .await
+            .expect("a slow provider for one session must not block another session");
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/mod.rs
@@ -3,5 +3,6 @@ pub mod engine;
 pub(crate) mod engine_pool;
 pub(crate) mod harness;
 pub mod platform;
+pub(crate) mod runtime_model;
 pub(crate) mod shell_output;
 pub(crate) mod timing;

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -34,6 +34,7 @@ use deepseek_tui::tui::approval::ApprovalMode;
 
 use self::bundle::{Pinvou3Bundle, INSTRUCTIONS_MD};
 use self::prefs::{ModelPreset, SavedModel, UserPrefs};
+use crate::features::assistant::runtime_model::RuntimeModelCredential;
 use crate::platform::credential_store::{CredentialStore, SystemCredentialStore};
 
 /// Qwen3.6 在 vLLM 里是 passthrough 字符串（不走 alias）。
@@ -101,6 +102,9 @@ pub struct Pinvou3Bridge {
     /// 本 engine 绑定的 session 锁定模型(per-session 不同模型)。None = 用 prefs 全局
     /// active。EnginePool spawn 时按该 session 的 model_id 注入(见 `with_session_model`)。
     pub session_model: Option<SavedModel>,
+    /// RuntimeModelProvider 为本次引擎准备的内存凭据。Some 时是最终值，不能再被
+    /// 环境变量或本地凭据库覆盖；Debug 由包装类型强制脱敏。
+    pub runtime_model_credential: Option<RuntimeModelCredential>,
     /// 本地 vLLM `/v1/models` 探测到的 `max_model_len`(上下文窗口)。EnginePool spawn
     /// 时由 `probe_vllm_model_info` 注入。Some → 与 SavedModel 声明取较小值后填入
     /// active_route_limits，并与 output profile 一起推导压缩阈值。
@@ -181,6 +185,7 @@ impl Pinvou3Bridge {
             bundle,
             workspace: paths::user_home_dir(),
             session_model: None,
+            runtime_model_credential: None,
             probed_context_tokens: None,
         };
         this.wire_max_output_tokens_env();
@@ -460,6 +465,9 @@ impl Pinvou3Bridge {
 
     /// 当前 active api_key（传给底座 `DtConfig.api_key`）。
     pub fn api_key(&self) -> String {
+        if let Some(credential) = &self.runtime_model_credential {
+            return credential.expose_api_key().to_string();
+        }
         if let Ok(v) = std::env::var("DEEPSEEK_API_KEY") {
             if !v.trim().is_empty() {
                 return v;
@@ -1312,6 +1320,7 @@ mod tests {
             bundle: Pinvou3Bundle::paths(),
             workspace: std::env::temp_dir(),
             session_model: None,
+            runtime_model_credential: None,
             probed_context_tokens: None,
         }
     }
@@ -2498,6 +2507,38 @@ mod tests {
         assert_eq!(bridge.provider(), "env-provider");
         assert_eq!(bridge.base_url(), "http://env:8000/v1");
         assert_eq!(bridge.api_key(), "env-key");
+    }
+
+    #[test]
+    fn runtime_credential_is_final_and_reaches_model_client_config() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "runtime-model",
+            "https://api.openai.com/v1",
+            "saved-key",
+        );
+        std::env::set_var("DEEPSEEK_API_KEY", "env-key");
+        bridge.runtime_model_credential =
+            Some(RuntimeModelCredential::api_key("runtime-key").expect("runtime credential"));
+
+        assert_eq!(bridge.api_key(), "runtime-key");
+        let config = bridge.build_dt_config();
+        assert_eq!(config.api_key.as_deref(), Some("runtime-key"));
+        assert_eq!(
+            config
+                .providers
+                .as_ref()
+                .and_then(|providers| providers.openai.api_key.as_deref()),
+            Some("runtime-key")
+        );
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/runtime_model.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/runtime_model.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::Serialize;
+use std::fmt;
 
 use crate::platform::prefs::SavedModel;
 
@@ -21,6 +22,35 @@ pub struct RuntimeModelRequest {
     pub scheduled_unattended: bool,
 }
 
+/// 运行时提供器准备的敏感模型凭据。
+///
+/// 凭据只保存在内存中，不参与序列化；`Debug` 固定脱敏，避免 bridge 或测试日志
+/// 意外输出明文。存在时它是本次引擎配置的最终凭据，优先于环境变量和本地凭据库。
+#[derive(Clone, PartialEq, Eq)]
+pub struct RuntimeModelCredential {
+    api_key: String,
+}
+
+impl RuntimeModelCredential {
+    pub fn api_key(api_key: impl Into<String>) -> Result<Self> {
+        let api_key = api_key.into();
+        if api_key.trim().is_empty() {
+            anyhow::bail!("runtime model API key must not be empty");
+        }
+        Ok(Self { api_key })
+    }
+
+    pub(crate) fn expose_api_key(&self) -> &str {
+        &self.api_key
+    }
+}
+
+impl fmt::Debug for RuntimeModelCredential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RuntimeModelCredential([REDACTED])")
+    }
+}
+
 /// 已完成运行时准备的模型。
 ///
 /// `revision` 只能包含非敏感版本标识（如令牌记录 ID 或更新时间），不得包含 API Key。
@@ -28,6 +58,7 @@ pub struct RuntimeModelRequest {
 #[derive(Clone, PartialEq, Eq)]
 pub struct PreparedRuntimeModel {
     pub model: SavedModel,
+    pub credential: Option<RuntimeModelCredential>,
     pub revision: Option<String>,
 }
 
@@ -35,6 +66,7 @@ impl PreparedRuntimeModel {
     pub fn unchanged(model: SavedModel) -> Self {
         Self {
             model,
+            credential: None,
             revision: None,
         }
     }
@@ -79,7 +111,7 @@ impl RuntimeModelProvider for PassthroughRuntimeModelProvider {
 mod tests {
     use super::{
         ModelCredentialMode, PassthroughRuntimeModelProvider, PreparedRuntimeModel,
-        RuntimeModelProvider, RuntimeModelRequest,
+        RuntimeModelCredential, RuntimeModelProvider, RuntimeModelRequest,
     };
     use crate::platform::credential_store::{CredentialEditAction, CredentialState};
     use crate::platform::prefs::{ModelPreset, SavedModel};
@@ -138,18 +170,43 @@ mod tests {
     }
 
     #[test]
+    fn runtime_credential_debug_output_is_redacted() {
+        let credential =
+            RuntimeModelCredential::api_key("runtime-secret").expect("runtime credential");
+        let rendered = format!("{credential:?}");
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(!rendered.contains("runtime-secret"));
+        assert!(RuntimeModelCredential::api_key("  ").is_err());
+    }
+
+    #[test]
     fn revision_change_requires_engine_rebuild() {
         let previous = PreparedRuntimeModel {
             model: model(),
+            credential: Some(
+                RuntimeModelCredential::api_key("runtime-secret").expect("runtime credential"),
+            ),
             revision: Some("revision-1".to_string()),
         };
         let unchanged = previous.clone();
         let rotated = PreparedRuntimeModel {
             model: model(),
+            credential: Some(
+                RuntimeModelCredential::api_key("runtime-secret").expect("runtime credential"),
+            ),
             revision: Some("revision-2".to_string()),
+        };
+        let rotated_credential = PreparedRuntimeModel {
+            model: model(),
+            credential: Some(
+                RuntimeModelCredential::api_key("runtime-secret-2")
+                    .expect("rotated runtime credential"),
+            ),
+            revision: Some("revision-1".to_string()),
         };
 
         assert!(!unchanged.requires_rebuild_from(&previous));
         assert!(rotated.requires_rebuild_from(&previous));
+        assert!(rotated_credential.requires_rebuild_from(&previous));
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/runtime_model.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/runtime_model.rs
@@ -1,0 +1,155 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::Serialize;
+
+use crate::platform::prefs::SavedModel;
+
+/// 模型凭据由谁负责提供。前端只消费这一语义，不需要认识具体模型或认证后端。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelCredentialMode {
+    None,
+    UserManaged,
+    BackendManaged,
+}
+
+/// 引擎创建或复用前交给运行时模型提供器的上下文。
+#[derive(Clone)]
+pub struct RuntimeModelRequest {
+    pub session_id: String,
+    pub model: SavedModel,
+    pub scheduled_unattended: bool,
+}
+
+/// 已完成运行时准备的模型。
+///
+/// `revision` 只能包含非敏感版本标识（如令牌记录 ID 或更新时间），不得包含 API Key。
+/// 当同一会话的 revision 或模型配置变化时，EnginePool 会回收旧引擎并使用新配置重建。
+#[derive(Clone, PartialEq, Eq)]
+pub struct PreparedRuntimeModel {
+    pub model: SavedModel,
+    pub revision: Option<String>,
+}
+
+impl PreparedRuntimeModel {
+    pub fn unchanged(model: SavedModel) -> Self {
+        Self {
+            model,
+            revision: None,
+        }
+    }
+
+    /// 判断当前准备结果是否要求替换已有引擎。
+    ///
+    /// 比较覆盖模型路由、运行时凭据和显式 revision；调用方无需读取或记录密钥。
+    pub fn requires_rebuild_from(&self, previous: &Self) -> bool {
+        self != previous
+    }
+}
+
+/// Community 默认实现无需外部服务；Official/Enterprise 可在私有层实现后台托管凭据。
+#[async_trait]
+pub trait RuntimeModelProvider: Send + Sync {
+    fn credential_mode(
+        &self,
+        _model: &SavedModel,
+        user_api_key_required: bool,
+    ) -> ModelCredentialMode {
+        if user_api_key_required {
+            ModelCredentialMode::UserManaged
+        } else {
+            ModelCredentialMode::None
+        }
+    }
+
+    async fn prepare(&self, request: RuntimeModelRequest) -> Result<PreparedRuntimeModel>;
+}
+
+#[derive(Debug, Default)]
+pub struct PassthroughRuntimeModelProvider;
+
+#[async_trait]
+impl RuntimeModelProvider for PassthroughRuntimeModelProvider {
+    async fn prepare(&self, request: RuntimeModelRequest) -> Result<PreparedRuntimeModel> {
+        Ok(PreparedRuntimeModel::unchanged(request.model))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ModelCredentialMode, PassthroughRuntimeModelProvider, PreparedRuntimeModel,
+        RuntimeModelProvider, RuntimeModelRequest,
+    };
+    use crate::platform::credential_store::{CredentialEditAction, CredentialState};
+    use crate::platform::prefs::{ModelPreset, SavedModel};
+
+    fn model() -> SavedModel {
+        SavedModel {
+            id: "model-1".to_string(),
+            name: "Model 1".to_string(),
+            preset: ModelPreset::OpenaiCompatible,
+            context_window_tokens: None,
+            max_output_tokens: None,
+            model: "model-1".to_string(),
+            base_url: "https://example.invalid/v1".to_string(),
+            provider_kind: None,
+            vendor: None,
+            endpoint_mode: None,
+            api_key: String::new(),
+            credential_ref: None,
+            credential_state: CredentialState::Missing,
+            has_secret: false,
+            credential_action: None::<CredentialEditAction>,
+        }
+    }
+
+    #[tokio::test]
+    async fn passthrough_provider_preserves_model_without_private_dependencies() {
+        let provider = PassthroughRuntimeModelProvider;
+        let prepared = provider
+            .prepare(RuntimeModelRequest {
+                session_id: "session-1".to_string(),
+                model: model(),
+                scheduled_unattended: false,
+            })
+            .await
+            .expect("prepare model");
+
+        assert_eq!(prepared.model.id, "model-1");
+        assert_eq!(prepared.revision, None);
+        assert_eq!(
+            provider.credential_mode(&prepared.model, true),
+            ModelCredentialMode::UserManaged
+        );
+        assert_eq!(
+            provider.credential_mode(&prepared.model, false),
+            ModelCredentialMode::None
+        );
+    }
+
+    #[test]
+    fn credential_modes_have_stable_wire_names() {
+        assert_eq!(
+            serde_json::to_string(&ModelCredentialMode::BackendManaged)
+                .expect("serialize credential mode"),
+            "\"backend_managed\""
+        );
+    }
+
+    #[test]
+    fn revision_change_requires_engine_rebuild() {
+        let previous = PreparedRuntimeModel {
+            model: model(),
+            revision: Some("revision-1".to_string()),
+        };
+        let unchanged = previous.clone();
+        let rotated = PreparedRuntimeModel {
+            model: model(),
+            revision: Some("revision-2".to_string()),
+        };
+
+        assert!(!unchanged.requires_rebuild_from(&previous));
+        assert!(rotated.requires_rebuild_from(&previous));
+    }
+}

--- a/pinvou3-app/src/hooks/useBridge.js
+++ b/pinvou3-app/src/hooks/useBridge.js
@@ -58,7 +58,10 @@ function shouldShowApiKeyGate(bs, currentView, bridgeAvailable) {
   const config = bs && bs.effectiveModelConfig;
   const missingCredential = config
     && (config.credential_state === 'missing' || config.credential_state === 'unavailable');
-  return !!(bridgeAvailable && inChat && missingCredential && !isLocalModel(config));
+  // 旧后端没有返回 requires_user_api_key 时保持原有安全门控；显式 false 表示凭据由
+  // 运行时或无鉴权端点负责，前端不能要求用户手工填写 API Key。
+  const requiresUserApiKey = config && config.requires_user_api_key !== false;
+  return !!(bridgeAvailable && inChat && missingCredential && requiresUserApiKey && !isLocalModel(config));
 }
 
 export {

--- a/pinvou3-app/tests/api_key_gate_logic.test.js
+++ b/pinvou3-app/tests/api_key_gate_logic.test.js
@@ -52,6 +52,22 @@ assert.strictEqual(isLocalModel({ preset: 'openai_compatible', base_url: 'https:
 assert.strictEqual(shouldShowApiKeyGate(state('missing'), 'chat', true), true);
 assert.strictEqual(shouldShowApiKeyGate(state('unavailable'), 'chat', true), true);
 assert.strictEqual(shouldShowApiKeyGate(state('configured'), 'chat', true), false);
+assert.strictEqual(
+  shouldShowApiKeyGate(state('missing', {
+    credential_mode: 'backend_managed',
+    requires_user_api_key: false,
+  }), 'chat', true),
+  false,
+  'runtime-managed credentials must not open the user API Key gate',
+);
+assert.strictEqual(
+  shouldShowApiKeyGate(state('unavailable', {
+    credential_mode: 'none',
+    requires_user_api_key: false,
+  }), 'chat', true),
+  false,
+  'no-auth models must not open the user API Key gate',
+);
 assert.strictEqual(shouldShowApiKeyGate(state('missing'), 'settings', true), false);
 assert.strictEqual(shouldShowApiKeyGate(state('missing'), 'chat', false), false);
 assert.strictEqual(


### PR DESCRIPTION
## 概述

为模型引擎增加通用运行时凭据提供器和凭据归属协议，使社区核心可以安全接入无鉴权、用户托管或运行时托管的模型，并为模型配置与凭据轮换建立明确的引擎重建边界。

## 背景

原有 API Key 门控只根据模型地址和本地配置判断。扩展版本如需在引擎创建前动态准备凭据，只能侵入通用引擎池或让前端认识具体认证后端；用户替换已有 Key 后，也无法可靠判断常驻引擎是否仍持有旧凭据。

## 变更

- 新增 `RuntimeModelProvider`、`PreparedRuntimeModel` 和 `ModelCredentialMode` 通用协议，社区版默认使用无外部依赖的透传实现。
- 为运行时 API Key 增加仅驻留内存、禁止空值且 `Debug` 强制脱敏的独立凭据对象；存在时作为本次引擎的最终凭据，不再受环境变量或本地凭据引用覆盖。
- 引擎创建和复用前按会话准备运行时模型；模型配置、运行时凭据或非敏感版本变化时，安全回收旧引擎并重建。
- 模型保存成功后递增非敏感内存修订号，使用户替换已有 Key 时在下一个 turn 重建引擎，同时不立即打断当前生成。
- 运行时准备使用独立的会话锁，避免慢凭据服务占用全局引擎表或阻塞其他会话。
- 有效模型配置向前端暴露凭据归属和是否需要用户填写 API Key，前端保留对旧后端的兼容门控。
- 增加凭据模式序列化、敏感值脱敏、运行时 Key 配置透传、凭据和版本轮换重建、跨会话锁隔离及 API Key 门控回归测试。

## 验证

- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-deps`
- `cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1`：750 passed，12 ignored
- `node pinvou3-app/tests/api_key_gate_logic.test.js`
- `python3 scripts/architecture-guard.py --base-ref origin/main`
- `./scripts/fork-guard.sh --fast`

## 备注

- 默认透传提供器不访问外部服务，社区版现有模型和 API Key 行为保持不变。
- 运行时凭据不序列化、不写入设置文件，日志中的 `Debug` 输出固定脱敏。
- 本 PR 不包含具体认证服务、设备逻辑、内部地址或私有依赖，也未修改 CodeWhale submodule。
