### PR TITLE
fix(security): 替换弱加密原语并修正硬编码 salt 误报命名

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/bundle/dingtalk-skills/dws/scripts/attendance_report_common.py
+++ b/pinvou3-app/src-tauri/resources/common/bundle/dingtalk-skills/dws/scripts/attendance_report_common.py
@@ -1517,7 +1517,8 @@ def download_and_convert_image(
         return None
 
     cache_dir = _ensure_image_cache_dir()
-    url_hash = hashlib.md5(url.encode("utf-8")).hexdigest()
+    # 仅作磁盘缓存文件名，非安全用途；仍用 sha256 避免弱哈希（CodeQL py/weak-sensitive-data-hashing）。
+    url_hash = hashlib.sha256(url.encode("utf-8")).hexdigest()
     local_path = os.path.join(cache_dir, f"{url_hash}.png")
 
     if os.path.exists(local_path) and os.path.getsize(local_path) > 0:

--- a/pinvou3-app/src-tauri/src/features/workflow/workflow_migrate.rs
+++ b/pinvou3-app/src-tauri/src/features/workflow/workflow_migrate.rs
@@ -60,10 +60,10 @@ fn strip_project_prefix(dir_name: &str) -> Option<&str> {
 /// `ppt-20260601-120000-solution_deck` → `wf-20260601-1200-<4hex>`。
 /// 前缀后解析不出合法时间戳 → None（调用方警告跳过）。
 ///
-/// salt：撞名去重用。不同 session 下同名目录推出同 run_id，第二个项目对
-/// `"<dirname>#<salt>"` 重新散列（salt 从 2 起）；salt<=1 用原目录名——
+/// dedup_seq：撞名去重序号。不同 session 下同名目录推出同 run_id，第二个项目对
+/// `"<dirname>#<dedup_seq>"` 重新散列（序号从 2 起）；序号<=1 用原目录名——
 /// 与历史推导完全兼容，同目录续跑永远推出同 id（幂等前提）。
-fn derive_run_id_salted(dir_name: &str, salt: usize) -> Option<String> {
+fn derive_run_id_dedup(dir_name: &str, dedup_seq: usize) -> Option<String> {
     let rest = strip_project_prefix(dir_name)?;
     let date = rest.get(0..8)?;
     let time6 = rest.get(9..15)?;
@@ -74,10 +74,10 @@ fn derive_run_id_salted(dir_name: &str, salt: usize) -> Option<String> {
         return None;
     }
     let hhmm = &time6[..4];
-    let key = if salt <= 1 {
+    let key = if dedup_seq <= 1 {
         dir_name.to_string()
     } else {
-        format!("{dir_name}#{salt}")
+        format!("{dir_name}#{dedup_seq}")
     };
     let id = format!("wf-{date}-{hhmm}-{:04x}", fnv1a64(&key) & 0xffff);
     // 产物必须过统一校验（路径穿越防线同源），过不了宁可跳过
@@ -85,7 +85,7 @@ fn derive_run_id_salted(dir_name: &str, salt: usize) -> Option<String> {
 }
 
 fn derive_run_id(dir_name: &str) -> Option<String> {
-    derive_run_id_salted(dir_name, 1)
+    derive_run_id_dedup(dir_name, 1)
 }
 
 /// 目录名尾段取 scenario：`<前缀><8位日期>-<6位时间>-<scenario>`。
@@ -129,7 +129,7 @@ fn migrate_one(src: &Path, dir_name: &str) -> Result<bool, String> {
         );
         return Ok(false);
     };
-    let mut salt = 1usize;
+    let mut dedup_seq = 1usize;
     loop {
         let occupied = paths::workflow_project_dir(&run_id);
         if !occupied.exists() {
@@ -140,16 +140,16 @@ fn migrate_one(src: &Path, dir_name: &str) -> Result<bool, String> {
         if !paths::workflow_run_dir(&run_id).join("run.json").exists() {
             write_run_meta(&run_id, &occupied, dir_name)?;
         }
-        salt += 1;
-        if salt > 0xffff {
+        dedup_seq += 1;
+        if dedup_seq > 0xffff {
             return Err(format!("run_id 去重耗尽（撞名规模异常）: {dir_name}"));
         }
         eprintln!(
-            "[workflow_migrate] run_id 撞名，去重重推: {} -> {dir_name}#{salt}",
+            "[workflow_migrate] run_id 撞名，去重重推: {} -> {dir_name}#{dedup_seq}",
             src.display()
         );
-        run_id = derive_run_id_salted(dir_name, salt)
-            .ok_or_else(|| format!("去重 run_id 推导失败: {dir_name}#{salt}"))?;
+        run_id = derive_run_id_dedup(dir_name, dedup_seq)
+            .ok_or_else(|| format!("去重 run_id 推导失败: {dir_name}#{dedup_seq}"))?;
     }
     let run_dir = paths::workflow_run_dir(&run_id);
     let target = paths::workflow_project_dir(&run_id);

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1009,7 +1009,12 @@ const FEISHU_STEPS = [
       useEffect(() => { loadBackendState(); }, []);
 
       const beginOAuthRequest = (backendId) => {
-        const requestId = `${Date.now()}-${Math.random()}`;
+        // OAuth 请求关联 ID 需不可预测，避免用 Math.random()（CodeQL js/insecure-randomness）。
+        const randomHex = Array.from(
+          window.crypto.getRandomValues(new Uint8Array(8)),
+          (b) => b.toString(16).padStart(2, '0'),
+        ).join('');
+        const requestId = `${Date.now()}-${randomHex}`;
         oauthRequestRef.current[backendId] = requestId;
         return requestId;
       };


### PR DESCRIPTION
## 概述

修复 3 条 CodeQL 弱加密类告警：OAuth 关联 ID 改用安全随机数、缓存哈希由 MD5 换为 SHA-256、Rust 侧误导性的 `salt` 命名修正为 `dedup_seq`。

## 背景

GitHub Code Scanning 报出 3 条弱加密原语告警，逐条核实结论：

1. `js/insecure-randomness`（high）`ToolStoreView.jsx`：OAuth 安装请求的关联 ID 使用 `Math.random()` 生成。该 ID 用于匹配异步 OAuth 回调与请求，**告警属实**（关联 ID 应不可预测），改用 `window.crypto.getRandomValues`。
2. `py/weak-sensitive-data-hashing`（high）`attendance_report_common.py:1520`：对图片 URL 做 MD5 仅用于本地缓存文件名，**非安全用途（实际为误报）**，但换用 SHA-256 成本极低，顺带消除告警。
3. `rust/hard-coded-cryptographic-value`（critical）`workflow_migrate.rs:88`：被标记的 `salt` 实为 run_id 撞名时的**去重序号**（从 2 起递增参与 FNV 散列），并非密码学盐，**属误报**；但命名确实误导，重命名为 `dedup_seq`（`derive_run_id_salted` → `derive_run_id_dedup`），行为完全不变。

## 变更

- `pinvou3-app/src/features/tools/ToolStoreView.jsx`：`beginOAuthRequest` 用 `crypto.getRandomValues` 生成 16 位十六进制随机段。
- `pinvou3-app/src-tauri/resources/common/bundle/dingtalk-skills/dws/scripts/attendance_report_common.py`：缓存键哈希 MD5 → SHA-256（旧缓存文件自然失效，无副作用）。
- `pinvou3-app/src-tauri/src/features/workflow/workflow_migrate.rs`：`salt` → `dedup_seq` 纯重命名，无行为变化。

## 验证

- `cargo check --lib` 通过（仅存量 warning）。
- `python3 -m py_compile` 通过。
- `node tests/marketplace_oauth_logic.test.js` 通过。