### PR TITLE
fix(ci): 工作流令牌权限与构建脚本命令路径加固

### DIFF
--- a/.github/workflows/arm64-connector-verify.yml
+++ b/.github/workflows/arm64-connector-verify.yml
@@ -19,6 +19,9 @@ on:
       - "pinvou3-app/src-tauri/src/platform/paths.rs"
       - "pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs"
 
+permissions:
+  contents: read
+
 jobs:
   verify-linux-arm64-connectors:
     runs-on: ubuntu-24.04-arm

--- a/pinvou3-app/scripts/tauri/codex-bridge.js
+++ b/pinvou3-app/scripts/tauri/codex-bridge.js
@@ -145,6 +145,13 @@ function checkedSpawn(spawn, command, args, options, label) {
   return result;
 }
 
+// curl/tar 使用 Windows 内置 System32 副本的绝对路径，避免 PATH 劫持
+// （CodeQL js/shell-command-injection-from-environment）。
+function windowsSystemTool(name) {
+  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  return path.join(systemRoot, "System32", name);
+}
+
 function downloadWindowsNode(archivePath, {
   environment,
   spawn,
@@ -153,7 +160,7 @@ function downloadWindowsNode(archivePath, {
   for (const url of WINDOWS_NODE_URLS) {
     fs.rmSync(archivePath, { force: true });
     const result = spawn(
-      "curl.exe",
+      windowsSystemTool("curl.exe"),
       [
         "--fail",
         "--location",
@@ -200,7 +207,7 @@ function prepareWindowsNode(stagingRoot, {
   fs.mkdirSync(extractedRoot, { recursive: true });
   checkedSpawn(
     spawn,
-    "tar.exe",
+    windowsSystemTool("tar.exe"),
     ["-xf", archivePath, "-C", extractedRoot],
     { env: environment, stdio: "inherit" },
     "解压 Windows Node.js Runtime",


### PR DESCRIPTION
## 概述

修复 2 条 CodeQL 告警：`arm64-connector-verify.yml` 补显式 `permissions`（#9），codex-bridge 构建脚本的 `curl.exe`/`tar.exe` 改用 System32 绝对路径（#10）。

## 背景

- **#9 `actions/missing-workflow-permissions`（medium）**：`arm64-connector-verify.yml` 未声明 `permissions`，`GITHUB_TOKEN` 默认拿过宽权限。**告警属实**，该 workflow 只需 checkout，按仓库其它 workflow 的既有做法补 `contents: read`。
- **#10 `js/shell-command-injection-from-environment`（medium）**：`pinvou3-app/scripts/tauri/codex-bridge.js` 以裸命令名 `spawn("curl.exe"/`"tar.exe")`，依赖 PATH 解析，构建机上存在 PATH 劫持的理论风险。该脚本为本地/CI 构建脚本，且下载的 Node 运行时包与 `node.exe` 均有硬编码 SHA256 校验，实际可利用性低；仍按告警改用 `SystemRoot/System32` 绝对路径消除隐患。

## 变更

- `.github/workflows/arm64-connector-verify.yml`：新增 `permissions: contents: read`。
- `pinvou3-app/scripts/tauri/codex-bridge.js`：新增 `windowsSystemTool()`，curl/tar 调用改为 System32 绝对路径。

## 验证

- YAML 语法解析通过。
- `node --check codex-bridge.js` 通过；`node tests/codex_acp_windows_contract.test.js` 通过。
- `codex_acp_windows_runtime_smoke.js` 需在 Windows runner 执行，macOS 本地按预期断言跳过（CI 侧验证）。

## 备注

告警 #10 的 5 条路径中还包含 `npm_execpath`/`ComSpec` 环境变量来源（`web-template.js` 的 `npmInstallInvocation`）。这些是 npm 自身注入的构建环境变量，属本地构建语境下的可接受风险，未做改动；如 CodeQL 复扫后仍报，将按 false positive 说明关闭。