### PR TITLE
build(deps): web-template 升级 react-router-dom 至 7.18.1 修复开放重定向/XSS 漏洞

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,3 +18,8 @@ jobs:
           vulnerability-check: true
           license-check: true
           retry-on-snapshot-warnings: true
+          # GHSA-qwww-vcr4-c8h2 仅影响 RSC/framework mode（server action CSRF）；
+          # 本仓库唯一依赖 react-router 的 web-template 是纯客户端 HashRouter SPA，
+          # 无服务端/RSC/action 端点，该漏洞代码路径不可达。react-router 8.3.0+ 才有
+          # 修复版，但其要求 React >=19.2.7，升级须随 React 19 迁移单独进行。
+          allow-ghsas: 'GHSA-qwww-vcr4-c8h2'

--- a/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
+++ b/pinvou3-app/src-tauri/resources/common/web-template/package-lock.json
@@ -11,7 +11,7 @@
         "chart.js": "^4.4.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",
@@ -813,15 +813,6 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmmirror.com/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1407,6 +1398,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
@@ -1759,35 +1763,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmmirror.com/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmmirror.com/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/rollup": {
@@ -1853,6 +1863,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmmirror.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/pinvou3-app/src-tauri/resources/common/web-template/package.json
+++ b/pinvou3-app/src-tauri/resources/common/web-template/package.json
@@ -12,7 +12,7 @@
     "chart.js": "^4.4.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## 概述

升级 web-template 的 `react-router-dom` 6.30.4 → 7.18.1，修复 3 条 Dependabot 告警（#10、#11、#12）；并在 dependency-review 中对 7.18.1 命中的新高危 GHSA-qwww-vcr4-c8h2 加豁免（该漏洞对本模板不可利用）。

## 背景

Dependabot 报出 `pinvou3-app/src-tauri/resources/common/web-template/package-lock.json` 中 `react-router`/`react-router-dom` 6.30.4 受三个 advisory 影响：

- GHSA-337j-9hxr-rhxg：SSR hydration `deserializeErrors()` 任意构造器注入（`>=6.4.0 <7.18.0`）
- GHSA-wrjc-x8rr-h8h6：`<Link>`/`useNavigate` 反斜杠开放重定向（`>=6.0.0 <7.18.0`）
- GHSA-jjmj-jmhj-qwj2：开放重定向导致 XSS（6.x 线无修复版）

告警属实（版本落在受影响区间），但该模板只用 `HashRouter` + `Routes`/`Route` 做纯客户端路由（`web-template/src/App.jsx`，无 Link/useNavigate/loader/action），无 SSR、无外部跳转目标，实际可利用性低。react-router 6.x 线无修复版本，补丁仅存在于 ≥7.13.0/7.18.0，故升级到 7.x。

升级后 dependency-review 报出 7.18.1 命中 GHSA-qwww-vcr4-c8h2（high，RSC Mode CSRF Bypass，影响 `>=7.12.0 <8.3.0`）：该漏洞仅作用于 RSC/framework mode 的 server action，本模板是纯客户端 SPA，无服务端、RSC 或 action 端点，漏洞代码路径不可达。修复版 8.3.0 要求 `react >=19.2.7`、`node >=22.22.0`，升级须随 React 19 迁移单独进行，故本次按不可利用豁免。

## 变更

- `web-template/package.json`：`react-router-dom` `^6.28.0` → `^7.18.1`。
- `web-template/package-lock.json`：重新生成（react-router 7.18.1）。模板使用的 `HashRouter`/`Routes`/`Route` API 在 v7 完全兼容，无代码改动。
- `.github/workflows/dependency-review.yml`：`allow-ghsas: GHSA-qwww-vcr4-c8h2`（附不可利用理由注释；React 19 迁移升级 react-router 8.3.0+ 后应移除该豁免）。

## 验证

- `npm ci && npm run build`（web-template，vite 单文件构建）成功。
- `node tests/web_template_packaging_contract.test.js` 通过（版本号变更不影响该契约测试）。
- YAML 语法解析通过。

## 备注

- `allow-ghsas` 为全仓库生效的单个 GHSA 豁免，react-router 后续任何新高危仍会被 `fail-on-severity: high` 门挡住。