### PR TITLE
build(rust): 同步 Cargo.lock 中 pinvou3-tauri 版本至 0.6.5

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -5981,7 +5981,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinvou3-tauri"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "agent-client-protocol",
  "anyhow",


### PR DESCRIPTION
## 概述

将 `Cargo.lock` 中 `pinvou3-tauri` 的版本记录从 0.6.4 同步到 0.6.5，与 `Cargo.toml` 保持一致。

## 背景

main 上 `pinvou3-app/src-tauri/Cargo.toml` 已升级到 0.6.5，但 `Cargo.lock` 未同步更新，导致任何开发者在本地执行 `cargo check`/`cargo build` 时都会产生一笔与本意无关的 lockfile diff，容易混入其他 PR（本次安全告警修复过程中即遇到）。

## 变更

- `pinvou3-app/src-tauri/Cargo.lock`：`pinvou3-tauri` 版本 0.6.4 → 0.6.5，仅版本号一行，无任何依赖变化。

## 验证

- `cargo check --lib` 通过，除该版本号外 lockfile 无其他变动。