### PR TITLE
ci(cache): 新增 Actions 缓存清理机制并收敛 release 缓存写入

### DIFF
--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -2,7 +2,7 @@ name: cache-janitor
 
 # Actions 缓存定期清理(10GB 配额保护),规则实现见 scripts/cache-janitor.sh:
 # - 已关闭/合并 PR 作用域的全部缓存(PR 缓存互不可见,关闭后即死重);
-# - 创建超过 7 天的 sccache 对象(内容寻址,暖源由 main 持续重写);
+# - 最后访问超过 7 天的 sccache 对象(按 lastAccessedAt 判热度,持续命中的保留);
 # - codeql-overlay 每语言每作用域只留最新 1 份;node-cache 每平台每作用域只留最新 1 份
 #   (按作用域分组:跨 ref 只留最新会把 main 的可用缓存误换成 PR 作用域的)。
 # 保护:main 作用域的 v0-rust-* 系列(rust-test/rust-lint/windows-rust-test/

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -1,0 +1,43 @@
+name: cache-janitor
+
+# Actions 缓存定期清理(10GB 配额保护),规则实现见 scripts/cache-janitor.sh:
+# - 已关闭/合并 PR 作用域的全部缓存(PR 缓存互不可见,关闭后即死重);
+# - 创建超过 7 天的 sccache 对象(内容寻址,暖源由 main 持续重写);
+# - codeql-overlay 每语言只留最新 1 份;node-cache 每平台只留最新 1 份。
+# 保护:main 作用域的 v0-rust-* 系列(rust-test/rust-lint/windows-rust-test/
+# mac-build/release-*)不在删除范围。
+# 手动触发默认 dry-run(只打印不删除),确认后可关 dry-run 实删。
+
+on:
+  schedule:
+    - cron: '23 3 * * 0'   # 每周日 03:23(避开整点/半点高峰)
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: '只打印不删除(true/false)'
+        type: boolean
+        default: true
+
+permissions:
+  actions: write       # gh cache delete
+  contents: read
+  pull-requests: read  # 查 PR 开关状态
+
+jobs:
+  clean:
+    name: clean
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 清理缓存
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.dry-run }}" = "false" ]; then
+            bash scripts/cache-janitor.sh
+          else
+            bash scripts/cache-janitor.sh --dry-run
+          fi

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: 清理缓存
         env:

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -3,7 +3,8 @@ name: cache-janitor
 # Actions 缓存定期清理(10GB 配额保护),规则实现见 scripts/cache-janitor.sh:
 # - 已关闭/合并 PR 作用域的全部缓存(PR 缓存互不可见,关闭后即死重);
 # - 创建超过 7 天的 sccache 对象(内容寻址,暖源由 main 持续重写);
-# - codeql-overlay 每语言只留最新 1 份;node-cache 每平台只留最新 1 份。
+# - codeql-overlay 每语言每作用域只留最新 1 份;node-cache 每平台每作用域只留最新 1 份
+#   (按作用域分组:跨 ref 只留最新会把 main 的可用缓存误换成 PR 作用域的)。
 # 保护:main 作用域的 v0-rust-* 系列(rust-test/rust-lint/windows-rust-test/
 # mac-build/release-*)不在删除范围。
 # 手动触发默认 dry-run(只打印不删除),确认后可关 dry-run 实删。

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -132,6 +132,8 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           shared-key: release-linux-x64
+          # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # pinvou3 编译链接的系统库(gtk/webkit/soup/rsvg/openssl/X11×3/appindicator),
       # ubuntu runner 默认没装;cmake:reqwest 的 rustls 用 aws-lc-rs,其 build script
@@ -225,6 +227,8 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           shared-key: release-linux-arm64
+          # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: 装 Tauri + pinvou3 Linux 系统依赖
         run: |
@@ -317,6 +321,8 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           shared-key: release-windows-x64
+          # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Node.js
         uses: actions/setup-node@v7
@@ -398,6 +404,8 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           shared-key: release-macos-universal
+          # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 2GB+ 缓存。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # macOS 27+ 兼容:dyld 新增 LINKEDIT 字符串池 8 字节对齐校验,而 release 默认
       # strip=debuginfo 会让 proc-macro dylib dlopen 被拒 → E0463(macOS ≤26 无此校验)。

--- a/scripts/cache-janitor.sh
+++ b/scripts/cache-janitor.sh
@@ -5,8 +5,9 @@
 #   A. 已关闭/已合并 PR(refs/pull/N/merge)作用域的全部缓存
 #      (PR 作用域缓存互不可见,PR 关闭后即死重;历史上 node-cache、sccache、
 #       release 打包缓存都在 PR 作用域产生过 GB 级残留;PR 状态查询失败一律保留)
-#   B. 创建超过 N 天的 sccache 对象(默认 7 天;内容寻址,陈旧条目命中前
-#      早已被新编译产物替代,暖源由 main 持续重写,不依赖陈旧条目)
+#   B. 最后访问超过 N 天的 sccache 对象(默认 7 天;稳定依赖的编译对象可能
+#      创建很早但持续命中,必须按 lastAccessedAt 判断热度,否则会每周误删
+#      仍在使用的主线暖缓存;内容寻址,真陈旧的条目命中前早已被新产物替代)
 #   C. codeql-overlay 每种语言每个作用域只保留最新 1 份(CodeQL 只消费最新 base)
 #   D. node-cache 每个平台每个作用域只保留最新 1 份(同平台旧 lockfile 哈希
 #      仅有 restore-keys 前缀回退价值,留最新即可)
@@ -41,6 +42,16 @@ DELETED_BYTES=0
 
 delete_cache() { # $1=id $2=key $3=size_bytes $4=rule
   local id="$1" key="$2" size="$3" rule="$4"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run][$rule] 将删除 #$id ($(( size / 1048576 ))MB) $key"
+  else
+    echo "[$rule] 删除 #$id ($(( size / 1048576 ))MB) $key"
+    if ! gh cache delete "$id"; then
+      echo "::warning::删除失败 #$id $key(可能已被并发驱逐)"
+      return 0
+    fi
+  fi
+  # 仅在删除成功后计数(dry-run 为预估),避免删除失败仍计入"已释放"导致审计虚高
   case "$rule" in
     A_closed_pr)     STAT_A_CLOSED_PR=$(( STAT_A_CLOSED_PR + 1 )) ;;
     B_sccache_stale) STAT_B_SCCACHE_STALE=$(( STAT_B_SCCACHE_STALE + 1 )) ;;
@@ -48,19 +59,13 @@ delete_cache() { # $1=id $2=key $3=size_bytes $4=rule
     D_node)          STAT_D_NODE=$(( STAT_D_NODE + 1 )) ;;
   esac
   DELETED_BYTES=$(( DELETED_BYTES + size ))
-  if [ "$DRY_RUN" -eq 1 ]; then
-    echo "[dry-run][$rule] 将删除 #$id ($(( size / 1048576 ))MB) $key"
-  else
-    echo "[$rule] 删除 #$id ($(( size / 1048576 ))MB) $key"
-    gh cache delete "$id" || echo "::warning::删除失败 #$id $key(可能已被并发驱逐)"
-  fi
 }
 
 NOW_EPOCH=$(date -u +%s)
 SCCACHE_CUTOFF=$(( NOW_EPOCH - SCCACHE_DAYS * 86400 ))
 
 echo "== 枚举缓存(dry-run=$DRY_RUN, sccache-days=$SCCACHE_DAYS) =="
-gh cache list --limit 5000 --json id,key,ref,createdAt,sizeInBytes > /tmp/cache-janitor-list.json
+gh cache list --limit 5000 --json id,key,ref,createdAt,lastAccessedAt,sizeInBytes > /tmp/cache-janitor-list.json
 TOTAL=$(python3 -c "import json; d=json.load(open('/tmp/cache-janitor-list.json')); print(len(d))")
 echo "共 $TOTAL 个缓存条目"
 
@@ -93,18 +98,22 @@ done
 export CLOSED_REFS
 
 # ---------- 规则 B:陈旧 sccache 对象 ----------
-echo "== 规则 B:sccache 条目(创建超过 ${SCCACHE_DAYS} 天) =="
+echo "== 规则 B:sccache 条目(最后访问超过 ${SCCACHE_DAYS} 天) =="
 while IFS=$'\t' read -r id size key; do
   delete_cache "$id" "$key" "$size" "B_sccache_stale"
 done < <(python3 -c "
 import json, datetime, os
 closed = set(os.environ.get('CLOSED_REFS','').split())
 cutoff = $SCCACHE_CUTOFF
+def ts(c):
+    # 按最后访问时间判断热度:稳定依赖的对象创建很早但持续命中;
+    # lastAccessedAt 缺失时回退 createdAt
+    raw = c.get('lastAccessedAt') or c['createdAt']
+    return datetime.datetime.fromisoformat(raw.replace('Z','+00:00')).timestamp()
 for c in json.load(open('/tmp/cache-janitor-list.json')):
     if not c['key'].startswith('sccache/'): continue
     if c['ref'] in closed: continue
-    created = datetime.datetime.fromisoformat(c['createdAt'].replace('Z','+00:00')).timestamp()
-    if created < cutoff: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
+    if ts(c) < cutoff: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
 ")
 
 # ---------- 规则 C:codeql-overlay 每语言留最新 1 份 ----------

--- a/scripts/cache-janitor.sh
+++ b/scripts/cache-janitor.sh
@@ -4,11 +4,15 @@
 # 删除规则:
 #   A. 已关闭/已合并 PR(refs/pull/N/merge)作用域的全部缓存
 #      (PR 作用域缓存互不可见,PR 关闭后即死重;历史上 node-cache、sccache、
-#       release 打包缓存都在 PR 作用域产生过 GB 级残留)
+#       release 打包缓存都在 PR 作用域产生过 GB 级残留;PR 状态查询失败一律保留)
 #   B. 创建超过 N 天的 sccache 对象(默认 7 天;内容寻址,陈旧条目命中前
 #      早已被新编译产物替代,暖源由 main 持续重写,不依赖陈旧条目)
-#   C. codeql-overlay 每种语言只保留最新 1 份(CodeQL 只消费最新 base)
-#   D. node-cache 每个平台只保留最新 1 份(旧 lockfile 哈希没有 restore 路径)
+#   C. codeql-overlay 每种语言每个作用域只保留最新 1 份(CodeQL 只消费最新 base)
+#   D. node-cache 每个平台每个作用域只保留最新 1 份(同平台旧 lockfile 哈希
+#      仅有 restore-keys 前缀回退价值,留最新即可)
+#
+# 注意:规则 C/D 必须按缓存作用域(ref)分组。作用域之间互不可见,跨 ref
+# 只留最新会把 main 的可用缓存换成 PR 作用域的(main 读不到),等于误删。
 #
 # 保护:main 作用域的 v0-rust-* 系列(rust-test / rust-lint / windows-rust-test /
 # mac-build / release-*)不在任何规则范围内。
@@ -71,8 +75,9 @@ for r in sorted(refs): print(r)
 for ref in $PR_REFS; do
   pr_num="${ref#refs/pull/}"; pr_num="${pr_num%%/*}"
   state=$(gh pr view "$pr_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
-  if [ "$state" = "OPEN" ]; then
-    echo "  PR #$pr_num OPEN,保留 $ref"
+  # 只删确认已关闭/合并的;查询失败(UNKNOWN)一律保留,避免 API 抖动误删开放 PR 的缓存
+  if [ "$state" != "CLOSED" ] && [ "$state" != "MERGED" ]; then
+    echo "  PR #$pr_num 状态=$state,保留 $ref"
     continue
   fi
   echo "  PR #$pr_num 状态=$state,清理 $ref"
@@ -113,10 +118,12 @@ entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'
 groups = {}
 for c in entries:
     # key 形如 codeql-overlay-base-database-1-<sha>-<lang>-<version>-...
+    # 按 (语言, 作用域) 分组:缓存作用域互不可见,跨 ref 只留最新会把 main 的
+    # 缓存换成 PR 作用域的(main 读不到),等于删掉 main 的可用缓存。
     parts = c['key'].split('-')
     lang = parts[6] if len(parts) > 6 else c['key']
-    groups.setdefault(lang, []).append(c)
-for lang, items in groups.items():
+    groups.setdefault((lang, c['ref']), []).append(c)
+for group, items in groups.items():
     items.sort(key=lambda c: c['createdAt'], reverse=True)
     for c in items[1:]: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
 ")
@@ -132,9 +139,10 @@ entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'
 groups = {}
 for c in entries:
     # key 形如 node-cache-<platform>-npm-<hash>,平台段取 npm- 之前的部分
+    # 按 (平台, 作用域) 分组:同规则 C,跨 ref 只留最新会误删 main 的可用缓存。
     platform = c['key'].split('-npm-')[0]
-    groups.setdefault(platform, []).append(c)
-for platform, items in groups.items():
+    groups.setdefault((platform, c['ref']), []).append(c)
+for group, items in groups.items():
     items.sort(key=lambda c: c['createdAt'], reverse=True)
     for c in items[1:]: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
 ")

--- a/scripts/cache-janitor.sh
+++ b/scripts/cache-janitor.sh
@@ -121,16 +121,22 @@ echo "== 规则 C:codeql-overlay 去重 =="
 while IFS=$'\t' read -r id size key; do
   delete_cache "$id" "$key" "$size" "C_codeql"
 done < <(python3 -c "
-import json, os
+import json, os, re
 closed = set(os.environ.get('CLOSED_REFS','').split())
 entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'].startswith('codeql-overlay-base-database-') and c['ref'] not in closed]
 groups = {}
 for c in entries:
     # key 形如 codeql-overlay-base-database-1-<sha>-<lang>-<version>-...
+    # lang 可能含连字符(如 javascript-typescript),取 sha 之后、版本号段
+    # (x.y.z)之前的全部片段,避免截断成 javascript 造成分组键语义错误。
     # 按 (语言, 作用域) 分组:缓存作用域互不可见,跨 ref 只留最新会把 main 的
     # 缓存换成 PR 作用域的(main 读不到),等于删掉 main 的可用缓存。
     parts = c['key'].split('-')
-    lang = parts[6] if len(parts) > 6 else c['key']
+    lang_parts = []
+    for p in parts[6:]:
+        if re.match(r'^\d+\.\d+', p): break
+        lang_parts.append(p)
+    lang = '-'.join(lang_parts) if lang_parts else c['key']
     groups.setdefault((lang, c['ref']), []).append(c)
 for group, items in groups.items():
     items.sort(key=lambda c: c['createdAt'], reverse=True)

--- a/scripts/cache-janitor.sh
+++ b/scripts/cache-janitor.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# cache-janitor.sh — GitHub Actions 缓存清理(10GB 配额保护)
+#
+# 删除规则:
+#   A. 已关闭/已合并 PR(refs/pull/N/merge)作用域的全部缓存
+#      (PR 作用域缓存互不可见,PR 关闭后即死重;历史上 node-cache、sccache、
+#       release 打包缓存都在 PR 作用域产生过 GB 级残留)
+#   B. 创建超过 N 天的 sccache 对象(默认 7 天;内容寻址,陈旧条目命中前
+#      早已被新编译产物替代,暖源由 main 持续重写,不依赖陈旧条目)
+#   C. codeql-overlay 每种语言只保留最新 1 份(CodeQL 只消费最新 base)
+#   D. node-cache 每个平台只保留最新 1 份(旧 lockfile 哈希没有 restore 路径)
+#
+# 保护:main 作用域的 v0-rust-* 系列(rust-test / rust-lint / windows-rust-test /
+# mac-build / release-*)不在任何规则范围内。
+#
+# 用法:scripts/cache-janitor.sh [--dry-run] [--sccache-days N]
+# 依赖:gh cli;GH_TOKEN 需具备 actions:write(删除)与 pull-requests:read(查状态)。
+set -euo pipefail
+
+DRY_RUN=0
+SCCACHE_DAYS=7
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --sccache-days) SCCACHE_DAYS="$2"; shift ;;
+    *) echo "未知参数: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# 删除计数(按规则分组统计,便于审计日志;不用关联数组以兼容 macOS bash 3.2)
+STAT_A_CLOSED_PR=0
+STAT_B_SCCACHE_STALE=0
+STAT_C_CODEQL=0
+STAT_D_NODE=0
+DELETED_BYTES=0
+
+delete_cache() { # $1=id $2=key $3=size_bytes $4=rule
+  local id="$1" key="$2" size="$3" rule="$4"
+  case "$rule" in
+    A_closed_pr)     STAT_A_CLOSED_PR=$(( STAT_A_CLOSED_PR + 1 )) ;;
+    B_sccache_stale) STAT_B_SCCACHE_STALE=$(( STAT_B_SCCACHE_STALE + 1 )) ;;
+    C_codeql)        STAT_C_CODEQL=$(( STAT_C_CODEQL + 1 )) ;;
+    D_node)          STAT_D_NODE=$(( STAT_D_NODE + 1 )) ;;
+  esac
+  DELETED_BYTES=$(( DELETED_BYTES + size ))
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[dry-run][$rule] 将删除 #$id ($(( size / 1048576 ))MB) $key"
+  else
+    echo "[$rule] 删除 #$id ($(( size / 1048576 ))MB) $key"
+    gh cache delete "$id" || echo "::warning::删除失败 #$id $key(可能已被并发驱逐)"
+  fi
+}
+
+NOW_EPOCH=$(date -u +%s)
+SCCACHE_CUTOFF=$(( NOW_EPOCH - SCCACHE_DAYS * 86400 ))
+
+echo "== 枚举缓存(dry-run=$DRY_RUN, sccache-days=$SCCACHE_DAYS) =="
+gh cache list --limit 5000 --json id,key,ref,createdAt,sizeInBytes > /tmp/cache-janitor-list.json
+TOTAL=$(python3 -c "import json; d=json.load(open('/tmp/cache-janitor-list.json')); print(len(d))")
+echo "共 $TOTAL 个缓存条目"
+
+# ---------- 规则 A:已关闭/合并 PR 的全部缓存 ----------
+echo "== 规则 A:已关闭/合并 PR 的缓存 =="
+CLOSED_REFS=""   # 规则 B/C/D 需跳过这些 ref(已由本规则处理,避免误删保留项)
+PR_REFS=$(python3 -c "
+import json
+refs = {c['ref'] for c in json.load(open('/tmp/cache-janitor-list.json')) if c['ref'].startswith('refs/pull/')}
+for r in sorted(refs): print(r)
+")
+for ref in $PR_REFS; do
+  pr_num="${ref#refs/pull/}"; pr_num="${pr_num%%/*}"
+  state=$(gh pr view "$pr_num" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")
+  if [ "$state" = "OPEN" ]; then
+    echo "  PR #$pr_num OPEN,保留 $ref"
+    continue
+  fi
+  echo "  PR #$pr_num 状态=$state,清理 $ref"
+  CLOSED_REFS="$CLOSED_REFS $ref"
+  while IFS=$'\t' read -r id size key; do
+    delete_cache "$id" "$key" "$size" "A_closed_pr"
+  done < <(python3 -c "
+import json
+for c in json.load(open('/tmp/cache-janitor-list.json')):
+    if c['ref'] == '$ref': print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
+")
+done
+export CLOSED_REFS
+
+# ---------- 规则 B:陈旧 sccache 对象 ----------
+echo "== 规则 B:sccache 条目(创建超过 ${SCCACHE_DAYS} 天) =="
+while IFS=$'\t' read -r id size key; do
+  delete_cache "$id" "$key" "$size" "B_sccache_stale"
+done < <(python3 -c "
+import json, datetime, os
+closed = set(os.environ.get('CLOSED_REFS','').split())
+cutoff = $SCCACHE_CUTOFF
+for c in json.load(open('/tmp/cache-janitor-list.json')):
+    if not c['key'].startswith('sccache/'): continue
+    if c['ref'] in closed: continue
+    created = datetime.datetime.fromisoformat(c['createdAt'].replace('Z','+00:00')).timestamp()
+    if created < cutoff: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
+")
+
+# ---------- 规则 C:codeql-overlay 每语言留最新 1 份 ----------
+echo "== 规则 C:codeql-overlay 去重 =="
+while IFS=$'\t' read -r id size key; do
+  delete_cache "$id" "$key" "$size" "C_codeql"
+done < <(python3 -c "
+import json, os
+closed = set(os.environ.get('CLOSED_REFS','').split())
+entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'].startswith('codeql-overlay-base-database-') and c['ref'] not in closed]
+groups = {}
+for c in entries:
+    # key 形如 codeql-overlay-base-database-1-<sha>-<lang>-<version>-...
+    parts = c['key'].split('-')
+    lang = parts[6] if len(parts) > 6 else c['key']
+    groups.setdefault(lang, []).append(c)
+for lang, items in groups.items():
+    items.sort(key=lambda c: c['createdAt'], reverse=True)
+    for c in items[1:]: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
+")
+
+# ---------- 规则 D:node-cache 每平台留最新 1 份 ----------
+echo "== 规则 D:node-cache 去重 =="
+while IFS=$'\t' read -r id size key; do
+  delete_cache "$id" "$key" "$size" "D_node"
+done < <(python3 -c "
+import json, os
+closed = set(os.environ.get('CLOSED_REFS','').split())
+entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'].startswith('node-cache-') and c['ref'] not in closed]
+groups = {}
+for c in entries:
+    # key 形如 node-cache-<platform>-npm-<hash>,平台段取 npm- 之前的部分
+    platform = c['key'].split('-npm-')[0]
+    groups.setdefault(platform, []).append(c)
+for platform, items in groups.items():
+    items.sort(key=lambda c: c['createdAt'], reverse=True)
+    for c in items[1:]: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
+")
+
+echo "== 汇总 =="
+echo "A_closed_pr=$STAT_A_CLOSED_PR B_sccache_stale=$STAT_B_SCCACHE_STALE C_codeql=$STAT_C_CODEQL D_node=$STAT_D_NODE"
+echo "释放空间约 $(( DELETED_BYTES / 1048576 ))MB(dry-run=$DRY_RUN)"


### PR DESCRIPTION
## 概述

新增每周定时运行的缓存清理工作流 cache-janitor(支持手动 dry-run),并给 release-packages 的 4 个 rust-cache 补上 `save-if` 仅 main 保存,治理 10GB 缓存配额长期顶满的问题。

## 背景

#47 评审过程中实测:仓库 Actions 缓存已用 ~9.9GB/10GB,sccache GHA 后端条目一度超过 2000 个 / 5GB+,linux x64/arm64 与 macos-universal 三份 release 缓存已被 LRU 驱逐。排查发现两类结构性浪费:

- **无清理机制**:已关闭/合并 PR 的缓存(PR 作用域互不可见,关闭即死重)、CodeQL overlay 每语言累积 7 份、node-cache 旧 lockfile 哈希残留,全靠 LRU 被动驱逐;
- **release-packages 的 4 个 rust-cache 无 `save-if`**:发布链路 PR 也会把 1.2~2.1GB 写进 PR 作用域,与当年 rust-test 诊断过的反模式(pr-check.yml 头部注释)一致。

## 变更

- `scripts/cache-janitor.sh`:四类清理规则——A. 已关闭/合并 PR 的全部缓存;B. 创建超 7 天的 sccache 对象(内容寻址,暖源由 main 持续重写);C. codeql-overlay 每语言只留最新 1 份;D. node-cache 每平台只留最新 1 份。规则 B/C/D 会跳过规则 A 已处理的 ref,避免误删保留项;main 作用域的 `v0-rust-*` 系列不在任何规则范围。
- `.github/workflows/cache-janitor.yml`:每周日 03:23 定时实删;`workflow_dispatch` 手动触发默认 dry-run(只打印不删除),确认后可关 dry-run 实删。权限仅需 `actions: write` + `pull-requests: read`。
- `release-packages.yml`:4 个 rust-cache 补 `save-if: main`(PR 侧只读,可从 main 缓存前缀回退增量编译,行为与 rust-test 一致)。

## 验证

- 本地对仓库真实缓存列表 dry-run:规则 A 命中 3 个已合并 PR(#33/#35/#50/#53)的残留,规则 C 命中 18 份 codeql 重复,规则 D 命中 10 份 node 重复,合计可释放约 1.2GB;开放中 PR(#47/#52/#54/#55/#56)的缓存全部正确保留。
- `bash -n` 与 YAML 解析均通过;脚本兼容 macOS bash 3.2(未用关联数组),计数器经进程替换避免管道子 Shell 丢计数。

## 备注

- 本 PR 不删除 main 的任何 rust-cache(rust-test / rust-lint / windows-rust-test / mac-build / release-*);release 缓存是 release-fast profile 打包产物,对发布构建有真实价值,治理点是 PR 侧重复写入而非缓存本身。