### PR TITLE
fix(codex): 修复安装态 ACP 启动并完善平台适配

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -27,7 +27,7 @@
     "test:diff-ui": "node tests/diff_viewer_ui_smoke.mjs",
     "test:marketplace-oauth": "node tests/marketplace_oauth_logic.test.js",
     "test:composer-tools": "node tests/composer_tool_menu_logic.test.js",
-    "test:codex-acp": "node tests/codex_acp_windows_contract.test.js && node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
+    "test:codex-acp": "node tests/codex_acp_platform_contract.test.js && node tests/codex_acp_windows_contract.test.js && node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
     "test:codex-acp-windows-runtime": "node tests/codex_acp_windows_runtime_smoke.js",
     "test:session-management": "node tests/session_management_logic.test.mjs",
     "test:chat-input-limit": "node tests/chat_input_limit_logic.test.js",

--- a/pinvou3-app/scripts/tauri/codex-bridge.js
+++ b/pinvou3-app/scripts/tauri/codex-bridge.js
@@ -40,7 +40,15 @@ const BRIDGE_PACKAGE_JSON = path.join(
   "package.json",
 );
 const MARKER_NAME = "manifest.json";
-const PREPARE_FORMAT_VERSION = 2;
+const PREPARE_FORMAT_VERSION = 3;
+const CODEX_PATH_SPAWN =
+  'spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv })';
+const HIDDEN_CODEX_PATH_SPAWN =
+  'spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv, windowsHide: true })';
+const BUNDLED_CODEX_SPAWN =
+  'spawn(process.execPath, [bundledCodexPath, "app-server"], { env: spawnEnv })';
+const HIDDEN_BUNDLED_CODEX_SPAWN =
+  'spawn(process.execPath, [bundledCodexPath, "app-server"], { env: spawnEnv, windowsHide: true })';
 const WINDOWS_NODE_VERSION = "22.22.0";
 const WINDOWS_NODE_ARCHIVE_NAME = `node-v${WINDOWS_NODE_VERSION}-win-x64.zip`;
 const WINDOWS_NODE_ARCHIVE_SHA256 =
@@ -77,7 +85,39 @@ function expectedMarker({ architecture = process.arch } = {}) {
     node: "../node/node.exe",
     entrypoint: BRIDGE_ENTRYPOINT.replaceAll(path.sep, "/"),
     requires_managed_codex: true,
+    windows_child_processes_hidden: true,
   };
+}
+
+function hideWindowsChildProcesses(entrypointPath) {
+  let source = fs.readFileSync(entrypointPath, "utf8");
+  const replacements = [
+    [CODEX_PATH_SPAWN, HIDDEN_CODEX_PATH_SPAWN],
+    [BUNDLED_CODEX_SPAWN, HIDDEN_BUNDLED_CODEX_SPAWN],
+  ];
+
+  for (const [visibleSpawn, hiddenSpawn] of replacements) {
+    if (source.includes(hiddenSpawn)) continue;
+    if (!source.includes(visibleSpawn)) {
+      throw new Error(
+        "Windows ACP Bridge 子进程入口已变化，无法安全应用隐藏控制台补丁",
+      );
+    }
+    source = source.replace(visibleSpawn, hiddenSpawn);
+  }
+  fs.writeFileSync(entrypointPath, source);
+}
+
+function windowsChildProcessesHidden(entrypointPath) {
+  try {
+    const source = fs.readFileSync(entrypointPath, "utf8");
+    return (
+      source.includes(HIDDEN_CODEX_PATH_SPAWN)
+      && source.includes(HIDDEN_BUNDLED_CODEX_SPAWN)
+    );
+  } catch {
+    return false;
+  }
 }
 
 function nonemptyFile(filePath) {
@@ -127,6 +167,7 @@ function isPrepared(
       JSON.stringify(actual) === JSON.stringify(expected) &&
       packageJson.version === expected.codex_acp_version &&
       nonemptyFile(path.join(outputRoot, BRIDGE_ENTRYPOINT)) &&
+      windowsChildProcessesHidden(path.join(outputRoot, BRIDGE_ENTRYPOINT)) &&
       nonemptyFile(path.join(nodeRoot, "node.exe")) &&
       fileSha256(path.join(nodeRoot, "node.exe")) ===
         expected.node_executable_sha256
@@ -297,6 +338,8 @@ function prepareWindowsCodexBridge({
       "安装 Windows ACP Bridge",
     );
 
+    hideWindowsChildProcesses(path.join(bridgeRoot, BRIDGE_ENTRYPOINT));
+
     fs.rmSync(path.join(acpRoot, "package.json"), { force: true });
     fs.rmSync(path.join(acpRoot, "package-lock.json"), { force: true });
     fs.writeFileSync(
@@ -375,6 +418,7 @@ module.exports = {
   WINDOWS_NODE_VERSION,
   WINDOWS_NPM_CI_ARGS,
   expectedMarker,
+  hideWindowsChildProcesses,
   isPrepared,
   main,
   prepareLinuxCodexBridge,

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -1830,10 +1830,12 @@ fn codex_upgrade_required(message: &str) -> bool {
 }
 
 fn installed_node_version(node: &Path) -> Option<String> {
-    let output = std::process::Command::new(crate::platform::os::external_application_path(node))
-        .arg("--version")
-        .output()
-        .ok()?;
+    let output = crate::platform::process::HiddenCommand::new(
+        crate::platform::os::external_application_path(node),
+    )
+    .arg("--version")
+    .output()
+    .ok()?;
     if !output.status.success() {
         return None;
     }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -6,11 +6,12 @@
 mod attachments;
 mod diagnostics;
 mod events;
+mod platform;
 mod runtime;
 mod store;
 pub(crate) mod workspace;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -309,18 +310,8 @@ struct RuntimeProbeCache {
 impl AcpPool {
     pub fn new(app: AppHandle, session_store: SessionStore) -> Result<Self> {
         let resource_root = app.path().resource_dir().ok();
-        let development_bridge = if crate::platform::capabilities::is_windows() {
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("target")
-                .join("windows-runtime")
-                .join("codex-bridge")
-        } else {
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("resources")
-                .join("platforms")
-                .join("linux")
-                .join("codex-bridge")
-        };
+        let development_bridge =
+            platform::development_bridge_root(Path::new(env!("CARGO_MANIFEST_DIR")));
         let bundled_adapter = resource_root.as_ref().and_then(|root| {
             [
                 root.join("runtime")
@@ -352,7 +343,8 @@ impl AcpPool {
                     .join("codex-acp")
                     .join("dist")
                     .join("index.js"),
-                root.join("codex-acp").join(adapter_filename()),
+                root.join("codex-acp")
+                    .join(platform::bundled_adapter_name()),
                 root.join("resources")
                     .join("codex-acp")
                     .join("node_modules")
@@ -362,7 +354,7 @@ impl AcpPool {
                     .join("index.js"),
                 root.join("resources")
                     .join("codex-acp")
-                    .join(adapter_filename()),
+                    .join(platform::bundled_adapter_name()),
                 development_bridge
                     .join("acp")
                     .join("node_modules")
@@ -375,11 +367,7 @@ impl AcpPool {
             .find(|candidate| candidate.is_file())
         });
         let bundled_node = resource_root.as_ref().and_then(|root| {
-            let node_name = if crate::platform::capabilities::is_windows() {
-                "node.exe"
-            } else {
-                "node"
-            };
+            let node_name = platform::node_executable_name();
             [
                 root.join("runtime").join("node").join(node_name),
                 root.join("runtime")
@@ -537,11 +525,7 @@ impl AcpPool {
         let node = adapter
             .as_deref()
             .and_then(|adapter| self.resolve_node(adapter));
-        let system_codex = find_in_path(if crate::platform::capabilities::is_windows() {
-            "codex.cmd"
-        } else {
-            "codex"
-        });
+        let system_codex = find_in_path(platform::system_codex_name());
         let legacy_codex = adapter.as_deref().and_then(codex_path_for_adapter);
         diagnostics::write(
             &operation_id,
@@ -758,7 +742,7 @@ impl AcpPool {
             "login:spawn",
             format!("codex_path={}", codex_path.display()),
         );
-        let mut command = codex_login_command(&codex_path);
+        let mut command = platform::codex_login_command(&codex_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         let mut child = command.spawn().context("启动 Codex CLI 登录失败")?;
         let stdout = child.stdout.take().context("读取 Codex 登录标准输出失败")?;
@@ -1226,7 +1210,7 @@ impl AcpPool {
             "session:spawn_start",
             format!("session_id={session_id}"),
         );
-        let runtime = match self.spawn_session(session_id).await {
+        let runtime = match self.spawn_session(session_id, &operation_id).await {
             Ok(runtime) => Arc::new(runtime),
             Err(error) => {
                 diagnostics::write(
@@ -1246,7 +1230,11 @@ impl AcpPool {
         Ok(runtime)
     }
 
-    async fn spawn_session(&self, pinvou_session_id: &str) -> Result<AcpSession> {
+    async fn spawn_session(
+        &self,
+        pinvou_session_id: &str,
+        operation_id: &str,
+    ) -> Result<AcpSession> {
         let adapter = self.resolve_adapter().context("Codex ACP 尚未安装")?;
         let workspace = self.execution_workspace(pinvou_session_id)?;
         if self.agents.get(pinvou_session_id).workspace_kind == CodexWorkspaceKind::Temporary {
@@ -1266,12 +1254,26 @@ impl AcpPool {
             .with_context(|| format!("启动 {} 失败", adapter.display()))?;
         let stdin = child.stdin.take().context("Codex ACP stdin 不可用")?;
         let stdout = child.stdout.take().context("Codex ACP stdout 不可用")?;
+        let stderr_tail = Arc::new(parking_lot::Mutex::new(VecDeque::<String>::new()));
         if let Some(stderr) = child.stderr.take() {
             let sid = pinvou_session_id.to_string();
+            let operation_id = operation_id.to_string();
+            let stderr_tail = stderr_tail.clone();
             tokio::spawn(async move {
                 let mut lines = BufReader::new(stderr).lines();
                 while let Ok(Some(line)) = lines.next_line().await {
-                    eprintln!("[codex-acp:{sid}] {line}");
+                    {
+                        let mut tail = stderr_tail.lock();
+                        if tail.len() >= 40 {
+                            tail.pop_front();
+                        }
+                        tail.push_back(line.chars().take(2_000).collect());
+                    }
+                    diagnostics::write(
+                        &operation_id,
+                        "session:bridge_stderr",
+                        format!("session_id={sid} stderr={line}"),
+                    );
                 }
             });
         }
@@ -1422,11 +1424,43 @@ impl AcpPool {
             }
         });
 
-        let (connection, initialized) = tokio::time::timeout(Duration::from_secs(30), ready_rx)
-            .await
-            .context("Codex ACP initialize 超时")?
-            .context("Codex ACP initialize 通道中断")?
-            .context("Codex ACP initialize 失败")?;
+        let ready_result: Result<_> = async {
+            let received = tokio::time::timeout(Duration::from_secs(30), ready_rx)
+                .await
+                .context("Codex ACP initialize 超时")?;
+            let initialized = received.context("Codex ACP initialize 通道中断")?;
+            initialized.context("Codex ACP initialize 失败")
+        }
+        .await;
+        let (connection, initialized) = match ready_result {
+            Ok(initialized) => initialized,
+            Err(error) => {
+                // Give the process and stderr reader a brief chance to publish the real failure.
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let exit_status = child
+                    .try_wait()
+                    .map(|status| {
+                        status
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "running".to_string())
+                    })
+                    .unwrap_or_else(|wait_error| format!("unknown ({wait_error})"));
+                let stderr = stderr_tail
+                    .lock()
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(" | ");
+                diagnostics::write(
+                    operation_id,
+                    "session:initialize_failed",
+                    format!(
+                        "session_id={pinvou_session_id} exit_status={exit_status} stderr={stderr} error={error:#}"
+                    ),
+                );
+                return Err(error);
+            }
+        };
 
         let saved = self.agents.get(pinvou_session_id);
         let (acp_session_id, mut mode_state, mut config_options) =
@@ -1531,12 +1565,8 @@ impl AcpPool {
         if let Some(path) = self.bundled_node.as_ref().filter(|path| path.is_file()) {
             return Some(path.clone());
         }
-        if adapter_needs_path_node_lookup(adapter, crate::platform::capabilities::is_windows()) {
-            return find_in_path(if crate::platform::capabilities::is_windows() {
-                "node.exe"
-            } else {
-                "node"
-            });
+        if platform::adapter_needs_node(adapter) {
+            return find_in_path(platform::node_executable_name());
         }
         None
     }
@@ -1546,14 +1576,17 @@ impl AcpPool {
     }
 
     fn adapter_command(&self, adapter: &Path) -> Result<Command> {
-        adapter_command(adapter, self.resolve_node(adapter).as_deref())
+        platform::adapter_command(adapter, self.resolve_node(adapter).as_deref())
     }
 
     fn configure_codex_path(&self, command: &mut Command, adapter: &Path) -> Result<()> {
         let codex = self
             .resolve_codex(adapter)
             .context("未检测到可用 Codex；请下载托管 Codex")?;
-        command.env("CODEX_PATH", &codex.path);
+        command.env(
+            "CODEX_PATH",
+            crate::platform::os::external_application_path(&codex.path),
+        );
         Ok(())
     }
 }
@@ -1717,70 +1750,10 @@ fn managed_runtime_dir() -> PathBuf {
 }
 
 fn managed_adapter_path() -> PathBuf {
-    let name = if crate::platform::capabilities::is_windows() {
-        "codex-acp.cmd"
-    } else {
-        "codex-acp"
-    };
     managed_runtime_dir()
         .join("node_modules")
         .join(".bin")
-        .join(name)
-}
-
-fn adapter_filename() -> &'static str {
-    if crate::platform::capabilities::is_windows() {
-        "codex-acp.exe"
-    } else {
-        "codex-acp"
-    }
-}
-
-fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
-    adapter_command_for_platform(adapter, node, crate::platform::capabilities::is_windows())
-}
-
-fn adapter_command_for_platform(
-    adapter: &Path,
-    node: Option<&Path>,
-    is_windows: bool,
-) -> Result<Command> {
-    if adapter.extension().and_then(|value| value.to_str()) == Some("js") {
-        let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
-        let mut command = Command::new(node);
-        command.arg(adapter);
-        Ok(command)
-    } else if is_windows_cmd_for_platform(adapter, is_windows) {
-        let mut command = Command::new("cmd");
-        command.args(["/D", "/S", "/C"]).arg(adapter);
-        Ok(command)
-    } else {
-        Ok(Command::new(adapter))
-    }
-}
-
-fn codex_login_command(codex: &Path) -> Command {
-    if is_windows_cmd(codex) {
-        let mut command = Command::new("cmd");
-        command.args(["/D", "/S", "/C"]).arg(codex).arg("login");
-        command
-    } else {
-        let mut command = Command::new(codex);
-        command.arg("login");
-        command
-    }
-}
-
-fn adapter_needs_path_node_lookup(adapter: &Path, is_windows: bool) -> bool {
-    is_windows || adapter.extension().and_then(|value| value.to_str()) == Some("js")
-}
-
-fn is_windows_cmd(path: &Path) -> bool {
-    is_windows_cmd_for_platform(path, crate::platform::capabilities::is_windows())
-}
-
-fn is_windows_cmd_for_platform(path: &Path, is_windows: bool) -> bool {
-    is_windows && path.extension().and_then(|value| value.to_str()) == Some("cmd")
+        .join(platform::managed_adapter_name())
 }
 
 async fn capture_login_output<R>(reader: R, login_url: Arc<parking_lot::RwLock<Option<String>>>)
@@ -1803,11 +1776,7 @@ fn extract_codex_login_url(line: &str) -> Option<&str> {
 }
 
 fn codex_path_for_adapter(adapter: &Path) -> Option<PathBuf> {
-    let name = if crate::platform::capabilities::is_windows() {
-        "codex.cmd"
-    } else {
-        "codex"
-    };
+    let name = platform::system_codex_name();
     if adapter
         .parent()?
         .file_name()
@@ -1839,11 +1808,7 @@ fn resolve_adapter_from(bundled: Option<&Path>) -> Option<PathBuf> {
     if nonempty_file(&managed) {
         return Some(managed);
     }
-    find_in_path(if crate::platform::capabilities::is_windows() {
-        "codex-acp.cmd"
-    } else {
-        "codex-acp"
-    })
+    find_in_path(platform::managed_adapter_name())
 }
 
 fn find_in_path(name: &str) -> Option<PathBuf> {
@@ -1865,7 +1830,7 @@ fn codex_upgrade_required(message: &str) -> bool {
 }
 
 fn installed_node_version(node: &Path) -> Option<String> {
-    let output = std::process::Command::new(node)
+    let output = std::process::Command::new(crate::platform::os::external_application_path(node))
         .arg("--version")
         .output()
         .ok()?;
@@ -1946,57 +1911,6 @@ mod tests {
         std::fs::write(&adapter, "console.log('ok');").expect("write adapter");
         assert!(nonempty_file(&adapter));
         std::fs::remove_dir_all(root).expect("cleanup adapter test directory");
-    }
-
-    #[test]
-    fn javascript_adapter_uses_node_runtime() {
-        let adapter = Path::new("C:\\runtime\\codex-acp.js");
-        let command =
-            adapter_command_for_platform(adapter, Some(Path::new("C:\\runtime\\node.exe")), true)
-                .expect("build JavaScript adapter command");
-
-        assert_eq!(command.as_std().get_program(), "C:\\runtime\\node.exe");
-        assert_eq!(
-            command
-                .as_std()
-                .get_args()
-                .map(|value| value.to_string_lossy().into_owned())
-                .collect::<Vec<_>>(),
-            vec!["C:\\runtime\\codex-acp.js"]
-        );
-    }
-
-    #[test]
-    fn windows_cmd_adapter_uses_command_interpreter() {
-        let adapter = Path::new("C:\\runtime\\codex-acp.cmd");
-        let command = adapter_command_for_platform(adapter, None, true)
-            .expect("build Windows command-shim adapter command");
-
-        assert_eq!(command.as_std().get_program(), "cmd");
-        assert_eq!(
-            command
-                .as_std()
-                .get_args()
-                .map(|value| value.to_string_lossy().into_owned())
-                .collect::<Vec<_>>(),
-            vec!["/D", "/S", "/C", "C:\\runtime\\codex-acp.cmd"]
-        );
-    }
-
-    #[test]
-    fn windows_adapter_status_always_checks_node_runtime() {
-        assert!(adapter_needs_path_node_lookup(
-            Path::new("C:\\runtime\\codex-acp.cmd"),
-            true
-        ));
-        assert!(adapter_needs_path_node_lookup(
-            Path::new("/runtime/codex-acp.js"),
-            false
-        ));
-        assert!(!adapter_needs_path_node_lookup(
-            Path::new("/runtime/codex-acp"),
-            false
-        ));
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/linux.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/linux.rs
@@ -1,0 +1,91 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tokio::process::Command;
+
+use super::ManagedCodexArtifact;
+
+pub(super) const NODE_EXECUTABLE_NAME: &str = "node";
+pub(super) const SYSTEM_CODEX_NAME: &str = "codex";
+pub(super) const MANAGED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const BUNDLED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex";
+
+pub(super) fn development_bridge_root(manifest_dir: &Path) -> PathBuf {
+    manifest_dir
+        .join("resources")
+        .join("platforms")
+        .join("linux")
+        .join("codex-bridge")
+}
+
+pub(super) fn adapter_needs_node(adapter: &Path) -> bool {
+    adapter.extension().and_then(|value| value.to_str()) == Some("js")
+}
+
+pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
+    if adapter_needs_node(adapter) {
+        let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
+        let mut command = Command::new(crate::platform::os::external_application_path(node));
+        command.arg(crate::platform::os::external_application_path(adapter));
+        Ok(command)
+    } else {
+        Ok(Command::new(
+            crate::platform::os::external_application_path(adapter),
+        ))
+    }
+}
+
+pub(super) fn codex_login_command(codex: &Path) -> Command {
+    let mut command = Command::new(crate::platform::os::external_application_path(codex));
+    command.arg("login");
+    command
+}
+
+pub(super) fn managed_artifact(architecture: &str) -> Result<ManagedCodexArtifact> {
+    match architecture {
+        "x86_64" => Ok(ManagedCodexArtifact {
+            urls: &[
+                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+            ],
+            integrity: "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
+            vendor_triple: "x86_64-unknown-linux-musl",
+        }),
+        "aarch64" => Ok(ManagedCodexArtifact {
+            urls: &[
+                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+            ],
+            integrity: "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
+            vendor_triple: "aarch64-unknown-linux-musl",
+        }),
+        _ => bail!("当前托管 Codex 下载不支持平台: linux-{architecture}"),
+    }
+}
+
+pub(super) fn should_retry_file_lock(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn managed_artifacts_are_available_for_supported_architectures() {
+        for architecture in ["x86_64", "aarch64"] {
+            let artifact =
+                managed_artifact(architecture).expect("resolve supported Linux Codex artifact");
+            assert!(!artifact.vendor_triple.is_empty());
+            assert!(artifact.urls[0].starts_with("https://"));
+            assert!(artifact.integrity.starts_with("sha512-"));
+        }
+    }
+
+    #[test]
+    fn file_lock_errors_are_not_retried() {
+        assert!(!should_retry_file_lock(&io::Error::from_raw_os_error(13)));
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/macos.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/macos.rs
@@ -1,0 +1,52 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tokio::process::Command;
+
+use super::ManagedCodexArtifact;
+
+pub(super) const NODE_EXECUTABLE_NAME: &str = "node";
+pub(super) const SYSTEM_CODEX_NAME: &str = "codex";
+pub(super) const MANAGED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const BUNDLED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex";
+
+pub(super) fn development_bridge_root(manifest_dir: &Path) -> PathBuf {
+    manifest_dir
+        .join("resources")
+        .join("platforms")
+        .join("macos")
+        .join("codex-bridge")
+}
+
+pub(super) fn adapter_needs_node(adapter: &Path) -> bool {
+    adapter.extension().and_then(|value| value.to_str()) == Some("js")
+}
+
+pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
+    if adapter_needs_node(adapter) {
+        let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
+        let mut command = Command::new(crate::platform::os::external_application_path(node));
+        command.arg(crate::platform::os::external_application_path(adapter));
+        Ok(command)
+    } else {
+        Ok(Command::new(
+            crate::platform::os::external_application_path(adapter),
+        ))
+    }
+}
+
+pub(super) fn codex_login_command(codex: &Path) -> Command {
+    let mut command = Command::new(crate::platform::os::external_application_path(codex));
+    command.arg("login");
+    command
+}
+
+pub(super) fn managed_artifact(architecture: &str) -> Result<ManagedCodexArtifact> {
+    bail!("当前托管 Codex 下载不支持平台: macos-{architecture}")
+}
+
+pub(super) fn should_retry_file_lock(_error: &io::Error) -> bool {
+    false
+}

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/mod.rs
@@ -1,0 +1,73 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use tokio::process::Command;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+mod unsupported;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "linux")]
+use linux as current;
+#[cfg(target_os = "macos")]
+use macos as current;
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+use unsupported as current;
+#[cfg(target_os = "windows")]
+use windows as current;
+
+pub(super) struct ManagedCodexArtifact {
+    pub(super) urls: &'static [&'static str],
+    pub(super) integrity: &'static str,
+    pub(super) vendor_triple: &'static str,
+}
+
+pub(super) fn development_bridge_root(manifest_dir: &Path) -> PathBuf {
+    current::development_bridge_root(manifest_dir)
+}
+
+pub(super) fn node_executable_name() -> &'static str {
+    current::NODE_EXECUTABLE_NAME
+}
+
+pub(super) fn system_codex_name() -> &'static str {
+    current::SYSTEM_CODEX_NAME
+}
+
+pub(super) fn managed_adapter_name() -> &'static str {
+    current::MANAGED_ADAPTER_NAME
+}
+
+pub(super) fn bundled_adapter_name() -> &'static str {
+    current::BUNDLED_ADAPTER_NAME
+}
+
+pub(super) fn managed_codex_executable_name() -> &'static str {
+    current::MANAGED_CODEX_EXECUTABLE_NAME
+}
+
+pub(super) fn adapter_needs_node(adapter: &Path) -> bool {
+    current::adapter_needs_node(adapter)
+}
+
+pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
+    current::adapter_command(adapter, node)
+}
+
+pub(super) fn codex_login_command(codex: &Path) -> Command {
+    current::codex_login_command(codex)
+}
+
+pub(super) fn managed_artifact(architecture: &str) -> Result<ManagedCodexArtifact> {
+    current::managed_artifact(architecture)
+}
+
+pub(super) fn should_retry_file_lock(error: &io::Error) -> bool {
+    current::should_retry_file_lock(error)
+}

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/unsupported.rs
@@ -1,0 +1,49 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tokio::process::Command;
+
+use super::ManagedCodexArtifact;
+
+pub(super) const NODE_EXECUTABLE_NAME: &str = "node";
+pub(super) const SYSTEM_CODEX_NAME: &str = "codex";
+pub(super) const MANAGED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const BUNDLED_ADAPTER_NAME: &str = "codex-acp";
+pub(super) const MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex";
+
+pub(super) fn development_bridge_root(manifest_dir: &Path) -> PathBuf {
+    manifest_dir.join("resources").join("codex-bridge")
+}
+
+pub(super) fn adapter_needs_node(adapter: &Path) -> bool {
+    adapter.extension().and_then(|value| value.to_str()) == Some("js")
+}
+
+pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
+    if adapter_needs_node(adapter) {
+        let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
+        let mut command = Command::new(node);
+        command.arg(adapter);
+        Ok(command)
+    } else {
+        Ok(Command::new(adapter))
+    }
+}
+
+pub(super) fn codex_login_command(codex: &Path) -> Command {
+    let mut command = Command::new(codex);
+    command.arg("login");
+    command
+}
+
+pub(super) fn managed_artifact(architecture: &str) -> Result<ManagedCodexArtifact> {
+    bail!(
+        "当前托管 Codex 下载不支持平台: {}-{architecture}",
+        std::env::consts::OS
+    )
+}
+
+pub(super) fn should_retry_file_lock(_error: &io::Error) -> bool {
+    false
+}

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/windows.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 use tokio::process::Command;
 
 use super::ManagedCodexArtifact;
+use crate::platform::process::HiddenTokioCommand;
 
 pub(super) const NODE_EXECUTABLE_NAME: &str = "node.exe";
 pub(super) const SYSTEM_CODEX_NAME: &str = "codex.cmd";
@@ -27,26 +28,27 @@ pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Com
     let adapter = crate::platform::os::external_application_path(adapter);
     if adapter.extension().and_then(|value| value.to_str()) == Some("js") {
         let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
-        let mut command = Command::new(crate::platform::os::external_application_path(node));
+        let mut command =
+            HiddenTokioCommand::new(crate::platform::os::external_application_path(node));
         command.arg(adapter);
         Ok(command)
     } else if adapter.extension().and_then(|value| value.to_str()) == Some("cmd") {
-        let mut command = Command::new("cmd");
+        let mut command = HiddenTokioCommand::new("cmd");
         command.args(["/D", "/S", "/C"]).arg(adapter);
         Ok(command)
     } else {
-        Ok(Command::new(adapter))
+        Ok(HiddenTokioCommand::new(adapter))
     }
 }
 
 pub(super) fn codex_login_command(codex: &Path) -> Command {
     let codex = crate::platform::os::external_application_path(codex);
     if codex.extension().and_then(|value| value.to_str()) == Some("cmd") {
-        let mut command = Command::new("cmd");
+        let mut command = HiddenTokioCommand::new("cmd");
         command.args(["/D", "/S", "/C"]).arg(codex).arg("login");
         command
     } else {
-        let mut command = Command::new(codex);
+        let mut command = HiddenTokioCommand::new(codex);
         command.arg("login");
         command
     }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/platform/windows.rs
@@ -1,0 +1,130 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use tokio::process::Command;
+
+use super::ManagedCodexArtifact;
+
+pub(super) const NODE_EXECUTABLE_NAME: &str = "node.exe";
+pub(super) const SYSTEM_CODEX_NAME: &str = "codex.cmd";
+pub(super) const MANAGED_ADAPTER_NAME: &str = "codex-acp.cmd";
+pub(super) const BUNDLED_ADAPTER_NAME: &str = "codex-acp.exe";
+pub(super) const MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex.exe";
+
+pub(super) fn development_bridge_root(manifest_dir: &Path) -> PathBuf {
+    manifest_dir
+        .join("target")
+        .join("windows-runtime")
+        .join("codex-bridge")
+}
+
+pub(super) fn adapter_needs_node(_adapter: &Path) -> bool {
+    true
+}
+
+pub(super) fn adapter_command(adapter: &Path, node: Option<&Path>) -> Result<Command> {
+    let adapter = crate::platform::os::external_application_path(adapter);
+    if adapter.extension().and_then(|value| value.to_str()) == Some("js") {
+        let node = node.context("Codex ACP Bridge 缺少可用 Node")?;
+        let mut command = Command::new(crate::platform::os::external_application_path(node));
+        command.arg(adapter);
+        Ok(command)
+    } else if adapter.extension().and_then(|value| value.to_str()) == Some("cmd") {
+        let mut command = Command::new("cmd");
+        command.args(["/D", "/S", "/C"]).arg(adapter);
+        Ok(command)
+    } else {
+        Ok(Command::new(adapter))
+    }
+}
+
+pub(super) fn codex_login_command(codex: &Path) -> Command {
+    let codex = crate::platform::os::external_application_path(codex);
+    if codex.extension().and_then(|value| value.to_str()) == Some("cmd") {
+        let mut command = Command::new("cmd");
+        command.args(["/D", "/S", "/C"]).arg(codex).arg("login");
+        command
+    } else {
+        let mut command = Command::new(codex);
+        command.arg("login");
+        command
+    }
+}
+
+pub(super) fn managed_artifact(architecture: &str) -> Result<ManagedCodexArtifact> {
+    match architecture {
+        "x86_64" => Ok(ManagedCodexArtifact {
+            urls: &[
+                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+            ],
+            integrity: "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
+            vendor_triple: "x86_64-pc-windows-msvc",
+        }),
+        _ => bail!("当前托管 Codex 下载不支持平台: windows-{architecture}"),
+    }
+}
+
+pub(super) fn should_retry_file_lock(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::PermissionDenied || matches!(error.raw_os_error(), Some(5 | 32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn installed_javascript_adapter_uses_native_windows_paths() {
+        let command = adapter_command(
+            Path::new(r"\\?\C:\Program Files\pinvou3\runtime\codex-bridge\index.js"),
+            Some(Path::new(
+                r"\\?\C:\Program Files\pinvou3\runtime\node\node.exe",
+            )),
+        )
+        .expect("build installed JavaScript adapter command");
+
+        assert_eq!(
+            command.as_std().get_program(),
+            r"C:\Program Files\pinvou3\runtime\node\node.exe"
+        );
+        assert_eq!(
+            command
+                .as_std()
+                .get_args()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec![r"C:\Program Files\pinvou3\runtime\codex-bridge\index.js"]
+        );
+    }
+
+    #[test]
+    fn command_shim_uses_windows_command_interpreter() {
+        let command = adapter_command(Path::new(r"C:\runtime\codex-acp.cmd"), None)
+            .expect("build Windows command-shim adapter command");
+        assert_eq!(command.as_std().get_program(), "cmd");
+        assert_eq!(
+            command
+                .as_std()
+                .get_args()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["/D", "/S", "/C", r"C:\runtime\codex-acp.cmd"]
+        );
+    }
+
+    #[test]
+    fn x64_managed_artifact_is_available() {
+        let artifact = managed_artifact("x86_64").expect("resolve Windows x64 Codex artifact");
+        assert_eq!(artifact.vendor_triple, "x86_64-pc-windows-msvc");
+        assert!(artifact.urls[0].starts_with("https://"));
+        assert!(artifact.integrity.starts_with("sha512-"));
+    }
+
+    #[test]
+    fn file_lock_errors_are_retryable() {
+        assert!(should_retry_file_lock(&io::Error::from_raw_os_error(5)));
+        assert!(should_retry_file_lock(&io::Error::from_raw_os_error(32)));
+        assert!(!should_retry_file_lock(&io::Error::from_raw_os_error(2)));
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/codex_acp/runtime.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/runtime.rs
@@ -14,7 +14,7 @@ use sha2::{Digest, Sha512};
 use tokio::io::AsyncWriteExt;
 use wait_timeout::ChildExt;
 
-use super::diagnostics;
+use super::{diagnostics, platform};
 
 pub const MANAGED_CODEX_VERSION: &str = "0.144.6";
 
@@ -45,44 +45,8 @@ pub struct ResolvedCodex {
     pub version: String,
 }
 
-struct ManagedCodexArtifact {
-    urls: &'static [&'static str],
-    integrity: &'static str,
-    vendor_triple: &'static str,
-}
-
-fn managed_artifact() -> Result<ManagedCodexArtifact> {
-    managed_artifact_for(std::env::consts::OS, std::env::consts::ARCH)
-}
-
-fn managed_artifact_for(os: &str, arch: &str) -> Result<ManagedCodexArtifact> {
-    match (os, arch) {
-        ("linux", "x86_64") => Ok(ManagedCodexArtifact {
-            urls: &[
-                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
-                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
-            ],
-            integrity: "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
-            vendor_triple: "x86_64-unknown-linux-musl",
-        }),
-        ("linux", "aarch64") => Ok(ManagedCodexArtifact {
-            urls: &[
-                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
-                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
-            ],
-            integrity: "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
-            vendor_triple: "aarch64-unknown-linux-musl",
-        }),
-        ("windows", "x86_64") => Ok(ManagedCodexArtifact {
-            urls: &[
-                "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
-                "https://registry.npmmirror.com/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
-            ],
-            integrity: "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
-            vendor_triple: "x86_64-pc-windows-msvc",
-        }),
-        _ => bail!("当前托管 Codex 下载不支持平台: {os}-{arch}"),
-    }
+fn managed_artifact() -> Result<platform::ManagedCodexArtifact> {
+    platform::managed_artifact(std::env::consts::ARCH)
 }
 
 fn runtime_root() -> PathBuf {
@@ -107,11 +71,7 @@ pub fn managed_codex_path() -> Option<PathBuf> {
         .join("vendor")
         .join(artifact.vendor_triple)
         .join("bin")
-        .join(if crate::platform::capabilities::is_windows() {
-            "codex.exe"
-        } else {
-            "codex"
-        });
+        .join(platform::managed_codex_executable_name());
     candidate.is_file().then_some(candidate)
 }
 
@@ -373,11 +333,7 @@ pub async fn install_managed_codex(
             .join("vendor")
             .join(artifact.vendor_triple)
             .join("bin")
-            .join(if crate::platform::capabilities::is_windows() {
-                "codex.exe"
-            } else {
-                "codex"
-            });
+            .join(platform::managed_codex_executable_name());
         if !codex.is_file() {
             bail!("托管 Codex 解压完成，但未找到可执行文件");
         }
@@ -442,7 +398,7 @@ async fn activate_runtime_with_retry(
     for attempt in 1..=MAX_ATTEMPTS {
         match tokio::fs::rename(extracted, target).await {
             Ok(()) => return Ok(()),
-            Err(error) if should_retry_windows_file_lock(&error) && attempt < MAX_ATTEMPTS => {
+            Err(error) if platform::should_retry_file_lock(&error) && attempt < MAX_ATTEMPTS => {
                 let delay_ms = u64::from(attempt.min(5)) * 500;
                 diagnostics::write(
                     operation_id,
@@ -467,7 +423,7 @@ async fn remove_existing_runtime_with_retry(target: &Path, operation_id: &str) -
         match tokio::fs::remove_dir_all(target).await {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-            Err(error) if should_retry_windows_file_lock(&error) && attempt < MAX_ATTEMPTS => {
+            Err(error) if platform::should_retry_file_lock(&error) && attempt < MAX_ATTEMPTS => {
                 let delay_ms = u64::from(attempt.min(5)) * 500;
                 diagnostics::write(
                     operation_id,
@@ -492,7 +448,7 @@ async fn remove_staging_with_retry(staging: &Path, operation_id: &str) -> io::Re
         match tokio::fs::remove_dir_all(staging).await {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Err(error),
-            Err(error) if should_retry_windows_file_lock(&error) && attempt < MAX_ATTEMPTS => {
+            Err(error) if platform::should_retry_file_lock(&error) && attempt < MAX_ATTEMPTS => {
                 let delay_ms = u64::from(attempt) * 300;
                 diagnostics::write(
                     operation_id,
@@ -507,16 +463,6 @@ async fn remove_staging_with_retry(staging: &Path, operation_id: &str) -> io::Re
         }
     }
     unreachable!("staging cleanup retry loop always returns")
-}
-
-fn should_retry_windows_file_lock(error: &io::Error) -> bool {
-    should_retry_file_lock_for_platform(error, crate::platform::capabilities::is_windows())
-}
-
-fn should_retry_file_lock_for_platform(error: &io::Error, is_windows: bool) -> bool {
-    is_windows
-        && (error.kind() == io::ErrorKind::PermissionDenied
-            || matches!(error.raw_os_error(), Some(5 | 32)))
 }
 
 fn verify_integrity(actual: &[u8], integrity: &str) -> Result<()> {
@@ -605,14 +551,6 @@ mod tests {
     }
 
     #[test]
-    fn windows_x64_managed_artifact_is_available() {
-        let artifact = managed_artifact_for("windows", "x86_64").unwrap();
-        assert_eq!(artifact.vendor_triple, "x86_64-pc-windows-msvc");
-        assert!(artifact.urls[0].starts_with("https://"));
-        assert!(artifact.integrity.starts_with("sha512-"));
-    }
-
-    #[test]
     fn minimum_version_rejects_old_system_codex() {
         assert!(!version_meets_minimum("0.139.0"));
         assert!(version_meets_minimum("0.144.6"));
@@ -655,25 +593,5 @@ mod tests {
         .unwrap();
         assert_eq!(selected.source, CodexRuntimeSource::Managed);
         assert_eq!(selected.version, MANAGED_CODEX_VERSION);
-    }
-
-    #[test]
-    fn windows_file_lock_errors_are_retryable() {
-        assert!(should_retry_file_lock_for_platform(
-            &io::Error::from_raw_os_error(5),
-            true
-        ));
-        assert!(should_retry_file_lock_for_platform(
-            &io::Error::from_raw_os_error(32),
-            true
-        ));
-        assert!(!should_retry_file_lock_for_platform(
-            &io::Error::from_raw_os_error(2),
-            true
-        ));
-        assert!(!should_retry_file_lock_for_platform(
-            &io::Error::from_raw_os_error(5),
-            false
-        ));
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/runtime.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/runtime.rs
@@ -141,12 +141,14 @@ pub fn codex_version(path: &Path) -> Option<String> {
 }
 
 fn codex_version_result(path: &Path) -> Result<String> {
-    let mut child = std::process::Command::new(path)
-        .arg("--version")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| format!("启动 Codex 自检失败: {}", path.display()))?;
+    let mut child = crate::platform::process::HiddenCommand::new(
+        crate::platform::os::external_application_path(path),
+    )
+    .arg("--version")
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .with_context(|| format!("启动 Codex 自检失败: {}", path.display()))?;
     let status = match child
         .wait_timeout(Duration::from_secs(3))
         .context("等待 Codex 自检进程失败")?

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
-use std::process::Command;
 use std::time::UNIX_EPOCH;
 
 use anyhow::{bail, Context, Result};
@@ -735,7 +734,7 @@ fn filesystem_changes(
 }
 
 fn git_root(root: &Path) -> Option<PathBuf> {
-    let output = Command::new("git")
+    let output = crate::platform::process::HiddenCommand::new("git")
         .current_dir(root)
         .args(["rev-parse", "--show-toplevel"])
         .output()
@@ -753,7 +752,7 @@ fn git_branch(root: &Path) -> Option<String> {
 }
 
 fn git_status_entries(root: &Path) -> Result<Vec<WorkspaceChange>> {
-    let output = Command::new("git")
+    let output = crate::platform::process::HiddenCommand::new("git")
         .current_dir(root)
         .args([
             "status",
@@ -815,7 +814,7 @@ fn git_status_label(x: char, y: char) -> &'static str {
 }
 
 fn git_output(root: &Path, arguments: &[&str]) -> Result<String> {
-    let output = Command::new("git")
+    let output = crate::platform::process::HiddenCommand::new("git")
         .current_dir(root)
         .args(arguments)
         .output()

--- a/pinvou3-app/tests/codex_acp_platform_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_platform_contract.test.js
@@ -30,7 +30,7 @@ assert.match(runtime, /platform::should_retry_file_lock\(&error\)/);
 assert.match(windows, /SYSTEM_CODEX_NAME: &str = "codex\.cmd"/);
 assert.match(windows, /MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex\.exe"/);
 assert.match(windows, /external_application_path\(adapter\)/);
-assert.match(windows, /Command::new\("cmd"\)/);
+assert.match(windows, /HiddenTokioCommand::new\("cmd"\)/);
 assert.match(windows, /x86_64-pc-windows-msvc/);
 
 assert.match(linux, /SYSTEM_CODEX_NAME: &str = "codex"/);

--- a/pinvou3-app/tests/codex_acp_platform_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_platform_contract.test.js
@@ -1,0 +1,44 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const appRoot = path.resolve(__dirname, "..");
+const read = (...parts) => fs.readFileSync(path.join(appRoot, ...parts), "utf8");
+const featureRoot = ["src-tauri", "src", "features", "codex_acp"];
+const runtime = read(...featureRoot, "runtime.rs");
+const platform = read(...featureRoot, "platform", "mod.rs");
+const windows = read(...featureRoot, "platform", "windows.rs");
+const linux = read(...featureRoot, "platform", "linux.rs");
+const macos = read(...featureRoot, "platform", "macos.rs");
+
+for (const os of ["windows", "linux", "macos"]) {
+  assert.match(
+    platform,
+    new RegExp(`#\\[cfg\\(target_os = "${os}"\\)\\][\\s\\S]*?${os} as current`),
+    `${os} Codex behavior must be selected at compile time`,
+  );
+}
+
+assert.ok(
+  !runtime.includes("capabilities::is_windows()")
+    && !runtime.includes("managed_artifact_for("),
+  "shared runtime management must delegate OS behavior to the Codex platform adapter",
+);
+assert.match(runtime, /platform::managed_artifact\(std::env::consts::ARCH\)/);
+assert.match(runtime, /platform::should_retry_file_lock\(&error\)/);
+
+assert.match(windows, /SYSTEM_CODEX_NAME: &str = "codex\.cmd"/);
+assert.match(windows, /MANAGED_CODEX_EXECUTABLE_NAME: &str = "codex\.exe"/);
+assert.match(windows, /external_application_path\(adapter\)/);
+assert.match(windows, /Command::new\("cmd"\)/);
+assert.match(windows, /x86_64-pc-windows-msvc/);
+
+assert.match(linux, /SYSTEM_CODEX_NAME: &str = "codex"/);
+assert.match(linux, /x86_64-unknown-linux-musl/);
+assert.match(linux, /aarch64-unknown-linux-musl/);
+assert.ok(!linux.includes('Command::new("cmd")'));
+
+assert.match(macos, /当前托管 Codex 下载不支持平台: macos-/);
+assert.match(macos, /should_retry_file_lock\(_error: &io::Error\) -> bool \{\s*false/);
+
+console.log("✓ Codex ACP compile-time platform contract passed");

--- a/pinvou3-app/tests/codex_acp_windows_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_windows_contract.test.js
@@ -53,9 +53,11 @@ const codexRuntime = read(
   "runtime.rs",
 );
 const buildScript = read("scripts", "tauri", "build.js");
+const bridgeBuildScript = read("scripts", "tauri", "codex-bridge.js");
 const {
   BRIDGE_ENTRYPOINT,
   expectedMarker,
+  hideWindowsChildProcesses,
   isPrepared,
   WINDOWS_NODE_VERSION,
   windowsBridgeOverlay,
@@ -78,8 +80,13 @@ assert.match(
 );
 assert.match(
   codexAcpWindows,
-  /Command::new\("cmd"\)[\s\S]*?\["\/D", "\/S", "\/C"\]/,
+  /HiddenTokioCommand::new\("cmd"\)[\s\S]*?\["\/D", "\/S", "\/C"\]/,
   "codex-acp.cmd must run through cmd /D /S /C",
+);
+assert.match(
+  codexAcpWindows,
+  /HiddenTokioCommand::new\(crate::platform::os::external_application_path\(node\)\)/,
+  "the installed Node Bridge must start without a visible Windows console",
 );
 assert.match(
   codexAcpWindows,
@@ -93,7 +100,7 @@ assert.match(
 );
 assert.match(
   codexAcpWindows,
-  /Command::new\(crate::platform::os::external_application_path\(node\)\)[\s\S]*?command\.arg\(adapter\)/,
+  /HiddenTokioCommand::new\(crate::platform::os::external_application_path\(node\)\)[\s\S]*?command\.arg\(adapter\)/,
   "bundled Node and the JavaScript Bridge must receive normalized installed paths",
 );
 assert.match(
@@ -105,6 +112,11 @@ assert.match(
   codexAcp,
   /"session:bridge_stderr"[\s\S]*?"session:initialize_failed"[\s\S]*?exit_status=/,
   "Bridge stderr and exit status must remain available in persistent ACP diagnostics",
+);
+assert.match(
+  bridgeBuildScript,
+  /windowsHide: true[\s\S]*?hideWindowsChildProcesses/,
+  "the packaged ACP Bridge must hide the Codex CLI process it starts on Windows",
 );
 assert.match(
   codexRuntime,
@@ -160,7 +172,15 @@ try {
     packageJsonPath,
     JSON.stringify({ version: expected.codex_acp_version }),
   );
-  fs.writeFileSync(path.join(bridgeRoot, BRIDGE_ENTRYPOINT), "bridge");
+  const bridgeEntrypoint = path.join(bridgeRoot, BRIDGE_ENTRYPOINT);
+  fs.writeFileSync(
+    bridgeEntrypoint,
+    [
+      'spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv })',
+      'spawn(process.execPath, [bundledCodexPath, "app-server"], { env: spawnEnv })',
+    ].join("\n"),
+  );
+  hideWindowsChildProcesses(bridgeEntrypoint);
   fs.writeFileSync(nodeExecutable, fakeNode);
 
   assert.equal(expected.node_version, WINDOWS_NODE_VERSION);

--- a/pinvou3-app/tests/codex_acp_windows_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_windows_contract.test.js
@@ -21,6 +21,30 @@ const codexAcp = read(
   "codex_acp",
   "mod.rs",
 );
+const codexAcpPlatform = read(
+  "src-tauri",
+  "src",
+  "features",
+  "codex_acp",
+  "platform",
+  "mod.rs",
+);
+const codexAcpWindows = read(
+  "src-tauri",
+  "src",
+  "features",
+  "codex_acp",
+  "platform",
+  "windows.rs",
+);
+const windowsPath = read(
+  "src-tauri",
+  "src",
+  "platform",
+  "os",
+  "windows",
+  "windows_path.rs",
+);
 const codexRuntime = read(
   "src-tauri",
   "src",
@@ -43,24 +67,44 @@ assert.match(
   "Windows and Linux must advertise Codex ACP capability",
 );
 assert.match(
-  codexAcp,
-  /fn adapter_needs_path_node_lookup[\s\S]*?is_windows\s*\|\|[\s\S]*?Some\("js"\)/,
+  codexAcpWindows,
+  /fn adapter_needs_node\(_adapter: &Path\) -> bool \{\s*true\s*\}/,
   "Windows adapters must validate Node even when the adapter is a command shim",
 );
 assert.match(
-  codexAcp,
-  /fn is_windows_cmd_for_platform[\s\S]*?Some\("cmd"\)/,
+  codexAcpWindows,
+  /adapter\.extension\(\)[\s\S]*?Some\("cmd"\)/,
   "Windows command shims must be detected explicitly",
 );
 assert.match(
-  codexAcp,
-  /is_windows_cmd_for_platform\(adapter, is_windows\)[\s\S]*?Command::new\("cmd"\)[\s\S]*?\["\/D", "\/S", "\/C"\]/,
+  codexAcpWindows,
+  /Command::new\("cmd"\)[\s\S]*?\["\/D", "\/S", "\/C"\]/,
   "codex-acp.cmd must run through cmd /D /S /C",
 );
 assert.match(
-  codexRuntime,
-  /\("windows", "x86_64"\)[\s\S]*?x86_64-pc-windows-msvc/,
+  codexAcpWindows,
+  /"x86_64"[\s\S]*?x86_64-pc-windows-msvc/,
   "Windows x64 must have a managed Codex artifact",
+);
+assert.match(
+  windowsPath,
+  /fn platform_compat_path[\s\S]*?strip_prefix\(r"\\\\\?\\UNC\\"\)[\s\S]*?strip_prefix\(r"\\\\\?\\"\)/,
+  "Windows OS paths must remove verbatim prefixes before external-process launch",
+);
+assert.match(
+  codexAcpWindows,
+  /Command::new\(crate::platform::os::external_application_path\(node\)\)[\s\S]*?command\.arg\(adapter\)/,
+  "bundled Node and the JavaScript Bridge must receive normalized installed paths",
+);
+assert.match(
+  codexAcpPlatform,
+  /#\[cfg\(target_os = "windows"\)\][\s\S]*?use windows as current/,
+  "Codex platform behavior must be selected at compile time",
+);
+assert.match(
+  codexAcp,
+  /"session:bridge_stderr"[\s\S]*?"session:initialize_failed"[\s\S]*?exit_status=/,
+  "Bridge stderr and exit status must remain available in persistent ACP diagnostics",
 );
 assert.match(
   codexRuntime,

--- a/pinvou3-app/tests/web_template_packaging_contract.test.js
+++ b/pinvou3-app/tests/web_template_packaging_contract.test.js
@@ -9,6 +9,7 @@ const {
 const {
   WINDOWS_NPM_CI_ARGS,
   expectedMarker: expectedBridgeMarker,
+  hideWindowsChildProcesses,
 } = require("../scripts/tauri/codex-bridge.js");
 
 const APP_ROOT = path.resolve(__dirname, "..");
@@ -87,6 +88,29 @@ assert.deepEqual(
 
 assert.ok(WINDOWS_NPM_CI_ARGS.includes("--omit=optional"));
 assert.equal(expectedBridgeMarker({ architecture: "x64" }).requires_managed_codex, true);
+assert.equal(
+  expectedBridgeMarker({ architecture: "x64" }).windows_child_processes_hidden,
+  true,
+);
+const bridgePatchRoot = fs.mkdtempSync(
+  path.join(require("node:os").tmpdir(), "pinvou3-codex-bridge-"),
+);
+try {
+  const entrypoint = path.join(bridgePatchRoot, "index.js");
+  fs.writeFileSync(
+    entrypoint,
+    [
+      'spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv })',
+      'spawn(process.execPath, [bundledCodexPath, "app-server"], { env: spawnEnv })',
+    ].join("\n"),
+  );
+  hideWindowsChildProcesses(entrypoint);
+  const patched = fs.readFileSync(entrypoint, "utf8");
+  assert.match(patched, /shell: true, env: spawnEnv, windowsHide: true/);
+  assert.match(patched, /bundledCodexPath[\s\S]*?windowsHide: true/);
+} finally {
+  fs.rmSync(bridgePatchRoot, { recursive: true, force: true });
+}
 const packageJson = JSON.parse(fs.readFileSync(path.join(APP_ROOT, "package.json"), "utf8"));
 assert.equal(
   packageJson.scripts["prepare:codex-bridge"],


### PR DESCRIPTION
## 概述

修复安装态 Codex ACP 因 Windows 路径格式导致的启动失败，并将不同操作系统的运行时行为拆分到功能内平台适配层。失败时会保留 Bridge 标准错误和退出状态，便于定位实际原因。

## 背景

安装目录可能使用 Windows 长路径或 verbatim 路径格式，直接传给 Node、Codex 或命令解释器时会导致外部进程无法启动。原有实现还在共享运行时代码中混合了多平台判断，不利于维护和验证。

## 变更

- 统一规范化外部进程使用的 Node、Bridge 和 Codex 路径，兼容 Windows 安装目录及长路径格式。
- 按 Windows、Linux、macOS 和不支持平台拆分 Codex ACP 命令、产物与文件锁处理逻辑，并在编译期选择实现。
- 在 ACP 初始化失败时记录 Bridge stderr 尾部内容和进程退出状态，提升故障诊断能力。
- 保留内置 Node 运行时与 Windows 文件占用重试机制，补充平台契约及安装态运行时回归测试。

## 影响面

- 影响桌面端 Codex ACP 的启动、登录、托管运行时安装与故障诊断。
- Windows 安装态启动路径兼容性得到修复；Linux 继续支持 x86_64 与 aarch64 托管产物；macOS 仍保持托管 Codex 下载不支持的显式提示。
- 不涉及界面、会话数据格式或 CodeWhale 子模块变更。

## 验证

- `npm --prefix pinvou3-app run test:codex-acp`
- `npm --prefix pinvou3-app run test:codex-acp-windows-runtime`
- `python scripts/architecture-guard.py`
- `cargo check --locked --offline`（`pinvou3-app/src-tauri`）