### PR TITLE
ci: 升级 GitHub Actions 至最新版本消除 Node 20 弃用告警

### DIFF
--- a/.github/workflows/arm64-connector-verify.yml
+++ b/.github/workflows/arm64-connector-verify.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check runner architecture
         run: |

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify DCO sign-offs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const commits = await github.paginate(

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
           vulnerability-check: true

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -41,7 +41,7 @@ jobs:
       # 不再需要 CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -81,10 +81,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -108,8 +108,8 @@ jobs:
       relay: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.relay }}
       windows_codex: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.windows_codex }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         if: github.event_name == 'pull_request'
         with:
@@ -201,7 +201,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout (含 submodule,fork 为 public 直接拉)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: false
           fetch-depth: 0
@@ -230,7 +230,7 @@ jobs:
           ./scripts/ci-fork-link-check.sh "origin/$base_ref"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
@@ -267,9 +267,9 @@ jobs:
       run:
         working-directory: pinvou3-app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -316,9 +316,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -343,7 +343,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: false
 
@@ -419,7 +419,7 @@ jobs:
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: false
 
@@ -463,7 +463,7 @@ jobs:
       # remote_control 的真实 relay 下载 e2e 需要 node + relay 依赖,缺 node_modules/ws 时
       # 该 e2e 会自动 skip —— 装上依赖让 CI 真正执行它,而不是绿灯假过。
       - name: Node.js (relay e2e)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -542,7 +542,7 @@ jobs:
       SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: false
 
@@ -560,7 +560,7 @@ jobs:
         run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -602,10 +602,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -58,12 +58,12 @@ jobs:
       version: ${{ steps.diff.outputs.version }}
     steps:
       # fetch-depth:0 确保 push 事件的 before commit 可用于整段 push 范围比较。
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -120,7 +120,7 @@ jobs:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -147,7 +147,7 @@ jobs:
             build-essential pkg-config cmake
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -193,7 +193,7 @@ jobs:
           ls -lh "$DST"
 
       - name: 上传 deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pinvou3-linux-${{ needs.check-version-bump.outputs.version }}-x64
           path: |
@@ -213,7 +213,7 @@ jobs:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -237,7 +237,7 @@ jobs:
             build-essential pkg-config cmake
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -277,7 +277,7 @@ jobs:
           ls -lh "$DEB"
 
       - name: 上传 deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pinvou3-linux-${{ needs.check-version-bump.outputs.version }}-arm64
           path: |
@@ -305,7 +305,7 @@ jobs:
       AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -319,7 +319,7 @@ jobs:
           shared-key: release-windows-x64
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -357,7 +357,7 @@ jobs:
           ls -lh "$EXE"
 
       - name: 上传 nsis artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pinvou3-windows-${{ needs.check-version-bump.outputs.version }}-x64
           path: |
@@ -379,7 +379,7 @@ jobs:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
     steps:
       - name: Checkout (含 submodule)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -414,7 +414,7 @@ jobs:
           fi
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -491,7 +491,7 @@ jobs:
           ls -lh "pinvou3_${VERSION}_universal.dmg"
 
       - name: 上传 dmg artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pinvou3-macos-${{ needs.check-version-bump.outputs.version }}-universal
           path: |

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,7 +13,7 @@ jobs:
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 概述

将仓库全部 7 个 CI workflow 中使用的 GitHub Actions 升级到各自最新大版本（全部运行于 Node 24），消除日志中的 Node 20 Deprecation Warning 以及老旧 action 被强制切换 Node 24 的告警。

## 背景

GitHub 已弃用基于 Node 20 的 action 运行时，旧版 action（checkout@v4、setup-node@v4 等）在运行日志中持续产生 Deprecation Warning，并会被强制切换到 Node 24 运行，存在后续被移除支持的风险。

## 变更

- `actions/checkout` v4 → v7（18 处）
- `actions/setup-node` v4 → v7（12 处）
- `actions/setup-python` v5 → v7
- `actions/upload-artifact` v4 → v7（4 处）
- `actions/github-script` v7 → v9
- `dorny/paths-filter` v3 → v4
- `actions/dependency-review-action` v4.9.0 → v5.0.0（保持 SHA 钉住风格，更新注释）

已逐一核对各大版本的破坏性变更，现有用法均不受影响：
- 无 `pull_request_target` / `workflow_run` 触发器，不受 checkout v7 的 fork PR 限制影响；
- dco.yml 脚本只使用注入的 `github`/`context`/`core`，不涉及 github-script v9 移除的 `require('@actions/github')`；
- setup-node v5+ 引入了基于 `packageManager` 字段的自动缓存（v6 起仅限 npm）：各 `package.json` 均无 `packageManager` 字段，不会触发；多数步骤本已显式配置 `cache: npm`（pr-check.yml 中 1 处未配 cache 的步骤保持不缓存，行为与升级前一致）；
- 未使用 setup-python v7 已删除的 `pip-install` 输入；
- dependency-review-action v5 的 `action.yml` 已核对，现有全部输入保留。

以下 action 经核实已是最新或已运行于 Node 24，未做改动：`Swatinem/rust-cache@v2`（浮动 tag 指向 v2.9.1，node24）、`mozilla-actions/sccache-action@v0.0.10`（node24）、`dtolnay/rust-toolchain@stable` 与 `taiki-e/install-action@v2`（composite）、gitleaks v8.30.1（docker，已最新）。

## 验证

- 所有新版本 tag 经 `git ls-remote` 确认存在；
- 7 个 workflow YAML 均通过解析校验；
- 本 PR 自身的 CI 运行即为对升级后 action 的实际验证。

## 备注

- 全部为 GitHub-hosted runner，runner 版本始终满足 Node 24 要求的 ≥2.327.1；
- 改动仅涉及 `uses:` 版本号，无任何 workflow 逻辑变更。
