### PR TITLE
fix(session): 修复历史会话路由、恢复与白屏

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -15,7 +15,7 @@ use crate::features::codex_acp::workspace::{
 use crate::features::codex_acp::{
     validate_codex_project_workspace, AcpEventEnvelope, AcpPool, CodexAcpPendingElicitation,
     CodexAcpPendingPermission, CodexAcpSessionInfo, CodexAcpStatus, CodexAcpWorkspaceInfo,
-    CodexWorkspaceKind,
+    CodexWorkspaceKind, CODEX_ACP_SESSION_MODEL,
 };
 use crate::features::sessions::{SessionKind, SessionStore};
 
@@ -372,7 +372,7 @@ pub async fn list_codex_acp_sessions(
         .map_err(|error| format!("list_codex_acp_sessions: {error:?}"))?;
     metas.retain(|metadata| {
         matches!(store.session_kind(&metadata.id), Ok(SessionKind::Chat))
-            && acp_pool.is_codex(&metadata.id)
+            && acp_pool.is_codex_metadata(metadata)
             && !store.is_hidden(&metadata.id)
     });
     metas
@@ -407,7 +407,11 @@ pub async fn create_codex_acp_session(
         .clone()
         .unwrap_or_else(|| pool.bridge.workspace.clone());
     let session = store
-        .create_new("Codex (ACP)".to_string(), None, metadata_workspace)
+        .create_new(
+            CODEX_ACP_SESSION_MODEL.to_string(),
+            None,
+            metadata_workspace,
+        )
         .map_err(|error| format!("create_codex_acp_session: {error:?}"))?;
     let kind = if project_workspace.is_some() {
         CodexWorkspaceKind::Project

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -69,7 +69,7 @@ pub async fn list_sessions(
     let mut metas = store.list().map_err(|e| format!("list_sessions: {e:?}"))?;
     metas.retain(|m| {
         matches!(store.session_kind(&m.id), Ok(SessionKind::Chat))
-            && !acp_pool.is_codex(&m.id)
+            && !acp_pool.is_codex_metadata(m)
             && !store.is_hidden(&m.id)
             && store
                 .active_skill(&m.id)

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -41,6 +41,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::features::sessions::SessionStore;
 use attachments::{prepare_codex_prompt, CodexDisplayAttachment};
+use deepseek_tui::session_manager::SessionMetadata;
 pub use events::AcpEventEnvelope;
 use events::{load_timeline, patch_acp_state, persist_acp_state, EventBridge};
 use runtime::{
@@ -52,7 +53,12 @@ pub use store::{
 };
 
 pub const CODEX_ACP_VERSION: &str = "1.1.5";
+pub const CODEX_ACP_SESSION_MODEL: &str = "Codex (ACP)";
 const CODEX_ACP_PACKAGE: &str = "@agentclientprotocol/codex-acp";
+
+fn is_codex_session(backend: AgentBackend, model: &str) -> bool {
+    backend == AgentBackend::CodexAcp || model == CODEX_ACP_SESSION_MODEL
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CodexAcpStatus {
@@ -413,8 +419,23 @@ impl AcpPool {
         &self.agents
     }
 
+    /// 会话类型以 ACP 辅助索引为主，并用 SavedSession 中持久化的模型类型兜底。
+    ///
+    /// `session-agents.json` 是可重建的辅助索引，缺失或损坏时不能让历史 Codex
+    /// 会话掉回普通聊天列表；创建会话时写入的 `Codex (ACP)` 元数据才是长期兼容
+    /// 依据。列表调用已经持有 metadata，应使用本方法避免重复读取 transcript。
+    pub fn is_codex_metadata(&self, metadata: &SessionMetadata) -> bool {
+        is_codex_session(self.agents.backend(&metadata.id), &metadata.model)
+    }
+
     pub fn is_codex(&self, session_id: &str) -> bool {
-        self.agents.backend(session_id) == AgentBackend::CodexAcp
+        let backend = self.agents.backend(session_id);
+        if backend == AgentBackend::CodexAcp {
+            return true;
+        }
+        self.session_store
+            .load(session_id)
+            .is_ok_and(|session| is_codex_session(backend, &session.metadata.model))
     }
 
     pub fn workspace_info(&self, session_id: &str) -> Result<CodexAcpWorkspaceInfo> {
@@ -1886,6 +1907,19 @@ fn codex_authenticated() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codex_session_classification_survives_missing_auxiliary_index() {
+        assert!(is_codex_session(
+            AgentBackend::Deepseek,
+            CODEX_ACP_SESSION_MODEL
+        ));
+        assert!(is_codex_session(
+            AgentBackend::CodexAcp,
+            "unexpected legacy model"
+        ));
+        assert!(!is_codex_session(AgentBackend::Deepseek, "deepseek-chat"));
+    }
 
     #[test]
     fn managed_path_is_versioned() {

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -11,7 +11,7 @@ mod runtime;
 mod store;
 pub(crate) mod workspace;
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -32,7 +32,7 @@ use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo};
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
@@ -48,6 +48,7 @@ use runtime::{
     install_managed_codex, is_managed_newer_than, resolve_codex_path, ResolvedCodex,
     MANAGED_CODEX_VERSION,
 };
+use store::SessionAgentRecord;
 pub use store::{
     validate_codex_project_workspace, AgentBackend, CodexWorkspaceKind, SessionAgentStore,
 };
@@ -58,6 +59,96 @@ const CODEX_ACP_PACKAGE: &str = "@agentclientprotocol/codex-acp";
 
 fn is_codex_session(backend: AgentBackend, model: &str) -> bool {
     backend == AgentBackend::CodexAcp || model == CODEX_ACP_SESSION_MODEL
+}
+
+fn same_workspace(left: &Path, right: &Path) -> bool {
+    left == right
+        || left
+            .canonicalize()
+            .ok()
+            .zip(right.canonicalize().ok())
+            .is_some_and(|(left, right)| left == right)
+}
+
+fn codex_recovery_record(
+    pinvou_session_id: &str,
+    state: &Value,
+    workspace_path: PathBuf,
+    temporary_workspace: &Path,
+) -> Result<SessionAgentRecord> {
+    if state["pinvouSessionId"].as_str() != Some(pinvou_session_id) {
+        bail!("acp-state.json 的 Pinvou 会话 ID 不匹配");
+    }
+    if state["adapter"]["package"].as_str() != Some(CODEX_ACP_PACKAGE) {
+        bail!("acp-state.json 不是 Codex ACP 状态");
+    }
+    let acp_session_id = state["session"]["session_id"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .context("acp-state.json 缺少原 ACP session id")?
+        .to_string();
+    if !workspace_path.is_absolute() {
+        bail!("Codex 工作目录记录不是绝对路径");
+    }
+    let workspace_kind = match state["workspace"]["kind"].as_str() {
+        Some("temporary") => {
+            if !same_workspace(&workspace_path, temporary_workspace) {
+                bail!("acp-state.json 的临时工作目录与会话目录不匹配");
+            }
+            CodexWorkspaceKind::Temporary
+        }
+        Some("project") => CodexWorkspaceKind::Project,
+        Some(other) => bail!("acp-state.json 包含未知工作目录类型: {other}"),
+        None if same_workspace(&workspace_path, temporary_workspace) => {
+            CodexWorkspaceKind::Temporary
+        }
+        None => CodexWorkspaceKind::Project,
+    };
+    Ok(SessionAgentRecord {
+        backend: AgentBackend::CodexAcp,
+        acp_session_id: Some(acp_session_id),
+        acp_model_id: state["session"]["current_model_id"]
+            .as_str()
+            .map(str::to_string),
+        acp_mode_id: state["session"]["modes"]["currentModeId"]
+            .as_str()
+            .map(str::to_string),
+        workspace_kind,
+        workspace_path: (workspace_kind == CodexWorkspaceKind::Project).then_some(workspace_path),
+    })
+}
+
+fn load_codex_recovery_record(
+    session_id: &str,
+    session_store: &SessionStore,
+) -> Result<SessionAgentRecord> {
+    let temporary_workspace = session_store.execution_workspace(session_id)?;
+    let session_root = crate::platform::paths::sessions_root().join(session_id);
+    let state_path = session_root.join("acp-state.json");
+    let state: Value = serde_json::from_slice(
+        &std::fs::read(&state_path)
+            .with_context(|| format!("读取 {} 失败", state_path.display()))?,
+    )
+    .with_context(|| format!("解析 {} 失败", state_path.display()))?;
+    let workspace_path = if let Some(path) = state["workspace"]["path"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+    {
+        PathBuf::from(path)
+    } else {
+        let baseline_path = session_root.join("codex-workspace-baseline.json");
+        let baseline: Value = serde_json::from_slice(
+            &std::fs::read(&baseline_path)
+                .with_context(|| format!("读取 {} 失败", baseline_path.display()))?,
+        )
+        .with_context(|| format!("解析 {} 失败", baseline_path.display()))?;
+        baseline["workspace_path"]
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .context("Codex 工作区基线缺少 workspace_path")?
+    };
+    codex_recovery_record(session_id, &state, workspace_path, &temporary_workspace)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -293,6 +384,7 @@ pub struct AcpPool {
     pending_permissions: Arc<Mutex<HashMap<String, PendingPermission>>>,
     pending_elicitations: Arc<Mutex<HashMap<String, PendingElicitation>>>,
     agents: SessionAgentStore,
+    codex_metadata_ids: Arc<parking_lot::RwLock<HashSet<String>>>,
     session_store: SessionStore,
     installing: Arc<AtomicBool>,
     login_in_progress: Arc<AtomicBool>,
@@ -395,12 +487,38 @@ impl AcpPool {
             .into_iter()
             .find(|candidate| candidate.is_file())
         });
+        let agents = SessionAgentStore::load_or_empty();
+        let metadata = session_store.list().unwrap_or_else(|error| {
+            eprintln!("[pinvou3-app] preload Codex session metadata failed: {error:#}");
+            Vec::new()
+        });
+        let codex_metadata_ids = metadata
+            .iter()
+            .filter(|metadata| metadata.model == CODEX_ACP_SESSION_MODEL)
+            .map(|metadata| metadata.id.clone())
+            .collect::<HashSet<_>>();
+        for session_id in &codex_metadata_ids {
+            if agents.backend(session_id) == AgentBackend::CodexAcp {
+                continue;
+            }
+            match load_codex_recovery_record(session_id, &session_store)
+                .and_then(|record| agents.restore_missing_codex_record(session_id, record))
+            {
+                Ok(()) => {
+                    eprintln!("[pinvou3-app] recovered Codex ACP session index for {session_id}")
+                }
+                Err(error) => eprintln!(
+                    "[pinvou3-app] Codex ACP session {session_id} remains read-only until its index can be recovered: {error:#}"
+                ),
+            }
+        }
         Ok(Self {
             app,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             pending_elicitations: Arc::new(Mutex::new(HashMap::new())),
-            agents: SessionAgentStore::load_or_empty(),
+            agents,
+            codex_metadata_ids: Arc::new(parking_lot::RwLock::new(codex_metadata_ids)),
             session_store,
             installing: Arc::new(AtomicBool::new(false)),
             login_in_progress: Arc::new(AtomicBool::new(false)),
@@ -425,21 +543,44 @@ impl AcpPool {
     /// 会话掉回普通聊天列表；创建会话时写入的 `Codex (ACP)` 元数据才是长期兼容
     /// 依据。列表调用已经持有 metadata，应使用本方法避免重复读取 transcript。
     pub fn is_codex_metadata(&self, metadata: &SessionMetadata) -> bool {
-        is_codex_session(self.agents.backend(&metadata.id), &metadata.model)
+        let is_codex = is_codex_session(self.agents.backend(&metadata.id), &metadata.model);
+        if is_codex {
+            self.codex_metadata_ids.write().insert(metadata.id.clone());
+        }
+        is_codex
     }
 
     pub fn is_codex(&self, session_id: &str) -> bool {
-        let backend = self.agents.backend(session_id);
-        if backend == AgentBackend::CodexAcp {
-            return true;
+        self.agents.backend(session_id) == AgentBackend::CodexAcp
+            || self.codex_metadata_ids.read().contains(session_id)
+    }
+
+    fn codex_record(&self, session_id: &str) -> Result<SessionAgentRecord> {
+        let record = self.agents.get(session_id);
+        if record.backend == AgentBackend::CodexAcp {
+            return Ok(record);
         }
-        self.session_store
-            .load(session_id)
-            .is_ok_and(|session| is_codex_session(backend, &session.metadata.model))
+        if self.codex_metadata_ids.read().contains(session_id) {
+            bail!(
+                "Codex 会话辅助索引缺失，且无法从 acp-state.json 与工作区基线完整恢复；\
+                 为避免在错误目录新建上下文，当前会话仅允许查看历史"
+            );
+        }
+        bail!("会话不是 Codex ACP 会话")
     }
 
     pub fn workspace_info(&self, session_id: &str) -> Result<CodexAcpWorkspaceInfo> {
         let record = self.agents.get(session_id);
+        if record.backend != AgentBackend::CodexAcp {
+            if self.codex_metadata_ids.read().contains(session_id) {
+                return Ok(CodexAcpWorkspaceInfo {
+                    workspace_kind: CodexWorkspaceKind::Temporary,
+                    workspace_path: "辅助索引缺失，无法安全恢复原工作目录".to_string(),
+                    workspace_available: false,
+                });
+            }
+            bail!("会话不是 Codex ACP 会话");
+        }
         let path = match record.workspace_kind {
             CodexWorkspaceKind::Project => record
                 .workspace_path
@@ -461,7 +602,7 @@ impl AcpPool {
     }
 
     fn execution_workspace(&self, session_id: &str) -> Result<PathBuf> {
-        let record = self.agents.get(session_id);
+        let record = self.codex_record(session_id)?;
         match record.workspace_kind {
             CodexWorkspaceKind::Temporary => self
                 .session_store
@@ -1546,6 +1687,10 @@ impl AcpPool {
                     "modes": &mode_state,
                     "config_options": &config_options,
                 },
+                "workspace": {
+                    "kind": saved.workspace_kind,
+                    "path": &workspace,
+                },
                 "lastStatus": "ready",
             }),
         )?;
@@ -1919,6 +2064,55 @@ mod tests {
             "unexpected legacy model"
         ));
         assert!(!is_codex_session(AgentBackend::Deepseek, "deepseek-chat"));
+    }
+
+    #[test]
+    fn codex_recovery_preserves_original_acp_session_and_workspace() {
+        let state = json!({
+            "pinvouSessionId": "pinvou-session",
+            "adapter": { "package": CODEX_ACP_PACKAGE },
+            "session": {
+                "session_id": "acp-session",
+                "current_model_id": "gpt-test",
+                "modes": { "currentModeId": "agent" },
+            },
+        });
+        let temporary = Path::new("/tmp/pinvou-session-workspace");
+        let project = PathBuf::from("/tmp/pinvou-project");
+        let recovered =
+            codex_recovery_record("pinvou-session", &state, project.clone(), temporary).unwrap();
+
+        assert_eq!(recovered.backend, AgentBackend::CodexAcp);
+        assert_eq!(recovered.acp_session_id.as_deref(), Some("acp-session"));
+        assert_eq!(recovered.acp_model_id.as_deref(), Some("gpt-test"));
+        assert_eq!(recovered.acp_mode_id.as_deref(), Some("agent"));
+        assert_eq!(recovered.workspace_kind, CodexWorkspaceKind::Project);
+        assert_eq!(recovered.workspace_path, Some(project));
+
+        let temporary_recovered =
+            codex_recovery_record("pinvou-session", &state, temporary.to_path_buf(), temporary)
+                .unwrap();
+        assert_eq!(
+            temporary_recovered.workspace_kind,
+            CodexWorkspaceKind::Temporary
+        );
+        assert_eq!(temporary_recovered.workspace_path, None);
+    }
+
+    #[test]
+    fn codex_recovery_rejects_incomplete_state() {
+        let state = json!({
+            "pinvouSessionId": "pinvou-session",
+            "adapter": { "package": CODEX_ACP_PACKAGE },
+            "session": {},
+        });
+        assert!(codex_recovery_record(
+            "pinvou-session",
+            &state,
+            PathBuf::from("/tmp/pinvou-project"),
+            Path::new("/tmp/pinvou-session-workspace"),
+        )
+        .is_err());
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
@@ -220,6 +220,32 @@ impl SessionAgentStore {
         self.persist()
     }
 
+    pub(super) fn restore_missing_codex_record(
+        &self,
+        session_id: &str,
+        recovered: SessionAgentRecord,
+    ) -> Result<()> {
+        if recovered.backend != AgentBackend::CodexAcp
+            || recovered
+                .acp_session_id
+                .as_deref()
+                .is_none_or(str::is_empty)
+        {
+            anyhow::bail!("恢复的 Codex 会话索引不完整");
+        }
+        {
+            let mut records = self.records.write();
+            if records
+                .get(session_id)
+                .is_some_and(|record| record.backend == AgentBackend::CodexAcp)
+            {
+                return Ok(());
+            }
+            records.insert(session_id.to_string(), recovered);
+        }
+        self.persist()
+    }
+
     pub fn remove(&self, session_id: &str) -> Result<()> {
         self.records.write().remove(session_id);
         self.persist()
@@ -327,6 +353,42 @@ mod tests {
             store.get("session-1").workspace_path.as_deref(),
             Some(root.as_path())
         );
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn recovered_codex_record_is_persisted_atomically() {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-codex-recovery-store-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("session-agents.json");
+        let store = SessionAgentStore {
+            path: path.clone(),
+            records: Arc::new(RwLock::new(HashMap::new())),
+        };
+        store
+            .restore_missing_codex_record(
+                "session-1",
+                SessionAgentRecord {
+                    backend: AgentBackend::CodexAcp,
+                    acp_session_id: Some("acp-session-1".to_string()),
+                    acp_model_id: Some("gpt-test".to_string()),
+                    acp_mode_id: Some("agent".to_string()),
+                    workspace_kind: CodexWorkspaceKind::Project,
+                    workspace_path: Some(root.clone()),
+                },
+            )
+            .unwrap();
+
+        let persisted: AgentStoreFile = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        let recovered = persisted.sessions.get("session-1").unwrap();
+        assert_eq!(recovered.backend, AgentBackend::CodexAcp);
+        assert_eq!(recovered.acp_session_id.as_deref(), Some("acp-session-1"));
+        assert_eq!(recovered.workspace_kind, CodexWorkspaceKind::Project);
+        assert_eq!(recovered.workspace_path.as_deref(), Some(root.as_path()));
         fs::remove_dir_all(&root).unwrap();
     }
 

--- a/pinvou3-app/src/features/conversation/deepseek-conversation.js
+++ b/pinvou3-app/src/features/conversation/deepseek-conversation.js
@@ -237,8 +237,9 @@ export function projectDeepSeekConversation({
   }
   const unassignedRecords = timeline.filter(record => !assigned.has(record.id));
   const unassignedTurns = userTurns.filter(turn => !turn.lifecycleKnown);
-  const trailingRecords = unassignedRecords.slice(-unassignedTurns.length);
-  const trailingTurns = unassignedTurns.slice(-trailingRecords.length);
+  const trailingPairCount = Math.min(unassignedRecords.length, unassignedTurns.length);
+  const trailingRecords = trailingPairCount > 0 ? unassignedRecords.slice(-trailingPairCount) : [];
+  const trailingTurns = trailingPairCount > 0 ? unassignedTurns.slice(-trailingPairCount) : [];
   trailingRecords.forEach((record, index) => {
     Object.assign(trailingTurns[index], {
       status: record.status,

--- a/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
+++ b/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
@@ -145,6 +145,19 @@ try {
   assert.equal(paired.length, 1, 'send_error timing records must not shift visible user turns');
   assert.equal(paired[0].status, 'incomplete');
 
+  const emptyHistory = projectDeepSeekConversation({
+    chatItems: [],
+    sessionId: 'empty-session',
+    timelineEvents: [
+      { turn_id: 'orphan-turn', event: 'user_start', timestamp: 10, ts: '1970-01-01T00:00:00Z' },
+    ],
+  });
+  assert.equal(
+    emptyHistory.turns.length,
+    0,
+    'orphan timeline records must not be assigned when the restored session has no visible turns',
+  );
+
   const search = searchToolDetails({
     name: 'web_search',
     rawInput: { query: '2026 年 AI 新闻' },


### PR DESCRIPTION
## 概述

修复 Codex ACP 历史会话误入普通列表和部分历史会话打开白屏的问题，并在辅助索引缺失时安全恢复原 ACP 上下文。

## 背景

Codex 会话类型原先依赖 `session-agents.json`。索引缺失后，会话可能进入错误列表；即使按持久化模型重新分类，也可能在错误工作区新建 ACP 上下文。空正文会话若仍有时间线记录，普通会话投影还会因合并到不存在的回合而导致页面白屏。

## 变更

- 使用持久化模型元数据区分普通会话与 Codex ACP 会话，并建立内存分类缓存，移除普通消息发送热路径的整份会话读取。
- 从 `acp-state.json` 和工作区基线恢复原 ACP session、模型、模式与工作区绑定；证据不完整时保留历史只读并明确阻止新建错误上下文。
- 在 ACP 状态中持续保存工作区类型和路径，增强后续索引重建能力。
- 修复空正文配残留时间线时的 `slice(-0)` 合并边界，避免历史会话渲染白屏。
- 增加会话分类、索引恢复、工作区恢复和空历史投影回归测试。

## 验证

- `cargo test --lib codex_session_classification_survives_missing_auxiliary_index`
- `cargo test --lib codex_recovery`
- `cargo test --lib recovered_codex_record_is_persisted_atomically`
- `cargo check`
- `npm run test:codex-acp`
- `npm run build:ui`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`

## 备注

无法同时确认原 ACP session 和工作区绑定的旧会话仍可查看历史，但会明确拒绝继续运行，避免在错误目录创建新上下文；不修改会话正文，不涉及 CodeWhale fork。