### PR TITLE
fix(models): 修复云端模型上下文长度推断与 MiniMax 过期端点

### DIFF
--- a/pinvou3-app/src-tauri/src/core/mod.rs
+++ b/pinvou3-app/src-tauri/src/core/mod.rs
@@ -1,1 +1,2 @@
 pub mod mode_state;
+pub mod model_context;

--- a/pinvou3-app/src-tauri/src/core/model_context.rs
+++ b/pinvou3-app/src-tauri/src/core/model_context.rs
@@ -1,0 +1,91 @@
+//! pinvou3 运行状态与 Engine 路由共用的模型上下文窗口解析。
+//!
+//! 已由 CodeWhale 维护的模型事实优先复用底座；这里只补充 pinvou3 设置页已经提供、
+//! 但当前底座尚未覆盖的云端模型。所有消费者必须走这一入口，避免页面显示窗口与
+//! `active_route_limits` / 压缩阈值使用不同口径。
+
+/// 精确匹配模型名，并容忍 `-` 分隔的日期、快照或服务档位后缀。
+fn model_name_matches(lower: &str, name: &str) -> bool {
+    lower == name
+        || lower
+            .strip_prefix(name)
+            .is_some_and(|rest| rest.starts_with('-'))
+}
+
+/// CodeWhale 已统一解析 `Nk` 后缀；这里只补它尚未覆盖的 `1m` 写法。
+fn explicit_one_million_hint(lower: &str) -> Option<u32> {
+    lower.contains("1m").then_some(1_048_576)
+}
+
+/// 解析 pinvou3 已知模型的上下文窗口。
+///
+/// 顺序为：显式 `1m` → CodeWhale 模型 catalog/`Nk` 启发式 → pinvou3 补充表。
+#[must_use]
+pub fn resolved_context_window(model: &str) -> Option<u32> {
+    let lower = model.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return None;
+    }
+    if let Some(window) = explicit_one_million_hint(&lower) {
+        return Some(window);
+    }
+    if let Some(window) = deepseek_tui::models::context_window_for_model(&lower) {
+        return Some(window);
+    }
+
+    const PINVOU_KNOWN: &[(&str, u32)] = &[
+        // Kimi K3 官方标称 100 万 token（platform.kimi.com/docs/models）。
+        ("kimi-k3", 1_048_576),
+        // Coding Plan 裸 k3 同为 1M；低档服务端限 256K 时由显式后缀优先覆盖。
+        ("k3", 1_048_576),
+        // kimi-for-coding 系属 K2.7 Code，官方 256K。
+        ("kimi-for-coding-highspeed", 262_144),
+        ("kimi-k2.7-code-highspeed", 262_144),
+        // 阿里云官方文档给 qwen3.7-plus/max/flash 1M 上下文。
+        ("qwen3.7-plus", 1_000_000),
+        ("qwen3.7-max", 1_000_000),
+        ("qwen3.7-flash", 1_000_000),
+        // 底座当前只覆盖带 `qwen/` 前缀的 qwen3.6-flash。
+        ("qwen3.6-flash", 1_000_000),
+        // 2026-07 火山引擎公告：doubao-seed-evolving 升为 1M 上下文。
+        ("doubao-seed-evolving", 1_048_576),
+        // 智谱官方标称 GLM-4.7 为 200K；沿用设置页二进制 K 展示口径。
+        ("glm-4.7", 204_800),
+    ];
+    PINVOU_KNOWN
+        .iter()
+        .find(|(name, _)| model_name_matches(&lower, name))
+        .map(|(_, window)| *window)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supplemental_cloud_models_resolve_to_verified_windows() {
+        for (model, expected) in [
+            ("kimi-k3", 1_048_576),
+            ("k3", 1_048_576),
+            ("qwen3.7-plus", 1_000_000),
+            ("qwen3.7-max", 1_000_000),
+            ("qwen3.7-flash", 1_000_000),
+            ("qwen3.6-flash", 1_000_000),
+            ("doubao-seed-evolving", 1_048_576),
+            ("glm-4.7", 204_800),
+        ] {
+            assert_eq!(resolved_context_window(model), Some(expected), "{model}");
+        }
+    }
+
+    #[test]
+    fn explicit_window_wins_and_codewhale_remains_the_base_catalog() {
+        assert_eq!(resolved_context_window("kimi-k3-256k"), Some(256_000));
+        assert_eq!(resolved_context_window("kimi-k3-1m"), Some(1_048_576));
+        assert_eq!(
+            resolved_context_window("gpt-5.6-sol"),
+            deepseek_tui::models::context_window_for_model("gpt-5.6-sol")
+        );
+        assert_eq!(resolved_context_window("unknown-cloud-model"), None);
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -561,24 +561,24 @@ impl Pinvou3Bridge {
         self.prefs.advanced.max_output_tokens.unwrap_or(24_576)
     }
 
-    /// 为一个具体 wire model 生成宿主已知的 route facts。正确性不依赖模型名：
-    /// SavedModel 显式能力与实时 probe 取更小值；本地 vLLM 无显式 context 时才
-    /// 使用模型 hint/128K 保守值。output 始终不超过 Pinvou 全局 24K 请求意图。
+    /// 为一个具体 wire model 生成宿主已知的 route facts：
+    /// SavedModel 显式能力与实时 probe 取更小值；两者都没有时复用运行状态页同一份
+    /// 模型 catalog，未知本地 vLLM 才使用 128K 保守值。output 始终不超过 Pinvou
+    /// 全局 24K 请求意图。
     fn route_limits_for_model(&self, model: &str) -> Option<codewhale_config::route::RouteLimits> {
         let saved = self.effective_model().filter(|saved| saved.model == model);
         let configured_context = saved.and_then(|saved| saved.context_window_tokens);
+        let inferred_context = crate::core::model_context::resolved_context_window(model);
+        let is_local_vllm = self.provider() == "vllm";
         let context_tokens = match (configured_context, self.probed_context_tokens) {
             (Some(configured), Some(probed)) => Some(configured.min(probed)),
             (Some(configured), None) => Some(configured),
             (None, Some(probed)) => Some(probed),
-            (None, None) if self.provider() == "vllm" => {
-                Some(deepseek_tui::models::context_window_for_model(model).unwrap_or(128_000))
-            }
-            (None, None) => None,
+            (None, None) => inferred_context.or_else(|| is_local_vllm.then_some(128_000)),
         };
         let configured_output = saved.and_then(|saved| saved.max_output_tokens);
         let output_tokens = configured_output
-            .or_else(|| (self.provider() == "vllm").then(|| self.max_output_tokens()))
+            .or_else(|| is_local_vllm.then(|| self.max_output_tokens()))
             .map(|tokens| tokens.min(self.max_output_tokens()))
             .map(|tokens| {
                 context_tokens.map_or(tokens, |context| {
@@ -603,7 +603,7 @@ impl Pinvou3Bridge {
             .and_then(|limits| limits.context_tokens)
             .and_then(|tokens| u32::try_from(tokens).ok())
             .unwrap_or_else(|| {
-                deepseek_tui::models::context_window_for_model(model).unwrap_or(128_000)
+                crate::core::model_context::resolved_context_window(model).unwrap_or(128_000)
             })
     }
 
@@ -1398,6 +1398,52 @@ mod tests {
             credential_action: None,
         }];
         bridge.prefs.advanced.active_model_id = Some("test-model".to_string());
+    }
+
+    #[test]
+    fn known_cloud_window_fills_route_limits_and_compaction_window() {
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::Qwen,
+            "qwen3.7-plus",
+            ModelPreset::Qwen.default_base_url(),
+            "",
+        );
+
+        let saved = bridge.effective_model().expect("active cloud model");
+        assert_eq!(
+            saved.context_window_tokens, None,
+            "云端 catalog 模型默认不要求用户手填窗口"
+        );
+        let limits = bridge
+            .route_limits_for_model(&bridge.model())
+            .expect("已知云端模型必须生成 route limits");
+        assert_eq!(limits.context_tokens, Some(1_000_000));
+        assert_eq!(
+            bridge
+                .build_engine_config()
+                .active_route_limits
+                .and_then(|route| route.context_tokens),
+            Some(1_000_000),
+            "运行状态与底座 active_route_limits 必须使用同一窗口"
+        );
+        assert_eq!(bridge.effective_context_window(&bridge.model()), 1_000_000);
+    }
+
+    #[test]
+    fn unknown_cloud_model_does_not_gain_a_speculative_route_limit() {
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "unknown-cloud-model",
+            "https://example.com/v1",
+            "",
+        );
+
+        assert_eq!(bridge.route_limits_for_model(&bridge.model()), None);
+        assert_eq!(bridge.effective_context_window(&bridge.model()), 128_000);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -457,7 +457,7 @@ impl Pinvou3Bridge {
             ModelPreset::OpenaiCompatible => "https://api.openai.com/v1".to_string(),
             ModelPreset::Qwen => "https://dashscope.aliyuncs.com/compatible-mode/v1".to_string(),
             ModelPreset::Doubao => "https://ark.cn-beijing.volces.com/api/v3".to_string(),
-            ModelPreset::Minimax => "https://api.minimax.chat/v1".to_string(),
+            ModelPreset::Minimax => "https://api.minimaxi.com/v1".to_string(),
             ModelPreset::Glm => "https://open.bigmodel.cn/api/paas/v4".to_string(),
             ModelPreset::Mimo => "https://api.xiaomimimo.com/v1".to_string(),
         }

--- a/pinvou3-app/src-tauri/src/features/monitor/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/mod.rs
@@ -893,75 +893,12 @@ pub async fn probe_openai_models(base_url: &str) -> Option<OpenAiModelsProbe> {
     })
 }
 
-/// 精确匹配模型名，并容忍 `-` 分隔的日期/快照后缀（如 `qwen3.7-plus-20260602`）。
-fn model_name_matches(lower: &str, name: &str) -> bool {
-    lower == name
-        || lower
-            .strip_prefix(name)
-            .is_some_and(|rest| rest.starts_with('-'))
-}
-
-/// pinvou3 侧补充表：底座 `context_window_for_model` 刻意不定义（如 qwen3.7-plus，
-/// 底座策略"不编造上限"）或尚未覆盖（kimi-k3 / doubao 全系 / glm-4.7）的云端模型。
-/// 取值依据见各条目注释；均为官方文档/官方升级公告口径。
-fn pinvou_known_context_window(lower: &str) -> Option<u32> {
-    const PINVOU_KNOWN: &[(&str, u32)] = &[
-        // Kimi K3 官方标称 100 万 token（platform.kimi.com/docs/models）。
-        ("kimi-k3", 1_048_576),
-        // Coding Plan 裸 k3 同为 1M 窗口（高档位解锁全量，低档服务端限 256K，标称取 1M）。
-        ("k3", 1_048_576),
-        // kimi-for-coding 系属 K2.7 Code，官方 256K（底座只覆盖 kimi-for-coding 本体）。
-        ("kimi-for-coding-highspeed", 262_144),
-        ("kimi-k2.7-code-highspeed", 262_144),
-        // 阿里云官方文档对 qwen3.7-plus 配 CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000；
-        // 底座对该模型刻意返回 None（不编造上限），pinvou3 按官方口径补 1M。
-        ("qwen3.7-plus", 1_000_000),
-        // 阿里云百炼官方模型列表：qwen3.7-max / qwen3.7-flash 同为 1M；
-        // 底座 catalog 无这两个裸名条目（qwen3.7-flash 为 qwen3.6-flash 的官方降本替代）。
-        ("qwen3.7-max", 1_000_000),
-        ("qwen3.7-flash", 1_000_000),
-        // 底座表只有带 `qwen/` 前缀的条目，裸名解析不到，这里补 1M（仓库 catalog 一致）。
-        ("qwen3.6-flash", 1_000_000),
-        // 2026-07 火山引擎官方升级公告：doubao-seed-evolving 升为 1M 上下文。
-        ("doubao-seed-evolving", 1_048_576),
-        // 智谱官方文档 glm-4.7 上下文 200K（无精确整数，取 200×1024，与显式后缀表一致）。
-        ("glm-4.7", 204_800),
-    ];
-    PINVOU_KNOWN
-        .iter()
-        .find(|(name, _)| model_name_matches(lower, name))
-        .map(|(_, window)| *window)
-}
-
 fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32> {
-    let lower = model.unwrap_or("").to_ascii_lowercase();
-    let explicit = [
-        ("1m", 1_048_576),
-        ("1000k", 1_024_000),
-        ("512k", 524_288),
-        ("256k", 262_144),
-        ("200k", 204_800),
-        ("128k", 131_072),
-        ("64k", 65_536),
-        ("32k", 32_768),
-        ("16k", 16_384),
-        ("8k", 8_192),
-    ]
-    .into_iter()
-    .find_map(|(needle, value)| lower.contains(needle).then_some(value));
-    if explicit.is_some() {
-        return explicit;
-    }
-    // 1. pinvou3 补充表（底座不定义的模型）。
-    if let Some(window) = pinvou_known_context_window(&lower) {
+    // 模型名事实与 Engine route_limits 共用同一入口，避免页面显示 1M、实际仍按
+    // 128K 压缩。这里只保留底座与补充表都无法识别时的供应商预设兜底。
+    if let Some(window) = model.and_then(crate::core::model_context::resolved_context_window) {
         return Some(window);
     }
-    // 2. 底座 catalog + 厂商启发式：deepseek v4→1M、gpt-5.5/5.6→1.05M、
-    //    glm-5.x、MiniMax-M3/M2.x、mimo-v2.5、qwen3.6-flash、kimi-k2.x 等。
-    if let Some(window) = deepseek_tui::models::context_window_for_model(&lower) {
-        return Some(window);
-    }
-    // 3. 预设兜底：仅用于以上两层都不认识的自定义模型名，取该厂商在售家族的保守值。
     match preset {
         ModelPreset::LocalVllm => Some(262_144),
         ModelPreset::Deepseek => Some(131_072),
@@ -1409,7 +1346,7 @@ vllm:request_time_per_output_token_seconds_sum{engine=\"0\",model_name=\"qwen36_
                 "kimi-for-coding-highspeed",
                 262_144,
             ),
-            (ModelPreset::OpenaiCompatible, "k3-256k", 262_144),
+            (ModelPreset::OpenaiCompatible, "k3-256k", 256_000),
             (ModelPreset::OpenaiCompatible, "k3", 1_048_576),
             // GLM：5.2 是 1M，5.1/5-turbo 是 202,752，4.7 官方 200K
             (ModelPreset::Glm, "glm-5.2", 1_000_000),
@@ -1456,7 +1393,7 @@ vllm:request_time_per_output_token_seconds_sum{engine=\"0\",model_name=\"qwen36_
         // 显式后缀优先于一切（含底座 catalog 里的同名模型）
         assert_eq!(
             infer_context_window(ModelPreset::Deepseek, Some("deepseek-v4-flash-128k")),
-            Some(131_072)
+            Some(128_000)
         );
         // 底座与补充表都不认识的自定义模型名 → 预设兜底
         assert_eq!(

--- a/pinvou3-app/src-tauri/src/features/monitor/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/mod.rs
@@ -893,6 +893,46 @@ pub async fn probe_openai_models(base_url: &str) -> Option<OpenAiModelsProbe> {
     })
 }
 
+/// 精确匹配模型名，并容忍 `-` 分隔的日期/快照后缀（如 `qwen3.7-plus-20260602`）。
+fn model_name_matches(lower: &str, name: &str) -> bool {
+    lower == name
+        || lower
+            .strip_prefix(name)
+            .is_some_and(|rest| rest.starts_with('-'))
+}
+
+/// pinvou3 侧补充表：底座 `context_window_for_model` 刻意不定义（如 qwen3.7-plus，
+/// 底座策略"不编造上限"）或尚未覆盖（kimi-k3 / doubao 全系 / glm-4.7）的云端模型。
+/// 取值依据见各条目注释；均为官方文档/官方升级公告口径。
+fn pinvou_known_context_window(lower: &str) -> Option<u32> {
+    const PINVOU_KNOWN: &[(&str, u32)] = &[
+        // Kimi K3 官方标称 100 万 token（platform.kimi.com/docs/models）。
+        ("kimi-k3", 1_048_576),
+        // Coding Plan 裸 k3 同为 1M 窗口（高档位解锁全量，低档服务端限 256K，标称取 1M）。
+        ("k3", 1_048_576),
+        // kimi-for-coding 系属 K2.7 Code，官方 256K（底座只覆盖 kimi-for-coding 本体）。
+        ("kimi-for-coding-highspeed", 262_144),
+        ("kimi-k2.7-code-highspeed", 262_144),
+        // 阿里云官方文档对 qwen3.7-plus 配 CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000；
+        // 底座对该模型刻意返回 None（不编造上限），pinvou3 按官方口径补 1M。
+        ("qwen3.7-plus", 1_000_000),
+        // 阿里云百炼官方模型列表：qwen3.7-max / qwen3.7-flash 同为 1M；
+        // 底座 catalog 无这两个裸名条目（qwen3.7-flash 为 qwen3.6-flash 的官方降本替代）。
+        ("qwen3.7-max", 1_000_000),
+        ("qwen3.7-flash", 1_000_000),
+        // 底座表只有带 `qwen/` 前缀的条目，裸名解析不到，这里补 1M（仓库 catalog 一致）。
+        ("qwen3.6-flash", 1_000_000),
+        // 2026-07 火山引擎官方升级公告：doubao-seed-evolving 升为 1M 上下文。
+        ("doubao-seed-evolving", 1_048_576),
+        // 智谱官方文档 glm-4.7 上下文 200K（无精确整数，取 200×1024，与显式后缀表一致）。
+        ("glm-4.7", 204_800),
+    ];
+    PINVOU_KNOWN
+        .iter()
+        .find(|(name, _)| model_name_matches(lower, name))
+        .map(|(_, window)| *window)
+}
+
 fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32> {
     let lower = model.unwrap_or("").to_ascii_lowercase();
     let explicit = [
@@ -912,6 +952,16 @@ fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32>
     if explicit.is_some() {
         return explicit;
     }
+    // 1. pinvou3 补充表（底座不定义的模型）。
+    if let Some(window) = pinvou_known_context_window(&lower) {
+        return Some(window);
+    }
+    // 2. 底座 catalog + 厂商启发式：deepseek v4→1M、gpt-5.5/5.6→1.05M、
+    //    glm-5.x、MiniMax-M3/M2.x、mimo-v2.5、qwen3.6-flash、kimi-k2.x 等。
+    if let Some(window) = deepseek_tui::models::context_window_for_model(&lower) {
+        return Some(window);
+    }
+    // 3. 预设兜底：仅用于以上两层都不认识的自定义模型名，取该厂商在售家族的保守值。
     match preset {
         ModelPreset::LocalVllm => Some(262_144),
         ModelPreset::Deepseek => Some(131_072),
@@ -919,9 +969,9 @@ fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32>
         ModelPreset::OpenaiCompatible => Some(131_072),
         ModelPreset::Qwen => Some(131_072),
         ModelPreset::Doubao => Some(262_144),
-        ModelPreset::Minimax => Some(245_760),
+        ModelPreset::Minimax => Some(204_800),
         ModelPreset::Glm => Some(131_072),
-        ModelPreset::Mimo => Some(128_000),
+        ModelPreset::Mimo => Some(1_000_000),
     }
 }
 
@@ -1337,5 +1387,91 @@ vllm:request_time_per_output_token_seconds_sum{engine=\"0\",model_name=\"qwen36_
         assert!(m.tpot_count.is_none());
         assert!(m.generation_tokens_total.is_none());
         assert!(m.prompt_tokens_total.is_none());
+    }
+
+    /// 运行状态上下文长度推断：覆盖设置页全部云端模型（2026-07 逐厂商核实，
+    /// 依据为仓库 catalog + 底座启发式 + 各厂商官方文档，见 pinvou_known_context_window 注释）。
+    #[test]
+    fn infer_context_window_cloud_models() {
+        let cases: &[(ModelPreset, &str, u32)] = &[
+            // DeepSeek：v4 全系 1M（原 bug：预设固定 128K）
+            (ModelPreset::Deepseek, "deepseek-v4-pro", 1_000_000),
+            (ModelPreset::Deepseek, "deepseek-v4-flash", 1_000_000),
+            // Kimi：k3 是 1M，k2.x / for-coding 系 256K
+            (ModelPreset::Kimi, "kimi-k3", 1_048_576),
+            (ModelPreset::Kimi, "kimi-k2.7-code", 262_144),
+            (ModelPreset::Kimi, "kimi-k2.7-code-highspeed", 262_144),
+            (ModelPreset::Kimi, "kimi-k2.6", 262_144),
+            // Kimi Coding Plan 走 openai_compatible 预设
+            (ModelPreset::OpenaiCompatible, "kimi-for-coding", 262_144),
+            (
+                ModelPreset::OpenaiCompatible,
+                "kimi-for-coding-highspeed",
+                262_144,
+            ),
+            (ModelPreset::OpenaiCompatible, "k3-256k", 262_144),
+            (ModelPreset::OpenaiCompatible, "k3", 1_048_576),
+            // GLM：5.2 是 1M，5.1/5-turbo 是 202,752，4.7 官方 200K
+            (ModelPreset::Glm, "glm-5.2", 1_000_000),
+            (ModelPreset::Glm, "glm-5.1", 202_752),
+            (ModelPreset::Glm, "glm-5-turbo", 202_752),
+            (ModelPreset::Glm, "glm-4.7", 204_800),
+            // MiniMax：M3 是 1M，M2.x 全系 204,800
+            (ModelPreset::Minimax, "MiniMax-M3", 1_000_000),
+            (ModelPreset::Minimax, "MiniMax-M2.7", 204_800),
+            (ModelPreset::Minimax, "MiniMax-M2.7-highspeed", 204_800),
+            (ModelPreset::Minimax, "MiniMax-M2.5", 204_800),
+            (ModelPreset::Minimax, "MiniMax-M2.5-highspeed", 204_800),
+            // MiMo：v2.5 全系 1M
+            (ModelPreset::Mimo, "mimo-v2.5-pro", 1_000_000),
+            (ModelPreset::Mimo, "mimo-v2.5", 1_000_000),
+            // Qwen：3.7 全系 / 3.6-flash 均 1M
+            (ModelPreset::Qwen, "qwen3.7-plus", 1_000_000),
+            (ModelPreset::Qwen, "qwen3.7-max", 1_000_000),
+            (ModelPreset::Qwen, "qwen3.7-flash", 1_000_000),
+            (ModelPreset::Qwen, "qwen3.6-flash", 1_000_000),
+            // 豆包：evolving 已升 1M，2.x 全系 256K
+            (ModelPreset::Doubao, "doubao-seed-evolving", 1_048_576),
+            (ModelPreset::Doubao, "doubao-seed-2.1-pro", 262_144),
+            (ModelPreset::Doubao, "doubao-seed-2.1-turbo", 262_144),
+            (ModelPreset::Doubao, "doubao-seed-2.0-pro", 262_144),
+            (ModelPreset::Doubao, "doubao-seed-2.0-lite", 262_144),
+            // OpenAI 兼容示例：gpt-5.6 全系 1.05M
+            (ModelPreset::OpenaiCompatible, "gpt-5.6-terra", 1_050_000),
+            (ModelPreset::OpenaiCompatible, "gpt-5.6-luna", 1_050_000),
+            (ModelPreset::OpenaiCompatible, "gpt-5.6-sol", 1_050_000),
+        ];
+        for (preset, model, expected) in cases {
+            assert_eq!(
+                infer_context_window(*preset, Some(model)),
+                Some(*expected),
+                "{model} 上下文窗口推断错误"
+            );
+        }
+    }
+
+    /// 推断优先级：显式 Nk 后缀 > pinvou 补充表/底座 > 预设兜底。
+    #[test]
+    fn infer_context_window_fallback_order() {
+        // 显式后缀优先于一切（含底座 catalog 里的同名模型）
+        assert_eq!(
+            infer_context_window(ModelPreset::Deepseek, Some("deepseek-v4-flash-128k")),
+            Some(131_072)
+        );
+        // 底座与补充表都不认识的自定义模型名 → 预设兜底
+        assert_eq!(
+            infer_context_window(ModelPreset::Deepseek, Some("my-custom-finetune")),
+            Some(131_072)
+        );
+        assert_eq!(
+            infer_context_window(ModelPreset::Minimax, Some("minimax-future-x")),
+            Some(204_800)
+        );
+        assert_eq!(
+            infer_context_window(ModelPreset::Mimo, Some("mimo-future-x")),
+            Some(1_000_000)
+        );
+        // 无模型名 → 预设兜底
+        assert_eq!(infer_context_window(ModelPreset::Kimi, None), Some(262_144));
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/prefs.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs.rs
@@ -202,7 +202,7 @@ impl ModelPreset {
             ModelPreset::OpenaiCompatible => "https://api.openai.com/v1",
             ModelPreset::Qwen => "https://dashscope.aliyuncs.com/compatible-mode/v1",
             ModelPreset::Doubao => "https://ark.cn-beijing.volces.com/api/v3",
-            ModelPreset::Minimax => "https://api.minimax.chat/v1",
+            ModelPreset::Minimax => "https://api.minimaxi.com/v1",
             ModelPreset::Glm => "https://open.bigmodel.cn/api/paas/v4",
             ModelPreset::Mimo => "https://api.xiaomimimo.com/v1",
         }
@@ -429,6 +429,19 @@ impl SavedModel {
 
     fn normalize_provider_metadata(&mut self) {
         self.base_url = strip_chat_completions_suffix(&self.base_url);
+        // MiniMax 旧域名 api.minimax.chat 已废弃,官方国内端点为 api.minimaxi.com;
+        // 存量配置在 load 时一次性改写,避免继续打已下线域名。
+        const LEGACY_MINIMAX_PREFIX: &str = "https://api.minimax.chat/";
+        if self
+            .base_url
+            .to_ascii_lowercase()
+            .starts_with(LEGACY_MINIMAX_PREFIX)
+        {
+            self.base_url = format!(
+                "https://api.minimaxi.com/{}",
+                &self.base_url[LEGACY_MINIMAX_PREFIX.len()..]
+            );
+        }
         if let Some((vendor, canonical_base_url)) = identify_coding_plan_endpoint(&self.base_url) {
             self.provider_kind = Some(MODEL_PROVIDER_KIND_CODING_PLAN.to_string());
             self.vendor = Some(vendor.to_string());
@@ -1066,6 +1079,32 @@ mod tests {
             Some(MODEL_PROVIDER_KIND_OFFICIAL_API)
         );
         assert!(model.vendor.is_none());
+    }
+
+    #[test]
+    fn legacy_minimax_chat_domain_is_rewritten() {
+        let mut prefs = UserPrefs::default();
+        prefs.migrate_models();
+        prefs.upsert_model(SavedModel {
+            id: "minimax-api".into(),
+            name: "MiniMax".into(),
+            preset: ModelPreset::Minimax,
+            context_window_tokens: None,
+            max_output_tokens: None,
+            model: "MiniMax-M3".into(),
+            base_url: "https://api.minimax.chat/v1".into(),
+            provider_kind: None,
+            vendor: None,
+            endpoint_mode: None,
+            api_key: String::new(),
+            credential_ref: None,
+            credential_state: CredentialState::Missing,
+            has_secret: false,
+            credential_action: None,
+        });
+
+        let model = prefs.model_by_id("minimax-api").expect("minimax model");
+        assert_eq!(model.base_url, "https://api.minimaxi.com/v1");
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/platform/prefs.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs.rs
@@ -145,6 +145,22 @@ fn strip_chat_completions_suffix(value: &str) -> String {
     }
 }
 
+fn migrated_minimax_base_url(value: &str) -> Option<String> {
+    const LEGACY_ORIGIN: &str = "https://api.minimax.chat";
+    const CURRENT_ORIGIN: &str = "https://api.minimaxi.com";
+
+    let trimmed = value.trim().trim_end_matches('/');
+    let lower = trimmed.to_ascii_lowercase();
+    if lower == LEGACY_ORIGIN {
+        return Some(CURRENT_ORIGIN.to_string());
+    }
+    lower.strip_prefix(LEGACY_ORIGIN).and_then(|suffix| {
+        suffix
+            .starts_with('/')
+            .then(|| format!("{CURRENT_ORIGIN}{}", &trimmed[LEGACY_ORIGIN.len()..]))
+    })
+}
+
 fn identify_coding_plan_endpoint(base_url: &str) -> Option<(&'static str, &'static str)> {
     let base = strip_chat_completions_suffix(base_url);
     let normalized = base.to_ascii_lowercase();
@@ -431,16 +447,8 @@ impl SavedModel {
         self.base_url = strip_chat_completions_suffix(&self.base_url);
         // MiniMax 旧域名 api.minimax.chat 已废弃,官方国内端点为 api.minimaxi.com;
         // 存量配置在 load 时一次性改写,避免继续打已下线域名。
-        const LEGACY_MINIMAX_PREFIX: &str = "https://api.minimax.chat/";
-        if self
-            .base_url
-            .to_ascii_lowercase()
-            .starts_with(LEGACY_MINIMAX_PREFIX)
-        {
-            self.base_url = format!(
-                "https://api.minimaxi.com/{}",
-                &self.base_url[LEGACY_MINIMAX_PREFIX.len()..]
-            );
+        if let Some(migrated) = migrated_minimax_base_url(&self.base_url) {
+            self.base_url = migrated;
         }
         if let Some((vendor, canonical_base_url)) = identify_coding_plan_endpoint(&self.base_url) {
             self.provider_kind = Some(MODEL_PROVIDER_KIND_CODING_PLAN.to_string());
@@ -617,11 +625,23 @@ impl UserPrefs {
             }),
             Err(_) => Self::default(),
         };
+        // 必须在 migrate_models/normalize 改写前记录；否则只能修正本次运行的内存值，
+        // save gate 看不到变化，旧域名会永久留在 settings.json 中、每次启动重复迁移。
+        let minimax_endpoint_changed = prefs
+            .advanced
+            .saved_models
+            .iter()
+            .any(|model| migrated_minimax_base_url(&model.base_url).is_some())
+            || prefs
+                .advanced
+                .custom_base_url
+                .as_deref()
+                .is_some_and(|url| migrated_minimax_base_url(url).is_some());
         prefs.migrate_models();
         prefs.normalize_saved_model_metadata();
         let migration = prefs.migrate_plaintext_api_keys_with_store(&SystemCredentialStore::new());
         let memory_policy_changed = prefs.enforce_memory_locale_policy();
-        if migration.settings_sanitized || memory_policy_changed {
+        if minimax_endpoint_changed || migration.settings_sanitized || memory_policy_changed {
             if let Err(e) = prefs.save() {
                 eprintln!("[pinvou3-app] settings normalization save failed: {e:?}");
             }
@@ -1083,6 +1103,15 @@ mod tests {
 
     #[test]
     fn legacy_minimax_chat_domain_is_rewritten() {
+        assert_eq!(
+            migrated_minimax_base_url("https://api.minimax.chat").as_deref(),
+            Some("https://api.minimaxi.com")
+        );
+        assert_eq!(
+            migrated_minimax_base_url("https://API.MINIMAX.CHAT/v1").as_deref(),
+            Some("https://api.minimaxi.com/v1")
+        );
+
         let mut prefs = UserPrefs::default();
         prefs.migrate_models();
         prefs.upsert_model(SavedModel {
@@ -1105,6 +1134,60 @@ mod tests {
 
         let model = prefs.model_by_id("minimax-api").expect("minimax model");
         assert_eq!(model.base_url, "https://api.minimaxi.com/v1");
+    }
+
+    #[test]
+    fn load_persists_legacy_minimax_domain_migration() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let old_home = std::env::var_os("PINVOU3_HOME");
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-prefs-minimax-domain-migration-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).expect("create temporary prefs home");
+        unsafe { std::env::set_var("PINVOU3_HOME", &tmp) };
+
+        let mut prefs = UserPrefs::default();
+        prefs.advanced.saved_models.push(SavedModel {
+            id: "minimax-api".into(),
+            name: "MiniMax".into(),
+            preset: ModelPreset::Minimax,
+            context_window_tokens: None,
+            max_output_tokens: None,
+            model: "MiniMax-M3".into(),
+            base_url: "https://api.minimax.chat".into(),
+            provider_kind: Some(MODEL_PROVIDER_KIND_OFFICIAL_API.into()),
+            vendor: None,
+            endpoint_mode: None,
+            api_key: String::new(),
+            credential_ref: None,
+            credential_state: CredentialState::Missing,
+            has_secret: false,
+            credential_action: None,
+        });
+        prefs.advanced.active_model_id = Some("minimax-api".into());
+        let path = super::super::paths::settings_path();
+        std::fs::write(
+            &path,
+            serde_json::to_string_pretty(&prefs).expect("serialize legacy prefs"),
+        )
+        .expect("write legacy prefs");
+
+        let loaded = UserPrefs::load();
+        assert_eq!(
+            loaded.active_model().map(|model| model.base_url.as_str()),
+            Some("https://api.minimaxi.com")
+        );
+        let persisted = std::fs::read_to_string(&path).expect("read migrated prefs");
+        assert!(!persisted.contains("api.minimax.chat"));
+        assert!(persisted.contains("api.minimaxi.com"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        match old_home {
+            Some(value) => unsafe { std::env::set_var("PINVOU3_HOME", value) },
+            None => unsafe { std::env::remove_var("PINVOU3_HOME") },
+        }
     }
 
     #[test]

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -369,7 +369,7 @@ function workspaceDisplayName(path) {
         openai_compatible: { baseUrl: 'https://api.openai.com/v1',        model: 'gpt-5.6-terra' },
         qwen:        { baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', model: 'qwen3.7-plus' },
         doubao:      { baseUrl: 'https://ark.cn-beijing.volces.com/api/v3', model: 'doubao-seed-evolving' },
-        minimax:     { baseUrl: 'https://api.minimax.chat/v1',            model: 'MiniMax-M3' },
+        minimax:     { baseUrl: 'https://api.minimaxi.com/v1',            model: 'MiniMax-M3' },
         glm:         { baseUrl: 'https://open.bigmodel.cn/api/paas/v4',   model: 'glm-5.2' },
         mimo:        { baseUrl: 'https://api.xiaomimimo.com/v1',          model: 'mimo-v2.5-pro' },
       };

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -435,7 +435,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
       openai_compatible: { baseUrl: 'https://api.openai.com/v1',        model: 'gpt-5.6-terra' },
       qwen:        { baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', model: 'qwen3.7-plus' },
       doubao:      { baseUrl: 'https://ark.cn-beijing.volces.com/api/v3', model: 'doubao-seed-evolving' },
-      minimax:     { baseUrl: 'https://api.minimax.chat/v1',            model: 'MiniMax-M3' },
+      minimax:     { baseUrl: 'https://api.minimaxi.com/v1',            model: 'MiniMax-M3' },
       glm:         { baseUrl: 'https://open.bigmodel.cn/api/paas/v4',   model: 'glm-5.2' },
       mimo:        { baseUrl: 'https://api.xiaomimimo.com/v1',          model: 'mimo-v2.5-pro' },
     };
@@ -645,7 +645,9 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
           vendor: 'qwen',
           items: [
             { model: 'qwen3.7-plus', title: 'qwen3.7-plus', desc: '最新推荐' },
-            { model: 'qwen3.6-flash', title: 'qwen3.6-flash', desc: '快速响应' },
+            { model: 'qwen3.7-max', title: 'qwen3.7-max', desc: '旗舰推理' },
+            { model: 'qwen3.7-flash', title: 'qwen3.7-flash', desc: '高性价比' },
+            { model: 'qwen3.6-flash', title: 'qwen3.6-flash', desc: '兼容保留' },
             { model: '', title: '自定义通义模型', desc: '手动填写模型 ID', custom: true },
           ],
         },


### PR DESCRIPTION
## 概述

修复运行状态页对云端模型上下文长度的错误推断，并让监控显示、实际路由限制和压缩阈值统一使用同一份模型窗口数据。同时迁移 MiniMax 已废弃的国内 API 域名，并补齐通义千问新模型条目。

## 背景

原运行状态逻辑无法识别当前部分云端模型，只能按供应商预设返回旧的固定窗口。最初修复虽然补齐了页面显示，但补充数据没有进入 `active_route_limits`，会出现页面显示 1M、实际引擎仍按 128K 提前压缩的问题。

此外，MiniMax 国内 API 已从 `api.minimax.chat` 迁移到 `api.minimaxi.com`；旧配置需要自动改写并持久化，避免每次启动重复迁移或继续请求失效地址。

## 变更

- 新增共享模型窗口解析入口，优先复用 CodeWhale catalog，并补充 Kimi K3、Qwen 3.7、豆包 Evolving、GLM-4.7 等底座暂未覆盖的模型。
- 运行状态与 Engine 路由共用同一解析结果；已知云端模型会填入 `active_route_limits` 并驱动压缩阈值，未知云端模型仍保持安全回退，不猜测上限。
- 显式 `Nk` 后缀复用 CodeWhale 的安全解析口径，额外兼容 `1m` 写法。
- 修正 MiniMax、MiMo 等预设兜底窗口，并更新 MiniMax 默认国内端点。
- MiniMax 旧域名迁移兼容无尾斜杠和大小写写法，并在加载后持久化到 `settings.json`。
- 新增 `qwen3.7-max`、`qwen3.7-flash`，保留 `qwen3.6-flash` 作为兼容项。

## 验证

- `cargo test --lib -- --test-threads=1`：759 passed，0 failed，12 ignored。
- `cargo clippy --lib --no-deps`：通过。
- `cargo fmt -- --check`：通过。
- `./scripts/fork-guard.sh --fast`：通过。
- `python3 scripts/architecture-guard.py --base-ref origin/main`：通过，无新增架构债。
- `npm run lint:ui`：通过。
- `npm run build:ui`：通过。
- `npm run test:settings-ui`：33 项全部通过。

## 备注

- `glm-4.7` 官方仅标称 200K，沿用设置页现有的 204800 展示口径。
- Kimi Coding Plan 的 `k3` 标称上限为 1M；带 `256k` 后缀的服务档位按底座安全值 256000 处理。
