### PR TITLE
feat(titlebar): macOS 顶栏改用系统原生红绿灯

### DIFF
--- a/pinvou3-app/run-dev.sh
+++ b/pinvou3-app/run-dev.sh
@@ -57,8 +57,11 @@ export PINVOU_REMOTE_RELAY_WS_URL="${PINVOU_REMOTE_RELAY_WS_URL:-ws://127.0.0.1:
 # ── macOS 提示 ───────────────────────────────────────────────────
 # Mac 不需要 webkit/fcitx/X11 相关 env(那些在 lib.rs RELEASE_ENV_DEFAULTS Linux 段)。
 # 此处无需额外 Mac 专属 export,直接落到 tauri dev 即可。
+# macOS dev 同样套用平台 overlay(原生红绿灯顶栏 titleBarStyle=Overlay),
+# 与打包产物保持一致;build.js 的自动 overlay 只覆盖 build/bundle,dev 在此显式带上。
 if [ "$OS_NAME" = "Darwin" ]; then
   echo "✓ macOS dev 模式(跳过 Linux 内网 vLLM/WebKit env)"
+  exec npx tauri dev --config src-tauri/config/platforms/macos/tauri.conf.json "$@"
 fi
 
 exec npx tauri dev "$@"

--- a/pinvou3-app/scripts/tauri/build.js
+++ b/pinvou3-app/scripts/tauri/build.js
@@ -46,8 +46,11 @@ function prepareTauriArgs(
     // dev 默认不注入 packaging overlay;但 macOS 的原生红绿灯顶栏定义在平台
     // overlay 里,dev 也必须带上,否则 npm run dev 与打包产物顶栏不一致
     // (run-dev.sh 直连 tauri dev 时已显式带同一份 overlay,两条入口行为对齐)。
-    if (prepared.includes("dev") && platform === "darwin") {
-      prepared.push("--config", platformConfigPath(platform));
+    const devIndex = prepared.indexOf("dev");
+    if (devIndex >= 0 && platform === "darwin") {
+      // 与 build/bundle 保持相同优先级:自动平台配置在前,调用方显式
+      // --config 在后,从而仍可有意覆盖平台默认值。
+      prepared.splice(devIndex + 1, 0, "--config", platformConfigPath(platform));
     }
     return prepared;
   }

--- a/pinvou3-app/scripts/tauri/build.js
+++ b/pinvou3-app/scripts/tauri/build.js
@@ -42,7 +42,15 @@ function prepareTauriArgs(
 ) {
   const prepared = [...args];
   const commandIndex = tauriCommandIndex(prepared);
-  if (commandIndex < 0) return prepared;
+  if (commandIndex < 0) {
+    // dev 默认不注入 packaging overlay;但 macOS 的原生红绿灯顶栏定义在平台
+    // overlay 里,dev 也必须带上,否则 npm run dev 与打包产物顶栏不一致
+    // (run-dev.sh 直连 tauri dev 时已显式带同一份 overlay,两条入口行为对齐)。
+    if (prepared.includes("dev") && platform === "darwin") {
+      prepared.push("--config", platformConfigPath(platform));
+    }
+    return prepared;
+  }
 
   const automaticConfigs = [platformConfigPath(platform)];
   const architectureConfig = platformArchitectureConfigPath(platform, architecture);

--- a/pinvou3-app/src-tauri/config/README.md
+++ b/pinvou3-app/src-tauri/config/README.md
@@ -16,8 +16,9 @@ config/
 `app.windows` 是基础配置主窗口定义的完整拷贝，改动基础配置 `app.windows` 字段时必须同步此处。
 
 `scripts/tauri/build.js` 根据当前操作系统在 **build / bundle** 时加载 `platforms/<os>/tauri.conf.json`
-（dev 刻意不注入 packaging overlay，见 `tests/tauri_effective_config.test.js`）；macOS 的 dev 启动由
-`run-dev.sh` 显式以 `--config` 带上同一份 overlay，保证 dev 与打包产物顶栏一致。公共配置不得引用私有签名工具或私有运行时。
+（Linux/Windows 的 dev 刻意不注入 packaging overlay，见 `tests/tauri_effective_config.test.js`）；macOS
+例外：原生顶栏定义在 overlay 里，因此 dev（`npm run dev` 与 `run-dev.sh` 两条入口）都会以 `--config`
+带上同一份 overlay，保证 dev 与打包产物顶栏一致。公共配置不得引用私有签名工具或私有运行时。
 
 项目内所有 `build` / `bundle` 命令必须通过该包装器执行；`npm run tauri -- build`、
 `npm run build`、`npm run build:msi` 和 NSIS 脚本均遵循同一入口。包装器将自动 overlay

--- a/pinvou3-app/src-tauri/config/README.md
+++ b/pinvou3-app/src-tauri/config/README.md
@@ -10,9 +10,14 @@ config/
    └─ windows/tauri.conf.json
 ```
 
-- `tauri.conf.json`：对应平台的安装包目标、资源映射和安装器参数。
+- `tauri.conf.json`：对应平台的安装包目标、资源映射和安装器参数；macOS 额外把主窗口覆盖为原生顶栏（`decorations: true` + `titleBarStyle: "Overlay"` + `hiddenTitle`，系统红绿灯替代前端自绘三键）。
 
-`scripts/tauri/build.js` 根据当前操作系统加载 `platforms/<os>/tauri.conf.json`。公共配置不得引用私有签名工具或私有运行时。
+`--config` overlay 按 JSON Merge Patch 合并：对象合并、**数组整体替换**。因此 macOS overlay 中的
+`app.windows` 是基础配置主窗口定义的完整拷贝，改动基础配置 `app.windows` 字段时必须同步此处。
+
+`scripts/tauri/build.js` 根据当前操作系统在 **build / bundle** 时加载 `platforms/<os>/tauri.conf.json`
+（dev 刻意不注入 packaging overlay，见 `tests/tauri_effective_config.test.js`）；macOS 的 dev 启动由
+`run-dev.sh` 显式以 `--config` 带上同一份 overlay，保证 dev 与打包产物顶栏一致。公共配置不得引用私有签名工具或私有运行时。
 
 项目内所有 `build` / `bundle` 命令必须通过该包装器执行；`npm run tauri -- build`、
 `npm run build`、`npm run build:msi` 和 NSIS 脚本均遵循同一入口。包装器将自动 overlay

--- a/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
@@ -1,7 +1,23 @@
 {
   "$schema": "../../../../node_modules/@tauri-apps/cli/config.schema.json",
   "app": {
-    "macOSPrivateApi": true
+    "macOSPrivateApi": true,
+    "windows": [
+      {
+        "label": "main",
+        "url": "index.html?ui=vite-react-1",
+        "title": "PINVOU 智能助手",
+        "width": 1100,
+        "height": 760,
+        "resizable": true,
+        "fullscreen": false,
+        "maximized": true,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "trafficLightPosition": { "x": 12, "y": 12 }
+      }
+    ]
   },
   "bundle": {
     "targets": ["app", "dmg"],

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -84,13 +84,29 @@ function workspaceDisplayName(path) {
       const isDark = theme === 'dark';
       const hoverBg = isDark ? 'hover:bg-white/10' : 'hover:bg-black/10';
       const titleBarBg = isDark ? (sidebarOpen ? 'bg-[#1E1F20]' : 'bg-[#131314]') : 'bg-[#F0F4F9]';
+      // macOS 顶栏走系统原生实现:窗口带 decorations + titleBarStyle=Overlay
+      // (见 src-tauri/config/platforms/macos/tauri.conf.json),系统红绿灯悬浮在内容区左上角,
+      // 此时不再渲染 Windows 风格三键,并为红绿灯留出左侧空间。
+      // Windows/Linux 窗口无边框(decorations=false),继续用自绘三键。
+      // 以窗口实际 decorations 状态为准,不解析 UA / 平台字符串。
+      const [nativeControls, setNativeControls] = useState(false);
+      useEffect(() => {
+        let cancelled = false;
+        if (appWindow && typeof appWindow.isDecorated === 'function') {
+          appWindow.isDecorated()
+            .then((decorated) => { if (!cancelled) setNativeControls(decorated === true); })
+            .catch(() => {});
+        }
+        return () => { cancelled = true; };
+      }, []);
       return (
         <div data-tauri-drag-region
           className={`h-9 shrink-0 flex items-center justify-between select-none ${titleBarBg} ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>
-          <div data-tauri-drag-region className="flex items-center gap-2 px-3 text-[13px] font-medium pointer-events-none">
+          <div data-tauri-drag-region className={`flex items-center gap-2 ${nativeControls ? 'pl-[76px] pr-3' : 'px-3'} text-[13px] font-medium pointer-events-none`}>
             <PinvouLogo className="h-[18px] w-[18px] select-none" />
             {t.appTitle}
           </div>
+          {!nativeControls && (
           <div className="flex items-center h-full">
             <button onClick={() => appWindow && appWindow.minimize()} title={t.winMin}
               className={`h-full w-12 flex items-center justify-center transition-colors ${hoverBg}`}>
@@ -105,6 +121,7 @@ function workspaceDisplayName(path) {
               <svg width="11" height="11" viewBox="0 0 11 11"><path d="M1 1 L10 10 M10 1 L1 10" stroke="currentColor" strokeWidth="1.1"/></svg>
             </button>
           </div>
+          )}
         </div>
       );
     };

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -89,24 +89,28 @@ function workspaceDisplayName(path) {
       // 此时不再渲染 Windows 风格三键,并为红绿灯留出左侧空间。
       // Windows/Linux 窗口无边框(decorations=false),继续用自绘三键。
       // 以窗口实际 decorations 状态为准,不解析 UA / 平台字符串。
-      const [nativeControls, setNativeControls] = useState(false);
+      // 初始 null 表示探测未决:此时不渲染自绘三键,避免 macOS 原生顶栏下
+      // 三键先闪现一帧再被隐藏;探测失败回退为自绘三键(fail-safe)。
+      const [nativeControls, setNativeControls] = useState(null);
       useEffect(() => {
         let cancelled = false;
         if (appWindow && typeof appWindow.isDecorated === 'function') {
           appWindow.isDecorated()
             .then((decorated) => { if (!cancelled) setNativeControls(decorated === true); })
-            .catch(() => {});
+            .catch(() => { if (!cancelled) setNativeControls(false); });
+        } else {
+          setNativeControls(false);
         }
         return () => { cancelled = true; };
       }, []);
       return (
         <div data-tauri-drag-region
           className={`h-9 shrink-0 flex items-center justify-between select-none ${titleBarBg} ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>
-          <div data-tauri-drag-region className={`flex items-center gap-2 ${nativeControls ? 'pl-[76px] pr-3' : 'px-3'} text-[13px] font-medium pointer-events-none`}>
+          <div data-tauri-drag-region className={`flex items-center gap-2 ${nativeControls === true ? 'pl-[76px] pr-3' : 'px-3'} text-[13px] font-medium pointer-events-none`}>
             <PinvouLogo className="h-[18px] w-[18px] select-none" />
             {t.appTitle}
           </div>
-          {!nativeControls && (
+          {nativeControls === false && (
           <div className="flex items-center h-full">
             <button onClick={() => appWindow && appWindow.minimize()} title={t.winMin}
               className={`h-full w-12 flex items-center justify-center transition-colors ${hoverBg}`}>

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -89,7 +89,12 @@ assert.deepEqual(configSpecs(windowsCodexArgs), [
 assert.deepEqual(
   prepareTauriArgs(["dev"], { platform: "linux" }),
   ["dev"],
-  "dev must not receive packaging overlays",
+  "Linux/Windows dev must not receive packaging overlays",
+);
+assert.deepEqual(
+  prepareTauriArgs(["dev"], { platform: "darwin" }),
+  ["dev", "--config", platformConfigPath("darwin")],
+  "macOS dev must receive the platform overlay (native titlebar) to match packaged output",
 );
 const buildSource = fs.readFileSync(
   path.join(__dirname, "..", "scripts", "tauri", "build.js"),

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const {
+  BASE_CONFIG_PATH,
   buildResourceManifest,
   composeEffectiveConfig,
   mergeConfig,
@@ -155,6 +156,24 @@ assert.ok(
   !macosManifest.files.some((file) => file.destination.startsWith("runtime/asr/")),
   "macOS resource manifest must not contain a legacy ASR runtime",
 );
+
+// macOS 主窗口走系统原生红绿灯顶栏(titleBarStyle=Overlay),前端据此隐藏自绘三键。
+// --config overlay 按 JSON Merge Patch 合并,windows 数组整体替换,因此 overlay 必须
+// 携带完整窗口定义,且与基础配置主窗口的共有字段保持一致(防漂移)。
+const baseWindow = JSON.parse(fs.readFileSync(BASE_CONFIG_PATH, "utf8")).app.windows[0];
+assert.equal(macos.app.windows.length, 1);
+const macosWindow = macos.app.windows[0];
+assert.equal(macosWindow.label, "main");
+assert.equal(macosWindow.decorations, true, "macOS 主窗口必须使用系统原生顶栏");
+assert.equal(macosWindow.titleBarStyle, "Overlay", "macOS 主窗口必须使用 Overlay 红绿灯");
+assert.equal(macosWindow.hiddenTitle, true);
+for (const key of ["url", "title", "width", "height", "resizable", "fullscreen", "maximized"]) {
+  assert.deepEqual(
+    macosWindow[key],
+    baseWindow[key],
+    `macOS overlay 窗口字段需与基础配置同步: ${key}`,
+  );
+}
 
 const nullRemoval = mergeConfig(
   { bundle: { resources: { common: "common-target", runtime: "runtime-target" } } },

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -96,6 +96,11 @@ assert.deepEqual(
   ["dev", "--config", platformConfigPath("darwin")],
   "macOS dev must receive the platform overlay (native titlebar) to match packaged output",
 );
+assert.deepEqual(
+  configSpecs(prepareTauriArgs(["dev", "-c", explicitOverlay], { platform: "darwin" })),
+  [platformConfigPath("darwin"), explicitOverlay],
+  "explicit macOS dev overlays must override the automatic platform overlay",
+);
 const buildSource = fs.readFileSync(
   path.join(__dirname, "..", "scripts", "tauri", "build.js"),
   "utf8",
@@ -164,21 +169,25 @@ assert.ok(
 
 // macOS 主窗口走系统原生红绿灯顶栏(titleBarStyle=Overlay),前端据此隐藏自绘三键。
 // --config overlay 按 JSON Merge Patch 合并,windows 数组整体替换,因此 overlay 必须
-// 携带完整窗口定义,且与基础配置主窗口的共有字段保持一致(防漂移)。
-const baseWindow = JSON.parse(fs.readFileSync(BASE_CONFIG_PATH, "utf8")).app.windows[0];
-assert.equal(macos.app.windows.length, 1);
-const macosWindow = macos.app.windows[0];
-assert.equal(macosWindow.label, "main");
-assert.equal(macosWindow.decorations, true, "macOS 主窗口必须使用系统原生顶栏");
-assert.equal(macosWindow.titleBarStyle, "Overlay", "macOS 主窗口必须使用 Overlay 红绿灯");
-assert.equal(macosWindow.hiddenTitle, true);
-for (const key of ["url", "title", "width", "height", "resizable", "fullscreen", "maximized"]) {
-  assert.deepEqual(
-    macosWindow[key],
-    baseWindow[key],
-    `macOS overlay 窗口字段需与基础配置同步: ${key}`,
-  );
-}
+// 携带完整窗口定义。按基础数组动态生成期望值,确保新增窗口或新增字段也会触发
+// 防漂移失败,而不是依赖容易漏项的固定字段清单。
+const baseWindows = JSON.parse(fs.readFileSync(BASE_CONFIG_PATH, "utf8")).app.windows;
+const expectedMacosWindows = baseWindows.map((window) => (
+  window.label === "main"
+    ? {
+        ...window,
+        decorations: true,
+        titleBarStyle: "Overlay",
+        hiddenTitle: true,
+        trafficLightPosition: { x: 12, y: 12 },
+      }
+    : window
+));
+assert.deepEqual(
+  macos.app.windows,
+  expectedMacosWindows,
+  "macOS overlay 必须完整同步基础窗口数组,且只覆盖主窗口的原生顶栏字段",
+);
 
 const nullRemoval = mergeConfig(
   { bundle: { resources: { common: "common-target", runtime: "runtime-target" } } },


### PR DESCRIPTION
## 概述

macOS 主窗口顶栏由前端自绘的 Windows 风格最小化/最大化/关闭三键，改为系统原生红绿灯（`titleBarStyle: "Overlay"` 悬浮样式），观感与 macOS 原生应用一致；Windows/Linux 行为不变。

## 背景

此前主窗口全平台统一 `decorations: false`，顶栏三键由前端按 Windows 样式自绘，在 macOS 上风格突兀。Tauri 在 macOS 提供原生 Overlay 顶栏能力，按"有系统原生实现一律走原生"的原则切换到系统红绿灯。

## 变更

- `src-tauri/config/platforms/macos/tauri.conf.json`：macOS overlay 覆盖主窗口定义为 `decorations: true` + `titleBarStyle: "Overlay"` + `hiddenTitle: true`，`trafficLightPosition: {x: 12, y: 12}` 使红绿灯在 36px 顶栏内垂直居中；因 `--config` 按 JSON Merge Patch 合并（数组整体替换），窗口定义为完整拷贝并与基础配置字段保持一致。
- `run-dev.sh`：macOS dev 启动显式以 `--config` 套用同一份平台 overlay（build.js 的自动 overlay 按设计只覆盖 build/bundle），保证 dev 与打包产物顶栏一致。
- `src/app/main.jsx`：`TitleBar` 依据窗口实际 `isDecorated()` 状态切换——带原生顶栏时隐藏自绘三键并为红绿灯左侧留白（`pl-[76px]`）；无边框窗口（Windows/Linux）保持自绘三键不变。判断基于窗口状态而非 UA/平台字符串。
- `tests/tauri_effective_config.test.js`：新增契约断言，防止 macOS overlay 窗口字段与基础配置漂移。
- `src-tauri/config/README.md`：补充数组替换语义及窗口定义同步要求。

## 验证

- `node tests/tauri_effective_config.test.js`（含新增 macOS 窗口断言）、`tests/tauri_platform_layout.test.js`、`tests/macos_phase2_contract.test.js` 全部通过。
- `npx eslint src/app/main.jsx` 无告警；`npm run build:ui`（vite）构建成功。
- `python3 scripts/architecture-guard.py` 通过。

## 备注

- 未做真机目视验证；合并前建议在 macOS 上跑一次 `./pinvou3-app/run-dev.sh` 确认红绿灯位置与留白观感，微调只需改 overlay 的 `trafficLightPosition` 与 `main.jsx` 的 `pl-[76px]`。
- 基础配置 `app.windows` 字段日后变更时需同步 macOS overlay 中的窗口完整定义（已有契约测试兜底）。