### PR TITLE
fix(chat): 保留会话未发送草稿

### DIFF
--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -253,9 +253,14 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const isDark = theme === 'dark';
       const chatCopy = t.uiChat;
       const canInstallLocalAsr = can('localModelSetup') && can('dependencyInstall');
-      const [inputText, setInputTextState] = useState('');
-      const [inputLimitReached, setInputLimitReached] = useState(false);
-      const inputTextRef = useRef('');
+      const initialInput = constrainChatInput(
+        bridge.available && bridge.chat && bridge.chat.getComposerDraft
+          ? bridge.chat.getComposerDraft()
+          : ((bs && bs.composerDraft) || '')
+      );
+      const [inputText, setInputTextState] = useState(initialInput.text);
+      const [inputLimitReached, setInputLimitReached] = useState(initialInput.limitReached);
+      const inputTextRef = useRef(initialInput.text);
       const setInputText = useCallback((valueOrUpdater) => {
         const rawValue = typeof valueOrUpdater === 'function'
           ? valueOrUpdater(inputTextRef.current)
@@ -264,6 +269,9 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         inputTextRef.current = constrained.text;
         setInputTextState(constrained.text);
         setInputLimitReached(constrained.limitReached);
+        if (bridge.available && bridge.chat && bridge.chat.setComposerDraft) {
+          bridge.chat.setComposerDraft(constrained.text);
+        }
       }, []);
       const [artifactsOpen, setArtifactsOpen] = useState(false);
       // ── 产物分栏:宽屏(≥900)并排可拖、窄屏回退覆盖抽屉 ──
@@ -507,6 +515,15 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         if (!activeSessionId) setArtifactsOpen(false);
       }, [activeSessionId]);
       const draftEpoch = bs ? bs.draftEpoch : 0;
+      // 切换 session / 新建草稿会话时读取各自 working set 里的未发送内容。
+      // 从设置、工具商店等页面返回时 ChatView 会重新挂载，初始 state 也从
+      // 同一份内存草稿恢复。
+      useEffect(() => {
+        const restored = bridge.available && bridge.chat && bridge.chat.getComposerDraft
+          ? bridge.chat.getComposerDraft()
+          : ((bs && bs.composerDraft) || '');
+        setInputText(restored);
+      }, [activeSessionId, draftEpoch, setInputText]);
       const voiceInput = (bs && bs.voiceInput) || { status: 'idle' };
       const voiceActive = voiceInput.status === 'requesting_permission' || voiceInput.status === 'recording' || voiceInput.status === 'transcribing';
       const voiceRecording = voiceInput.status === 'recording';
@@ -1095,6 +1112,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
               />
               <textarea
                 ref={composerRef}
+                data-testid="chat-composer-input"
                 value={inputText}
                 onChange={e => setInputText(e.target.value)}
                 onKeyDown={handleKeyDown}

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -628,6 +628,7 @@
     var bg = sessionStates[sid]; if (!bg) return;
     touchSessionBuffer(sid, bg, isScheduledRunSession(sid));
     var realId = state.activeSessionId;
+    var draftComposer = realId ? "" : (state.composerDraft || "");
     saveWorkingSetTo(getBuffer(realId));
     loadWorkingSetFrom(bg);
     state.activeSessionId = sid;
@@ -639,8 +640,11 @@
       state.activeSessionId = realId;
       // realId 为 null(草稿态)时 getBuffer(null)=null、loadWorkingSetFrom(null) 是 no-op,
       // 会把刚处理的后台 session 工作集泄漏进草稿视图(activeSessionId=null 却带着它的 chatItems),
-      // 召唤检阅等依赖 activeSessionId 的操作随之错乱。草稿态须切回干净的空工作集。
-      loadWorkingSetFrom(realId ? getBuffer(realId) : freshBuffer());
+      // 召唤检阅等依赖 activeSessionId 的操作随之错乱。草稿态须切回干净工作集，
+      // 但要保留用户正在输入的未发送文本。
+      var restoreBuffer = realId ? getBuffer(realId) : freshBuffer();
+      if (!realId) restoreBuffer.composerDraft = draftComposer;
+      loadWorkingSetFrom(restoreBuffer);
     }
   }
   // 事件监听器统一入口:按 payload.session_id 路由同步逻辑;后台变更后补一次 notify 刷新列表。

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -160,6 +160,9 @@
     // 跨页面预填输入框请求。比如本地知识 → 产出物点击「续写/新项目」：
     // 只把草稿放进 composer，不自动发送给模型。
     composerPrefill: { id: 0, text: "" },
+    // 当前会话未发送的输入草稿。只存内存，随 session working set 切换；
+    // 不落盘，避免把敏感的未发送内容带到下次启动。
+    composerDraft: "",
     messages: [],      // Anthropic Messages schema
     chatItems: [],     // display items for React
     // DeepSeek Turn 生命周期(user_start / assistant_done)，来自 timing_events.jsonl；
@@ -522,6 +525,8 @@
   var flushQueued = chatFeature.flushQueued;
   var sendMessageToSession = chatFeature.sendMessageToSession;
   var sendMessage = chatFeature.sendMessage;
+  var getComposerDraft = chatFeature.getComposerDraft;
+  var setComposerDraft = chatFeature.setComposerDraft;
   var prefillComposer = chatFeature.prefillComposer;
   var removeQueued = chatFeature.removeQueued;
   var summonPinvou = chatFeature.summonPinvou;
@@ -840,7 +845,7 @@
   var STATE_SLICE_FIELDS = {
     platform: ["appVersion", "backendOnline", "platformCapabilities"],
     sessions: ["sessions", "archivedSessions", "activeSessionId", "sessionBusy", "draftEpoch"],
-    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
+    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
     voice: ["voiceInput", "voiceAsrSetup"],
     knowledge: ["kbModelSetup", "mountedCollection"],
     scheduled: ["scheduledRunContext", "scheduledTaskAutoOpenId", "scheduledTaskBusyAction", "scheduledTaskCreationSessionId", "scheduledTaskDetail", "scheduledTaskDraft", "scheduledTaskError", "scheduledTaskErrorKind", "scheduledTaskLoading", "scheduledTaskPendingGuide", "scheduledTaskRecentRuns", "scheduledTaskRuns", "scheduledTasks", "scheduledTaskSelectionGeneration", "selectedScheduledTaskId"],
@@ -1695,6 +1700,8 @@
     chat: {
       sendMessage: sendMessage,
       sendMessageToSession: sendMessageToSession,
+      getComposerDraft: getComposerDraft,
+      setComposerDraft: setComposerDraft,
       prefillComposer: prefillComposer,
       removeQueued: removeQueued,
       cancelGeneration: cancelGeneration,

--- a/pinvou3-app/src/platform/tauri/bridge/chat.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat.js
@@ -28,6 +28,20 @@
     var parseScheduledTaskDraftFromText = context.parseScheduledTaskDraftFromText;
     var autoCreateScheduledTaskDraft = context.autoCreateScheduledTaskDraft;
 
+  // Composer 草稿是纯前端短期状态：写入时不 notify，避免每次按键都克隆
+  // 整个 chat slice 并触发 App 重渲染。会话切换本身会 notify，ChatView 会在
+  // activeSessionId 变化后主动读取目标 working set 的草稿。
+  function getComposerDraft() {
+    return String(state.composerDraft || "");
+  }
+  function setComposerDraft(value) {
+    var text = value == null ? "" : String(value);
+    state.composerDraft = text;
+    var activeBuffer = state.activeSessionId && sessionStates[state.activeSessionId];
+    if (activeBuffer) activeBuffer.composerDraft = text;
+    return text;
+  }
+
   // ── Chat Items (display format for React) ────────────────────────
   function addChatItem(item) {
     item.id = ++context.itemIdSeq;
@@ -634,6 +648,8 @@
       flushQueued: flushQueued,
       sendMessageToSession: sendMessageToSession,
       sendMessage: sendMessage,
+      getComposerDraft: getComposerDraft,
+      setComposerDraft: setComposerDraft,
       prefillComposer: prefillComposer,
       removeQueued: removeQueued,
       summonPinvou: summonPinvou,

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -45,7 +45,7 @@
     var sessionSwitchRequestToken = 0;
   function freshBuffer() {
     return {
-      messages: [], chatItems: [], turnTimeline: [], activeTurnTimelineId: null, personaEvents: [], pinvouReviews: [], artifacts: [], busy: false, queued: [],
+      messages: [], chatItems: [], composerDraft: "", turnTimeline: [], activeTurnTimelineId: null, personaEvents: [], pinvouReviews: [], artifacts: [], busy: false, queued: [],
       loadedFromDisk: false,
       localTurnOwned: false,
       remoteTurnActive: false,
@@ -263,6 +263,7 @@
   function saveWorkingSetTo(buf) {
     if (!buf) return;
     buf.messages = state.messages; buf.chatItems = state.chatItems; buf.artifacts = state.artifacts;
+    buf.composerDraft = state.composerDraft || "";
     buf.turnTimeline = state.turnTimeline;
     buf.activeTurnTimelineId = state.activeTurnTimelineId;
     buf.personaEvents = state.personaEvents;
@@ -282,6 +283,7 @@
   function loadWorkingSetFrom(buf) {
     if (!buf) return;
     state.messages = buf.messages; state.chatItems = buf.chatItems; state.artifacts = buf.artifacts;
+    state.composerDraft = buf.composerDraft || "";
     state.turnTimeline = buf.turnTimeline || [];
     state.activeTurnTimelineId = buf.activeTurnTimelineId || null;
     state.personaEvents = buf.personaEvents || [];
@@ -401,7 +403,11 @@
 
     // 已在干净草稿态 → 只 notify(epoch 已自增)。注意要连 chatItems 一起判空:messages 与 chatItems
     // 会背离(persona 气泡 / ensureSession 失败的 system 报错卡只进 chatItems),否则残留卡顶掉「你好」。
-    if (!state.activeSessionId && state.messages.length === 0 && state.chatItems.length === 0) { notify(); return; }
+    if (!state.activeSessionId && state.messages.length === 0 && state.chatItems.length === 0) {
+      state.composerDraft = "";
+      notify();
+      return;
+    }
     if (state.activeSessionId) saveWorkingSetTo(getBuffer(state.activeSessionId));
     state.activeSessionId = null;
     loadWorkingSetFrom(freshBuffer());
@@ -417,7 +423,14 @@
     // 多 session 并发:不预热 engine。新建空 session 的 buffer 由 switchActiveTo({fresh}) 起。
     try {
       var meta = await invoke("create_session");
+      // create_session 等待期间用户可能已发送/清空输入，必须读取最新值，
+      // 不能把 await 前的已发送文本带入新 session。
+      var composerDraft = state.composerDraft || "";
       switchActiveTo(meta.id, { fresh: true });
+      // 草稿态因首条消息/加卡等实质操作物化为 session 时，输入草稿也要
+      // 跟随迁移；这不是用户主动切换到另一个已有会话。
+      state.composerDraft = composerDraft;
+      sessionStates[meta.id].composerDraft = composerDraft;
       await refreshHistoryList();
       await syncModeState();
       await syncActivePersona();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -90,6 +90,9 @@
     // 跨页面预填输入框请求。比如本地知识 → 产出物点击「续写/新项目」：
     // 只把草稿放进 composer，不自动发送给模型。
     composerPrefill: { id: 0, text: "" },
+    // 当前会话未发送的输入草稿。只存内存，随 session working set 切换；
+    // 不落盘，避免把敏感的未发送内容带到下次启动。
+    composerDraft: "",
     messages: [],      // Anthropic Messages schema
     chatItems: [],     // display items for React
     // DeepSeek Turn 生命周期(user_start / assistant_done)，来自 timing_events.jsonl；
@@ -390,7 +393,7 @@
   var personaPlaceholderTitles = {};
   function freshBuffer() {
     return {
-      messages: [], chatItems: [], turnTimeline: [], activeTurnTimelineId: null, personaEvents: [], pinvouReviews: [], artifacts: [], busy: false, queued: [],
+      messages: [], chatItems: [], composerDraft: "", turnTimeline: [], activeTurnTimelineId: null, personaEvents: [], pinvouReviews: [], artifacts: [], busy: false, queued: [],
       loadedFromDisk: false,
       localTurnOwned: false,
       remoteTurnActive: false,
@@ -606,6 +609,7 @@
   function saveWorkingSetTo(buf) {
     if (!buf) return;
     buf.messages = state.messages; buf.chatItems = state.chatItems; buf.artifacts = state.artifacts;
+    buf.composerDraft = state.composerDraft || "";
     buf.turnTimeline = state.turnTimeline;
     buf.activeTurnTimelineId = state.activeTurnTimelineId;
     buf.personaEvents = state.personaEvents;
@@ -625,6 +629,7 @@
   function loadWorkingSetFrom(buf) {
     if (!buf) return;
     state.messages = buf.messages; state.chatItems = buf.chatItems; state.artifacts = buf.artifacts;
+    state.composerDraft = buf.composerDraft || "";
     state.turnTimeline = buf.turnTimeline || [];
     state.activeTurnTimelineId = buf.activeTurnTimelineId || null;
     state.personaEvents = buf.personaEvents || [];
@@ -1966,7 +1971,11 @@
 
     // 已在干净草稿态 → 只 notify(epoch 已自增)。注意要连 chatItems 一起判空:messages 与 chatItems
     // 会背离(persona 气泡 / ensureSession 失败的 system 报错卡只进 chatItems),否则残留卡顶掉「你好」。
-    if (!state.activeSessionId && state.messages.length === 0 && state.chatItems.length === 0) { notify(); return; }
+    if (!state.activeSessionId && state.messages.length === 0 && state.chatItems.length === 0) {
+      state.composerDraft = "";
+      notify();
+      return;
+    }
     if (state.activeSessionId) saveWorkingSetTo(getBuffer(state.activeSessionId));
     state.activeSessionId = null;
     loadWorkingSetFrom(freshBuffer());
@@ -1982,7 +1991,11 @@
     // 多 session 并发:不预热 engine。新建空 session 的 buffer 由 switchActiveTo({fresh}) 起。
     try {
       var meta = await invoke(IS_WEB ? "web_access_create_session" : "create_session");
+      // create_session 等待期间用户可能已发送/清空输入，迁移当下的最新值。
+      var composerDraft = state.composerDraft || "";
       switchActiveTo(meta.id, { fresh: true });
+      state.composerDraft = composerDraft;
+      sessionStates[meta.id].composerDraft = composerDraft;
       getBuffer(meta.id).sessionRevision = String(meta.transcript_revision || meta.transcriptRevision || "");
       await refreshHistoryList();
       await syncModeState();
@@ -3554,6 +3567,16 @@
       });
       notify();
     }
+  }
+  function getComposerDraft() {
+    return String(state.composerDraft || "");
+  }
+  function setComposerDraft(value) {
+    var text = value == null ? "" : String(value);
+    state.composerDraft = text;
+    var activeBuffer = state.activeSessionId && sessionStates[state.activeSessionId];
+    if (activeBuffer) activeBuffer.composerDraft = text;
+    return text;
   }
   function prefillComposer(text) {
     state.composerPrefill = { id: (state.composerPrefill.id || 0) + 1, text: String(text || "") };
@@ -7115,6 +7138,8 @@
     init: init,
     sendMessage: sendMessage,
     sendMessageToSession: sendMessageToSession,
+    getComposerDraft: getComposerDraft,
+    setComposerDraft: setComposerDraft,
     prefillComposer: prefillComposer,
     removeQueued: removeQueued,
     startVoiceInput: startVoiceInput,
@@ -7332,7 +7357,7 @@
   var fields = {
     platform: ["appVersion", "backendOnline", "platformCapabilities"],
     sessions: ["sessions", "archivedSessions", "activeSessionId", "sessionBusy", "draftEpoch"],
-    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
+    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
     voice: ["voiceInput", "voiceAsrSetup"],
     knowledge: ["kbModelSetup", "mountedCollection"],
     scheduled: ["scheduledRunContext", "scheduledTaskAutoOpenId", "scheduledTaskBusyAction", "scheduledTaskCreationSessionId", "scheduledTaskDetail", "scheduledTaskDraft", "scheduledTaskError", "scheduledTaskErrorKind", "scheduledTaskLoading", "scheduledTaskPendingGuide", "scheduledTaskRecentRuns", "scheduledTaskRuns", "scheduledTasks", "scheduledTaskSelectionGeneration", "selectedScheduledTaskId"],
@@ -7390,7 +7415,7 @@
     lifecycle: { init: flat.init },
     state: { get: get, getMany: getMany, subscribe: subscribe, subscribeMany: subscribeMany },
     platform: {},
-    chat: domain(["sendMessage", "sendMessageToSession", "prefillComposer", "removeQueued", "cancelGeneration", "cancelShellTask"]),
+    chat: domain(["sendMessage", "sendMessageToSession", "getComposerDraft", "setComposerDraft", "prefillComposer", "removeQueued", "cancelGeneration", "cancelShellTask"]),
     voice: domain(["startVoiceInput", "installVoiceAsr", "closeVoiceAsrSetup", "cancelVoiceInput", "clearVoiceInput", "appendVoiceText", "runVoiceInputDebugAssertions"]),
     knowledge: domain(["downloadKbModel", "cancelKbModel", "mountCollection", "unmountCollection", "listCollections", "kbModelStatus"]),
     scheduled: domain(["loadScheduledTasks", "readScheduledTask", "loadScheduledTaskRuns", "loadScheduledTaskRecentRuns", "selectScheduledTask", "refreshScheduledTaskData", "clearScheduledTaskSelection", "dismissScheduledTaskError", "createScheduledTask", "updateScheduledTask", "pauseScheduledTask", "resumeScheduledTask", "toggleScheduledTaskPinned", "deleteScheduledTask", "runScheduledTaskNow", "pickFolder", "startScheduledTaskChat", "confirmScheduledTaskDraft", "clearScheduledTaskDraft", "openScheduledRunChat", "exitScheduledRunChat"]),

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -786,6 +786,7 @@
     var bg = sessionStates[sid]; if (!bg) return;
     touchSessionBuffer(sid, bg, isScheduledRunSession(sid));
     var realId = state.activeSessionId;
+    var draftComposer = realId ? "" : (state.composerDraft || "");
     saveWorkingSetTo(getBuffer(realId));
     loadWorkingSetFrom(bg);
     state.activeSessionId = sid;
@@ -797,8 +798,11 @@
       state.activeSessionId = realId;
       // realId 为 null(草稿态)时 getBuffer(null)=null、loadWorkingSetFrom(null) 是 no-op,
       // 会把刚处理的后台 session 工作集泄漏进草稿视图(activeSessionId=null 却带着它的 chatItems),
-      // 召唤检阅等依赖 activeSessionId 的操作随之错乱。草稿态须切回干净的空工作集。
-      loadWorkingSetFrom(realId ? getBuffer(realId) : freshBuffer());
+      // 召唤检阅等依赖 activeSessionId 的操作随之错乱。草稿态须切回干净工作集，
+      // 但要保留用户正在输入的未发送文本。
+      var restoreBuffer = realId ? getBuffer(realId) : freshBuffer();
+      if (!realId) restoreBuffer.composerDraft = draftComposer;
+      loadWorkingSetFrom(restoreBuffer);
     }
   }
   // 事件监听器统一入口:按 payload.session_id 路由同步逻辑;后台变更后补一次 notify 刷新列表。

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -141,7 +141,7 @@ vm.runInContext(read('bridge.js'), context, { filename: 'bridge.js' });
 const api = windowObject.TauriBridge;
 const expectedApi = {
   lifecycle: ['init'], state: ['get', 'getMany', 'subscribe', 'subscribeMany'], platform: ['loadPlatformCapabilities', 'refreshConnectorAuthGates'],
-  chat: ['cancelGeneration', 'cancelShellTask', 'prefillComposer', 'removeQueued', 'sendMessage', 'sendMessageToSession'],
+  chat: ['cancelGeneration', 'cancelShellTask', 'getComposerDraft', 'prefillComposer', 'removeQueued', 'sendMessage', 'sendMessageToSession', 'setComposerDraft'],
   voice: ['appendVoiceText', 'cancelVoiceAsrSetup', 'cancelVoiceInput', 'clearVoiceInput', 'closeVoiceAsrSetup', 'installVoiceAsr', 'runVoiceInputDebugAssertions', 'startVoiceInput'],
   knowledge: ['cancelKbModel', 'downloadKbModel', 'kbModelStatus', 'listCollections', 'loadKnowledgeEmbedderAfterFirstFrame', 'mountCollection', 'unmountCollection'],
   scheduled: ['clearScheduledTaskDraft', 'clearScheduledTaskSelection', 'confirmScheduledTaskDraft', 'createScheduledTask', 'deleteScheduledTask', 'dismissScheduledTaskError', 'exitScheduledRunChat', 'loadScheduledTaskRecentRuns', 'loadScheduledTaskRuns', 'loadScheduledTasks', 'openScheduledRunChat', 'pauseScheduledTask', 'pickFolder', 'readScheduledTask', 'refreshScheduledTaskData', 'resumeScheduledTask', 'runScheduledTaskNow', 'selectScheduledTask', 'startScheduledTaskChat', 'toggleScheduledTaskPinned', 'updateScheduledTask'],

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -612,6 +612,37 @@ async function expand(page) {
     draftInputFound && draftEntered && draftViewChanged && restoredDraft === composerDraft &&
     newSessionDraft === '' && restoredSessionDraft === composerDraft,
     JSON.stringify({ draftInputFound, draftEntered, draftViewChanged, restoredDraft, newSessionDraft, restoredSessionDraft }));
+
+  // 尚未物化的新对话没有 session buffer。后台已有 session 收到事件时，
+  // 临时切换工作集再恢复，仍必须保住当前输入框草稿。
+  await clickText(page, '新对话');
+  await sleep(300);
+  const pendingDraft = '后台事件期间也不能丢失的新对话草稿';
+  const pendingDraftResult = await page.evaluate(async (value) => {
+    const textarea = document.querySelector('[data-testid="chat-composer-input"]');
+    if (!textarea) return { inputFound: false };
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    for (const handler of (window.__TAURI_EVENT_HANDLERS__['chat:usage'] || [])) {
+      await handler({
+        event: 'chat:usage',
+        payload: { session_id: 's1', input_tokens: 42 },
+      });
+    }
+    return {
+      inputFound: true,
+      activeSessionId: window.TauriBridge.state.getMany(['sessions']).activeSessionId,
+      bridgeDraft: window.TauriBridge.chat.getComposerDraft(),
+      visibleDraft: textarea.value,
+    };
+  }, pendingDraft);
+  rec('③f 新对话草稿不被后台 session 事件清空',
+    pendingDraftResult.inputFound &&
+    pendingDraftResult.activeSessionId === null &&
+    pendingDraftResult.bridgeDraft === pendingDraft &&
+    pendingDraftResult.visibleDraft === pendingDraft,
+    JSON.stringify(pendingDraftResult));
   await page.evaluate(() => {
     const textarea = document.querySelector('[data-testid="chat-composer-input"]');
     if (!textarea) return;
@@ -619,6 +650,8 @@ async function expand(page) {
     setter.call(textarea, '');
     textarea.dispatchEvent(new Event('input', { bubbles: true }));
   });
+  await clickText(page, '第三季度财报分析');
+  await sleep(900);
 
   // 实时事件也必须使用同一 producer 判定：validator 的 shell JSON 不能进产物面板，
   // 真 MCP producer 返回路径仍要被跟踪。

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -6,6 +6,7 @@
  *   ② 工具商店渲染出 Obsidian 与钉钉连接器卡。
  *   ③ 聊天流产物卡(artifact_card)挂出「品/悟」召唤 pinvou 按钮。
  *   ④ 记忆候选事件渲染卡片，且确认/忽略/不再提示分别调用正确后端命令。
+ *   ⑤ session 内未发送的 composer 草稿在跳转其他页面后仍能恢复。
  * 依赖:puppeteer-core(自动从 node_modules / ~/.npm/_npx 发现)+ 系统 chromium(或 env CHROME 指定)。
  * 用法:node pinvou3-app/tests/ui_smoke.js   (全 PASS → exit 0,任一 FAIL → exit 1,缺依赖 → exit 2)
  */
@@ -576,6 +577,48 @@ async function expand(page) {
     restored.shellHistoryCount === 1 && restored.shellHistoryTaskId === 'task-history-done' &&
     restored.shellHistoryOutput === 'history output',
     JSON.stringify({ hit, ...restored }));
+
+  // 会话输入框是页面条件渲染的：跳工具商店会卸载 ChatView，返回同一 session
+  // 必须恢复未发送内容，不得因组件重建清空。
+  const composerDraft = '这是尚未发送的 session 草稿';
+  const draftInputFound = await page.evaluate((value) => {
+    const textarea = document.querySelector('[data-testid="chat-composer-input"]');
+    if (!textarea) return false;
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+    setter.call(textarea, value);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    return true;
+  }, composerDraft);
+  await sleep(100);
+  const draftEntered = await page.evaluate((value) =>
+    document.querySelector('[data-testid="chat-composer-input"]')?.value === value, composerDraft);
+  await page.evaluate(() => document.querySelector('[data-nav="toolstore"]')?.click());
+  await sleep(700);
+  const draftViewChanged = await page.evaluate(() =>
+    document.querySelector('[data-testid="app-root"]')?.getAttribute('data-current-view') === 'toolStore');
+  await clickText(page, '第三季度财报分析');
+  await sleep(900);
+  const restoredDraft = await page.evaluate(() =>
+    document.querySelector('[data-testid="chat-composer-input"]')?.value || '');
+  await clickText(page, '新对话');
+  await sleep(300);
+  const newSessionDraft = await page.evaluate(() =>
+    document.querySelector('[data-testid="chat-composer-input"]')?.value || '');
+  await clickText(page, '第三季度财报分析');
+  await sleep(900);
+  const restoredSessionDraft = await page.evaluate(() =>
+    document.querySelector('[data-testid="chat-composer-input"]')?.value || '');
+  rec('③e session 未发送草稿跨页面恢复',
+    draftInputFound && draftEntered && draftViewChanged && restoredDraft === composerDraft &&
+    newSessionDraft === '' && restoredSessionDraft === composerDraft,
+    JSON.stringify({ draftInputFound, draftEntered, draftViewChanged, restoredDraft, newSessionDraft, restoredSessionDraft }));
+  await page.evaluate(() => {
+    const textarea = document.querySelector('[data-testid="chat-composer-input"]');
+    if (!textarea) return;
+    const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+    setter.call(textarea, '');
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  });
 
   // 实时事件也必须使用同一 producer 判定：validator 的 shell JSON 不能进产物面板，
   // 真 MCP producer 返回路径仍要被跟踪。

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -113,6 +113,14 @@ assert.match(webBridge, /listen\("session:list_changed"/);
 assert.match(desktopSessionsBridge, /listen\("session:list_changed"/);
 assert.match(commands, /app\.emit\(event, payload\.clone\(\)\)/);
 assert.match(commands, /forward_app_event\(app, event, payload\)/);
+assert.match(webBridge, /composerDraft: ""/,
+  'WebUI must keep a per-session in-memory composer draft');
+assert.match(webBridge, /chat: domain\(\["sendMessage", "sendMessageToSession", "getComposerDraft", "setComposerDraft"/,
+  'WebUI domain facade must expose the same composer draft API as desktop');
+assert.match(webBridge, /buf\.composerDraft = state\.composerDraft/,
+  'WebUI session switching must save the active composer draft');
+assert.match(webBridge, /state\.composerDraft = buf\.composerDraft/,
+  'WebUI session switching must restore the destination composer draft');
 assert.match(workflowCommands, /start_skill_session\([\s\S]*?app: AppHandle[\s\S]*?emit_session_event\(&app, "session:list_changed", &sid, "created"\)/);
 assert.match(remoteControlCommands, /web_access_start_skill_session\([\s\S]*?app: AppHandle[\s\S]*?start_skill_session\(name, Some\(false\), app, store, pool\)/);
 for (const eventName of ['session:model_changed', 'session:persona_changed']) {

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -121,6 +121,10 @@ assert.match(webBridge, /buf\.composerDraft = state\.composerDraft/,
   'WebUI session switching must save the active composer draft');
 assert.match(webBridge, /state\.composerDraft = buf\.composerDraft/,
   'WebUI session switching must restore the destination composer draft');
+assert.match(webBridge, /var draftComposer = realId \? "" : \(state\.composerDraft \|\| ""\)/,
+  'WebUI background session events must snapshot an unmaterialized draft');
+assert.match(webBridge, /if \(!realId\) restoreBuffer\.composerDraft = draftComposer/,
+  'WebUI background session events must restore an unmaterialized draft');
 assert.match(workflowCommands, /start_skill_session\([\s\S]*?app: AppHandle[\s\S]*?emit_session_event\(&app, "session:list_changed", &sid, "created"\)/);
 assert.match(remoteControlCommands, /web_access_start_skill_session\([\s\S]*?app: AppHandle[\s\S]*?start_skill_session\(name, Some\(false\), app, store, pool\)/);
 for (const eventName of ['session:model_changed', 'session:persona_changed']) {


### PR DESCRIPTION
## 概述

保留聊天 session 中未发送的输入草稿；用户切换到设置、工具商店等页面再返回时，输入内容不再丢失。桌面端与 WebUI 使用一致的会话级内存草稿语义。

## 背景

`ChatView` 原先把输入内容只保存在组件本地 `useState` 中。页面条件渲染会卸载该组件，返回聊天页时状态重新初始化为空；同时缺少 session 级隔离，无法正确处理会话切换。

## 变更

- 将未发送草稿纳入 session working set，在会话切换时分别保存和恢复。
- 新建会话时清空草稿，草稿 session 物化时迁移最新内容，发送或手动清空后不再恢复旧文本。
- 同步桌面 Tauri bridge 与 WebUI bridge 的草稿 API，输入时避免触发全量状态广播。
- 增加 UI 冒烟和 bridge/WebUI 契约回归，覆盖跨页面恢复、新会话隔离及返回原 session 恢复。

## 验证

- `npm run lint:ui`
- `npm run build:ui`
- `npm test`
- `npm run test:ui-smoke`（39 项全部通过）
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `agent-browser`：输入草稿 → 设置页 → 返回聊天页，草稿保留

## 备注

- 草稿仅保存在当前应用进程内，不写入磁盘；应用重启后不会恢复未发送内容。
