### PR TITLE
fix(codex): 默认继承系统权限配置

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -27,7 +27,7 @@
     "test:diff-ui": "node tests/diff_viewer_ui_smoke.mjs",
     "test:marketplace-oauth": "node tests/marketplace_oauth_logic.test.js",
     "test:composer-tools": "node tests/composer_tool_menu_logic.test.js",
-    "test:codex-acp": "node tests/codex_acp_platform_contract.test.js && node tests/codex_acp_windows_contract.test.js && node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
+    "test:codex-acp": "node tests/codex_acp_platform_contract.test.js && node tests/codex_acp_config_inheritance.test.js && node tests/codex_acp_windows_contract.test.js && node tests/codex_acp_timeline.test.mjs && node tests/deepseek_conversation_timeline.test.mjs",
     "test:codex-acp-windows-runtime": "node tests/codex_acp_windows_runtime_smoke.js",
     "test:session-management": "node tests/session_management_logic.test.mjs",
     "test:chat-input-limit": "node tests/chat_input_limit_logic.test.js",

--- a/pinvou3-app/scripts/prepare-codex-bridge-runtime.sh
+++ b/pinvou3-app/scripts/prepare-codex-bridge-runtime.sh
@@ -9,6 +9,7 @@ NODE_VERSION="22.22.0"
 CODEX_ACP_VERSION="1.1.5"
 CODEX_ACP_PACKAGE="@agentclientprotocol/codex-acp"
 BRIDGE_PACKAGE_DIR="$SCRIPT_DIR/codex-bridge-runtime"
+PATCH_SCRIPT="$SCRIPT_DIR/tauri/codex-acp-patch.js"
 
 bridge_runtime_valid() {
   local root="$1"
@@ -21,7 +22,8 @@ bridge_runtime_valid() {
     env CODEX_PATH="$(command -v codex || true)" \
       "$node" "$entry" --version 2>/dev/null
   )" || return 1
-  [ "$version_output" = "$CODEX_ACP_PACKAGE $CODEX_ACP_VERSION" ]
+  [ "$version_output" = "$CODEX_ACP_PACKAGE $CODEX_ACP_VERSION" ] || return 1
+  "$node" "$PATCH_SCRIPT" --check "$entry" >/dev/null 2>&1
 }
 
 if bridge_runtime_valid "$OUT_DIR"; then
@@ -86,6 +88,9 @@ PATH="$NODE_DIST_ROOT/bin:$PATH" "$NODE_DIST_ROOT/bin/npm" ci \
   --no-audit \
   --no-fund \
   --omit=dev
+
+"$NODE_DIST_ROOT/bin/node" "$PATCH_SCRIPT" \
+  "$ACP_ROOT/node_modules/@agentclientprotocol/codex-acp/dist/index.js"
 
 # Bridge 总是通过 CODEX_PATH 启动系统或托管 Codex，不需要随包携带平台 Codex。
 rm -rf -- "$ACP_ROOT/node_modules/@openai"/codex-*

--- a/pinvou3-app/scripts/tauri/codex-acp-patch.js
+++ b/pinvou3-app/scripts/tauri/codex-acp-patch.js
@@ -1,0 +1,108 @@
+const fs = require("node:fs");
+
+const INHERIT_MODE = `  static Inherit = new _AgentMode(
+    "inherit",
+    "Codex settings",
+    "Use approval and sandbox defaults from Codex config.toml.",
+    null,
+    null,
+    "inherit"
+  );
+`;
+
+const READ_ONLY_ANCHOR = "  static ReadOnly = new _AgentMode(\n";
+const DEFAULT_MODE_SOURCE = "  static DEFAULT_AGENT_MODE = _AgentMode.Agent;";
+const DEFAULT_MODE_PATCHED = "  static DEFAULT_AGENT_MODE = _AgentMode.Inherit;";
+const MODE_LIST_SOURCE =
+  "    return [_AgentMode.ReadOnly, _AgentMode.Agent, _AgentMode.AgentFullAccess];";
+const MODE_LIST_PATCHED =
+  "    return [_AgentMode.Inherit, _AgentMode.ReadOnly, _AgentMode.Agent, _AgentMode.AgentFullAccess];";
+const TURN_POLICY_SOURCE = `      approvalPolicy: agentMode.approvalPolicy,
+      sandboxPolicy: addAdditionalDirectoriesToSandboxPolicy(agentMode.sandboxPolicy, additionalDirectories),`;
+const TURN_POLICY_PATCHED = `      ...(agentMode.approvalPolicy === null ? {} : { approvalPolicy: agentMode.approvalPolicy }),
+      ...(agentMode.sandboxPolicy === null ? {} : {
+        sandboxPolicy: addAdditionalDirectoriesToSandboxPolicy(agentMode.sandboxPolicy, additionalDirectories)
+      }),`;
+
+const PATCH_MARKERS = [
+  "  static Inherit = new _AgentMode(",
+  DEFAULT_MODE_PATCHED,
+  MODE_LIST_PATCHED,
+  "...(agentMode.approvalPolicy === null ? {} : { approvalPolicy: agentMode.approvalPolicy })",
+  "...(agentMode.sandboxPolicy === null ? {} : {",
+];
+
+function codexAcpInheritsSettings(source) {
+  return PATCH_MARKERS.every(marker => source.includes(marker));
+}
+
+function replaceExactlyOnce(source, before, after, label) {
+  const first = source.indexOf(before);
+  if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
+    throw new Error(`Codex ACP ${label} 入口已变化，无法安全应用配置继承补丁`);
+  }
+  return `${source.slice(0, first)}${after}${source.slice(first + before.length)}`;
+}
+
+function patchCodexAcpInheritSettings(entrypointPath) {
+  let source = fs.readFileSync(entrypointPath, "utf8");
+  if (codexAcpInheritsSettings(source)) return false;
+  if (PATCH_MARKERS.some(marker => source.includes(marker))) {
+    throw new Error("Codex ACP 配置继承补丁不完整，拒绝继续打包");
+  }
+
+  source = replaceExactlyOnce(
+    source,
+    READ_ONLY_ANCHOR,
+    `${INHERIT_MODE}${READ_ONLY_ANCHOR}`,
+    "mode",
+  );
+  source = replaceExactlyOnce(
+    source,
+    DEFAULT_MODE_SOURCE,
+    DEFAULT_MODE_PATCHED,
+    "default mode",
+  );
+  source = replaceExactlyOnce(source, MODE_LIST_SOURCE, MODE_LIST_PATCHED, "mode list");
+  source = replaceExactlyOnce(
+    source,
+    TURN_POLICY_SOURCE,
+    TURN_POLICY_PATCHED,
+    "turn policy",
+  );
+  if (!codexAcpInheritsSettings(source)) {
+    throw new Error("Codex ACP 配置继承补丁应用后校验失败");
+  }
+  fs.writeFileSync(entrypointPath, source);
+  return true;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const checkOnly = args[0] === "--check";
+  const entrypointPath = checkOnly ? args[1] : args[0];
+  if (!entrypointPath) {
+    throw new Error("缺少 Codex ACP entrypoint 路径");
+  }
+  if (checkOnly) {
+    if (!codexAcpInheritsSettings(fs.readFileSync(entrypointPath, "utf8"))) {
+      throw new Error("Codex ACP 尚未应用系统配置继承补丁");
+    }
+    return;
+  }
+  patchCodexAcpInheritSettings(entrypointPath);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[codex-acp-patch] ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  codexAcpInheritsSettings,
+  patchCodexAcpInheritSettings,
+};

--- a/pinvou3-app/scripts/tauri/codex-bridge.js
+++ b/pinvou3-app/scripts/tauri/codex-bridge.js
@@ -5,6 +5,10 @@ const { spawnSync } = require("node:child_process");
 
 const { APP_ROOT } = require("./platform-config.js");
 const { npmInstallInvocation } = require("./web-template.js");
+const {
+  codexAcpInheritsSettings,
+  patchCodexAcpInheritSettings,
+} = require("./codex-acp-patch.js");
 
 const BRIDGE_PACKAGE_ROOT = path.join(APP_ROOT, "scripts", "codex-bridge-runtime");
 const LOCKFILE_PATH = path.join(BRIDGE_PACKAGE_ROOT, "package-lock.json");
@@ -40,7 +44,7 @@ const BRIDGE_PACKAGE_JSON = path.join(
   "package.json",
 );
 const MARKER_NAME = "manifest.json";
-const PREPARE_FORMAT_VERSION = 3;
+const PREPARE_FORMAT_VERSION = 4;
 const CODEX_PATH_SPAWN =
   'spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv })';
 const HIDDEN_CODEX_PATH_SPAWN =
@@ -86,6 +90,7 @@ function expectedMarker({ architecture = process.arch } = {}) {
     entrypoint: BRIDGE_ENTRYPOINT.replaceAll(path.sep, "/"),
     requires_managed_codex: true,
     windows_child_processes_hidden: true,
+    inherits_codex_settings_by_default: true,
   };
 }
 
@@ -168,6 +173,9 @@ function isPrepared(
       packageJson.version === expected.codex_acp_version &&
       nonemptyFile(path.join(outputRoot, BRIDGE_ENTRYPOINT)) &&
       windowsChildProcessesHidden(path.join(outputRoot, BRIDGE_ENTRYPOINT)) &&
+      codexAcpInheritsSettings(
+        fs.readFileSync(path.join(outputRoot, BRIDGE_ENTRYPOINT), "utf8"),
+      ) &&
       nonemptyFile(path.join(nodeRoot, "node.exe")) &&
       fileSha256(path.join(nodeRoot, "node.exe")) ===
         expected.node_executable_sha256
@@ -338,6 +346,7 @@ function prepareWindowsCodexBridge({
       "安装 Windows ACP Bridge",
     );
 
+    patchCodexAcpInheritSettings(path.join(bridgeRoot, BRIDGE_ENTRYPOINT));
     hideWindowsChildProcesses(path.join(bridgeRoot, BRIDGE_ENTRYPOINT));
 
     fs.rmSync(path.join(acpRoot, "package.json"), { force: true });

--- a/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
@@ -53,8 +53,8 @@ pub struct SessionAgentRecord {
     pub acp_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acp_model_id: Option<String>,
-    /// 用户明确选择的 Codex 权限模式。ACP Agent 在 new/load 时会恢复默认
-    /// `agent`，所以 Pinvou 必须在运行时就绪前重新应用该期望值。
+    /// 用户明确选择的 Codex 权限模式。未选择时保留 None，让 ACP Agent 使用
+    /// `inherit` 默认值并继承系统 Codex 配置；仅在用户主动覆盖后才恢复该模式。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acp_mode_id: Option<String>,
     /// Codex 的执行目录类型。旧记录没有该字段时按临时会话兼容。

--- a/pinvou3-app/tests/codex_acp_config_inheritance.test.js
+++ b/pinvou3-app/tests/codex_acp_config_inheritance.test.js
@@ -1,0 +1,85 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  codexAcpInheritsSettings,
+  patchCodexAcpInheritSettings,
+} = require("../scripts/tauri/codex-acp-patch.js");
+
+const linuxBuildScript = fs.readFileSync(
+  path.join(__dirname, "..", "scripts", "prepare-codex-bridge-runtime.sh"),
+  "utf8",
+);
+assert.match(
+  linuxBuildScript,
+  /"\$NODE_DIST_ROOT\/bin\/node" "\$PATCH_SCRIPT"[\s\S]*?codex-acp\/dist\/index\.js/,
+  "Linux packages must patch the installed Codex ACP bridge",
+);
+assert.match(
+  linuxBuildScript,
+  /"\$node" "\$PATCH_SCRIPT" --check "\$entry"/,
+  "Linux packages must reject a cached bridge that does not inherit Codex settings",
+);
+
+const fixture = `var AgentMode = class _AgentMode {
+  static ReadOnly = new _AgentMode(
+    "read-only"
+  );
+  static AgentFullAccess = new _AgentMode(
+    "agent-full-access"
+  );
+  static DEFAULT_AGENT_MODE = _AgentMode.Agent;
+  static all() {
+    return [_AgentMode.ReadOnly, _AgentMode.Agent, _AgentMode.AgentFullAccess];
+  }
+};
+async function sendPrompt(agentMode, additionalDirectories) {
+  return await this.codexClient.runTurn({
+      threadId: "thread",
+      approvalPolicy: agentMode.approvalPolicy,
+      sandboxPolicy: addAdditionalDirectoriesToSandboxPolicy(agentMode.sandboxPolicy, additionalDirectories),
+      summary: "auto"
+    });
+}
+`;
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pinvou-codex-config-"));
+try {
+  const entrypoint = path.join(tempRoot, "index.js");
+  fs.writeFileSync(entrypoint, fixture);
+
+  assert.equal(patchCodexAcpInheritSettings(entrypoint), true);
+  const patched = fs.readFileSync(entrypoint, "utf8");
+  assert.equal(codexAcpInheritsSettings(patched), true);
+  assert.match(patched, /static DEFAULT_AGENT_MODE = _AgentMode\.Inherit/);
+  assert.match(patched, /Use approval and sandbox defaults from Codex config\.toml/);
+  assert.match(
+    patched,
+    /agentMode\.approvalPolicy === null \? \{\} : \{ approvalPolicy:/,
+    "inherit mode must omit turn-level approvalPolicy",
+  );
+  assert.match(
+    patched,
+    /agentMode\.sandboxPolicy === null \? \{\} : \{/,
+    "inherit mode must omit turn-level sandboxPolicy",
+  );
+  assert.equal(
+    patchCodexAcpInheritSettings(entrypoint),
+    false,
+    "the packaged runtime patch must be idempotent",
+  );
+
+  const unknownEntrypoint = path.join(tempRoot, "unknown.js");
+  fs.writeFileSync(unknownEntrypoint, "console.log('changed upstream');\n");
+  assert.throws(
+    () => patchCodexAcpInheritSettings(unknownEntrypoint),
+    /入口已变化/,
+    "an upstream bundle layout change must fail closed instead of shipping an unpatched bridge",
+  );
+} finally {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+console.log("✓ Codex ACP defaults to inherited system approval and sandbox settings");

--- a/pinvou3-app/tests/codex_acp_windows_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_windows_contract.test.js
@@ -62,6 +62,9 @@ const {
   WINDOWS_NODE_VERSION,
   windowsBridgeOverlay,
 } = require("../scripts/tauri/codex-bridge.js");
+const {
+  patchCodexAcpInheritSettings,
+} = require("../scripts/tauri/codex-acp-patch.js");
 
 assert.match(
   capabilities,
@@ -117,6 +120,11 @@ assert.match(
   bridgeBuildScript,
   /windowsHide: true[\s\S]*?hideWindowsChildProcesses/,
   "the packaged ACP Bridge must hide the Codex CLI process it starts on Windows",
+);
+assert.match(
+  bridgeBuildScript,
+  /patchCodexAcpInheritSettings\(path\.join\(bridgeRoot, BRIDGE_ENTRYPOINT\)\)/,
+  "the packaged ACP Bridge must inherit system Codex settings before applying explicit session overrides",
 );
 assert.match(
   codexRuntime,
@@ -181,6 +189,18 @@ try {
     ].join("\n"),
   );
   hideWindowsChildProcesses(bridgeEntrypoint);
+  fs.writeFileSync(
+    bridgeEntrypoint,
+    [
+      fs.readFileSync(bridgeEntrypoint, "utf8"),
+      "  static ReadOnly = new _AgentMode(\n",
+      "  static DEFAULT_AGENT_MODE = _AgentMode.Agent;",
+      "    return [_AgentMode.ReadOnly, _AgentMode.Agent, _AgentMode.AgentFullAccess];",
+      "      approvalPolicy: agentMode.approvalPolicy,",
+      "      sandboxPolicy: addAdditionalDirectoriesToSandboxPolicy(agentMode.sandboxPolicy, additionalDirectories),",
+    ].join("\n"),
+  );
+  patchCodexAcpInheritSettings(bridgeEntrypoint);
   fs.writeFileSync(nodeExecutable, fakeNode);
 
   assert.equal(expected.node_version, WINDOWS_NODE_VERSION);


### PR DESCRIPTION
## 概述

让 Pinvou 代码模式默认继承系统 Codex 的审批与沙箱配置。用户未在 Pinvou 会话中主动选择权限模式时，不再由 ACP Bridge 将 Codex 强制覆盖为 `on-request + workspace-write`。

## 背景

`codex-acp` 虽然会通过 `codex app-server` 加载 `~/.codex/config.toml` 和项目配置，但默认 `Agent` 模式会在每个 `turn/start` 中显式发送 `approvalPolicy` 与 `sandboxPolicy`，覆盖 Codex 已加载的用户设置。这会导致已经配置为少确认或无确认的用户，在 Pinvou 中仍频繁收到文件修改确认。

## 变更

- 为打包的 Codex ACP Bridge 增加 `Codex settings` 继承模式，并设为默认。
- 继承模式下省略 turn 级审批与沙箱字段，让 Codex 使用全局/项目配置；用户显式选择 Read-only、Agent 或 Full access 时仍按会话覆盖。
- Linux 与 Windows 构建都应用并校验补丁；上游 bundle 结构变化或补丁不完整时拒绝打包。
- Windows Bridge 格式版本升级，自动淘汰未应用继承语义的缓存 Runtime。
- 增加补丁幂等、失败关闭及跨平台打包契约测试。

## 验证

- `npm run lint:ui`
- `npm run build:ui`
- `npm test`
- `npm run test:ui-smoke`（38 项全部通过）
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- Tauri ARM64 Debug 原生打包成功
- 真实 ACP → Codex app-server：默认模式为 `inherit`，`turn/start` 未携带 `approvalPolicy` / `sandboxPolicy`，任务正常结束
- 本地 App：权限模式显示 `Codex settings`，系统 Codex 0.145.0 正常连接

## 备注

- Pinvou 内显式选择权限模式仍然优先于系统默认。
- 本修复不解析或复制用户的 `config.toml`；Codex 仍是配置真相源。
