### PR TITLE
fix(codex): 接入统一产出物管理

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -10,7 +10,8 @@ use tauri::State;
 
 use crate::features::assistant::engine_pool::EnginePool;
 use crate::features::codex_acp::workspace::{
-    self, WorkspaceChanges, WorkspaceDiff, WorkspaceEntry, WorkspaceListing, WorkspacePreview,
+    self, WorkspaceArtifact, WorkspaceChanges, WorkspaceDiff, WorkspaceEntry, WorkspaceListing,
+    WorkspacePreview,
 };
 use crate::features::codex_acp::{
     validate_codex_project_workspace, AcpEventEnvelope, AcpPool, CodexAcpPendingElicitation,
@@ -263,6 +264,64 @@ pub async fn reveal_codex_workspace_file(
         crate::platform::os::external_application_path(directory),
         "Codex 工作区目录",
     )
+}
+
+/// Reconcile Codex outputs into Pinvou's shared Session artifact index.
+///
+/// ACP Code mode bypasses the regular chat tool-event bridge, so without this
+/// explicit handoff its files can be browsed in the workspace but cannot be
+/// previewed or managed as Pinvou artifacts.
+#[tauri::command]
+pub async fn reconcile_codex_acp_artifacts(
+    session_id: String,
+    store: State<'_, SessionStore>,
+    acp_pool: State<'_, AcpPool>,
+) -> Result<Vec<WorkspaceArtifact>, String> {
+    let root = codex_workspace_root(&session_id, &acp_pool)?;
+    let workspace_info = acp_pool
+        .workspace_info(&session_id)
+        .map_err(|error| format!("读取 Codex 工作目录失败: {error:#}"))?;
+    let timeline = acp_pool
+        .timeline(&session_id)
+        .map_err(|error| format!("读取 Codex ACP timeline 失败: {error:#}"))?;
+    let saved = store
+        .load(&session_id)
+        .map_err(|error| format!("读取 Codex 会话产出物失败: {error:#}"))?;
+    let retained = saved
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.storage_path.clone())
+        .collect::<Vec<_>>();
+    let temporary = workspace_info.workspace_kind == CodexWorkspaceKind::Temporary;
+    let discovery_session_id = session_id.clone();
+    let artifacts = tauri::async_runtime::spawn_blocking(move || {
+        workspace::discover_artifacts(
+            &discovery_session_id,
+            &root,
+            temporary,
+            &timeline,
+            &retained,
+        )
+        .map_err(|error| format!("识别 Codex 会话产出物失败: {error:#}"))
+    })
+    .await
+    .map_err(|error| format!("识别 Codex 会话产出物任务失败: {error}"))??;
+
+    let next_paths = artifacts
+        .iter()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
+    let current_paths = saved
+        .artifacts
+        .iter()
+        .map(|artifact| artifact.storage_path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    if current_paths != next_paths {
+        store
+            .update_artifacts(&session_id, next_paths)
+            .map_err(|error| format!("保存 Codex 会话产出物失败: {error:#}"))?;
+    }
+    Ok(artifacts)
 }
 
 #[tauri::command]

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -10,12 +10,19 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use walkdir::{DirEntry, WalkDir};
 
+use super::events::AcpEventEnvelope;
+
 const LIST_LIMIT: usize = 500;
 const SEARCH_LIMIT: usize = 300;
 const WALK_LIMIT: usize = 20_000;
 const PREVIEW_LIMIT: usize = 512 * 1024;
 const IMAGE_PREVIEW_LIMIT: u64 = 10 * 1024 * 1024;
 const DIFF_LIMIT: usize = 1024 * 1024;
+
+const DELIVERABLE_EXTENSIONS: &[&str] = &[
+    "pptx", "ppt", "docx", "doc", "pdf", "html", "htm", "xlsx", "xls", "md", "csv", "png", "jpg",
+    "jpeg", "svg", "gif", "webp", "zip",
+];
 
 const IGNORED_DIRECTORIES: &[&str] = &[
     ".git",
@@ -89,6 +96,22 @@ pub struct WorkspaceDiff {
     pub relative_path: String,
     pub text: String,
     pub truncated: bool,
+}
+
+/// A user-facing deliverable discovered in a Codex workspace.
+///
+/// Code mode has its own ACP event stream, so it does not pass through the
+/// regular chat bridge's `write_file` artifact tracker.  This compact record is
+/// returned to the Code UI and persisted into the shared Session artifact
+/// index so previews and Local Knowledge can consume the same source of truth.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceArtifact {
+    pub path: String,
+    pub basename: String,
+    pub relative_path: String,
+    pub size: u64,
+    pub modified: i64,
 }
 
 #[derive(Debug, Clone)]
@@ -254,6 +277,173 @@ pub fn preview_workspace_file(root: &Path, relative_path: &str) -> Result<Worksp
         data_url: None,
         truncated: false,
     })
+}
+
+/// Discover durable, user-facing outputs produced by a Codex session.
+///
+/// Temporary workspaces are fully session-owned, so deliverable-shaped files
+/// can be indexed directly.  Project workspaces may contain unrelated user
+/// files; there we only retain previously indexed outputs, structured ACP diff
+/// paths, and files that the workspace baseline attributes to this session.
+/// Every candidate is canonicalized back under the workspace root before it is
+/// returned.
+pub fn discover_artifacts(
+    session_id: &str,
+    root: &Path,
+    temporary_workspace: bool,
+    events: &[AcpEventEnvelope],
+    retained_paths: &[PathBuf],
+) -> Result<Vec<WorkspaceArtifact>> {
+    let root = canonical_workspace(root)?;
+    let mut candidates = BTreeSet::new();
+
+    for path in retained_paths {
+        if let Some(path) = resolve_artifact_candidate(&root, path) {
+            candidates.insert(path);
+        }
+    }
+
+    for raw in timeline_diff_paths(events) {
+        if let Some(path) = resolve_artifact_candidate(&root, Path::new(&raw)) {
+            candidates.insert(path);
+        }
+    }
+
+    if temporary_workspace {
+        for entry in WalkDir::new(&root)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(should_walk)
+            .filter_map(|entry| entry.ok())
+            .take(WALK_LIMIT)
+        {
+            if entry.depth() == 0 || !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.into_path();
+            let Ok(relative) = path.strip_prefix(&root) else {
+                continue;
+            };
+            if !is_deliverable_path(relative) {
+                continue;
+            }
+            if let Some(path) = resolve_artifact_candidate(&root, &path) {
+                candidates.insert(path);
+            }
+        }
+    } else {
+        // Baseline comparison is an enrichment path. If a legacy session has
+        // no usable baseline (or git status temporarily fails), keep the
+        // retained/timeline candidates instead of making its artifact panel
+        // unavailable altogether.
+        if let Ok(changes) = workspace_changes(session_id, &root) {
+            for change in changes.changes {
+                if change.origin != "session" && change.origin != "preexisting_modified" {
+                    continue;
+                }
+                if let Some(path) =
+                    resolve_artifact_candidate(&root, Path::new(&change.relative_path))
+                {
+                    candidates.insert(path);
+                }
+            }
+        }
+    }
+
+    let mut artifacts = candidates
+        .into_iter()
+        .filter_map(|path| {
+            let metadata = fs::metadata(&path).ok()?;
+            let basename = path.file_name()?.to_str()?.to_string();
+            let relative_path = relative_text(&root, &path).ok()?;
+            Some(WorkspaceArtifact {
+                path: path.to_string_lossy().into_owned(),
+                basename,
+                relative_path,
+                size: metadata.len(),
+                modified: modified_seconds(&metadata),
+            })
+        })
+        .collect::<Vec<_>>();
+    artifacts.sort_by(|left, right| {
+        right
+            .modified
+            .cmp(&left.modified)
+            .then_with(|| left.relative_path.cmp(&right.relative_path))
+    });
+    Ok(artifacts)
+}
+
+fn timeline_diff_paths(events: &[AcpEventEnvelope]) -> Vec<String> {
+    let mut paths = Vec::new();
+    for envelope in events {
+        if envelope.event.event_type != "tool_call"
+            && envelope.event.event_type != "tool_call_update"
+        {
+            continue;
+        }
+        let Some(content) = envelope
+            .event
+            .data
+            .get("update")
+            .and_then(|value| value.get("content"))
+        else {
+            continue;
+        };
+        collect_diff_paths(content, &mut paths);
+    }
+    paths
+}
+
+fn collect_diff_paths(value: &serde_json::Value, paths: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_diff_paths(item, paths);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            if object.get("type").and_then(|value| value.as_str()) == Some("diff") {
+                if let Some(path) = object.get("path").and_then(|value| value.as_str()) {
+                    paths.push(path.to_string());
+                }
+            }
+            for child in object.values() {
+                if child.is_array() || child.is_object() {
+                    collect_diff_paths(child, paths);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn resolve_artifact_candidate(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let joined = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        root.join(candidate)
+    };
+    let canonical = fs::canonicalize(joined).ok()?;
+    let relative = canonical.strip_prefix(root).ok()?;
+    if !canonical.is_file() || !is_deliverable_path(relative) {
+        return None;
+    }
+    Some(canonical)
+}
+
+fn is_deliverable_path(path: &Path) -> bool {
+    if path.components().any(|component| {
+        matches!(component, Component::Normal(value) if value == "tmp" || is_ignored_directory(&value.to_string_lossy()))
+    }) {
+        return false;
+    }
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    DELIVERABLE_EXTENSIONS.contains(&extension.as_str())
 }
 
 pub fn capture_baseline(session_id: &str, root: &Path) -> Result<()> {
@@ -984,5 +1174,84 @@ mod tests {
             classify_origin(root.path(), Some(&baseline), "new.txt").unwrap(),
             "session"
         );
+    }
+
+    #[test]
+    fn temporary_workspace_discovers_deliverables_without_process_files() {
+        let root = TestDir::new("temporary-artifacts");
+        fs::create_dir_all(root.path().join("public")).unwrap();
+        fs::create_dir_all(root.path().join("tmp")).unwrap();
+        fs::create_dir_all(root.path().join("node_modules/pkg")).unwrap();
+        fs::write(root.path().join("public/game.html"), "<html>game</html>").unwrap();
+        fs::write(root.path().join("README.md"), "# Game").unwrap();
+        fs::write(root.path().join("package.json"), "{}").unwrap();
+        fs::write(root.path().join("tmp/draft.html"), "draft").unwrap();
+        fs::write(root.path().join("node_modules/pkg/demo.html"), "ignored").unwrap();
+
+        let artifacts =
+            discover_artifacts("missing-baseline", root.path(), true, &[], &[]).unwrap();
+        let paths = artifacts
+            .iter()
+            .map(|artifact| artifact.relative_path.as_str())
+            .collect::<Vec<_>>();
+        assert!(paths.contains(&"public/game.html"));
+        assert!(paths.contains(&"README.md"));
+        assert!(!paths.contains(&"package.json"));
+        assert!(!paths.contains(&"tmp/draft.html"));
+        assert!(!paths.contains(&"node_modules/pkg/demo.html"));
+    }
+
+    #[test]
+    fn project_workspace_uses_structured_diff_paths_and_rejects_escape() {
+        let root = TestDir::new("project-artifacts");
+        let outside = TestDir::new("outside-artifacts");
+        fs::create_dir_all(root.path().join("public")).unwrap();
+        fs::write(root.path().join("public/game.html"), "<html>game</html>").unwrap();
+        fs::write(root.path().join("preexisting.md"), "old").unwrap();
+        fs::write(outside.path().join("secret.html"), "secret").unwrap();
+        let event: AcpEventEnvelope = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "sessionId": "session-1",
+            "turnId": "turn-1",
+            "seq": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "event": {
+                "type": "tool_call",
+                "data": {
+                    "update": {
+                        "kind": "edit",
+                        "content": [
+                            { "type": "diff", "path": "public/game.html" },
+                            { "type": "diff", "path": outside.path().join("secret.html") }
+                        ]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let artifacts =
+            discover_artifacts("missing-baseline", root.path(), false, &[event], &[]).unwrap();
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].relative_path, "public/game.html");
+    }
+
+    #[test]
+    fn project_workspace_discovers_shell_generated_deliverables_from_baseline() {
+        let root = TestDir::new("project-shell-artifacts");
+        let session_id = format!("workspace-artifact-test-{}", std::process::id());
+        fs::write(root.path().join("preexisting.md"), "old").unwrap();
+        capture_baseline(&session_id, root.path()).unwrap();
+        fs::create_dir_all(root.path().join("release")).unwrap();
+        fs::write(
+            root.path().join("release/report.html"),
+            "<html>report</html>",
+        )
+        .unwrap();
+
+        let artifacts = discover_artifacts(&session_id, root.path(), false, &[], &[]).unwrap();
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].relative_path, "release/report.html");
+        let _ = fs::remove_file(baseline_path(&session_id));
     }
 }

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -630,6 +630,7 @@ pub fn run() {
             commands::codex::get_codex_workspace_diff,
             commands::codex::open_codex_workspace_file,
             commands::codex::reveal_codex_workspace_file,
+            commands::codex::reconcile_codex_acp_artifacts,
             commands::settings::test_model_connection,
             commands::settings::test_search_provider,
             commands::voice::transcribe_voice_audio,

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertTriangle, CheckCircle2, ChevronDown, FileText, FolderOpen, Paperclip, Send,
-  Sparkles, StopCircle, Terminal, Wrench,
+  Package, Sparkles, StopCircle, Terminal, Wrench,
 } from '../../components/icons.jsx';
 import { CodexLogo } from '../../components/CodexLogo.jsx';
+import { ArtifactsPanel } from '../artifacts/ArtifactsPanel.jsx';
 import { CodexWorkspacePanel } from './CodexWorkspacePanel.jsx';
 import {
   appendAcpEvent,
@@ -681,6 +682,8 @@ export function CodexAcpView({
   const [workspaceReferenceDrafts, setWorkspaceReferenceDrafts] = useState({});
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [workspaceChangeCount, setWorkspaceChangeCount] = useState(0);
+  const [artifactsOpen, setArtifactsOpen] = useState(false);
+  const [artifacts, setArtifacts] = useState([]);
   const [now, setNow] = useState(Date.now());
   const useUnifiedConversationUi = unifiedConversationUiEnabled();
   const [configApplying, setConfigApplying] = useState('');
@@ -734,6 +737,11 @@ export function CodexAcpView({
   const attachmentKey = activeId || DRAFT_ATTACHMENT_KEY;
   const attachments = attachmentDrafts[attachmentKey] || [];
   const workspaceReferences = workspaceReferenceDrafts[attachmentKey] || [];
+  const artifactState = useMemo(() => ({
+    activeSessionId: activeId,
+    artifacts,
+    artifactChange: null,
+  }), [activeId, artifacts]);
 
   function applySessionInfo(info) {
     setSessionInfo(info);
@@ -753,18 +761,35 @@ export function CodexAcpView({
     return next;
   }
 
+  async function refreshArtifacts(id = activeIdRef.current) {
+    if (!id) return [];
+    const next = await invoke('reconcile_codex_acp_artifacts', { sessionId: id });
+    const list = Array.isArray(next) ? next.map(item => ({
+      ...item,
+      basename: item.basename || workspaceName(item.path, item.path),
+      sessionId: id,
+    })) : [];
+    if (activeIdRef.current === id) setArtifacts(list);
+    return list;
+  }
+
   async function loadSession(id) {
     activeIdRef.current = id;
     setError('');
     setSessionInfo(null);
-    const [timeline, permissions, elicitations] = await Promise.all([
+    const [timeline, permissions, elicitations, discoveredArtifacts] = await Promise.all([
       invoke('get_codex_acp_timeline', { sessionId: id }),
       invoke('get_codex_acp_pending_permissions', { sessionId: id }),
       invoke('get_codex_acp_pending_elicitations', { sessionId: id }),
+      refreshArtifacts(id).catch(error => {
+        console.warn('[codex] artifact reconciliation failed', error);
+        return [];
+      }),
     ]);
     setEvents(timeline || []);
     setPending(permissions || []);
     setPendingElicitations(elicitations || []);
+    if (activeIdRef.current === id) setArtifacts(discoveredArtifacts || []);
     const runtime = await refreshStatus();
     if (runtime.installed && runtime.node_supported) {
       try {
@@ -817,6 +842,8 @@ export function CodexAcpView({
     setEvents([]);
     setPending([]);
     setPendingElicitations([]);
+    setArtifacts([]);
+    setArtifactsOpen(false);
     setSessionInfo(null);
     setError('');
     if (onActiveSessionChange) onActiveSessionChange(null);
@@ -959,8 +986,14 @@ export function CodexAcpView({
             item => item.elicitationId !== data.elicitationId,
           ));
         } else if (type === 'permission_resolved' || type === 'turn_completed') {
-          if (type === 'permission_resolved') setPending(current => current.filter(item => item.toolCallId !== data.toolCallId));
-          refreshSessions().catch(() => {});
+          if (type === 'permission_resolved') {
+            setPending(current => current.filter(item => item.toolCallId !== data.toolCallId));
+            refreshSessions().catch(() => {});
+          } else {
+            refreshArtifacts(incoming.sessionId)
+              .catch(error => console.warn('[codex] artifact reconciliation failed', error))
+              .finally(() => refreshSessions().catch(() => {}));
+          }
         } else if (type === 'runtime_ready') {
           invoke('get_codex_acp_session_info', { sessionId: incoming.sessionId }).then(applySessionInfo).catch(() => {});
         }
@@ -977,6 +1010,8 @@ export function CodexAcpView({
       setEvents([]);
       setPending([]);
       setPendingElicitations([]);
+      setArtifacts([]);
+      setArtifactsOpen(false);
       setSessionInfo(null);
       return;
     }
@@ -1206,7 +1241,33 @@ export function CodexAcpView({
           {busy && <StatusBadge status="running" copy={t.uiConversation} />}
           <button
             type="button"
-            onClick={() => setWorkspaceOpen(value => !value)}
+            data-testid="codex-artifacts-entry"
+            onClick={() => {
+              setWorkspaceOpen(false);
+              setArtifactsOpen(true);
+              refreshArtifacts(activeId).catch(showError);
+            }}
+            className={`h-8 px-2.5 rounded-lg inline-flex items-center gap-1.5 text-[11px] transition-colors ${
+              artifactsOpen
+                ? 'bg-blue-500/10 text-blue-600 dark:text-blue-300'
+                : 'text-gray-500 dark:text-gray-400 hover:bg-black/[0.04] dark:hover:bg-white/[0.06]'
+            }`}
+            title={t.artifacts}
+          >
+            <Package size={14} />
+            <span>{t.artifacts}</span>
+            {artifacts.length > 0 && (
+              <span className="min-w-4 h-4 px-1 rounded-full bg-blue-500 text-white inline-flex items-center justify-center text-[9px] font-medium">
+                {artifacts.length > 99 ? '99+' : artifacts.length}
+              </span>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setArtifactsOpen(false);
+              setWorkspaceOpen(value => !value);
+            }}
             className={`h-8 px-2.5 rounded-lg inline-flex items-center gap-1.5 text-[11px] transition-colors ${
               workspaceOpen
                 ? 'bg-blue-500/10 text-blue-600 dark:text-blue-300'
@@ -1531,6 +1592,15 @@ export function CodexAcpView({
             refreshToken={events.length}
             onChangeCount={setWorkspaceChangeCount}
             copy={t.uiCodexWorkspace}
+          />
+        )}
+        {activeSession && artifactsOpen && (
+          <ArtifactsPanel
+            bs={artifactState}
+            theme={theme}
+            t={t}
+            onClose={() => setArtifactsOpen(false)}
+            isWide={false}
           />
         )}
         </div>

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -243,6 +243,10 @@ try {
   assert.ok(codexCommands.includes('pub async fn get_codex_acp_pending_elicitations'));
   assert.ok(codexCommands.includes('pub async fn respond_codex_acp_elicitation'));
   assert.ok(codexCommands.includes('list_codex_acp_sessions'));
+  assert.ok(codexCommands.includes('pub async fn reconcile_codex_acp_artifacts'),
+    'Code mode must reconcile outputs into the shared Pinvou artifact index');
+  assert.ok(codexCommands.includes('.update_artifacts(&session_id, next_paths)'),
+    'reconciled Codex outputs must be persisted with the Session');
   assert.ok(codexCommands.includes('workspace_path: Option<String>'), 'Codex creation must accept an explicit project directory');
   assert.ok(codexCommands.includes('validate_codex_project_workspace'), 'project workspace must be validated before session creation');
 
@@ -278,6 +282,13 @@ try {
     && codexView.includes('beginDraft(null)')
     && codexView.includes('setWorkspaceMenuOpen(true)'),
   'missing project sessions must keep their history and offer a link into the existing new-session workspace menu');
+  assert.ok(codexView.includes('data-testid="codex-artifacts-entry"')
+    && codexView.includes('<ArtifactsPanel')
+    && codexView.includes("invoke('reconcile_codex_acp_artifacts'"),
+  'Code mode must expose the standard Pinvou artifact manager and refresh its durable index');
+  assert.ok(codexView.includes("type === 'turn_completed'")
+    && codexView.includes('refreshArtifacts(incoming.sessionId)'),
+  'completed Codex turns must automatically reconcile their deliverables');
   const composerFooterIndex = codexView.indexOf('data-testid="codex-composer-footer"');
   const workspaceSelectorIndex = codexView.indexOf('data-testid="codex-workspace-selector"');
   const attachmentButtonIndex = codexView.indexOf('title={codexCopy.addAttachment}', composerFooterIndex);


### PR DESCRIPTION
## 概述
为 Codex ACP 代码会话接入 Pinvou 统一产出物索引和管理面板。会话生成的 HTML、文档、图片等成品会在任务完成或重新打开会话时自动被发现，并可直接预览、系统打开及定位。

## 背景
代码模式直接消费 ACP 事件，未经过普通聊天的 `write_file` / `present_artifact` 跟踪链路。因此成品虽然已经生成在工作区，`SavedSession.artifacts` 仍为空，用户无法通过 Pinvou 的产出物入口统一查看和管理。

## 变更
- 增加 Codex 工作区成品识别与会话产出物对账命令，将结果持久化到共享 Session 索引。
- 临时工作区按成品类型扫描；项目工作区结合会话基线和 ACP 结构化改动路径识别，避免收录原有无关文件，并校验所有路径均位于工作区内。
- 在代码模式顶部增加产出物入口与数量提示，复用标准 `ArtifactsPanel` 提供预览、系统打开和文件定位能力。
- 在每轮完成及历史会话加载时自动对账，兼容升级前已生成但未登记的成品。
- 补充工作区识别单元测试和代码模式前后端契约测试。

## 验证
- `npm run lint:ui`
- `npm run build:ui`
- `npm test`
- `cargo test --lib -- --test-threads=1`（754 passed，12 ignored）
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `git diff --check origin/main...HEAD`

## 备注
- 本 PR 独立基于 `main`，仅处理 Codex 成品发现与管理；系统 Codex 配置继承由 #71 单独处理。
- 未修改 CodeWhale gitlink 或 fork 行为。