### PR TITLE
fix(ci): 缩短 arm64 发布验证构建时间

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -213,6 +213,13 @@ jobs:
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
+      # GitHub 原生 ARM runner 会在约 40 分钟后被托管服务回收；该 artifact
+      # 用于 PR 发布链路验证，保留 release 的 opt-level/strip/panic 设置，
+      # 但关闭 fat-LTO 并提高代码生成并行度。正式 Linux 发布仍由
+      # scripts/release-deb.sh 使用 Cargo.toml 中的完整 release profile。
+      CARGO_PROFILE_RELEASE_LTO: "false"
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v7
@@ -238,7 +245,7 @@ jobs:
             librsvg2-dev libssl-dev \
             libx11-dev libxi-dev libxtst-dev \
             libayatana-appindicator3-dev \
-            build-essential pkg-config cmake
+            build-essential pkg-config cmake lld
 
       - name: Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -213,13 +213,6 @@ jobs:
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
-      # GitHub 原生 ARM runner 会在约 40 分钟后被托管服务回收；该 artifact
-      # 用于 PR 发布链路验证，保留 release 的 opt-level/strip/panic 设置，
-      # 但关闭 fat-LTO 并提高代码生成并行度。正式 Linux 发布仍由
-      # scripts/release-deb.sh 使用 Cargo.toml 中的完整 release profile。
-      CARGO_PROFILE_RELEASE_LTO: "false"
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
-      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v7
@@ -271,7 +264,22 @@ jobs:
 
       # arm64 原生构建:build.js 检测到 linux/arm64 会自动跑
       # scripts/fetch-linux-arm64-connectors.sh 下载连接器二进制(gitignored)。
-      - name: 构建 deb
+      # GitHub 原生 ARM runner 会在约 40 分钟后被托管服务回收。PR 只验证发布
+      # 链路，因此保留 release 的 opt-level/strip/panic，同时关闭 fat-LTO、
+      # 提高代码生成并行度并使用 lld。
+      - name: 构建 deb（PR 快速验证）
+        if: github.event_name == 'pull_request'
+        working-directory: pinvou3-app
+        env:
+          CARGO_PROFILE_RELEASE_LTO: "false"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
+          RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+        run: node scripts/tauri/build.js build --bundles deb
+
+      # main 的 VERSION bump 和 workflow_dispatch 都产出正式发布 artifact，
+      # 必须完整使用 Cargo.toml 的 release profile，不注入 PR 加速参数。
+      - name: 构建 deb（正式发布配置）
+        if: github.event_name != 'pull_request'
         working-directory: pinvou3-app
         run: node scripts/tauri/build.js build --bundles deb
 

--- a/scripts/tests/test_release_arm64_policy.py
+++ b/scripts/tests/test_release_arm64_policy.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
+
+
+class ReleaseArm64PolicyTests(unittest.TestCase):
+    def test_arm64_release_validation_uses_fast_link_profile(self):
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        arm64_job = workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
+            "\n  build-windows-x64:", maxsplit=1
+        )[0]
+
+        self.assertIn('CARGO_PROFILE_RELEASE_LTO: "false"', arm64_job)
+        self.assertIn('CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"', arm64_job)
+        self.assertIn('RUSTFLAGS: "-C link-arg=-fuse-ld=lld"', arm64_job)
+        self.assertIn("build-essential pkg-config cmake lld", arm64_job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_arm64_policy.py
+++ b/scripts/tests/test_release_arm64_policy.py
@@ -7,16 +7,37 @@ RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
 
 
 class ReleaseArm64PolicyTests(unittest.TestCase):
-    def test_arm64_release_validation_uses_fast_link_profile(self):
+    def setUp(self):
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        arm64_job = workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
+        self.arm64_job = workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
             "\n  build-windows-x64:", maxsplit=1
         )[0]
 
-        self.assertIn('CARGO_PROFILE_RELEASE_LTO: "false"', arm64_job)
-        self.assertIn('CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"', arm64_job)
-        self.assertIn('RUSTFLAGS: "-C link-arg=-fuse-ld=lld"', arm64_job)
-        self.assertIn("build-essential pkg-config cmake lld", arm64_job)
+    def test_arm64_pr_validation_uses_fast_link_profile(self):
+        pr_build = self.arm64_job.split(
+            "\n      - name: 构建 deb（PR 快速验证）", maxsplit=1
+        )[1].split("\n      - name: 构建 deb（正式发布配置）", maxsplit=1)[0]
+
+        self.assertIn("if: github.event_name == 'pull_request'", pr_build)
+        self.assertIn('CARGO_PROFILE_RELEASE_LTO: "false"', pr_build)
+        self.assertIn('CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"', pr_build)
+        self.assertIn('RUSTFLAGS: "-C link-arg=-fuse-ld=lld"', pr_build)
+        self.assertIn("build-essential pkg-config cmake lld", self.arm64_job)
+
+    def test_arm64_formal_release_keeps_full_release_profile(self):
+        job_env = self.arm64_job.split("\n    steps:", maxsplit=1)[0]
+        formal_build = self.arm64_job.split(
+            "\n      - name: 构建 deb（正式发布配置）", maxsplit=1
+        )[1].split("\n      # tauri deb 产物默认名", maxsplit=1)[0]
+
+        self.assertIn("if: github.event_name != 'pull_request'", formal_build)
+        for setting in (
+            "CARGO_PROFILE_RELEASE_LTO",
+            "CARGO_PROFILE_RELEASE_CODEGEN_UNITS",
+            "RUSTFLAGS",
+        ):
+            self.assertNotIn(setting, job_env)
+            self.assertNotIn(setting, formal_build)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概述

优化 Linux arm64 发布验证包的链接配置，降低冷缓存构建耗时和 hosted runner 被提前回收的风险；同时增加回归测试锁定该配置。

## 背景

`Pinvou/pinvou3#319` 在冷缓存下复现了 arm64 构建超过 runner 可用窗口、收到 shutdown signal 并以 143 退出的问题。开源仓近期依赖暖缓存暂未失败，但仍使用 `fat LTO + codegen-units=1`，存在相同的冷缓存风险，因此将已验证方案回流。

## 变更

- 仅为 Linux arm64 CI 验证包关闭 fat LTO，并将 codegen units 调整为 16。
- 安装并通过 `RUSTFLAGS` 启用 `lld` 链接器。
- 新增发布工作流契约测试，确保上述 arm64 配置不会被后续改动意外移除。

## 验证

- `python3 -m unittest discover -s scripts/tests -p "test_*.py"`：22 个测试全部通过。
- `.github/workflows/release-packages.yml` YAML 解析通过。
- `node scripts/sync-version.mjs --check`：版本一致性通过。
- `./scripts/fork-guard.sh --fast`：通过。
- `python3 scripts/architecture-guard.py --base-ref origin/main`：通过，仅有既有大文件提示。

## 备注

- 调整仅作用于 GitHub Actions 的 arm64 验证 artifact；正式 Linux 发布仍由 `scripts/release-deb.sh` 使用 `Cargo.toml` 的完整 release profile。
- Linux x86_64、Windows、macOS 构建配置不变。