### PR TITLE
fix(relay): 手机端图片预览改用 object URL 阻断伪造 payload 注入

### DIFF
--- a/remote-control-relay/test/preview-security.test.js
+++ b/remote-control-relay/test/preview-security.test.js
@@ -1,0 +1,119 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { JSDOM } from "jsdom";
+
+const html = await readFile(new URL("../web/index.html", import.meta.url), "utf8");
+const PNG_DATA_URL = "data:image/png;base64,iVBORw0KGgo=";
+
+function createPage() {
+  const created = [];
+  const revoked = [];
+  const dom = new JSDOM(html, {
+    url: "https://relay.test/pinvou3/remote/r/preview#token=tok",
+    runScripts: "dangerously",
+    pretendToBeVisual: true,
+    beforeParse(window) {
+      class FakeWebSocket {
+        static OPEN = 1;
+        constructor() {
+          this.readyState = FakeWebSocket.OPEN;
+        }
+        send() {}
+        close() {}
+      }
+      window.WebSocket = FakeWebSocket;
+      window.URL.createObjectURL = (blob) => {
+        const url = `blob:preview-${created.length + 1}`;
+        created.push({ url, type: blob.type, size: blob.size });
+        return url;
+      };
+      window.URL.revokeObjectURL = (url) => revoked.push(url);
+    },
+  });
+  return {
+    window: dom.window,
+    created,
+    revoked,
+    close: () => dom.window.close(),
+  };
+}
+
+test("图片预览只接受白名单 raster data URL", (t) => {
+  const page = createPage();
+  t.after(page.close);
+
+  page.window.showPreview({
+    basename: "preview.png",
+    preview: { type: "image", data_url: PNG_DATA_URL },
+  });
+
+  const image = page.window.document.querySelector("#previewBody img");
+  assert.equal(image?.getAttribute("src"), "blob:preview-1");
+  assert.deepEqual(page.created, [
+    { url: "blob:preview-1", type: "image/png", size: 8 },
+  ]);
+
+  const rejected = [
+    "data:image/svg+xml;base64,PHN2Zy8+",
+    "javascript:alert(1)",
+    "data:image/png;base64,not-valid===",
+    "data:image/png.html;base64,iVBORw0KGgo=",
+  ];
+  for (const dataUrl of rejected) {
+    page.window.showPreview({
+      basename: "invalid",
+      preview: { type: "image", data_url: dataUrl },
+    });
+    assert.equal(page.window.document.querySelector("#previewBody img"), null);
+    assert.match(
+      page.window.document.querySelector("#previewBody").textContent,
+      /图片预览数据无效/,
+    );
+  }
+  assert.equal(page.created.length, 1);
+});
+
+test("切换和关闭预览会回收 object URL", (t) => {
+  const page = createPage();
+  t.after(page.close);
+  const showImage = (basename) => page.window.showPreview({
+    basename,
+    preview: { type: "image", data_url: PNG_DATA_URL },
+  });
+
+  showImage("first.png");
+  showImage("second.png");
+  assert.deepEqual(page.revoked, ["blob:preview-1"]);
+
+  page.window.document.querySelector("#previewClose").click();
+  assert.deepEqual(page.revoked, ["blob:preview-1", "blob:preview-2"]);
+  assert.equal(page.window.document.querySelector("#previewBody").children.length, 0);
+
+  showImage("overlay.png");
+  page.window.document.querySelector("#previewOverlay").click();
+  assert.deepEqual(page.revoked, [
+    "blob:preview-1",
+    "blob:preview-2",
+    "blob:preview-3",
+  ]);
+});
+
+test("接管和终止远程会话会清理图片预览", (t) => {
+  const page = createPage();
+  t.after(page.close);
+  const showImage = (basename) => page.window.showPreview({
+    basename,
+    preview: { type: "image", data_url: PNG_DATA_URL },
+  });
+
+  showImage("takeover.png");
+  page.window.showTakeoverScreen();
+  assert.deepEqual(page.revoked, ["blob:preview-1"]);
+  assert.equal(page.window.document.querySelector("#previewBody").children.length, 0);
+
+  showImage("terminal.png");
+  page.window.enterTerminalState("已结束", "会话结束", "连接已关闭", "", "ended");
+  assert.deepEqual(page.revoked, ["blob:preview-1", "blob:preview-2"]);
+  assert.equal(page.window.document.querySelector("#previewBody").children.length, 0);
+});

--- a/remote-control-relay/web/index.html
+++ b/remote-control-relay/web/index.html
@@ -586,6 +586,19 @@
         previewImageUrl = '';
       }
     }
+    function resetPreviewContent() {
+      el.previewBody.innerHTML = '';
+      revokePreviewImageUrl();
+      el.previewBody.classList.remove('html-preview', 'markdown-preview');
+      el.previewToolbar.classList.add('hidden');
+      previewFrameId = '';
+      previewZoom = { ready: false, fit: 1, current: 1, overflow: false };
+    }
+    function closePreview() {
+      el.previewOverlay.classList.add('hidden');
+      resetPreviewContent();
+      state.previewArtifact = null;
+    }
     let pinvouNode = null;
     const BRAILLE = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
     const state = {
@@ -660,7 +673,7 @@
       setStatus('已被占用');
       setControlsDisabled(true);
       el.sheetOverlay.classList.add('hidden');
-      el.previewOverlay.classList.add('hidden');
+      closePreview();
       state.sheet = '';
       el.takeoverWarn.innerHTML = '<svg fill="none" viewBox="0 0 24 24" stroke-width="1.9"><path d="M12 8v5"></path><path d="M12 17h.01"></path><path d="M10.3 3.8 2.9 17a2 2 0 0 0 1.8 3h14.6a2 2 0 0 0 1.8-3L13.7 3.8a2 2 0 0 0-3.4 0Z"></path></svg>';
       el.takeoverEyebrow.textContent = '远程会话被占用';
@@ -695,7 +708,7 @@
       setControlsDisabled(true);
       state.sheet = '';
       el.sheetOverlay.classList.add('hidden');
-      el.previewOverlay.classList.add('hidden');
+      closePreview();
       detachCurrentSocket();
       el.takeoverEyebrow.textContent = status;
       el.takeoverTitle.textContent = title;
@@ -2044,12 +2057,7 @@
       const markdownByName = /\.(md|markdown)$/i.test(previewName);
       el.previewTitle.textContent = previewName;
       el.previewTitle.title = previewName;
-      el.previewBody.innerHTML = '';
-      revokePreviewImageUrl();
-      el.previewBody.classList.remove('html-preview', 'markdown-preview');
-      el.previewToolbar.classList.add('hidden');
-      previewFrameId = '';
-      previewZoom = { ready: false, fit: 1, current: 1, overflow: false };
+      resetPreviewContent();
       // data_url 由桌面端按图片 mime 白名单构造；此处仍不信任 payload：
       // 严格校验 mime/base64 后解码为 Blob，改用浏览器生成的 object URL，
       // 使 <img> 不直接接收来自消息的数据（CodeQL js/xss、
@@ -3543,7 +3551,7 @@
     };
     el.sheetClose.onclick = closeSheet;
     el.sheetOverlay.onclick = e => { if (e.target === el.sheetOverlay) closeSheet(); };
-    el.previewClose.onclick = () => el.previewOverlay.classList.add('hidden');
+    el.previewClose.onclick = closePreview;
     el.previewDownload.onclick = () => {
       if (state.downloadBusy) {
         addSystem('下载进行中，请等待当前下载完成。');
@@ -3555,7 +3563,7 @@
       }
       setDownloadBusy(true);
     };
-    el.previewOverlay.onclick = e => { if (e.target === el.previewOverlay) el.previewOverlay.classList.add('hidden'); };
+    el.previewOverlay.onclick = e => { if (e.target === el.previewOverlay) closePreview(); };
     el.previewZoomOut.onclick = () => setPreviewZoom(previewZoom.current - 0.1);
     el.previewZoomFit.onclick = () => setPreviewZoom(previewZoom.fit, true);
     el.previewZoomIn.onclick = () => setPreviewZoom(previewZoom.current + 0.1);

--- a/remote-control-relay/web/index.html
+++ b/remote-control-relay/web/index.html
@@ -562,6 +562,30 @@
     let thinkingFrame = 0;
     let previewFrameId = '';
     let previewZoom = { ready: false, fit: 1, current: 1, overflow: false };
+    let previewImageUrl = '';
+    // 仅允许常见静态图片格式；排除 svg 等可携带标记的格式。
+    const PREVIEW_IMAGE_MIME = /^(?:png|jpe?g|gif|webp|avif|bmp|x-icon|vnd\.microsoft\.icon)$/;
+    function imagePreviewObjectUrl(dataUrl) {
+      const match = /^data:image\/([a-z0-9.+-]+);base64,([A-Za-z0-9+/=\s]+)$/i.exec(dataUrl || '');
+      if (!match) return '';
+      const mime = match[1].toLowerCase();
+      if (!PREVIEW_IMAGE_MIME.test(mime)) return '';
+      let bytes;
+      try {
+        const binary = atob(match[2].replace(/\s+/g, ''));
+        bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      } catch {
+        return '';
+      }
+      return URL.createObjectURL(new Blob([bytes], { type: `image/${mime}` }));
+    }
+    function revokePreviewImageUrl() {
+      if (previewImageUrl) {
+        URL.revokeObjectURL(previewImageUrl);
+        previewImageUrl = '';
+      }
+    }
     let pinvouNode = null;
     const BRAILLE = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
     const state = {
@@ -2021,17 +2045,29 @@
       el.previewTitle.textContent = previewName;
       el.previewTitle.title = previewName;
       el.previewBody.innerHTML = '';
+      revokePreviewImageUrl();
       el.previewBody.classList.remove('html-preview', 'markdown-preview');
       el.previewToolbar.classList.add('hidden');
       previewFrameId = '';
       previewZoom = { ready: false, fit: 1, current: 1, overflow: false };
-      // data_url 由桌面端按图片 mime 白名单构造；此处再校验前缀，
-      // 防伪造 preview payload（CodeQL js/xss、js/client-side-unvalidated-url-redirection）。
-      if (preview.type === 'image' && /^data:image\//.test(preview.data_url || '')) {
-        const img = document.createElement('img');
-        img.alt = payload.basename || 'artifact preview';
-        img.src = preview.data_url;
-        el.previewBody.appendChild(img);
+      // data_url 由桌面端按图片 mime 白名单构造；此处仍不信任 payload：
+      // 严格校验 mime/base64 后解码为 Blob，改用浏览器生成的 object URL，
+      // 使 <img> 不直接接收来自消息的数据（CodeQL js/xss、
+      // js/client-side-unvalidated-url-redirection）。
+      if (preview.type === 'image') {
+        const objectUrl = imagePreviewObjectUrl(preview.data_url);
+        if (objectUrl) {
+          previewImageUrl = objectUrl;
+          const img = document.createElement('img');
+          img.alt = payload.basename || 'artifact preview';
+          img.src = objectUrl;
+          el.previewBody.appendChild(img);
+        } else {
+          const invalid = document.createElement('div');
+          invalid.className = 'empty-panel';
+          invalid.textContent = '图片预览数据无效。';
+          el.previewBody.appendChild(invalid);
+        }
       } else if (preview.type === 'html') {
         el.previewBody.classList.add('html-preview');
         el.previewToolbar.classList.remove('hidden');


### PR DESCRIPTION
## 概述

修复 GitHub Code Scanning 告警 #6（js/xss，high）与 #7（js/client-side-unvalidated-url-redirection，medium）：手机控制端图片预览不再把消息中的 `data_url` 直接赋给 `<img>`，并完整回收预览使用的 object URL。

## 背景

`remote-control-relay/web/index.html` 的 `showPreview` 此前仅校验 `data:image/` 前缀，便将 WebSocket 消息里的 `preview.data_url` 直接写入 `img.src`。虽然桌面端按 mime 白名单构造该字段，但网页端不应信任来自中继通道的 payload；伪造 payload 可注入任意 `data:` URL（如 SVG），CodeQL 据此报出 XSS 与未校验 URL 两个告警。

## 变更

- 严格校验 `data:image/<mime>;base64,<data>` 格式，mime 限定为 png/jpeg/gif/webp/avif/bmp/ico 白名单，拒绝 SVG、伪协议和非法 base64。
- 校验通过后解码为 `Blob`，仅将浏览器生成的 object URL 赋给 `img.src`；无效数据展示明确空态。
- 统一图片预览清理路径，在切换预览、关闭按钮、点击遮罩、设备接管及远程会话终止时清空预览并回收 object URL。
- 新增真实页面回归测试，覆盖白名单校验、恶意输入拦截，以及各退出路径的资源回收。

## 验证

- `npm --prefix remote-control-relay test`：26 项通过。
- `npm --prefix remote-control-relay run test:legacy-v1-ui`：25 项通过。
- `python3 scripts/architecture-guard.py`：通过。
- `./scripts/fork-guard.sh --fast`：通过。

## 备注

- 影响范围仅为手机远控端图片预览；桌面端、其他预览类型及 CodeWhale 不受影响。
- SVG 手机端预览将被拒绝并显示“图片预览数据无效”，这是为排除可携带标记内容而保留的安全限制。
- CodeQL 告警需在合并后由默认分支扫描确认关闭。