### PR TITLE
fix(build): 校验 SystemRoot 环境变量防止构建命令路径被劫持

### DIFF
--- a/pinvou3-app/scripts/tauri/codex-bridge.js
+++ b/pinvou3-app/scripts/tauri/codex-bridge.js
@@ -186,10 +186,15 @@ function checkedSpawn(spawn, command, args, options, label) {
   return result;
 }
 
-// curl/tar 使用 Windows 内置 System32 副本的绝对路径，避免 PATH 劫持
+// curl/tar 使用 Windows 内置 System32 副本的绝对路径，避免 PATH 劫持。
+// SystemRoot 只接受“盘符:\Windows”标准形态，异常值一律回退 C:\Windows，
+// 防止被篡改的环境变量把命令路径引向任意目录
 // （CodeQL js/shell-command-injection-from-environment）。
 function windowsSystemTool(name) {
-  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  const envRoot = process.env.SystemRoot;
+  const systemRoot = envRoot && /^[a-z]:\\windows$/i.test(envRoot)
+    ? envRoot
+    : "C:\\Windows";
   return path.join(systemRoot, "System32", name);
 }
 


### PR DESCRIPTION
## 概述
修复 GitHub Code Scanning 告警 #10（js/shell-command-injection-from-environment，medium）：Windows 构建脚本中 `SystemRoot` 环境变量经严格校验后才参与拼接 curl/tar 的命令路径。

## 背景
`pinvou3-app/scripts/tauri/codex-bridge.js` 的 `windowsSystemTool` 为避免 PATH 劫持，用 `process.env.SystemRoot` 拼出 System32 下 curl.exe / tar.exe 的绝对路径。但 `SystemRoot` 本身也是环境变量，若被篡改（如指向攻击者目录），构建过程会执行任意路径下的同名程序，CodeQL 据此报告“shell command depends on an uncontrolled absolute path”。

## 变更
- `windowsSystemTool` 仅接受 `盘符:\Windows` 标准形态（大小写不敏感）的 `SystemRoot`，异常、缺失或包含路径穿越/UNC/追加命令等形态一律回退 `C:\Windows`。
- 行为兼容：正常 Windows 环境的 `SystemRoot` 即为 `C:\Windows`（或其他盘符的 `\Windows`），不受影响。

## 验证
- 对 `windowsSystemTool` 做逻辑自测：标准 `C:\Windows`、小写盘符正常通过；`C:\evil`、路径穿越、UNC 路径、追加命令串、空值、未设置均被拒绝并回退 `C:\Windows`，8 个用例全部通过。
- `tests/codex_acp_windows_contract.test.js`、`tests/tauri_effective_config.test.js` 通过。