### PR TITLE
build(macos): 最低系统版本要求降为 macOS 11

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 50
     env:
-      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
       # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],
       # 不再需要 CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -381,7 +381,7 @@ jobs:
     # 首次双 target + fat LTO 实跑约 48 分钟，50 分钟几乎无 runner 抖动余量。
     timeout-minutes: 90
     env:
-      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
       VERSION: ${{ needs.check-version-bump.outputs.version }}
     steps:
       - name: Checkout (含 submodule)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Endpoints, model names, and API keys can also be managed directly in the applica
 - The [Tauri 2 system dependencies](https://v2.tauri.app/start/prerequisites/) for your platform
 - An accessible OpenAI-compatible model endpoint
 
-The source tree supports **Linux, Windows, and macOS**. The initial macOS target is Apple Silicon on macOS 14 or later.
+The source tree supports **Linux, Windows, and macOS**. The initial macOS target is Apple Silicon on macOS 11 or later.
 
 ### Run from source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,7 +101,7 @@ export DEEPSEEK_MODEL="qwen36_35b_256k"
 - [Tauri 2 系统依赖](https://v2.tauri.app/start/prerequisites/)
 - 一个可访问的 OpenAI-compatible 模型端点
 
-源码树支持 **Linux、Windows 和 macOS**；macOS 当前目标为 Apple Silicon (arm64) + macOS 14.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
+源码树支持 **Linux、Windows 和 macOS**；macOS 当前目标为 Apple Silicon (arm64) + macOS 11.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
 
 ### 启动应用
 

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -156,7 +156,7 @@ objc2-foundation = "0.3"
 # voice_asr_speech.rs 用 block2::RcBlock 包装 Rust 闭包。版本对齐 objc2 0.6 family。
 block2 = "0.6"
 # macOS 系统 Speech framework 绑定,替代内嵌 SenseVoice ASR 引擎——免模型下载、
-# 免 ffmpeg、零额外体积。项目构建与应用最低系统版本统一为 macOS 14。
+# 免 ffmpeg、零额外体积。项目构建与应用最低系统版本统一为 macOS 11。
 objc2-speech = { version = "0.3", default-features = false, features = [
     "std",
     "SFSpeechRecognizer",

--- a/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
@@ -26,7 +26,7 @@
       "resources/platforms/macos/codex-bridge/": "runtime/codex-bridge"
     },
     "macOS": {
-      "minimumSystemVersion": "14.0",
+      "minimumSystemVersion": "11.0",
       "signingIdentity": "-",
       "entitlements": "packaging/macos/entitlements.plist",
       "infoPlist": "packaging/macos/Info.plist"

--- a/pinvou3-app/src-tauri/packaging/macos/Info.plist
+++ b/pinvou3-app/src-tauri/packaging/macos/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleName</key>
     <string>pinvou3</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>11.0</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>pinvou3 需要访问麦克风以提供语音输入功能。</string>
     <key>NSSpeechRecognitionUsageDescription</key>

--- a/pinvou3-app/src-tauri/src/features/voice/platform/macos.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/platform/macos.rs
@@ -64,7 +64,7 @@ pub fn asr_model_exists() -> bool {
 }
 
 pub fn asr_tool_exists() -> bool {
-    // 项目最低支持 macOS 14，系统 Speech framework 是平台能力，不是需要安装的
+    // 项目最低支持 macOS 11，系统 Speech framework 是平台能力，不是需要安装的
     // 应用依赖。`SFSpeechRecognizer::isAvailable` 表示指定 locale 的瞬时服务状态，
     // 不能拿系统默认 locale 的结果充当录音前置门禁；否则默认语言不可用时会误拦截
     // 另一个仍可用的 UI 语言。授权、locale 与在线服务状态在实际识别时检查。

--- a/pinvou3-app/tests/macos_phase2_contract.test.js
+++ b/pinvou3-app/tests/macos_phase2_contract.test.js
@@ -74,8 +74,8 @@ for (const [name, source] of [
 ]) {
   assert.match(
     source,
-    /MACOSX_DEPLOYMENT_TARGET:\s*"14\.0"/,
-    `${name} must match the declared macOS 14 minimum`,
+    /MACOSX_DEPLOYMENT_TARGET:\s*"11\.0"/,
+    `${name} must match the declared macOS 11 minimum`,
   );
 }
 

--- a/scripts/release-macos.sh
+++ b/scripts/release-macos.sh
@@ -22,7 +22,7 @@ fi
 
 VERSION="$V_TAURI"
 TAG="${1:-v$VERSION}"
-export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 
 for target in aarch64-apple-darwin x86_64-apple-darwin; do
   rustup target list --installed | grep -q "^${target}$" || rustup target add "$target"

--- a/scripts/run-mac-verify.sh
+++ b/scripts/run-mac-verify.sh
@@ -25,7 +25,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_SRC_TAURI="$REPO_ROOT/pinvou3-app/src-tauri"
 
 # Mac 编译需要正确的部署目标(同 release-macos.sh)
-export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 
 if [ "$SKIP_TEST" -eq 0 ]; then
   # cargo check/test 用 host 原生 aarch64(macos-15 runner 即 arm64)。
@@ -85,17 +85,17 @@ else
     echo "  ❌ tauri.conf.json 缺少 app/dmg targets" >&2
     VERIFY_FAIL=1
 fi
-if jq -e '.bundle.macOS.minimumSystemVersion == "14.0"' "$MAC_OVERLAY" >/dev/null; then
-    echo "  ✓ minimumSystemVersion=14.0"
+if jq -e '.bundle.macOS.minimumSystemVersion == "11.0"' "$MAC_OVERLAY" >/dev/null; then
+    echo "  ✓ minimumSystemVersion=11.0"
 else
-    echo "  ⚠ macOS.minimumSystemVersion 不是 14.0"
+    echo "  ⚠ macOS.minimumSystemVersion 不是 11.0"
 fi
 # Info.plist 的 LSMinimumSystemVersion 必须与 tauri.conf.json 一致(防二者漂移)。
 PLIST_MIN_SYS="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$APP_SRC_TAURI/packaging/macos/Info.plist" 2>/dev/null || true)"
-if [ "$PLIST_MIN_SYS" = "14.0" ]; then
-    echo "  ✓ Info.plist LSMinimumSystemVersion=14.0"
+if [ "$PLIST_MIN_SYS" = "11.0" ]; then
+    echo "  ✓ Info.plist LSMinimumSystemVersion=11.0"
 else
-    echo "  ⚠ Info.plist LSMinimumSystemVersion=$PLIST_MIN_SYS(期望 14.0,与 tauri.conf.json 可能漂移)"
+    echo "  ⚠ Info.plist LSMinimumSystemVersion=$PLIST_MIN_SYS(期望 11.0,与 tauri.conf.json 可能漂移)"
 fi
 
 echo "=== 6. Info.plist / entitlements.plist 存在校验 ==="


### PR DESCRIPTION
## 概述

将 pinvou3 的 macOS 最低系统版本要求由 14.0 统一降为 11.0，扩大应用可安装和运行的系统范围。

## 背景

项目此前将 macOS 最低版本定为 14.0，限制过严。依赖层面并无障碍：系统 Speech framework 要求 macOS 10.15+，Tauri 2 本身支持 macOS 10.13+，且 Apple Silicon 机型天然从 macOS 11 起步，与现有 arm64/universal 构建目标一致。

## 变更

- 打包配置：`tauri.conf.json` 的 `minimumSystemVersion` 与 `Info.plist` 的 `LSMinimumSystemVersion` 改为 11.0
- 构建脚本：`release-macos.sh`、`run-mac-verify.sh` 的 `MACOSX_DEPLOYMENT_TARGET` 默认值改为 11.0
- CI：`mac-build.yml`、`release-packages.yml` 的 `MACOSX_DEPLOYMENT_TARGET` 改为 11.0
- 校验同步：`run-mac-verify.sh` 的版本一致性检查与 `macos_phase2_contract.test.js` 契约测试改为断言 11.0
- 文档与注释：`README.md`、`README.zh-CN.md`、`Cargo.toml`、`voice/platform/macos.rs` 中的版本描述更新为 macOS 11

## 验证

- `node pinvou3-app/tests/macos_phase2_contract.test.js` 通过
- `node pinvou3-app/tests/tauri_effective_config.test.js` 通过
- `python3 scripts/architecture-guard.py` 通过

## 备注

配置层面已允许 macOS 11.0 安装运行，但实际兼容性还取决于依赖 crates 使用的系统 API，建议下次 release 构建后在 macOS 11/12 实机做一次冒烟验证。