### PR TITLE
fix(ui): 修复新对话「工具」弹层被模式切换文字遮挡

### DIFF
--- a/pinvou3-app/src/components/IosControls.jsx
+++ b/pinvou3-app/src/components/IosControls.jsx
@@ -54,9 +54,11 @@ function IosSegmentedControl({
   const activeIndex = Math.max(0, segments.findIndex(segment => segment.key === value));
 
   if (compact && prominent) {
+    // isolate 让容器自成层叠上下文：内部按钮的 z-10 只用于压在滑块之上，
+    // 不会逸出到外层（否则会盖住 composer 弹层，如「工具」菜单）。
     return (
       <div
-        className={`relative inline-grid h-10 shrink-0 items-center rounded-[16px] p-1 ${className}`}
+        className={`relative isolate inline-grid h-10 shrink-0 items-center rounded-[16px] p-1 ${className}`}
         style={{
           gridTemplateColumns: `repeat(${segments.length}, minmax(82px, 1fr))`,
           background: controlFill(isDark),


### PR DESCRIPTION
## 概述

修复新对话界面点开「工具」菜单时，输入框正上方的「工作」模式切换文字覆盖弹层 UI 的问题。

## 背景

新对话界面输入框上方渲染「工作/代码」模式切换器（`IosSegmentedControl` 的 compact+prominent 分支）。其内部按钮带 `relative z-10`（用于压在滑动指示块之上），但容器为 `relative` 且 `z-index: auto`，未形成层叠上下文，按钮的 `z-10` 直接逸出到 composer 外层容器（`z-20`）参与排序；而「工具」弹层的 `z-50` 被限制在输入框卡片内部——卡片因 `backdrop-blur` 自成层叠上下文、层级为 0。因此「工作」文字始终绘制在弹层之上，正好遮挡弹出的面板。

## 变更

- `pinvou3-app/src/components/IosControls.jsx`：prominent 分段控件容器添加 `isolate`，使其自成层叠上下文，按钮 `z-10` 仅在控件内部生效；「工具」及模型/知识库/模式等 composer 弹层恢复覆盖在切换器上方。

## 验证

- `npx eslint src/components/IosControls.jsx` 通过
- `node tests/codex_acp_timeline.test.mjs`、`node tests/composer_tool_menu_logic.test.js` 通过
- `python3 scripts/architecture-guard.py` 通过