### PR TITLE
docs(readme): 修复 Star History 图表加载失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,13 @@ Licensing, third-party attribution, SBOM, and brand-use boundaries are documente
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Pinvou/pinvou-agent&type=Date)](https://star-history.com/#Pinvou/pinvou-agent&Date)
+<a href="https://www.star-history.com/?repos=pinvou%2Fpinvou-agent&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&theme=dark&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+ </picture>
+</a>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,7 +197,13 @@ docs/                 架构设计、验证报告与维护文档
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Pinvou/pinvou-agent&type=Date)](https://star-history.com/#Pinvou/pinvou-agent&Date)
+<a href="https://www.star-history.com/?repos=pinvou%2Fpinvou-agent&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&theme=dark&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=pinvou%2Fpinvou-agent&type=date&sealed_token=dH-un0EupjNPvTStPHK9G9AkXKJFl3LHuv30_BOI9z759gjx6gu1te1lVdtZvSYu9xJelAf5fYH1MuPMfbPR5bqc7MZj69CDjVTABUcOxqLN1qdH8Rzv8ZbzaOD9VS7maAlMp2arBTxkehnFhMD3XrAwDT3_KbSEHUKEf7A3qdK45xY0OmfEx1TbuA7a" />
+ </picture>
+</a>
 
 ---
 


### PR DESCRIPTION
## 概述

修复 README 中 Star History 星标趋势图加载失败的问题，改用 star-history 官方当前推荐的 `/chart` 嵌入方式，图表恢复正常显示，并顺带支持深色模式。

## 背景

README 原有图表使用 star-history 旧的 `api.star-history.com/svg` 公开接口。该接口依赖官方维护的 GitHub API 令牌池，长期处于限流状态（持续返回 503 `All GitHub API tokens are rate-limited`）；叠加 2026 年 7 月 GitHub 收紧 stargazers 接口权限（仅仓库管理员/协作者可访问），旧接口已无法出图。官方新接口 `/chart` 要求嵌入方提供加密的 `sealed_token`，使用嵌入者自己的 token 读取星标数据。

## 变更

- `README.md`、`README.zh-CN.md`：Star History 一节由旧的单行 Markdown 图片替换为官方当前格式的 `<picture>` 嵌入代码，接口由 `/svg` 迁移至 `/chart`
- 附带 `sealed_token`：由仅对本仓库有 Metadata 只读权限的 fine-grained PAT 加密生成，只有 star-history 服务端可解密（官方设计的安全用法）
- 新增 `prefers-color-scheme` 深色/浅色主题自适应

## 验证

- 对 README 中实际写入的两个图表 URL（亮色/暗色）直接发起请求，均返回 200 及正常 SVG 内容

## 备注

- 图表显示依赖生成 `sealed_token` 所用的 fine-grained PAT 持续有效，请勿吊销该 token；若日后更换，需要重新生成 `sealed_token` 并更新 README