### PR TITLE
fix(monitor): 修复 macOS 图形处理器不可用与运行活动柱状图假数据

### DIFF
--- a/pinvou3-app/src-tauri/src/features/monitor/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/mod.rs
@@ -2,7 +2,8 @@
 //!
 //! 数据流：**按需采样**——前端在监控页面 mount 时启 1s interval 调
 //! `get_monitor_snapshot`，离开页面就停。后端每次 command 直接跑一次
-//! `sample_all`。设计目的：用户不在监控页面时**完全不跑 nvidia-smi**。
+//! `sample_all`。设计目的：用户不在监控页面时**完全不跑 GPU 探测**
+//! (nvidia-smi / Windows 性能计数器 / macOS ioreg)。
 //! GPU util 峰值靠前端 5 个值滑窗 max（A+B）补足瞬时采样易错过推理峰的问题。
 //!
 //! 设计原则：**任何采样失败都 graceful degrade**——返回 None / OFFLINE，
@@ -385,7 +386,8 @@ async fn sample_all_with_cpu(
     }
 }
 
-/// Return GPU telemetry when the current platform provides NVIDIA probe candidates.
+/// Return GPU telemetry: NVIDIA probe (nvidia-smi) first, then the platform
+/// sampler (Windows performance counters / macOS ioreg IOAccelerator).
 fn gpu_snapshot() -> Option<GpuSnapshot> {
     static GPU_CACHE: OnceLock<Mutex<GpuSnapshotCache>> = OnceLock::new();
     let cache = GPU_CACHE.get_or_init(|| Mutex::new(GpuSnapshotCache::default()));

--- a/pinvou3-app/src-tauri/src/features/monitor/platform/macos_gpu.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/platform/macos_gpu.rs
@@ -1,0 +1,134 @@
+//! macOS GPU 采样:解析 `ioreg -r -c IOAccelerator -d 1` 输出。
+//!
+//! Apple Silicon(及 Intel Mac 的独显)IOAccelerator 字典自带:
+//!   - `"model" = "Apple M3 Max"`                     → GPU 名称
+//!   - `PerformanceStatistics` 里 `"Device Utilization %"=48` → 核心利用率(无需 root)
+//!   - `"In use system memory"=1221361664`            → GPU 在用的统一内存(字节)
+//! Apple Silicon 是统一内存架构,没有独立 VRAM:vram_* 置 0,前端据此切到
+//! 「统一内存」显示(与 GB10 的 vram=[N/A] 同一通路)。温度/功耗无公开免 root
+//! 接口(powermetrics 要 sudo),留 None,前端只渲染有数据的行。
+//!
+//! 解析失败(无 GPU 字典、输出格式变化)→ None,前端显示「状态不可用」,
+//! 与现有 graceful degrade 原则一致。
+
+use super::super::GpuSnapshot;
+
+pub fn gpu_snapshot() -> Option<GpuSnapshot> {
+    let out = std::process::Command::new("/usr/sbin/ioreg")
+        .args(["-r", "-c", "IOAccelerator", "-d", "1"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    parse_ioreg_gpu(&text)
+}
+
+fn parse_ioreg_gpu(text: &str) -> Option<GpuSnapshot> {
+    // 至少要有 GPU 名称,否则视为无可用 GPU(不拿一个全空快照冒充可用)。
+    let name = parse_quoted_property(text, "model")?;
+    let utilization = parse_perf_stat(text, "Device Utilization %")
+        .map(|v| v.min(100) as u32)
+        .unwrap_or(0);
+    let shared_memory_used_mib =
+        parse_perf_stat(text, "In use system memory").map(|b| b / 1024 / 1024);
+    Some(GpuSnapshot {
+        name,
+        vram_used_mib: 0,
+        vram_total_mib: 0,
+        utilization_pct: utilization,
+        processor_utilization_pct: None,
+        shared_memory_used_mib,
+        temperature_c: None,
+        power_w: None,
+    })
+}
+
+/// 提取 `"key" = "value"` 形式的字符串属性(取首个匹配)。
+fn parse_quoted_property(text: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\" = \"");
+    let start = text.find(&needle)? + needle.len();
+    let end = text[start..].find('"')? + start;
+    let value = text[start..end].trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// 提取 `PerformanceStatistics` 内 `"key"=<整数>` 的数值(取首个匹配)。
+/// key 带完整引号匹配,`"In use system memory"` 不会误中
+/// `"In use system memory (driver)"`。
+fn parse_perf_stat(text: &str, key: &str) -> Option<u64> {
+    let needle = format!("\"{key}\"=");
+    let start = text.find(&needle)? + needle.len();
+    let digits: String = text[start..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 本机真实输出节选(Apple M3 Max,ioreg -r -c IOAccelerator -d 1)。
+    const REAL_EXCERPT: &str = r#"
+    +-o AGXAcceleratorG15X  <class AGXAcceleratorG15X, id 0x100000455, registered, matched, active, busy 0 (396 ms), retain 56>
+    {
+      "IOClass" = "AGXAcceleratorG15X"
+      "MetalPluginName" = "AGXMetalG15X_M1"
+      "PerformanceStatistics" = {"In use system memory (driver)"=0,"Alloc system memory"=4869685248,"Tiler Utilization %"=48,"recoveryCount"=0,"Renderer Utilization %"=47,"Device Utilization %"=48,"In use system memory"=1221361664}
+      "model" = "Apple M3 Max"
+      "gpu-core-count" = 30
+    }
+"#;
+
+    #[test]
+    fn parses_apple_silicon_gpu() {
+        let snap = parse_ioreg_gpu(REAL_EXCERPT).expect("应解析出 GPU 快照");
+        assert_eq!(snap.name, "Apple M3 Max");
+        assert_eq!(snap.utilization_pct, 48);
+        // 统一内存:vram 恒 0,前端切统一内存显示。
+        assert_eq!(snap.vram_total_mib, 0);
+        assert_eq!(snap.vram_used_mib, 0);
+        // "In use system memory"=1221361664 字节 = 1164 MiB;且不能误中 (driver) 变体(=0)。
+        assert_eq!(snap.shared_memory_used_mib, Some(1221361664 / 1024 / 1024));
+        assert_eq!(snap.temperature_c, None);
+        assert_eq!(snap.power_w, None);
+    }
+
+    #[test]
+    fn missing_model_returns_none() {
+        // 无 "model" 属性(空输出 / 无 GPU)→ None,前端显示「状态不可用」。
+        assert!(parse_ioreg_gpu("").is_none());
+        assert!(parse_ioreg_gpu("{ \"IOClass\" = \"AGXAcceleratorG15X\" }").is_none());
+    }
+
+    #[test]
+    fn missing_utilization_defaults_zero_but_keeps_name() {
+        // 老系统可能没有 PerformanceStatistics:名称仍在,利用率按 0 显示,
+        // 比整块「不可用」更有信息量。
+        let text = r#"{ "model" = "Apple M1" }"#;
+        let snap = parse_ioreg_gpu(text).unwrap();
+        assert_eq!(snap.name, "Apple M1");
+        assert_eq!(snap.utilization_pct, 0);
+        assert_eq!(snap.shared_memory_used_mib, None);
+    }
+
+    #[test]
+    fn utilization_clamped_to_100() {
+        let text =
+            r#"{ "PerformanceStatistics" = {"Device Utilization %"=137} "model" = "Apple M2" }"#;
+        let snap = parse_ioreg_gpu(text).unwrap();
+        assert_eq!(snap.utilization_pct, 100);
+    }
+
+    #[test]
+    fn gpu_snapshot_real_host() {
+        // 集成测试(本机 darwin):ioreg 在真实 macOS 上应解析出带名称的 GPU 快照。
+        // mirror macos_memory::ram_snapshot_cache_serves_repeat_calls 的本机集成测试模式。
+        let snap = gpu_snapshot().expect("gpu_snapshot 在 macOS host 上应返回 Some");
+        assert!(!snap.name.is_empty());
+        assert!(snap.utilization_pct <= 100);
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/monitor/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/platform/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(target_os = "linux")]
 mod linux_memory;
 #[cfg(target_os = "macos")]
+mod macos_gpu;
+#[cfg(target_os = "macos")]
 mod macos_memory;
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod unsupported;
@@ -29,7 +31,9 @@ pub use windows_gpu::gpu_snapshot;
 #[cfg(target_os = "windows")]
 pub use windows_memory::ram_snapshot;
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "macos")]
+pub use macos_gpu::gpu_snapshot;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 pub fn gpu_snapshot() -> Option<super::GpuSnapshot> {
     None
 }

--- a/pinvou3-app/src/features/monitor/MonitorView.jsx
+++ b/pinvou3-app/src/features/monitor/MonitorView.jsx
@@ -249,43 +249,48 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
     );
     const getMonitorHistoryStore = () => {
       if (!window.__pinvou3MonitorHistoryStore) {
-        window.__pinvou3MonitorHistoryStore = { ctx: [], queue: [], ttft: [], tps: [], kv: [] };
+        window.__pinvou3MonitorHistoryStore = { ctx: [], queue: [], ttft: [], tps: [], kv: [], activity: [], activityGen: null };
       }
       return window.__pinvou3MonitorHistoryStore;
     };
-    const cloneMonitorHistory = () => ({
-      ctx: getMonitorHistoryStore().ctx.slice(),
-      queue: getMonitorHistoryStore().queue.slice(),
-      ttft: getMonitorHistoryStore().ttft.slice(),
-      tps: getMonitorHistoryStore().tps.slice(),
-      kv: getMonitorHistoryStore().kv.slice(),
-    });
-    const MonitorActivityBars = ({ color }) => {
-      const [tick, setTick] = useState(0);
-      useEffect(() => {
-        const id = setInterval(() => setTick((value) => value + 1), 220);
-        return () => clearInterval(id);
-      }, []);
-      const base = [32, 48, 44, 56, 36, 62, 39, 28, 52, 68, 55, 31, 64, 24, 42, 30, 51, 70];
-      const values = base.map((height, i) => {
-        const wave = Math.sin((tick + i) * 0.72) * 14 + Math.cos((tick * 0.48 + i) * 0.9) * 8;
-        return Math.max(18, Math.min(82, height + wave));
-      });
+    const cloneMonitorHistory = () => {
+      const store = getMonitorHistoryStore();
+      return {
+        ctx: store.ctx.slice(),
+        queue: store.queue.slice(),
+        ttft: store.ttft.slice(),
+        tps: store.tps.slice(),
+        kv: store.kv.slice(),
+        activity: (store.activity || []).slice(),
+        activityGen: typeof store.activityGen === 'number' ? store.activityGen : null,
+      };
+    };
+    // 运行活动柱状图:每个轮询周期(1s)实际生成的 token 数,右起最新。
+    // 无对话活动时全部为低位平条——不造假动画。
+    const ACTIVITY_BAR_COUNT = 18;
+    const MonitorActivityBars = ({ color, data }) => {
+      const samples = Array.isArray(data) ? data.slice(-ACTIVITY_BAR_COUNT) : [];
+      const pad = ACTIVITY_BAR_COUNT - samples.length;
+      const max = Math.max(0, ...samples.map((v) => Number(v) || 0));
       return (
         <div className="flex items-center justify-between h-12 gap-1.5 opacity-90 px-2">
-          {values.map((height, i) => (
-            <div key={i} className="w-full bg-black/5 dark:bg-white/5 rounded-full overflow-hidden h-full flex flex-col justify-end">
-              <div
-                className="w-full rounded-full transition-[height,opacity,box-shadow] duration-300 ease-out"
-                style={{
-                  height: `${height}%`,
-                  backgroundColor: color,
-                  opacity: 0.68 + (height / 100) * 0.32,
-                  boxShadow: `0 0 ${Math.round(height / 7)}px ${color}55`
-                }}
-              />
-            </div>
-          ))}
+          {Array.from({ length: ACTIVITY_BAR_COUNT }).map((_, i) => {
+            const v = i < pad ? null : Number(samples[i - pad]) || 0;
+            const height = v == null || max <= 0 ? 8 : Math.max(12, Math.round((v / max) * 82));
+            return (
+              <div key={i} className="w-full bg-black/5 dark:bg-white/5 rounded-full overflow-hidden h-full flex flex-col justify-end">
+                <div
+                  className="w-full rounded-full transition-[height,opacity,box-shadow] duration-300 ease-out"
+                  style={{
+                    height: `${height}%`,
+                    backgroundColor: color,
+                    opacity: v == null ? 0.22 : 0.68 + (height / 100) * 0.32,
+                    boxShadow: `0 0 ${Math.round(height / 7)}px ${color}55`
+                  }}
+                />
+              </div>
+            );
+          })}
         </div>
       );
     };
@@ -402,19 +407,31 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
           const m = String(value || '').match(/-?\d+(\.\d+)?/);
           return m ? Number(m[0]) : null;
         };
+        const genNow = fmt && fmt.vllmRaw && typeof fmt.vllmRaw.gen === 'number' ? fmt.vllmRaw.gen : null;
         setHistory(prev => {
           const push = (arr, value) => value == null ? arr : [...arr, value].slice(-20);
+          // 运行活动:本轮询周期实际生成的 token 增量(counter 倒退 = 清除统计/后端重启,按 0)。
+          // 清除动画期间(clearOverride)不采样,避免一帧一个 0 把历史冲掉。
+          let activity = prev.activity;
+          let activityGen = prev.activityGen;
+          if (genNow != null && !clearOverride) {
+            const delta = activityGen != null && genNow >= activityGen ? genNow - activityGen : 0;
+            activity = [...activity, delta].slice(-ACTIVITY_BAR_COUNT);
+            activityGen = genNow;
+          }
           const next = {
             ctx: push(prev.ctx, readNum(vllmMaxLen)),
             queue: push(prev.queue, readNum(vllmQueue)),
             ttft: push(prev.ttft, readNum(clearOverride ? clearOverride.ttft : vllmTtft)),
             tps: push(prev.tps, readNum(clearOverride ? clearOverride.tps : vllmTps)),
             kv: push(prev.kv, (clearOverride || (fmt && fmt.vllmKvHasData)) ? readNum(clearOverride ? clearOverride.kv : vllmKv) : null),
+            activity,
+            activityGen,
           };
           Object.assign(getMonitorHistoryStore(), next);
           return next;
         });
-      }, [vllmMaxLen, vllmQueue, vllmTtft, vllmTps, vllmKv, clearOverride]);
+      }, [vllmMaxLen, vllmQueue, vllmTtft, vllmTps, vllmKv, clearOverride, updatedAt]);
       useEffect(() => {
         const timer = setInterval(() => setClockNow(new Date()), 1000);
         return () => clearInterval(timer);
@@ -450,6 +467,7 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
       const computeAvailable = fmt ? !!fmt.computeAvailable : gpuAvailable;
       const processorUtilPct = fmt && fmt.processorUtilPct != null ? fmt.processorUtilPct : 0;
       const gpuSharedMemory = fmt && fmt.gpuSharedMemory ? fmt.gpuSharedMemory : loadingValue;
+      const gpuHasSharedMemory = !!(fmt && fmt.gpuSharedMemory && fmt.gpuSharedMemory !== '—');
       const isLocalProcessor = !gpuAvailable && cpuAvailable;
       const isUnifiedGpu = gpuAvailable && !gpuHasVram && !isLocalProcessor;
       const unifiedMemoryPct = isUnifiedGpu ? ramPct : gpuVramPct;
@@ -527,14 +545,24 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
                       <MonitorRing label={isLocalProcessor ? t.graphicsLoad : (isUnifiedGpu ? t.unifiedMem : t.vram)} percent={isLocalProcessor ? gpuUtilPct : unifiedMemoryPct} color={monitorColors.orange} />
                     </div>
                     <div className="pt-4 border-t border-black/5 dark:border-white/5 space-y-3 text-[12px] font-semibold">
-                      <div className="flex justify-between items-center text-black/40 dark:text-white/40">
-                        <span>{isLocalProcessor ? t.sharedMemory : t.temp}</span>
-                        <span className="text-black dark:text-white">{isLocalProcessor ? gpuSharedMemory : (gpuTemp || '—')}</span>
-                      </div>
-                      <div className="flex justify-between items-center text-black/40 dark:text-white/40">
-                        <span>{isLocalProcessor ? t.deviceTemp : t.power}</span>
-                        <span className="text-black dark:text-white">{isLocalProcessor ? (gpuTemp || '—') : (gpuPower || '—')}</span>
-                      </div>
+                      {(isLocalProcessor || gpuHasSharedMemory) && (
+                        <div className="flex justify-between items-center text-black/40 dark:text-white/40">
+                          <span>{t.sharedMemory}</span>
+                          <span className="text-black dark:text-white">{gpuSharedMemory}</span>
+                        </div>
+                      )}
+                      {(isLocalProcessor || gpuTemp) && (
+                        <div className="flex justify-between items-center text-black/40 dark:text-white/40">
+                          <span>{isLocalProcessor ? t.deviceTemp : t.temp}</span>
+                          <span className="text-black dark:text-white">{gpuTemp || '—'}</span>
+                        </div>
+                      )}
+                      {!isLocalProcessor && gpuPower && (
+                        <div className="flex justify-between items-center text-black/40 dark:text-white/40">
+                          <span>{t.power}</span>
+                          <span className="text-black dark:text-white">{gpuPower}</span>
+                        </div>
+                      )}
                     </div>
                   </div>
                 </MonitorCard>
@@ -560,7 +588,7 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
                     </div>
                     <div className="mt-auto bg-white/55 dark:bg-[#2C2C2E] rounded-3xl p-4 border border-black/[0.055] dark:border-white/[0.055] shadow-[0_10px_28px_rgba(15,23,42,0.06)] dark:shadow-[0_20px_48px_rgba(0,0,0,0.48),0_7px_18px_rgba(0,0,0,0.36)] transition-all duration-300 hover:-translate-y-0.5 hover:bg-white/80 dark:hover:!bg-[#3A3A3C]">
                       <span className="text-[10px] font-bold tracking-[0.04em] text-black/50 dark:text-white/50 block mb-3 px-2">{t.uiMonitor.activity}</span>
-                      <MonitorActivityBars color={monitorColors.blue} />
+                      <MonitorActivityBars color={monitorColors.blue} data={history.activity} />
                     </div>
                   </div>
                 </MonitorCard>


### PR DESCRIPTION
## 概述
修复运行状态页两个问题：macOS 上图形处理器卡显示「状态不可用」，以及应用服务卡「运行活动」柱状图为无真实数据的装饰动画。

## 背景
- GPU 采样此前只有 nvidia-smi（NVIDIA）和 Windows 性能计数器两条通路，macOS 上 `platform::gpu_snapshot()` 恒返回 `None`，CPU 采样同样为空，整张算力卡只能显示「状态不可用」。
- 「运行活动」柱状图是硬编码数组叠加 sin/cos 波形的定时器动画，不接任何真实数据，属于纯装饰 UI。

## 变更
- 新增 `macos_gpu.rs`：解析 `ioreg -r -c IOAccelerator`（无需 root），获取 GPU 名称（如 Apple M3 Max）、`Device Utilization %` 核心利用率、`In use system memory` 统一内存占用；Apple Silicon 无独立 VRAM，沿用 GB10 的统一内存显示通路；采样失败仍按原原则降级为「状态不可用」
- 算力卡尾行改为按数据有无渲染：有共享内存/温度/功耗数据才显示对应行（macOS 免 root 拿不到温度功耗，不再常驻两行 —；GB10、NVIDIA、Windows 本机算力分支显示不变）
- 「运行活动」柱状图移除假动画，改为显示每个轮询周期（1s）实际生成的 token 增量（app 侧自测 counter 差分，清除统计/后端重启按 0 处理），无对话活动时呈低位平条
- 顺带更新 monitor 模块注释，反映新增的 macOS ioreg 探测通路

## 验证
- `cargo test --lib monitor`：33 个测试全过，含新增 5 个（真实 ioreg 输出解析、driver 字段防误匹配、无 GPU 降级、利用率封顶 100、本机集成测试）；本机实测解析出 Apple M3 Max
- `eslint`、`vite build`、`architecture-guard.py`、bridge 协议契约与 i18n 覆盖测试均通过

## 备注
- 温度/功耗在 macOS 上无公开免 root 接口（powermetrics 需 sudo），故不显示；如后续需要可再评估授权方案
- 不涉及 CodeWhale fork 改动