### PR TITLE
feat(tools): append_file 工具输出支持 diff 预览

### DIFF
--- a/docs/fork-modifications.en.md
+++ b/docs/fork-modifications.en.md
@@ -8,11 +8,11 @@
 | Item | Value |
 |---|---|
 | Upstream | `Hmbown/CodeWhale` tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
-| Public release | `Pinvou/CodeWhale` tag `pinvou-v0.9.0-r1` |
-| Pinned commit | `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e` |
+| Public release | `Pinvou/CodeWhale` tag `pinvou-v0.9.0-r2` |
+| Pinned commit | `cb93e0f4466d60e306252ed08bbbe214f2def752` |
 | Maintenance branch | `pinvou3-clean` |
-| Organization | 6 long-lived product themes, 3 maintenance/fix commits, and 3 public baseline/security commits |
-| Diff from upstream tag | 3,878 insertions, 550 deletions, 57 files |
+| Organization | 6 long-lived product themes, 4 follow-up behavior/maintenance commits, and 3 public baseline/security commits |
+| Diff from upstream tag | 4,045 insertions, 550 deletions, 57 files |
 
 The delta exceeds the 1,500-line soft limit and has therefore received a mandatory boundary review. The retained code owns behavior that cannot be reconstructed safely in the desktop wrapper: task persistence, workflow completion, prompt-source sealing, and engine-level safety. Shell rendering and platform-specific desktop behavior remain in the parent repository and do not add fork drift.
 
@@ -24,7 +24,7 @@ Exposes the upstream bin-first crate as a library for the desktop host. It expor
 
 ### T2 — Tool surface and execution safety
 
-Defines the Pinvou tool surface, write-size limits, truncated-argument guidance, wildcard tool restrictions, and fail-closed handling for dangerous commands and required approvals. Result-oriented golden and safety tests protect the behavior.
+Defines the Pinvou tool surface, write-size limits, truncated-argument guidance, wildcard tool restrictions, and fail-closed handling for dangerous commands and required approvals. `append_file` emits a bounded inline unified diff with byte-summary, oversized-file, and non-UTF-8 fallbacks. Result-oriented golden and safety tests protect the behavior.
 
 ### T3 — Sealed prompts and one context source
 
@@ -44,13 +44,13 @@ Exposes an opaque runtime route receipt, explicit route limits, and shared recon
 
 ## Public baseline maintenance
 
-The three commits above the product baseline add:
+The three public baseline/security commits add:
 
 - a full-history Gitleaks workflow and two exact allowlist entries for public upstream test fixtures;
 - `PINVOU_FORK.md` and the README fork notice;
 - removal of one internal project-name comment without changing behavior.
 
-They do not introduce a seventh product theme.
+They do not introduce a seventh product theme. The `cb93e0f44` follow-up extends T2 with `append_file` inline diffs.
 
 ## Verification
 
@@ -66,6 +66,6 @@ The parent repository additionally verifies that:
 - `.gitmodules` uses `https://github.com/Pinvou/CodeWhale.git`;
 - no floating submodule branch is configured;
 - the gitlink commit is publicly reachable;
-- `pinvou-v0.9.0-r1^{}` equals the pinned gitlink.
+- `pinvou-v0.9.0-r2^{}` equals the pinned gitlink.
 
 For any future gitlink or fork-behavior change, update this inventory, the Chinese source-of-truth inventory, fingerprints, and result-oriented tests in the same PR.

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -4,15 +4,15 @@
 > 基线、主题边界、守护指纹和每次 sync 结论都以本文与 `docs/fork-policy.md` 为准。
 > English: [`docs/fork-modifications.en.md`](fork-modifications.en.md)
 
-## 0. 当前状态（2026-07-24 · v0.9.0）
+## 0. 当前状态（2026-07-30 · v0.9.0）
 
 | 项 | 当前值 |
 |---|---|
 | 上游基线 | tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
-| 公开固定基线 | tag `pinvou-v0.9.0-r1`，commit `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e` |
-| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `070f4413eeb0` |
-| 组织方式 | **6 个长期主题 commit + 3 个维护/修复 commit + 3 个公开基线/安全维护 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
-| drift | 对 `v0.9.0`：**+3878 / -550，57 文件** |
+| 公开固定基线 | tag `pinvou-v0.9.0-r2`，commit `cb93e0f4466d60e306252ed08bbbe214f2def752` |
+| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `cb93e0f4466d` |
+| 组织方式 | **6 个长期主题 commit + 4 个行为补充/维护 commit + 3 个公开基线/安全维护 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
+| drift | 对 `v0.9.0`：**+4045 / -550，57 文件** |
 | 守护 | `scripts/fork-guard.sh`：v0.9 主题指纹 + 宿主 ShellManager 观察器与生命周期指纹 + submodule/app `forkguard_` 行为测试 |
 | app 状态 | `pinvou3-tauri` 主库编译通过，lib test target 可完整编译；macOS 适配保留在父仓平台抽象中，不增加 fork drift |
 
@@ -41,7 +41,7 @@
 
 ### T2 `fork`：工具面、文件写入与执行安全
 
-- **commit**：`092e3c885 feat(fork): 收敛工具面、文件写入与执行安全`。
+- **commit**：`092e3c885 feat(fork): 收敛工具面、文件写入与执行安全`；`cb93e0f44 feat(fork): append_file 输出 inline unified diff`。
 - **核心文件**：`tools/pinvou3_blocklist.rs`、`core/engine/tool_catalog.rs`、`tools/file.rs`、`core/engine/dispatch.rs`、`tools/shell.rs`、`core/engine/turn_loop.rs`、`command_safety.rs`、审批策略相关文件。
 - **内容**：
   - pinvou3 native 工具黑名单与 deferred activator 结果式 golden。
@@ -116,7 +116,7 @@
 - `23d4c9b5 docs(fork): 记录 Pinvou 公开基线`
 - `070f4413 chore(fork): 清理内部项目注释`
 
-这三个提交只增加公开 fork 的说明、全历史 Gitleaks 门禁与精确测试夹具白名单，并移除一处内部项目代号注释；不改变 T1–T6 的产品行为。父仓只固定到稳定标签 `pinvou-v0.9.0-r1`，不跟随维护分支漂移。
+这三个提交只增加公开 fork 的说明、全历史 Gitleaks 门禁与精确测试夹具白名单，并移除一处内部项目代号注释；不改变 T1–T6 的产品行为。`cb93e0f44` 是 T2 的行为补充，不新增长期主题。父仓只固定到稳定标签 `pinvou-v0.9.0-r2`，不跟随维护分支漂移。
 
 ### T7 macOS 平台目标支持 (2026-07)
 
@@ -197,6 +197,12 @@ diff /tmp/pre-sync-prompt.txt /tmp/post-sync-prompt.txt
 本地 `/tmp` 空间不足时，显式把 `TMPDIR` 和 `CARGO_TARGET_DIR` 指到项目盘；不要用清理用户目录解决构建问题。
 
 ## 5. Sync 历史
+
+### v0.9.0 r2 append_file inline diff（2026-07-30）
+
+- `Pinvou/CodeWhale#2` 以 squash commit `cb93e0f4466d60e306252ed08bbbe214f2def752` 合入 `pinvou3-clean`，并发布不可变标签 `pinvou-v0.9.0-r2`。
+- `append_file` 输出 inline unified diff 和尾部字节摘要；旧文件超过 512KB 或非 UTF-8 时安全回退。
+- CodeWhale CI 已通过全 workspace/all-targets 编译、77 项 `tools::file` 定向测试、`forkguard_` 回归、格式、DCO、Gitleaks 与贡献门禁。
 
 ### v0.9.0 公开固定基线（2026-07-24）
 

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -46,10 +46,11 @@
 - **内容**：
   - pinvou3 native 工具黑名单与 deferred activator 结果式 golden。
   - `write_file` / `append_file` 64KB 单次内容上限和缺字段修复提示。
+  - `append_file` 与 `write_file` 一样输出 inline unified diff(尾部 context + 追加行,字节摘要保留在末尾);已存文件超过 512KB(`APPEND_FILE_INLINE_DIFF_LIMIT_BYTES`)或非 UTF-8 时回退 `[diff omitted]` / 纯字节摘要。
   - `disallowed_tools` 支持 `*` 前缀规则。
   - Dangerous 命令在所有模式阻断；审批缓存、workflow plan 审批保持 fail-closed。
 - **为什么留 fork**：工具面是 pinvou3 产品定位；append_file 与大产物引导耦合。Shell 展示能力已经移到 app，不再作为本主题的 fork-distinct 代码维护。
-- **守护**：`forkguard_blocklist_golden`、`forkguard_yolo_no_deferred_activator_first_class`、文件上限测试和命令安全测试。
+- **守护**：`forkguard_blocklist_golden`、`forkguard_yolo_no_deferred_activator_first_class`、`forkguard_append_file_emits_inline_diff`、文件上限测试和命令安全测试。
 
 ### T3 `fork`：提示词密封与 context / skill 单一来源
 

--- a/docs/fork-policy.en.md
+++ b/docs/fork-policy.en.md
@@ -1,15 +1,15 @@
 # CodeWhale Fork Maintenance Policy
 
-> Last updated: 2026-07-24
-> Released baseline: `pinvou-v0.9.0-r1@070f4413`
+> Last updated: 2026-07-30
+> Released baseline: `pinvou-v0.9.0-r2@cb93e0f4`
 > Detailed inventory: [`fork-modifications.en.md`](fork-modifications.en.md)
 
 ## 1. Baseline and ownership
 
 - Upstream: [`Hmbown/CodeWhale`](https://github.com/Hmbown/CodeWhale), tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f`.
 - Public fork: [`Pinvou/CodeWhale`](https://github.com/Pinvou/CodeWhale).
-- Maintenance branch: `pinvou3-clean`, currently at `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e`.
-- Pinvou Agent pins the immutable tag `pinvou-v0.9.0-r1`, which dereferences to that commit.
+- Maintenance branch: `pinvou3-clean`, currently at `cb93e0f4466d60e306252ed08bbbe214f2def752`.
+- Pinvou Agent pins the immutable tag `pinvou-v0.9.0-r2`, which dereferences to that commit.
 - `.gitmodules` intentionally has no `branch` entry. A parent-repository checkout must never move merely because the maintenance branch moved.
 
 The fork is maintained as six long-lived themes:

--- a/docs/fork-policy.md
+++ b/docs/fork-policy.md
@@ -1,6 +1,6 @@
 # pinvou3 对 CodeWhale 底座的 fork 维护策略
 
-> 最后更新：2026-07-24（公开发布基线 `pinvou-v0.9.0-r1@070f4413`）
+> 最后更新：2026-07-30（公开发布基线 `pinvou-v0.9.0-r2@cb93e0f4`）
 > 配套：`docs/fork-modifications.md`、`scripts/fork-guard.sh`、`docs/底座升级验收清单.md`
 > English: [`docs/fork-policy.en.md`](fork-policy.en.md)
 
@@ -8,8 +8,8 @@
 
 - 上游：`Hmbown/CodeWhale` tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f`。
 - 公开 fork：`https://github.com/Pinvou/CodeWhale`。
-- 维护分支：`pinvou3-clean`，当前 head `070f4413eeb0e0c4e6f2634f1ada13c60fd2e86e`。
-- 父仓固定标签：`pinvou-v0.9.0-r1`，解引用后必须是上述 commit；`.gitmodules` 不配置浮动 `branch`。
+- 维护分支：`pinvou3-clean`，当前 head `cb93e0f4466d60e306252ed08bbbe214f2def752`。
+- 父仓固定标签：`pinvou-v0.9.0-r2`，解引用后必须是上述 commit；`.gitmodules` 不配置浮动 `branch`。
 - fork 不再按历史 C1–C12 / W1–W13 批量编号维护，当前只保留 **6 个长期主题**：
 
   1. 宿主 library facade
@@ -39,7 +39,7 @@ Engine、ToolRegistry、SSE、Session、SkillRegistry、Commands、MCP client、
 - 总 drift 软上限：1500 行。
 - 单文件 fork-distinct 改动软上限：200 行。
 - 超过不是自动拒绝，但必须在 `fork-modifications.md` 记录：为什么不能放 app/skill/MCP、哪些已 harvest、后续减量顺序。
-- 当前公开基线相对 v0.9.0 为 `+3878/-550，57 文件`，已经完成强制评估；结论见修改清单 §0。
+- 当前公开基线相对 v0.9.0 为 `+4045/-550，57 文件`，已经完成强制评估；结论见修改清单 §0。
 
 ### 1.3 主题提交
 

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -73,8 +73,12 @@ const ToolOutput = ({ item, isDark, t }) => {
         // append_file 与 write_file 一样由后端输出 unified diff,走 DiffView;
         // 旧 session 落盘的是 "appended N bytes" 纯文本,保留字节摘要兜底。
         if (looksDiff(out)) return <DiffView text={out} isDark={isDark} />;
-        const m = String(out).match(/appended (\d+) bytes[\s\S]*?\((\d+) -> (\d+) bytes\)/i);
-        if (m) return <div className={outBox(isDark)}>{t.appendBytes(/^Created/i.test(out), m[1], m[2], m[3])}</div>;
+        // 旧文件超大时后端输出 "summary\n[diff omitted] ...":不能只显示字节摘要,
+        // 否则 omit 说明被吞掉 —— 与 write_file 一样落到 OutputPre 展示完整原文。
+        if (!/\[diff omitted\]/i.test(out)) {
+          const m = String(out).match(/appended (\d+) bytes[\s\S]*?\((\d+) -> (\d+) bytes\)/i);
+          if (m) return <div className={outBox(isDark)}>{t.appendBytes(/^Created/i.test(out), m[1], m[2], m[3])}</div>;
+        }
       }
       else if (TODO_TOOLS.indexOf(item.name) >= 0) { const v = tryTailJson(out); if (v && Array.isArray(v.items)) return <TodoView snap={v} isDark={isDark} t={t} />; }
       return <OutputPre text={out} isDark={isDark} />;

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -70,6 +70,9 @@ const ToolOutput = ({ item, isDark, t }) => {
       // (PR #195 M2)。若未来后端给 apply_patch 输出 unified diff,再把它加回来。
       else if (item.name === 'edit_file' || item.name === 'write_file') { if (looksDiff(out)) return <DiffView text={out} isDark={isDark} />; }
       else if (item.name === 'append_file') {
+        // append_file 与 write_file 一样由后端输出 unified diff,走 DiffView;
+        // 旧 session 落盘的是 "appended N bytes" 纯文本,保留字节摘要兜底。
+        if (looksDiff(out)) return <DiffView text={out} isDark={isDark} />;
         const m = String(out).match(/appended (\d+) bytes[\s\S]*?\((\d+) -> (\d+) bytes\)/i);
         if (m) return <div className={outBox(isDark)}>{t.appendBytes(/^Created/i.test(out), m[1], m[2], m[3])}</div>;
       }

--- a/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
+++ b/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
@@ -92,6 +92,7 @@ try {
       appendAddCount: document.querySelectorAll('[data-testid="append-output"] [data-diff-kind="add"]').length,
       appendSummary: document.querySelector('[data-testid="append-output"] [data-testid="diff-summary"]')?.innerText || '',
       appendLegacyText: document.querySelector('[data-testid="append-legacy-output"]')?.innerText || '',
+      appendOmittedText: document.querySelector('[data-testid="append-omitted-output"]')?.innerText || '',
     };
   });
 
@@ -110,6 +111,7 @@ try {
   assert(initial.appendAddCount === 1, 'append_file diff 新增行渲染数量错误', initial);
   assert(initial.appendSummary.includes('Appended 8 bytes'), 'append_file 字节摘要未随 diff 渲染', initial);
   assert(initial.appendLegacyText.includes('追加 8 字节'), '旧格式 append_file 字节摘要兜底失效', initial);
+  assert(initial.appendOmittedText.includes('[diff omitted]') && initial.appendOmittedText.includes('Appended 8 bytes'), 'append_file [diff omitted] 输出未完整展示原文', initial);
 
   await page.click('[data-testid="edit-output"] [aria-label="展开完整 diff"]');
   await page.waitForFunction(() => document.querySelector('[data-testid="edit-output"] [data-testid="diff-view"]')?.clientHeight > 200);

--- a/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
+++ b/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
@@ -87,6 +87,11 @@ try {
       writeHeader: document.querySelector('[data-testid="write-output"] [data-testid="diff-file-header"]')?.innerText || '',
       writeAddCount: document.querySelectorAll('[data-testid="write-output"] [data-diff-kind="add"]').length,
       writeBackground: getComputedStyle(document.querySelector('[data-testid="write-output"] [data-testid="diff-view"]')).backgroundColor,
+      appendHasDiff: !!document.querySelector('[data-testid="append-output"] [data-testid="diff-view"]'),
+      appendHeader: document.querySelector('[data-testid="append-output"] [data-testid="diff-file-header"]')?.innerText || '',
+      appendAddCount: document.querySelectorAll('[data-testid="append-output"] [data-diff-kind="add"]').length,
+      appendSummary: document.querySelector('[data-testid="append-output"] [data-testid="diff-summary"]')?.innerText || '',
+      appendLegacyText: document.querySelector('[data-testid="append-legacy-output"]')?.innerText || '',
     };
   });
 
@@ -101,6 +106,10 @@ try {
   assert(!initial.fallbackHasDiff && initial.fallbackText.includes('Replaced 0 occurrences'), '非 diff 文本没有降级到普通输出', initial);
   assert(initial.writeHeader.includes('b/notes/new file.md') && initial.writeHeader.includes('+2'), 'write_file 没有路由到深色 diff 视图', initial);
   assert(initial.writeAddCount === 2 && initial.writeBackground !== 'rgba(0, 0, 0, 0)', 'write_file 深色 diff 渲染错误', initial);
+  assert(initial.appendHasDiff && initial.appendHeader.includes('b/notes/deck.html') && initial.appendHeader.includes('+1'), 'append_file 没有路由到 diff 视图', initial);
+  assert(initial.appendAddCount === 1, 'append_file diff 新增行渲染数量错误', initial);
+  assert(initial.appendSummary.includes('Appended 8 bytes'), 'append_file 字节摘要未随 diff 渲染', initial);
+  assert(initial.appendLegacyText.includes('追加 8 字节'), '旧格式 append_file 字节摘要兜底失效', initial);
 
   await page.click('[data-testid="edit-output"] [aria-label="展开完整 diff"]');
   await page.waitForFunction(() => document.querySelector('[data-testid="edit-output"] [data-testid="diff-view"]')?.clientHeight > 200);

--- a/pinvou3-app/tests/fixtures/diff_viewer_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/diff_viewer_smoke.jsx
@@ -44,6 +44,13 @@ const appendDiffOutput = [
 // 旧 session 落盘的 append_file 输出:纯字节摘要,无 diff,走 appendBytes 兜底。
 const appendLegacyOutput = 'Appended 8 bytes to notes/deck.html (7 -> 15 bytes)';
 
+// 旧文件超 512KB 时 append_file 输出:字节摘要 + [diff omitted] 说明。
+// 不能走 appendBytes 兜底(omit 说明会被吞掉),应落到 OutputPre 展示完整原文。
+const appendOmittedOutput = [
+  'Appended 8 bytes to notes/big.log (524289 -> 524297 bytes)',
+  '[diff omitted] notes/big.log is too large for an inline append_file diff (old=524289 bytes, limit=524288 bytes). Use read_file with line ranges to inspect it.',
+].join('\n');
+
 const t = {
   receiptNote: '输出已截断',
   receiptEmpty: '无输出',
@@ -84,6 +91,13 @@ const Fixture = () => (
     <section data-testid="append-legacy-output">
       <ToolOutput
         item={{ name: 'append_file', output: appendLegacyOutput, success: true }}
+        isDark={false}
+        t={t}
+      />
+    </section>
+    <section data-testid="append-omitted-output">
+      <ToolOutput
+        item={{ name: 'append_file', output: appendOmittedOutput, success: true }}
         isDark={false}
         t={t}
       />

--- a/pinvou3-app/tests/fixtures/diff_viewer_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/diff_viewer_smoke.jsx
@@ -30,7 +30,26 @@ const writeDiffOutput = [
   'Created notes/new file.md (23 bytes)',
 ].join('\n');
 
-const t = { receiptNote: '输出已截断', receiptEmpty: '无输出' };
+// append_file 新版输出:unified diff(尾部 context + 追加行) + 字节摘要末尾行。
+const appendDiffOutput = [
+  '--- a/notes/deck.html',
+  '+++ b/notes/deck.html',
+  '@@ -1 +1,2 @@',
+  ' <html>',
+  '+</html>',
+  '',
+  'Appended 8 bytes to notes/deck.html (7 -> 15 bytes)',
+].join('\n');
+
+// 旧 session 落盘的 append_file 输出:纯字节摘要,无 diff,走 appendBytes 兜底。
+const appendLegacyOutput = 'Appended 8 bytes to notes/deck.html (7 -> 15 bytes)';
+
+const t = {
+  receiptNote: '输出已截断',
+  receiptEmpty: '无输出',
+  appendBytes: (created, appended, before, after) =>
+    `${created ? '创建并追加' : '追加'} ${appended} 字节（${before} → ${after} 字节）`,
+};
 
 const Fixture = () => (
   <main className="mx-auto grid max-w-[900px] gap-6">
@@ -52,6 +71,20 @@ const Fixture = () => (
       <ToolOutput
         item={{ name: 'write_file', output: writeDiffOutput, success: true }}
         isDark
+        t={t}
+      />
+    </section>
+    <section data-testid="append-output" className="dark rounded-lg bg-[#131314] p-3">
+      <ToolOutput
+        item={{ name: 'append_file', output: appendDiffOutput, success: true }}
+        isDark
+        t={t}
+      />
+    </section>
+    <section data-testid="append-legacy-output">
+      <ToolOutput
+        item={{ name: 'append_file', output: appendLegacyOutput, success: true }}
+        isDark={false}
         t={t}
       />
     </section>

--- a/scripts/fork-guard.sh
+++ b/scripts/fork-guard.sh
@@ -63,7 +63,7 @@ fingerprints=(
   "T6|automation reconcile shared API    |CodeWhale/crates/tui/src/automation_manager.rs|pub async fn reconcile_run_statuses_shared("
 
   "CI|公开 fork 全目标编译门禁           |CodeWhale/.github/workflows/pinvou-fork-ci.yml|cargo check --workspace --all-targets --locked"
-  "CI|父仓固定公开 CodeWhale 标签         |scripts/verify-public-submodule.sh|PINVOU_CODEWHALE_TAG=\"pinvou-v0.9.0-r1\""
+  "CI|父仓固定公开 CodeWhale 标签         |scripts/verify-public-submodule.sh|PINVOU_CODEWHALE_TAG=\"pinvou-v0.9.0-r2\""
 
   "APP|消息携带 resolved route            |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|resolve_runtime_route_for_model"
   "APP|部署级 route profile               |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|fn route_limits_for_model("

--- a/scripts/fork-guard.sh
+++ b/scripts/fork-guard.sh
@@ -21,6 +21,7 @@ fingerprints=(
   "T1|宿主额外工具入口                   |CodeWhale/crates/tui/src/core/engine.rs|pub extra_tools: ExtraTools"
 
   "T2|写文件 64KB 上限                  |CodeWhale/crates/tui/src/tools/file.rs|WRITE_FILE_MAX_CONTENT_BYTES"
+  "T2|append_file 内联 diff              |CodeWhale/crates/tui/src/tools/file.rs|fn forkguard_append_file_emits_inline_diff"
   "T2|截断参数修复提示                   |CodeWhale/crates/tui/src/core/engine/dispatch.rs|truncated_args_hint"
   "T2|工具黑名单结果 golden              |CodeWhale/crates/tui/src/tools/pinvou3_blocklist.rs|fn forkguard_blocklist_golden"
   "T2|deferred 激活面 golden             |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_yolo_no_deferred_activator_first_class"

--- a/scripts/verify-public-submodule.sh
+++ b/scripts/verify-public-submodule.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PINVOU_CODEWHALE_PATH="CodeWhale"
 PINVOU_CODEWHALE_URL="https://github.com/Pinvou/CodeWhale.git"
-PINVOU_CODEWHALE_TAG="pinvou-v0.9.0-r1"
+PINVOU_CODEWHALE_TAG="pinvou-v0.9.0-r2"
 
 actual_path="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.path)"
 actual_url="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.url)"


### PR DESCRIPTION
## 概述

让 `append_file` 与 `write_file` / `edit_file` 一样展示带行号、着色和可展开的 inline unified diff，同时兼容旧 session 的纯字节摘要。

## 变更

- CodeWhale fork：`append_file` 输出 inline unified diff 和尾部字节摘要；旧文件超过 512KB 或非 UTF-8 时安全回退。
- 前端：新版输出进入 `DiffView`；旧格式继续显示字节摘要；`[diff omitted]` 保留完整原因。
- fork 合规：CodeWhale PR #2 已合并为 `cb93e0f4466d`，发布稳定标签 `pinvou-v0.9.0-r2`；父仓 gitlink、固定标签、守护指纹及中英文 fork 文档已同步。
- 测试：补齐 append diff、旧格式和省略 diff 三类真实渲染断言，以及 CodeWhale forkguard 行为回归。

## 实际验证

- `cargo fmt --all -- --check`
- `cargo test -p codewhale-tui --lib tools::file --no-fail-fast`：77 passed
- CodeWhale CI：workspace/all-targets、forkguard、DCO、Gitleaks、贡献门禁全部通过
- `./scripts/verify-public-submodule.sh`
- `./scripts/fork-guard.sh --fast`
- `python3 scripts/architecture-guard.py`
- `node pinvou3-app/tests/unified_diff_parser.test.js`：24 passed
- `node pinvou3-app/tests/diff_viewer_ui_smoke.mjs`
- `npm --prefix pinvou3-app run lint:ui`

## 风险

inline diff 仅在旧文件不超过 512KB 时生成；超限和非 UTF-8 文件不会读取并比较完整内容，避免大文件内存放大。