### PR TITLE
fix(titlebar): 对齐 macOS 原生红绿灯与顶栏内容中线

### DIFF
--- a/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json
@@ -15,7 +15,7 @@
         "decorations": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 12, "y": 12 }
+        "trafficLightPosition": { "x": 12, "y": 20 }
       }
     ]
   },

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -87,6 +87,9 @@ function workspaceDisplayName(path) {
       // macOS 顶栏走系统原生实现:窗口带 decorations + titleBarStyle=Overlay
       // (见 src-tauri/config/platforms/macos/tauri.conf.json),系统红绿灯悬浮在内容区左上角,
       // 此时不再渲染 Windows 风格三键,并为红绿灯留出左侧空间。
+      // 红绿灯纵向位置由 overlay 配置 trafficLightPosition y=20 决定:tao 按
+      // "容器高 = 按钮高(14) + y" 布局,按钮顶边距窗口顶 y-9,按钮圆心 7,
+      // 故 y=20 时圆心 18,正好与本 h-9(36px)顶栏内容中线对齐;调整顶栏高度需同步改 y。
       // Windows/Linux 窗口无边框(decorations=false),继续用自绘三键。
       // 以窗口实际 decorations 状态为准,不解析 UA / 平台字符串。
       // 初始 null 表示探测未决:此时不渲染自绘三键,避免 macOS 原生顶栏下

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -197,7 +197,7 @@ const expectedMacosWindows = baseWindows.map((window) => (
         decorations: true,
         titleBarStyle: "Overlay",
         hiddenTitle: true,
-        trafficLightPosition: { x: 12, y: 12 },
+        trafficLightPosition: { x: 12, y: 20 },
       }
     : window
 ));


### PR DESCRIPTION
## 背景

macOS 顶栏走系统原生红绿灯(titleBarStyle=Overlay,见 #67)。当前左上角关闭/最小化/最大化三键与旁边的品悟图标、标题(PINVOU AI Assistant)垂直方向不对齐,红绿灯明显偏上约 8px。

## 根因

`trafficLightPosition` 的 y 并非"按钮距顶部距离"。tao 0.35.2(`inset_traffic_lights`)按"标题栏容器高 = 按钮高(14) + y"布局,AppKit 重排后按钮顶边实际位于 `y - 9`、圆心位于 `y - 2`(已在本机用真实 AppKit 窗口按 tao 相同算法实测验证:y=0/6/12/22 时顶边恒为 y-9)。顶栏为 h-9(36px),logo/标题中线在 18px,而 y=12 时红绿灯圆心约 10px。

## 变更

- `config/platforms/macos/tauri.conf.json`:`trafficLightPosition` 的 y 由 12 改为 20,红绿灯圆心恰好落在 18px 中线上(x=12 不变)
- `tests/tauri_effective_config.test.js`:同步期望值
- `src/app/main.jsx`:注释记录"y=20 ↔ h-9 中线"的对应关系,后续调整顶栏高度需同步改 y

## 验证

- 用真实 AppKit 窗口(Overlay + hiddenTitle)复刻 tao 布局与前端 36px 顶栏(18px logo + 13px 标题),离屏渲染对比:y=12 复现偏上错位,y=20 三者同线居中
- `tauri_effective_config` / `macos_phase2_contract` / `tauri_platform_layout` 测试全部通过

## 已知风险

- 圆心偏移量(y-2)为 macOS 当前版本的 AppKit 内部布局常量,理论上有随系统版本变化的可能;若未来 macOS 改版导致再次错位,只需按 main.jsx 注释中的公式重调 y。
- 开发机无"屏幕录制"权限,未能对真实 App 窗口截图,视觉效果以上述等效探针验证为准。