### PR TITLE
fix(monitor): 修复 mac-build CI 中 GPU 主机集成测试失败

### DIFF
--- a/pinvou3-app/src-tauri/src/features/monitor/platform/macos_gpu.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/platform/macos_gpu.rs
@@ -127,7 +127,25 @@ mod tests {
     fn gpu_snapshot_real_host() {
         // 集成测试(本机 darwin):ioreg 在真实 macOS 上应解析出带名称的 GPU 快照。
         // mirror macos_memory::ram_snapshot_cache_serves_repeat_calls 的本机集成测试模式。
-        let snap = gpu_snapshot().expect("gpu_snapshot 在 macOS host 上应返回 Some");
+        // CI 的 macOS runner 是虚拟化环境,IOAccelerator 字典没有 "model" 属性,
+        // gpu_snapshot 按设计返回 None(前端显示「状态不可用」),不能强制 Some。
+        // 因此先探原始 ioreg 输出:仅当环境确实暴露 GPU model 时才要求解析成功。
+        let Ok(out) = std::process::Command::new("/usr/sbin/ioreg")
+            .args(["-r", "-c", "IOAccelerator", "-d", "1"])
+            .output()
+        else {
+            eprintln!("ioreg 不可用,跳过主机断言");
+            return;
+        };
+        let text = String::from_utf8_lossy(&out.stdout);
+        if parse_quoted_property(&text, "model").is_none() {
+            assert!(
+                gpu_snapshot().is_none(),
+                "ioreg 输出无 GPU model 时 gpu_snapshot 必须返回 None"
+            );
+            return;
+        }
+        let snap = gpu_snapshot().expect("ioreg 输出含 GPU model 时 gpu_snapshot 必须返回 Some");
         assert!(!snap.name.is_empty());
         assert!(snap.utilization_pct <= 100);
     }


### PR DESCRIPTION
## 背景

main 最新提交 `a8d6e82d` 的 mac-build CI 失败:`features::monitor::platform::macos_gpu::tests::gpu_snapshot_real_host` panic(`gpu_snapshot 在 macOS host 上应返回 Some`)。

根因:该测试假设真实 macOS 上 `ioreg -r -c IOAccelerator` 必含 `"model"` 属性,但 GitHub Actions 的 macOS runner 是虚拟化环境,IOAccelerator 字典没有 `"model"`,`gpu_snapshot()` 按设计返回 `None`(前端显示「状态不可用」),断言直接 panic。

## 变更

仅改测试 `gpu_snapshot_real_host`:先探测原始 ioreg 输出——

- 环境确实暴露 GPU model(真实 Mac)→ 要求 `gpu_snapshot()` 返回 `Some` 且名称非空、利用率 ≤100;
- 无 model(虚拟化 CI runner)→ 断言必须返回 `None`,与生产代码的 graceful degrade 逻辑互为镜像;
- ioreg 不可用 → 跳过。

生产代码零改动。

## 验证

- 本机(Apple Silicon 真实 Mac)`cargo test --lib features::monitor::platform::macos_gpu`:5/5 通过,走 `Some` 断言路径。
- CI 虚拟化路径的 `None` 断言与生产解析逻辑共用 `parse_quoted_property`,由 `missing_model_returns_none` 单测覆盖。

## 已知风险

无;不改变任何运行时行为。