### PR TITLE
fix(knowledge): 产出物一级视图「加入知识库」后卡死在隐藏分段

### DIFF
--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -846,7 +846,7 @@ let kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], al
                                   <span className={`hidden md:block text-right text-[12px] ${muted}`}>{fmtSize(f.size)}</span>
                                   <span className={`hidden md:block text-[12px] font-medium tabular-nums ${muted}`}>{fmtDate(f.mtime)}</span>
                                   <div className="flex shrink-0 items-center justify-end gap-1">
-                                    <button title={t.kbAddToKb} onClick={(e2) => { e2.stopPropagation(); setAddToKb(f.path); }}
+                                    <button title={t.kbAddToKb} onClick={(e2) => { e2.stopPropagation(); setAddToKb(f.path); if (outputsOnly) loadColls(); }}
                                       className={`grid h-8 w-8 place-items-center rounded-[9px] transition-colors active:opacity-70 ${isDark ? 'text-[#C7C7CC] hover:bg-white/[0.08]' : 'text-[#3A3A3C] hover:bg-[#F2F2F7]'}`}>
                                       <Plus size={15} />
                                     </button>
@@ -1339,12 +1339,12 @@ let kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], al
                 ) : (
                   <div className="flex flex-col gap-1 mb-4 max-h-[240px] overflow-y-auto">
                     {colls.map((c) => (
-                      <button key={c.id} onClick={async () => { try { setIdx(await inv('kb_collection_add_sources', { collectionId: c.id, paths: Array.isArray(addToKb) ? addToKb : [addToKb] })); } catch (e) {} setAddToKb(null); setSub('kb'); }}
+                      <button key={c.id} onClick={async () => { try { setIdx(await inv('kb_collection_add_sources', { collectionId: c.id, paths: Array.isArray(addToKb) ? addToKb : [addToKb] })); } catch (e) {} setAddToKb(null); if (!outputsOnly) setSub('kb'); }}
                         className={`text-left px-4 py-2.5 rounded-xl text-[14px] ${card} ${iconHover} ${ink}`}>{c.name}</button>
                     ))}
                   </div>
                 )}
-                <button onClick={() => { const p = addToKb; setAddToKb(null); setSub('kb'); setNewColl({ name: '', category: '' }); }} className={`w-full px-4 py-2.5 rounded-xl text-[13px] font-medium ${soft}`}>+ {t.kbNewColl}</button>
+                <button onClick={() => { const p = addToKb; setAddToKb(null); if (!outputsOnly) setSub('kb'); setNewColl({ name: '', category: '' }); }} className={`w-full px-4 py-2.5 rounded-xl text-[13px] font-medium ${soft}`}>+ {t.kbNewColl}</button>
               </div>
             </div>
           )}


### PR DESCRIPTION
## 概述

修复 PR #83 合并后遗留的一个交互缺陷：在一级「产出物」视图里对某个产出物执行「加入知识库」后，视图卡死在「产出物标题 + 知识库内容」状态无法切回。

## 背景

PR #83 将产出物拆为一级导航，`outputsOnly` 模式隐藏了分段切换器。但产出物行的「加入知识库」浮层仍保留旧逻辑：选中知识集或点「+ 新建知识集」后无条件 `setSub('kb')`。由于切换器已隐藏，用户没有办法切回产出物段，只能离开视图重新进入。此外 `outputsOnly` 模式下知识集列表的加载 effect 被 `!outputsOnly` 门控，浮层打开时 `colls` 为空，会误显示「还没有知识集」。

## 变更

- 产出物行「加入知识库」按钮：`outputsOnly` 模式打开浮层时按需触发 `loadColls()`，保证浮层列出真实知识集
- 浮层选中知识集 / 「+ 新建知识集」：`outputsOnly` 模式下不再 `setSub('kb')`，操作完成后停留在产出物视图（新建知识集表单本身是独立浮层，不受影响）

## 验证

- `npx eslint src/features/knowledge/KnowledgeView.jsx`：无告警
- 真实 Chrome e2e `node tests/kb_smoke.js`（基于 `npm run build:ui` 新构建）：10/10 PASS

## 备注

- 初次复跑 kb_smoke 时 ⓪ 项失败，定位为本地 `dist/` 是合并前旧构建所致，重新 `npm run build:ui` 后全过，与本次修改无关
- 无 Rust / 协议改动；Web 端共用同一组件同步生效