### PR TITLE
fix(ci): 按成本审计优化工作流触发与门禁

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -32,7 +32,10 @@ jobs:
               "dependabot[bot]",
               "github-actions[bot]",
             ]);
-            const unsigned = commits.filter(({ author, committer, commit }) => {
+            // merge commit(parents > 1,如同步 main 产生的 "Merge branch 'main' into ...")
+            // 天然不带 sign-off,按 probot/dco 惯例豁免;普通 commit 缺 sign-off 仍 fail。
+            const unsigned = commits.filter(({ author, committer, commit, parents }) => {
+              if ((parents?.length ?? 0) > 1) return false;
               const login = author?.login ?? committer?.login;
               return !trustedBots.has(login) && !signoff.test(commit.message);
             });

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -12,15 +12,15 @@ name: mac-build
 #   该依赖)。因此不设 PINVOU_REQUIRE_REMOTE_E2E,让 e2e 测试在缺依赖时静默跳过而非 panic。
 #
 # 分层触发(2026-07 CI 成本审计:暖 cache 全量 ~17min,其中 universal bundle smoke 占
-# 8.6min ≈ 50%,与 release-packages 在 VERSION bump/打包链路 PR 时的真实 dmg 构建重叠;
+# 8.6min ≈ 50%,与 release-packages 在 VERSION bump 时的真实 dmg 构建重叠;
 # main 高峰期 ~19 pushes/天,每次全量跑完一天排队 5+ 小时 mac runner):
 # - 每次触发:check + test + release-fast + verify(~8min),macOS 原生回归核心。
 # - 仅打包链路(bundle_chain)变更:追加 universal bundle smoke。链路覆盖仍完整:
-#   链路 PR 合入前由 release-packages 全平台真实打包验证;VERSION bump 全量 dmg。
+#   链路 PR 合入前由 pr-check 跑轻量发布契约;VERSION bump 再构建全量 dmg。
 # - cancel-in-progress 保持 true(verify-tip):8min 任务在 push 间隙大概率跑完,
 #   被取消的中间 run 由更新的 tip 取代,不为每个中间 commit 排队。
 # - 纯前端改动(pinvou3-app/src/**)不触发:cargo check/test 不依赖前端产物,
-#   前端进包由打包链路的 bundle smoke 与 release-packages 覆盖。
+#   前端进包由打包链路的 bundle smoke 与正式 release-packages 覆盖。
 
 on:
   push:
@@ -162,7 +162,7 @@ jobs:
 
       # tauri bundle smoke:验证 dmg/app 实际打包链路(Info.plist/entitlements/资源打包)。
       # 仅打包链路(bundle_chain)变更时跑(占全量 job 约 50% 耗时,见头部「分层触发」);
-      # 打包链路 PR 合入前由 release-packages 全平台真实打包验证,VERSION bump 全量 dmg。
+      # 打包链路 PR 合入前由 pr-check 跑轻量发布契约,VERSION bump 再构建全量 dmg。
       # universal 打包失败会让 mac-build 失败,避免主线在没有可发布 arm64 + x86_64 产物时仍显示成功。
       - name: Tauri bundle smoke (验证 dmg/app 打包,仅打包链路变更)
         if: needs.changes.outputs.bundle_chain == 'true'

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -6,20 +6,31 @@ name: mac-build
 #
 # 与 pr-check.yml 的 rust-test 关系:
 # - rust-test 在 ubuntu 上跑完整 lib tests,是主线 gate。
-# - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟
-#   (cargo build 与 tauri bundle 共用同一 release-fast profile,产物互相复用,不重复编译),
+# - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟,
 #   验证 macOS 平台目标零回归。真发版的 fat-LTO --release 产物由 scripts/release-macos.sh 产出。
 # - mac-build 不跑 relay e2e(那需要 remote-control-relay 的 node_modules,mac-build 不装
 #   该依赖)。因此不设 PINVOU_REQUIRE_REMOTE_E2E,让 e2e 测试在缺依赖时静默跳过而非 panic。
+#
+# 分层触发(2026-07 CI 成本审计:暖 cache 全量 ~17min,其中 universal bundle smoke 占
+# 8.6min ≈ 50%,与 release-packages 在 VERSION bump/打包链路 PR 时的真实 dmg 构建重叠;
+# main 高峰期 ~19 pushes/天,每次全量跑完一天排队 5+ 小时 mac runner):
+# - 每次触发:check + test + release-fast + verify(~8min),macOS 原生回归核心。
+# - 仅打包链路(bundle_chain)变更:追加 universal bundle smoke。链路覆盖仍完整:
+#   链路 PR 合入前由 release-packages 全平台真实打包验证;VERSION bump 全量 dmg。
+# - cancel-in-progress 保持 true(verify-tip):8min 任务在 push 间隙大概率跑完,
+#   被取消的中间 run 由更新的 tip 取代,不为每个中间 commit 排队。
+# - 纯前端改动(pinvou3-app/src/**)不触发:cargo check/test 不依赖前端产物,
+#   前端进包由打包链路的 bundle smoke 与 release-packages 覆盖。
 
 on:
   push:
     branches: [main]
     paths:
       - 'pinvou3-app/src-tauri/**'
-      - 'pinvou3-app/src/**'
+      - 'pinvou3-app/scripts/tauri/**'
       - 'pinvou3-app/package.json'
       - 'pinvou3-app/package-lock.json'
+      - 'pinvou3-app/vite.config.js'
       - 'CodeWhale'
       - '.github/workflows/mac-build.yml'
       - 'scripts/run-mac-verify.sh'
@@ -32,7 +43,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 打包链路检测:仅这些路径变化时才跑 8.6min 的 universal bundle smoke。
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      bundle_chain: ${{ steps.filter.outputs.bundle_chain }}
+    steps:
+      # fetch-depth:0:dorny/paths-filter 在 push 事件下用 before..sha 本地 diff。
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            bundle_chain:
+              - 'pinvou3-app/scripts/tauri/**'
+              - 'pinvou3-app/src-tauri/tauri.conf.json'
+              - 'pinvou3-app/src-tauri/config/**'
+              - 'pinvou3-app/src-tauri/packaging/**'
+              - 'pinvou3-app/src-tauri/resources/**'
+              - 'pinvou3-app/package.json'
+              - 'pinvou3-app/package-lock.json'
+              - 'pinvou3-app/vite.config.js'
+              - 'VERSION'
+              - '.github/workflows/mac-build.yml'
+
   build:
+    needs: changes
     runs-on: macos-15
     timeout-minutes: 50
     env:
@@ -121,10 +161,11 @@ jobs:
         run: cargo build --profile release-fast --target aarch64-apple-darwin --lib
 
       # tauri bundle smoke:验证 dmg/app 实际打包链路(Info.plist/entitlements/资源打包)。
-      # 只在 main push 跑，不作为 PR 检测项。Universal 打包失败会让 mac-build 失败，
-      # 避免主线在没有可发布 arm64 + x86_64 产物时仍显示成功。
-      - name: Tauri bundle smoke (验证 dmg/app 打包,仅 main push)
-        if: github.ref == 'refs/heads/main'
+      # 仅打包链路(bundle_chain)变更时跑(占全量 job 约 50% 耗时,见头部「分层触发」);
+      # 打包链路 PR 合入前由 release-packages 全平台真实打包验证,VERSION bump 全量 dmg。
+      # universal 打包失败会让 mac-build 失败,避免主线在没有可发布 arm64 + x86_64 产物时仍显示成功。
+      - name: Tauri bundle smoke (验证 dmg/app 打包,仅打包链路变更)
+        if: needs.changes.outputs.bundle_chain == 'true'
         working-directory: pinvou3-app
         # universal-apple-darwin 是 Tauri 专属 target(内部跑 aarch64+x86_64 两次 cargo + lipo),
         # 不是合法 rustc target triple;故 cargo check/test/build 仍用 host(aarch64),

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -44,6 +44,11 @@ concurrency:
 
 jobs:
   # 打包链路检测:仅这些路径变化时才跑 8.6min 的 universal bundle smoke。
+  # 注意:bundle_chain 的每条路径都必须被上方 on.push.paths 覆盖,否则是死条目
+  # (workflow 根本不会触发,filter 无从匹配);scripts/tests/test_ci_gate_policy.py
+  # 对此有回归断言。VERSION 刻意不在其中:VERSION-only push 不触发本 workflow
+  # (VERSION bump 的全量 dmg 由 release-packages 构建),而真实版本同步提交必伴随
+  # tauri.conf.json/package.json 变更,经这两条进入 bundle_chain,smoke 不会漏。
   changes:
     name: changes
     runs-on: ubuntu-latest
@@ -68,7 +73,6 @@ jobs:
               - 'pinvou3-app/package.json'
               - 'pinvou3-app/package-lock.json'
               - 'pinvou3-app/vite.config.js'
-              - 'VERSION'
               - '.github/workflows/mac-build.yml'
 
   build:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -12,7 +12,7 @@ name: PR Check
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
 #   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
 #   欠账由清理 PR(#35 及后续)消化后逐个升 deny。
-# - windows-rust-test:只在 main push 跑，不作为 PR 或 Merge Queue 合入门禁。
+# - windows-rust-test:只在 main push 且 rust 相关路径变更时跑，不作为 PR 或 Merge Queue 合入门禁。
 # - windows-codex-runtime-test:相关 PR 在 Windows 原生准备 Node + ACP Bridge，并核对安装包资源。
 # - required-gate:汇总所有适用检查，作为 PR 与 Merge Queue 的唯一 required check。
 # - merge_group:进入 Merge Queue 后基于最新 main 跑完整检查，不要求开放 PR 反复 rebase。
@@ -95,9 +95,11 @@ jobs:
         run: node scripts/sync-version.mjs --check
 
   # PR 按路径选择检查；Merge Queue 对最新 main 组合跑完整检查。
+  # push(main) 也跑:dorny/paths-filter 在 push 下用 before..sha 本地 diff(需 fetch-depth:0),
+  # 供 windows-rust-test 按路径触发(docs-only 推送不再烧 32min Windows runner)。
   changes:
     name: changes
-    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group' }}
+    if: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group' || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -110,9 +112,11 @@ jobs:
       windows_codex: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.windows_codex }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v4
         id: filter
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             rust:
@@ -545,8 +549,11 @@ jobs:
 
   windows-rust-test:
     name: windows-rust-test
-    # 跨平台构建不作为 PR 检测项；合入 main 后再做 Windows 原生验证。
-    if: ${{ github.event_name == 'push' }}
+    needs: changes
+    # 跨平台构建不作为 PR 检测项；合入 main 后按路径做 Windows 原生验证:
+    # 仅 rust 相关改动才跑(docs-only 推送烧 32min Windows runner 零收益——其 cache
+    # shared-key 只被自身消费,不为 PR 提供暖 cache)。
+    if: ${{ !cancelled() && github.event_name == 'push' && needs.changes.outputs.rust == 'true' }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,10 +4,11 @@ name: PR Check
 # - commit-message:强制校验 PR/push/Merge Queue 的 Git commit 信息规范。
 # - version-consistency:强制校验 VERSION 单一事实来源与 SemVer 规则。
 # - fast-gate(秒级,每 PR 都跑):fork-guard 指纹 + fork 合规联动 + Python 确定性测试。
-# - changes:检测本 PR 有没有 Rust/依赖、L1 harness 或前端改动,给编译/前端 job 做 paths filter。
+# - changes:检测本 PR 有没有 Rust 代码、发布契约、L1 harness 或前端改动,给后续 job 做 paths filter。
 # - frontend-test:前端/Relay/WebUI 改动时跑 lint、构建、逻辑测试和浏览器旅程。
-# - rust-test(编译类):**仅当改了 Rust/Cargo/submodule 才跑**(非 Rust PR 直接 skip,不耗
-#   编译时间)。占位 bge-m3 → cargo test --lib(真 bge-m3/vLLM 测试已 #[ignore])。
+# - release-contract-test:发布链路改动只跑配置/脚本契约,不在 PR 构建安装包。
+# - rust-test(编译类):普通 PR 默认不跑;进入 Merge Queue 后基于最新 main 跑完整测试。
+#   高风险 PR 可加 ci:full-rust 标签提前跑,无需等待到入队。
 # - rust-lint:fmt / clippy / cargo-deny 三项硬门禁(均无 continue-on-error),
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
 #   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
@@ -19,14 +20,14 @@ name: PR Check
 #
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
-# - push main 也跑 rust-test:cache 存 main 作用域,所有 PR 都读得到(暖 cache 唯一来源)。
+# - Rust 相关 push main 跑 rust-test:cache 存 main 作用域,供 Merge Queue/显式 PR 复用。
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
 # - sccache(2026-07 补充):rust-cache 只罩第三方依赖;checkout 会刷新仓库内源文件
 #   mtime,cargo 按 mtime 判 dirty,CodeWhale path 依赖 + 主 crate 每轮必重编(~5min)。
 #   sccache 按内容哈希缓存编译产物(GHA cache 后端,scoping 与 actions/cache 一致),
-#   仓库内 crate 源码不变即全命中;main push 恒跑 rust-test 同时充当 sccache 暖源。
+#   仓库内 crate 源码不变即全命中;Rust 相关 main push 同时充当 sccache 暖源。
 #   PR/merge queue 侧 SCCACHE_GHA_RW_MODE=READ_ONLY(对齐 rust-cache save-if 仅 main),
 #   只读暖 cache,不向共享 10GB 配额写入。
 #   接入范围仅 rust-test / windows-rust-test;rust-lint 不接入(见该 job 注释)。
@@ -34,8 +35,9 @@ name: PR Check
 on:
   pull_request:
     branches: [main]
+    # 标签事件用于按需开启/关闭 ci:full-rust。
     # closed 事件会进入同一个 concurrency group，及时取消已合并/关闭 PR 的旧任务。
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened, labeled, unlabeled, closed]
   merge_group:
     types: [checks_requested]
   push:
@@ -45,11 +47,11 @@ permissions:
   contents: read
   pull-requests: read   # dorny/paths-filter 调 API 读 PR 改了哪些文件
 
-# 同一 PR 连续 push 或被合并/关闭时,取消上一次未跑完的检查,省 runner。
-# main push 使用 refs/heads/main 分组，不会被 PR closed 事件取消，仍跑完整 Rust 验证。
+# 同一 PR 连续 push 或被合并/关闭时取消旧检查；main/merge queue 的完整 Rust
+# 验证不取消，避免 cache writer 反复被截断导致后续持续冷编译。
 concurrency:
   group: pr-check-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   commit-message:
@@ -103,7 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      rust: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.rust }}
+      rust_code: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.rust_code }}
+      release_contract: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.release_contract }}
       l1: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.l1 }}
       pet: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.pet }}
       frontend: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.frontend }}
@@ -119,19 +122,36 @@ jobs:
         if: github.event_name != 'merge_group'
         with:
           filters: |
-            rust:
+            rust_code:
               - '**/*.rs'
               - '**/Cargo.toml'
               - '**/Cargo.lock'
-              - '**/tauri.conf.json'
-              - 'pinvou3-app/src-tauri/config/**'
-              - 'pinvou3-app/src-tauri/packaging/**'
-              - 'pinvou3-app/src-tauri/resources/**'
-              - 'pinvou3-app/src/platform/web/access-policy.json'
+              - '**/build.rs'
               - 'CodeWhale'
               - '.gitmodules'
               - '.github/workflows/pr-check.yml'
               - '.github/workflows/mac-build.yml'
+            release_contract:
+              - 'VERSION'
+              - 'scripts/sync-version.mjs'
+              - 'scripts/tests/sync-version.test.mjs'
+              - 'scripts/tests/test_ci_gate_policy.py'
+              - 'scripts/tests/test_release_arm64_policy.py'
+              - '.github/workflows/release-packages.yml'
+              - '.github/workflows/pr-check.yml'
+              - '.github/workflows/mac-build.yml'
+              - '.gitmodules'
+              - 'private-runtimes/windows'
+              - 'pinvou3-app/package.json'
+              - 'pinvou3-app/package-lock.json'
+              - 'pinvou3-app/scripts/tauri/**'
+              - 'pinvou3-app/src-tauri/tauri.conf.json'
+              - 'pinvou3-app/src-tauri/config/**'
+              - 'pinvou3-app/src-tauri/packaging/**'
+              - 'pinvou3-app/src-tauri/resources/**'
+              - 'pinvou3-app/tests/codex_acp_windows_*'
+              - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
+              - 'pinvou3-app/tests/macos_phase2_contract.test.js'
             l1:
               - 'pinvou3-app/src-tauri/tests/l1_dialog_harness.rs'
               - 'pinvou3-app/src-tauri/src/features/assistant/platform/**'
@@ -354,6 +374,34 @@ jobs:
       - name: Relay 回归
         run: npm --prefix remote-control-relay test
 
+  release-contract-test:
+    name: release-contract-test
+    needs: changes
+    # PR 只验证版本同步、Tauri overlay 与各平台打包契约，不生成 deb/dmg/nsis。
+    # Merge Queue 全量执行，确保组合后的 main 仍满足发布契约。
+    if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'merge_group' || needs.changes.outputs.release_contract == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: pinvou3-app/package-lock.json
+
+      - name: 安装前端依赖
+        run: npm --prefix pinvou3-app ci --prefer-offline --no-audit
+
+      - name: 版本与发布配置契约
+        run: |
+          node scripts/sync-version.mjs --check
+          npm --prefix pinvou3-app run test:tauri-layout
+          npm --prefix pinvou3-app run test:tauri-effective-config
+          npm --prefix pinvou3-app run test:web-template-packaging
+          npm --prefix pinvou3-app run test:macos-phase2
+
   # clippy/fmt/deny 独立 job:与 rust-test 并行,各自独立 cache。
   # clippy 用 clippy-driver 编译,产物不能被 cargo test(rustc)复用;在同一 job 里
   # 串行跑会导致依赖图被编译两遍。拆成并行 job 后 wall-clock ≈ max(lint, test)。
@@ -362,7 +410,7 @@ jobs:
   rust-lint:
     name: rust-lint
     needs: changes
-    if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
+    if: ${{ !cancelled() && github.event.action != 'closed' && needs.changes.outputs.rust_code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -426,9 +474,22 @@ jobs:
   rust-test:
     name: rust-test
     needs: changes
-    # PR:只在改了 Rust/Cargo/submodule 时跑;push main:恒跑(暖 cache)。
-    # changes 在 push 时被 skip,需 !cancelled() 才能让本 job 不被连带 skip。
-    if: ${{ !cancelled() && github.event.action != 'closed' && (github.event_name == 'push' || needs.changes.outputs.rust == 'true') }}
+    # 普通 PR 即使改 Rust 也默认跳过，避免评审阶段每次 push 都等完整编译。
+    # Merge Queue 必跑；Rust 相关 main push 跑并写暖 cache；高风险 PR 可用标签提前跑。
+    if: >-
+      ${{
+        !cancelled() &&
+        github.event.action != 'closed' &&
+        (
+          github.event_name == 'merge_group' ||
+          (github.event_name == 'push' && needs.changes.outputs.rust_code == 'true') ||
+          (
+            github.event_name == 'pull_request' &&
+            needs.changes.outputs.rust_code == 'true' &&
+            contains(github.event.pull_request.labels.*.name, 'ci:full-rust')
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     # Tauri + fastembed + aws-lc-sys 全冷编译耗时长;设上限避免卡死 runner 占用
     # (GitHub 默认 6h,此处收紧到 45min,与 mac-build 的 50min 量级一致)。
@@ -529,9 +590,9 @@ jobs:
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1
 
       - name: L1 harness 严格错误回归（不调用真模型）
-        # PR 仅在 harness 相关路径变化时跑；main push 恒跑，保留合并后的完整验证。
+        # Merge Queue/main 完整跑；显式 PR 只在 harness 相关路径变化时追加。
         # 保留 --test-threads=1:仅 3 个 strict_mode_ 测试,harness 本身需串行语义。
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.l1 == 'true' }}
+        if: ${{ github.event_name == 'merge_group' || github.event_name == 'push' || needs.changes.outputs.l1 == 'true' }}
         run: >-
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml
           --test l1_dialog_harness strict_mode_
@@ -553,7 +614,7 @@ jobs:
     # 跨平台构建不作为 PR 检测项；合入 main 后按路径做 Windows 原生验证:
     # 仅 rust 相关改动才跑(docs-only 推送烧 32min Windows runner 零收益——其 cache
     # shared-key 只被自身消费,不为 PR 提供暖 cache)。
-    if: ${{ !cancelled() && github.event_name == 'push' && needs.changes.outputs.rust == 'true' }}
+    if: ${{ !cancelled() && github.event_name == 'push' && needs.changes.outputs.rust_code == 'true' }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 45min:aws-lc-sys(NASM 预生成对象)冷编译比纯 Rust 图更久。
@@ -676,6 +737,7 @@ jobs:
       - fast-gate
       - frontend-test
       - relay-test
+      - release-contract-test
       - rust-lint
       - rust-test
       - macos-codex-runtime-test
@@ -692,6 +754,7 @@ jobs:
           FAST_GATE_RESULT: ${{ needs.fast-gate.result }}
           FRONTEND_RESULT: ${{ needs.frontend-test.result }}
           RELAY_RESULT: ${{ needs.relay-test.result }}
+          RELEASE_CONTRACT_RESULT: ${{ needs.release-contract-test.result }}
           RUST_LINT_RESULT: ${{ needs.rust-lint.result }}
           RUST_RESULT: ${{ needs.rust-test.result }}
           MACOS_CODEX_RESULT: ${{ needs.macos-codex-runtime-test.result }}
@@ -706,6 +769,7 @@ jobs:
           for item in \
             "frontend-test:$FRONTEND_RESULT" \
             "relay-test:$RELAY_RESULT" \
+            "release-contract-test:$RELEASE_CONTRACT_RESULT" \
             "rust-lint:$RUST_LINT_RESULT" \
             "rust-test:$RUST_RESULT" \
             "macos-codex-runtime-test:$MACOS_CODEX_RESULT" \

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -52,12 +52,12 @@ on:
       - 'private-runtimes/windows'
       - 'pinvou3-app/package.json'
       - 'pinvou3-app/package-lock.json'
-      - 'pinvou3-app/scripts/tauri/build.js'
-      - 'pinvou3-app/scripts/tauri/codex-bridge.js'
-      - 'pinvou3-app/scripts/tauri/windows-installer.js'
-      - 'pinvou3-app/scripts/tauri/windows-runtime.js'
-      - 'pinvou3-app/src-tauri/config/platforms/windows/**'
-      - 'pinvou3-app/src-tauri/packaging/windows/**'
+      # 整目录 glob 覆盖 build/codex-bridge/effective-config/windows-* 等全部打包脚本。
+      - 'pinvou3-app/scripts/tauri/**'
+      - 'pinvou3-app/src-tauri/tauri.conf.json'
+      # 覆盖 config/platforms/{windows,linux,macos} 与 packaging/** 全平台发布配置。
+      - 'pinvou3-app/src-tauri/config/**'
+      - 'pinvou3-app/src-tauri/packaging/**'
       - 'pinvou3-app/tests/codex_acp_windows_*'
       - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
   workflow_dispatch:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -52,12 +52,18 @@ on:
       - 'private-runtimes/windows'
       - 'pinvou3-app/package.json'
       - 'pinvou3-app/package-lock.json'
-      # 整目录 glob 覆盖 build/codex-bridge/effective-config/windows-* 等全部打包脚本。
+      # 整目录 glob 覆盖 build/codex-bridge/effective-config/windows-* 等全部打包脚本,
+      # 以及 config/platforms/{windows,linux,macos} 与 packaging/** 全平台发布配置。
       - 'pinvou3-app/scripts/tauri/**'
       - 'pinvou3-app/src-tauri/tauri.conf.json'
-      # 覆盖 config/platforms/{windows,linux,macos} 与 packaging/** 全平台发布配置。
       - 'pinvou3-app/src-tauri/config/**'
       - 'pinvou3-app/src-tauri/packaging/**'
+      # 以下三条字面路径虽已被上方 glob 覆盖,但必须保留:
+      # tests/windows_runtime_packaging_contract.test.js 按字面字符串断言它们在
+      # push 与 pull_request 两处 paths 中各出现一次(私有运行时发布契约)。
+      - 'pinvou3-app/scripts/tauri/windows-runtime.js'
+      - 'pinvou3-app/src-tauri/config/platforms/windows/**'
+      - 'pinvou3-app/src-tauri/packaging/windows/**'
       - 'pinvou3-app/tests/codex_acp_windows_*'
       - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
   workflow_dispatch:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,12 +1,11 @@
 name: release-packages
 
-# VERSION 或发布链路变更时自动构建全平台安装包,挂为 GitHub Actions artifact(保留 90 天)。
+# 仅正式版本或人工明确要求时构建全平台安装包,挂为 GitHub Actions artifact(保留 90 天)。
 #
 # 触发条件:
-# - push main 且 VERSION 或发布链路文件被修改(paths 限定);
-# - 影响版本/打包链路的 PR:构建公开平台产物并运行无私有凭据的 Windows 静态契约;
-# - push 事件按 github.event.before..github.sha 做精确发布链路 diff;
-# - workflow_dispatch 手动触发:跳过 diff,无条件全量构建(用于补打/重打某版本)。
+# - push main 且 VERSION 被修改;
+# - workflow_dispatch 手动触发:无条件全量构建(用于补打/重打或显式验证)。
+# 普通 PR 不进入本工作流；版本/打包脚本的轻量契约由 pr-check.yml 验证。
 #
 # 版本号单一事实来源 = 根目录 VERSION 文件。gate job 先跑
 # scripts/sync-version.mjs --check 校验各处版本文件(tauri.conf.json / Cargo.toml /
@@ -14,8 +13,9 @@ name: release-packages
 # 保证打进包里的任何版本号都来自 VERSION。
 #
 # 与其他 workflow 的分工:
-# - pr-check / mac-build:每次改动跑编译验证 gate(不产出可用产物)。
-# - release-packages(本 workflow):VERSION bump 或发布链路 PR 跑,产出全平台安装包 artifact。
+# - pr-check:PR 快速门禁与发布契约验证(不产出安装包)。
+# - mac-build:相关改动进入 main 后跑 macOS 原生回归。
+# - release-packages(本 workflow):VERSION bump 或人工触发时产出全平台安装包 artifact。
 # - 本 workflow 只上传 CI artifact,绝不创建/推送 GitHub Release,release 由人工填写。
 #
 # 签名:Windows nsis 不签名(config/platforms/windows 无证书配置);macOS ad-hoc
@@ -28,44 +28,6 @@ on:
     branches: [main]
     paths:
       - 'VERSION'
-      - 'scripts/sync-version.mjs'
-      - '.github/workflows/release-packages.yml'
-      - '.gitmodules'
-      - 'private-runtimes/windows'
-      - 'pinvou3-app/package.json'
-      - 'pinvou3-app/package-lock.json'
-      - 'pinvou3-app/scripts/tauri/build.js'
-      - 'pinvou3-app/scripts/tauri/codex-bridge.js'
-      - 'pinvou3-app/scripts/tauri/windows-installer.js'
-      - 'pinvou3-app/scripts/tauri/windows-runtime.js'
-      - 'pinvou3-app/src-tauri/config/platforms/windows/**'
-      - 'pinvou3-app/src-tauri/packaging/windows/**'
-      - 'pinvou3-app/tests/codex_acp_windows_*'
-      - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'VERSION'
-      - 'scripts/sync-version.mjs'
-      - '.github/workflows/release-packages.yml'
-      - '.gitmodules'
-      - 'private-runtimes/windows'
-      - 'pinvou3-app/package.json'
-      - 'pinvou3-app/package-lock.json'
-      # 整目录 glob 覆盖 build/codex-bridge/effective-config/windows-* 等全部打包脚本,
-      # 以及 config/platforms/{windows,linux,macos} 与 packaging/** 全平台发布配置。
-      - 'pinvou3-app/scripts/tauri/**'
-      - 'pinvou3-app/src-tauri/tauri.conf.json'
-      - 'pinvou3-app/src-tauri/config/**'
-      - 'pinvou3-app/src-tauri/packaging/**'
-      # 以下三条字面路径虽已被上方 glob 覆盖,但必须保留:
-      # tests/windows_runtime_packaging_contract.test.js 按字面字符串断言它们在
-      # push 与 pull_request 两处 paths 中各出现一次(私有运行时发布契约)。
-      - 'pinvou3-app/scripts/tauri/windows-runtime.js'
-      - 'pinvou3-app/src-tauri/config/platforms/windows/**'
-      - 'pinvou3-app/src-tauri/packaging/windows/**'
-      - 'pinvou3-app/tests/codex_acp_windows_*'
-      - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
   workflow_dispatch:
 
 permissions:
@@ -73,22 +35,19 @@ permissions:
 
 concurrency:
   group: release-packages-${{ github.ref }}
-  # PR 连续更新时取消旧验证；main 的正式版本构建必须完整保留。
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # 正式产物不可被后续 push 或重复点击中途取消。
+  cancel-in-progress: false
 
 jobs:
-  # ── Job 1: 发布链路变更检测(gate,跑 ubuntu 快) ────────────────────
-  # push 对比事件 before..sha 的实际路径,覆盖一次 push 含多个 commit 的情况。
-  # pull_request / workflow_dispatch 无条件放行,保证发布链路改动在合入前真实打包。
-  # 首次 push 或 before commit 不可达时直接放行,宁可多构建也不漏构建。
-  # 同时用 sync-version.mjs --check 校验三处版本文件与 VERSION 一致,不一致 fail。
+  # ── Job 1: 发布 gate(跑 ubuntu 快) ─────────────────────────────────
+  # 只有 VERSION push 或人工触发能进入本工作流，因此通过版本一致性检查后直接放行。
   check-version-bump:
-    name: 检测发布链路变更
+    name: 校验发布版本
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      build_required: ${{ steps.diff.outputs.build_required }}
-      version: ${{ steps.diff.outputs.version }}
+      build_required: ${{ steps.release.outputs.build_required }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       # fetch-depth:0 确保 push 事件的 before commit 可用于整段 push 范围比较。
       - uses: actions/checkout@v7
@@ -108,40 +67,14 @@ jobs:
       - name: 校验各处版本文件与 VERSION 一致
         run: node scripts/sync-version.mjs --check
 
-      - name: 对比发布链路
-        id: diff
+      - name: 输出发布版本
+        id: release
         run: |
           set -euo pipefail
 
           V=$(tr -d '[:space:]' < VERSION)
           echo "当前 VERSION: $V"
-
-          EVENT_NAME="${{ github.event_name }}"
-          BEFORE="${{ github.event.before }}"
-
-          # PR 改动需要在合入前验证公开产物和静态契约;手动触发用于补打/重打。
-          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "✓ $EVENT_NAME 触发,无条件验证"
-            BUILD_REQUIRED=true
-          # 首次 push 的 before 为全零;强推后 before commit 也可能不可达。
-          elif [ -z "$BEFORE" ] || [[ "$BEFORE" =~ ^0+$ ]] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-            echo "⚠️ before commit 不存在或不可达,放行构建"
-            BUILD_REQUIRED=true
-          else
-            CHANGED_FILES=$(git diff --name-only "$BEFORE" "$GITHUB_SHA")
-            echo "push 变更路径:"
-            printf '%s\n' "$CHANGED_FILES"
-            if printf '%s\n' "$CHANGED_FILES" | grep -Eq \
-              '^(VERSION|scripts/sync-version\.mjs|\.github/workflows/release-packages\.yml|\.gitmodules|private-runtimes/windows|pinvou3-app/(package(-lock)?\.json|scripts/tauri/(build|codex-bridge|windows-installer|windows-runtime)\.js|src-tauri/(config/platforms/windows|packaging/windows)/|tests/(codex_acp_windows_|windows_runtime_packaging_contract\.test\.js)))'; then
-              echo "✓ 发布链路变化,触发构建"
-              BUILD_REQUIRED=true
-            else
-              echo "✗ 未检测到发布链路变化,跳过"
-              BUILD_REQUIRED=false
-            fi
-          fi
-
-          echo "build_required=$BUILD_REQUIRED" >> "$GITHUB_OUTPUT"
+          echo "build_required=true" >> "$GITHUB_OUTPUT"
           echo "version=$V" >> "$GITHUB_OUTPUT"
 
   # ── Job 2: Linux x86_64 deb ─────────────────────────────────────────
@@ -167,7 +100,7 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           shared-key: release-linux-x64
-          # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
+          # 手动分支验证只读，main 正式发布保存。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # pinvou3 编译链接的系统库(gtk/webkit/soup/rsvg/openssl/X11×3/appindicator),
@@ -299,22 +232,8 @@ jobs:
 
       # arm64 原生构建:build.js 检测到 linux/arm64 会自动跑
       # scripts/fetch-linux-arm64-connectors.sh 下载连接器二进制(gitignored)。
-      # GitHub 原生 ARM runner 会在约 40 分钟后被托管服务回收。PR 只验证发布
-      # 链路，因此保留 release 的 opt-level/strip/panic，同时关闭 fat-LTO、
-      # 提高代码生成并行度并使用 lld。
-      - name: 构建 deb（PR 快速验证）
-        if: github.event_name == 'pull_request'
-        working-directory: pinvou3-app
-        env:
-          CARGO_PROFILE_RELEASE_LTO: "false"
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
-          RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
-        run: node scripts/tauri/build.js build --bundles deb
-
-      # main 的 VERSION bump 和 workflow_dispatch 都产出正式发布 artifact，
-      # 必须完整使用 Cargo.toml 的 release profile，不注入 PR 加速参数。
-      - name: 构建 deb（正式发布配置）
-        if: github.event_name != 'pull_request'
+      # VERSION bump 与人工触发都产出正式 artifact，完整使用 release profile。
+      - name: 构建 deb
         working-directory: pinvou3-app
         run: node scripts/tauri/build.js build --bundles deb
 
@@ -340,44 +259,11 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-  # ── Job 4: PR 的 Windows 静态验证(不接触私有凭据) ─────────────────
-  validate-windows-runtime-pr:
-    name: 验证 Windows 私有运行时契约
-    needs: check-version-bump
-    if: github.event_name == 'pull_request' && needs.check-version-bump.outputs.build_required == 'true'
-    runs-on: windows-latest
-    timeout-minutes: 20
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - name: Checkout (不初始化私有 submodule)
-        uses: actions/checkout@v7
-        with:
-          submodules: false
-
-      - name: Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: pinvou3-app/package-lock.json
-
-      - name: 安装前端依赖
-        working-directory: pinvou3-app
-        run: npm ci --prefer-offline --no-audit
-
-      - name: 验证 Windows 打包契约
-        working-directory: pinvou3-app
-        run: |
-          npm run test:windows-runtime
-          npm run test:codex-acp-windows-runtime
-
-  # ── Job 5: Windows x86_64 nsis(仅受保护的非 PR 上下文) ────────────
+  # ── Job 4: Windows x86_64 nsis(仅受保护的 main 上下文) ─────────────
   build-windows-x64:
     name: 构建 Windows x86_64 nsis
     needs: check-version-bump
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && needs.check-version-bump.outputs.build_required == 'true'
+    if: github.ref == 'refs/heads/main' && needs.check-version-bump.outputs.build_required == 'true'
     runs-on: windows-latest
     timeout-minutes: 90
     environment:
@@ -475,7 +361,7 @@ jobs:
           retention-days: 90
           if-no-files-found: error
 
-  # ── Job 6: macOS universal dmg(沿用原 macOS 发布流程的做法) ──────────
+  # ── Job 5: macOS universal dmg(沿用原 macOS 发布流程的做法) ──────────
   build-macos-universal:
     name: 构建 macOS universal dmg
     needs: check-version-bump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,18 @@ Run additional frontend, Relay, Rust, CodeWhale, or platform checks when relevan
 
 Tests requiring a live model, network service, credential, or large model asset must be ignored by default and provide an explicit opt-in command.
 
+## CI and merge queue
+
+Pull requests use a fast, path-aware gate. Release-chain changes run lightweight contract tests only; full deb, dmg, and nsis packages are built only after a `VERSION` change reaches `main`, or through an explicit `workflow_dispatch`.
+
+Full Rust tests run against the latest `main` in the merge queue. Add the `ci:full-rust` label when a high-risk Rust pull request should run them before queueing. During review, maintainers should inspect only required checks:
+
+```bash
+gh pr checks <number> --required
+```
+
+Do not wait for non-required post-merge platform or release builds. Do not repeatedly rebase during review; sync with the latest `main` once when the pull request is ready to enter the merge queue.
+
 ## Pull requests
 
 Review the actual diff against the target branch and complete the quality self-check required by [AGENTS.md](AGENTS.md) before submission.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -79,6 +79,18 @@ cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-thre
 
 依赖真实模型、网络服务、凭据或大型模型资源的测试必须默认忽略，并提供显式启用命令。
 
+## CI 与合并队列
+
+PR 使用按路径选择的快速门禁。发布链路改动只跑轻量契约测试；完整 deb、dmg、nsis 安装包仅在 `VERSION` 改动进入 `main` 后，或人工明确触发 `workflow_dispatch` 时构建。
+
+完整 Rust 测试在 Merge Queue 中基于最新 `main` 执行。高风险 Rust PR 如需提前验证，可添加 `ci:full-rust` 标签。评审阶段只查看 required checks：
+
+```bash
+gh pr checks <编号> --required
+```
+
+不要等待非 required 的合入后平台构建或发布构建；评审期间也不要因 `main` 更新反复 rebase，只在准备进入 Merge Queue 时同步一次最新主线。
+
 ## Pull Request
 
 提交前检查目标分支的实际差异，并完成 [AGENTS.md](AGENTS.md) 要求的质量自检。

--- a/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
+++ b/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
@@ -56,6 +56,7 @@ const installerAdapter = readApp("scripts", "tauri", "windows-installer.js");
 const buildScript = readApp("scripts", "tauri", "build.js");
 const bridgeScript = readApp("scripts", "tauri", "codex-bridge.js");
 const releaseWorkflow = readRepo(".github", "workflows", "release-packages.yml");
+const prWorkflow = readRepo(".github", "workflows", "pr-check.yml");
 
 assert.match(
   gitmodules,
@@ -271,36 +272,40 @@ try {
   fs.rmSync(temporaryRoot, { recursive: true, force: true });
 }
 
-const prValidationJobStart = releaseWorkflow.indexOf(
-  "  validate-windows-runtime-pr:",
-);
 const windowsBuildJobStart = releaseWorkflow.indexOf("  build-windows-x64:");
 const macosBuildJobStart = releaseWorkflow.indexOf(
   "  build-macos-universal:",
 );
-assert.notEqual(prValidationJobStart, -1);
-assert.ok(windowsBuildJobStart > prValidationJobStart);
+assert.ok(windowsBuildJobStart >= 0);
 assert.ok(macosBuildJobStart > windowsBuildJobStart);
 
-const prValidationJob = releaseWorkflow.slice(
-  prValidationJobStart,
-  windowsBuildJobStart,
-);
 const windowsBuildJob = releaseWorkflow.slice(
   windowsBuildJobStart,
   macosBuildJobStart,
 );
-assert.match(prValidationJob, /github\.event_name == 'pull_request'/);
-assert.match(prValidationJob, /npm run test:windows-runtime/);
-assert.match(prValidationJob, /npm run test:codex-acp-windows-runtime/);
-assert.match(prValidationJob, /submodules: false/);
+const windowsPrValidationStart = prWorkflow.indexOf(
+  "  windows-codex-runtime-test:",
+);
+const macosPrValidationStart = prWorkflow.indexOf(
+  "  macos-codex-runtime-test:",
+);
+assert.ok(windowsPrValidationStart >= 0);
+assert.ok(macosPrValidationStart > windowsPrValidationStart);
+const prValidationJob = prWorkflow.slice(
+  windowsPrValidationStart,
+  macosPrValidationStart,
+);
+assert.match(prValidationJob, /npm --prefix pinvou3-app run test:windows-runtime/);
+assert.match(
+  prValidationJob,
+  /npm --prefix pinvou3-app run test:codex-acp-windows-runtime/,
+);
 assert.doesNotMatch(
   prValidationJob,
   /PINVOU3_WINDOWS_RUNTIME_TOKEN|secrets\./,
   "PR validation must never reference private credentials",
 );
 
-assert.match(windowsBuildJob, /github\.event_name != 'pull_request'/);
 assert.match(windowsBuildJob, /github\.ref == 'refs\/heads\/main'/);
 assert.match(windowsBuildJob, /environment:\s*\n\s*name: windows-release/);
 assert.match(windowsBuildJob, /PINVOU3_WINDOWS_RUNTIME_TOKEN/);
@@ -315,29 +320,35 @@ assert.doesNotMatch(
   "protected Windows builds must not fall back to a reduced PR path",
 );
 
+assert.doesNotMatch(
+  releaseWorkflow,
+  /^\s{2}pull_request:/mu,
+  "full release packaging must never run automatically for pull requests",
+);
+assert.match(
+  releaseWorkflow,
+  /push:\s*\n\s+branches: \[main\]\s*\n\s+paths:\s*\n\s+- 'VERSION'/,
+);
+
 for (const triggerPath of [
   ".gitmodules",
   "private-runtimes/windows",
   "pinvou3-app/package-lock.json",
-  "pinvou3-app/scripts/tauri/windows-runtime.js",
-  "pinvou3-app/src-tauri/config/platforms/windows/**",
-  "pinvou3-app/src-tauri/packaging/windows/**",
+  "pinvou3-app/scripts/tauri/**",
+  "pinvou3-app/src-tauri/config/**",
+  "pinvou3-app/src-tauri/packaging/**",
   "pinvou3-app/tests/windows_runtime_packaging_contract.test.js",
 ]) {
   const escapedPath = triggerPath.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const occurrences = releaseWorkflow.match(new RegExp(escapedPath, "gu")) ?? [];
+  const occurrences = prWorkflow.match(new RegExp(escapedPath, "gu")) ?? [];
   assert.ok(
-    occurrences.length >= 2,
-    `${triggerPath} must trigger both pull_request and push builds`,
+    occurrences.length >= 1,
+    `${triggerPath} must trigger the lightweight PR contract gate`,
   );
 }
 assert.match(
   releaseWorkflow,
-  /git diff --name-only "\$BEFORE" "\$GITHUB_SHA"/,
-);
-assert.match(
-  releaseWorkflow,
-  /build_required: \$\{\{ steps\.diff\.outputs\.build_required \}\}/,
+  /build_required: \$\{\{ steps\.release\.outputs\.build_required \}\}/,
 );
 
 console.log("Windows private runtime packaging contract: ok");

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -5,6 +5,27 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PR_WORKFLOW = ROOT / ".github/workflows/pr-check.yml"
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
+MAC_WORKFLOW = ROOT / ".github/workflows/mac-build.yml"
+
+
+def _extract_quoted_paths(block):
+    """提取 YAML 块中 `- 'path'` 形式的路径条目(保持文本序)。"""
+    paths = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- '") and stripped.endswith("'"):
+            paths.append(stripped[3:-1])
+    return paths
+
+
+def _is_covered_by_trigger(entry, trigger_paths):
+    """entry 被 trigger path 覆盖:完全相同,或 trigger 是其上层 `/**` 目录 glob。"""
+    for trigger in trigger_paths:
+        if entry == trigger:
+            return True
+        if trigger.endswith("/**") and entry.startswith(trigger[:-2]):
+            return True
+    return False
 
 
 class CiGatePolicyTests(unittest.TestCase):
@@ -67,6 +88,31 @@ class CiGatePolicyTests(unittest.TestCase):
             "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
             concurrency,
         )
+
+    def test_mac_bundle_chain_paths_are_reachable_by_workflow_trigger(self):
+        # mac-build 的 bundle_chain filter 决定何时追加 universal bundle smoke。
+        # filter 只在该 workflow 被触发后才有机会匹配,因此 bundle_chain 的每条
+        # 路径都必须被 on.push.paths 覆盖;不被覆盖的条目永远不会命中(死条目),
+        # 会误导读者以为该路径变更会跑 smoke(例如 VERSION:VERSION-only push
+        # 不触发 mac-build,版本同步提交经 tauri.conf.json/package.json 进入)。
+        mac_workflow = MAC_WORKFLOW.read_text(encoding="utf-8")
+        trigger_block = mac_workflow.split("\non:", maxsplit=1)[1].split(
+            "\npermissions:", maxsplit=1
+        )[0]
+        trigger_paths = _extract_quoted_paths(trigger_block)
+        self.assertTrue(trigger_paths, "mac-build on.push.paths 解析为空")
+
+        bundle_chain_block = mac_workflow.split(
+            "\n            bundle_chain:", maxsplit=1
+        )[1].split("\n\n", maxsplit=1)[0]
+        bundle_chain_paths = _extract_quoted_paths(bundle_chain_block)
+        self.assertTrue(bundle_chain_paths, "mac-build bundle_chain 解析为空")
+
+        for entry in bundle_chain_paths:
+            self.assertTrue(
+                _is_covered_by_trigger(entry, trigger_paths),
+                f"bundle_chain 路径不被 on.push.paths 覆盖(死条目): {entry}",
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -1,0 +1,73 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PR_WORKFLOW = ROOT / ".github/workflows/pr-check.yml"
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
+
+
+class CiGatePolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pr_workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+        cls.release_workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_full_release_only_runs_for_version_or_manual_trigger(self):
+        trigger = self.release_workflow.split("\non:", maxsplit=1)[1].split(
+            "\npermissions:", maxsplit=1
+        )[0]
+        self.assertNotIn("pull_request:", trigger)
+        self.assertIn("push:", trigger)
+        self.assertIn("paths:\n      - 'VERSION'", trigger)
+        self.assertIn("workflow_dispatch:", trigger)
+        self.assertIn("cancel-in-progress: false", self.release_workflow)
+
+    def test_pull_request_has_lightweight_release_contract_gate(self):
+        self.assertIn("release_contract:", self.pr_workflow)
+        self.assertIn("  release-contract-test:", self.pr_workflow)
+        self.assertIn(
+            "needs.changes.outputs.release_contract == 'true'",
+            self.pr_workflow,
+        )
+        required_gate = self.pr_workflow.split(
+            "\n  required-gate:", maxsplit=1
+        )[1]
+        self.assertIn("- release-contract-test", required_gate)
+        self.assertIn(
+            '"release-contract-test:$RELEASE_CONTRACT_RESULT"',
+            required_gate,
+        )
+
+    def test_full_rust_runs_in_merge_queue_or_by_explicit_label(self):
+        self.assertIn("merge_group:", self.pr_workflow)
+        self.assertIn("ci:full-rust", self.pr_workflow)
+        rust_test = self.pr_workflow.split("\n  rust-test:", maxsplit=1)[1].split(
+            "\n  windows-rust-test:", maxsplit=1
+        )[0]
+        self.assertIn("github.event_name == 'merge_group'", rust_test)
+        self.assertIn(
+            "contains(github.event.pull_request.labels.*.name, 'ci:full-rust')",
+            rust_test,
+        )
+        self.assertIn(
+            "github.event_name == 'push' && needs.changes.outputs.rust_code == 'true'",
+            rust_test,
+        )
+        self.assertNotIn(
+            "github.event_name == 'push' || needs.changes.outputs.rust_code == 'true'",
+            rust_test,
+        )
+
+    def test_main_cache_writer_is_not_cancelled(self):
+        concurrency = self.pr_workflow.split(
+            "\nconcurrency:", maxsplit=1
+        )[1].split("\njobs:", maxsplit=1)[0]
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            concurrency,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_arm64_policy.py
+++ b/scripts/tests/test_release_arm64_policy.py
@@ -8,36 +8,33 @@ RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
 
 class ReleaseArm64PolicyTests(unittest.TestCase):
     def setUp(self):
-        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        self.arm64_job = workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
+        self.workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.arm64_job = self.workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
             "\n  build-windows-x64:", maxsplit=1
         )[0]
 
-    def test_arm64_pr_validation_uses_fast_link_profile(self):
-        pr_build = self.arm64_job.split(
-            "\n      - name: 构建 deb（PR 快速验证）", maxsplit=1
-        )[1].split("\n      - name: 构建 deb（正式发布配置）", maxsplit=1)[0]
+    def test_release_workflow_does_not_run_for_pull_requests(self):
+        self.assertNotIn("\n  pull_request:", self.workflow)
+        self.assertIn("\n  workflow_dispatch:", self.workflow)
+        trigger = self.workflow.split("\non:", maxsplit=1)[1].split(
+            "\npermissions:", maxsplit=1
+        )[0]
+        self.assertIn("paths:\n      - 'VERSION'", trigger)
 
-        self.assertIn("if: github.event_name == 'pull_request'", pr_build)
-        self.assertIn('CARGO_PROFILE_RELEASE_LTO: "false"', pr_build)
-        self.assertIn('CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"', pr_build)
-        self.assertIn('RUSTFLAGS: "-C link-arg=-fuse-ld=lld"', pr_build)
-        self.assertIn("build-essential pkg-config cmake lld", self.arm64_job)
-
-    def test_arm64_formal_release_keeps_full_release_profile(self):
+    def test_arm64_build_keeps_full_release_profile(self):
         job_env = self.arm64_job.split("\n    steps:", maxsplit=1)[0]
-        formal_build = self.arm64_job.split(
-            "\n      - name: 构建 deb（正式发布配置）", maxsplit=1
+        build = self.arm64_job.split(
+            "\n      - name: 构建 deb", maxsplit=1
         )[1].split("\n      # tauri deb 产物默认名", maxsplit=1)[0]
 
-        self.assertIn("if: github.event_name != 'pull_request'", formal_build)
+        self.assertIn("build-essential pkg-config cmake lld", self.arm64_job)
         for setting in (
             "CARGO_PROFILE_RELEASE_LTO",
             "CARGO_PROFILE_RELEASE_CODEGEN_UNITS",
             "RUSTFLAGS",
         ):
             self.assertNotIn(setting, job_env)
-            self.assertNotIn(setting, formal_build)
+            self.assertNotIn(setting, build)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概述

将日常 PR 门禁、合并前完整验证和正式发布构建拆成三层，减少评审阶段误触发安装包构建及反复等待完整 Rust 测试的时间。

## 背景

现有 `release-packages` 会被普通发布链路 PR 触发，`rust-test` 也会在每次 Rust PR 更新后执行；这让 PR 评估与合并频繁等待长任务，并消耗不必要的 Linux、Windows、macOS runner。

## 变更

- 普通 PR 只跑按路径选择的快速门禁；发布链路改动改为轻量契约测试，不生成 deb、dmg、nsis。
- 完整 Rust 测试移至 Merge Queue；高风险 Rust PR 可添加 `ci:full-rust` 标签提前运行。
- `release-packages` 仅在 `VERSION` 进入 `main` 或人工 `workflow_dispatch` 时运行，正式产物不再被普通 PR 触发。
- Rust 相关 main push 继续写入共享 cache，且不再被后续 main push 中途取消。
- macOS main 构建按路径分层，纯前端改动不触发，只有打包链路改动才追加 universal bundle smoke。
- DCO 对 merge commit 豁免，普通人工提交仍要求 Signed-off-by。
- 补充 CI 策略回归测试、Windows 发布契约测试及中英文贡献流程说明。

## 验证

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`（27 项通过）
- `npm --prefix pinvou3-app test`（通过）
- `node scripts/tests/sync-version.test.mjs`（通过）
- `node scripts/sync-version.mjs --check`（通过）
- `python3 scripts/architecture-guard.py`（通过，仅既有大文件告警）
- `./scripts/fork-guard.sh --fast`（通过）
- 全部 `.github/workflows/*.yml` YAML 解析通过
- `git diff --check`（通过）

## 备注

- 本 PR 合入后再启用仓库 Merge Queue；启用前不会改变当前分支保护行为。
- `mac-build` 与正式发布构建均不是 PR required check，评审和合并不需要等待。