### PR TITLE
fix(ci): 补齐合并队列必需检查触发

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,6 +3,8 @@ name: DCO
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -13,7 +15,14 @@ jobs:
     name: Signed-off commits
     runs-on: ubuntu-latest
     steps:
+      # 进入 Merge Queue 前，每个 PR 已通过本 required check。merge_group 中只包含
+      # GitHub 生成的组合提交，此处复用同名 check 上报成功，避免队列等待缺失上下文。
+      - name: 确认队列中的 PR 已通过 DCO
+        if: github.event_name == 'merge_group'
+        run: echo "DCO 已在各 PR 入队前验证"
+
       - name: Verify DCO sign-offs
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,8 @@ name: dependency-review
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -14,6 +16,9 @@ jobs:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
+          # dependency-review-action 对非 pull_request 事件需要显式 base/head。
+          base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
+          head-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || '' }}
           fail-on-severity: high
           vulnerability-check: true
           license-check: true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,6 +2,8 @@ name: secret-scan
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [main]
 

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -6,6 +6,12 @@ ROOT = Path(__file__).resolve().parents[2]
 PR_WORKFLOW = ROOT / ".github/workflows/pr-check.yml"
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
 MAC_WORKFLOW = ROOT / ".github/workflows/mac-build.yml"
+REQUIRED_WORKFLOWS = (
+    ROOT / ".github/workflows/dco.yml",
+    ROOT / ".github/workflows/secret-scan.yml",
+    ROOT / ".github/workflows/dependency-review.yml",
+    PR_WORKFLOW,
+)
 
 
 def _extract_quoted_paths(block):
@@ -88,6 +94,24 @@ class CiGatePolicyTests(unittest.TestCase):
             "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
             concurrency,
         )
+
+    def test_all_required_workflows_report_on_merge_group(self):
+        for workflow_path in REQUIRED_WORKFLOWS:
+            workflow = workflow_path.read_text(encoding="utf-8")
+            trigger = workflow.split("\non:", maxsplit=1)[1].split(
+                "\npermissions:", maxsplit=1
+            )[0]
+            self.assertIn(
+                "merge_group:",
+                trigger,
+                f"{workflow_path.name} 缺少 Merge Queue 触发",
+            )
+
+        dependency_review = (
+            ROOT / ".github/workflows/dependency-review.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("github.event.merge_group.base_sha", dependency_review)
+        self.assertIn("github.event.merge_group.head_sha", dependency_review)
 
     def test_mac_bundle_chain_paths_are_reachable_by_workflow_trigger(self):
         # mac-build 的 bundle_chain filter 决定何时追加 universal bundle smoke。


### PR DESCRIPTION
## 概述

补齐 Merge Queue 所需的 required check 触发，避免队列创建 `merge_group` 后永久等待 DCO、Gitleaks 或 dependency-review 上报。

## 背景

PR #95 已让 `required-gate` 支持 `merge_group`，但当前主线另外三个 required workflows 仍只监听 `pull_request`。GitHub Merge Queue 要求所有 required checks 都在 `merge_group` 上报告结果，因此必须先补齐再启用仓库规则。

## 变更

- DCO 在 `merge_group` 上复用入队前已通过的 PR 级校验结果，并保持普通 PR 的逐提交签署检查不变。
- Gitleaks 在 `merge_group` 的组合提交上重新扫描。
- dependency-review 在 `merge_group` 上显式传入 base/head SHA。
- CI 策略测试新增 required workflows 的 `merge_group` 覆盖断言。

## 验证

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`（29 项通过）
- 全部 `.github/workflows/*.yml` YAML 解析通过
- `python3 scripts/architecture-guard.py`（通过，仅既有大文件告警）
- `./scripts/fork-guard.sh --fast`（通过）
- `git diff --check`（通过）

## 备注

本 PR 不改应用代码、发布触发或现有 required checks，只让它们能在 Merge Queue 上正常报告。