### PR TITLE
fix(acp): 修复开发启动误用旧 Bridge

### DIFF
--- a/pinvou3-app/run-dev.sh
+++ b/pinvou3-app/run-dev.sh
@@ -6,19 +6,9 @@ cd "$(dirname "$0")"
 OS_NAME="$(uname -s)"
 
 # Linux/macOS 开发环境自动准备与正式包一致的应用隔离 Node + 精简 ACP Bridge。生成物被
-# gitignore；已有完整 Bridge 时不重复下载和安装。
+# gitignore；完整性判断统一交给准备脚本，避免新增 Agent 后开发入口仍把旧 Runtime 误判为可用。
 if [ "$OS_NAME" = "Linux" ] || [ "$OS_NAME" = "Darwin" ]; then
-  if [ "$OS_NAME" = "Linux" ]; then
-    BRIDGE_PLATFORM_DIR="linux"
-  else
-    BRIDGE_PLATFORM_DIR="macos"
-  fi
-  BRIDGE_NODE="src-tauri/resources/platforms/$BRIDGE_PLATFORM_DIR/codex-bridge/node/bin/node"
-  BRIDGE_ENTRY="src-tauri/resources/platforms/$BRIDGE_PLATFORM_DIR/codex-bridge/acp/node_modules/@agentclientprotocol/codex-acp/dist/index.js"
-  if [ ! -x "$BRIDGE_NODE" ] || [ ! -f "$BRIDGE_ENTRY" ]; then
-    echo "正在准备 Codex ACP Bridge(dev)..."
-    ./scripts/prepare-codex-bridge-runtime.sh
-  fi
+  ./scripts/prepare-codex-bridge-runtime.sh
 fi
 
 # 注:源 workflows/ → bundle 嵌入快照的同步已移入 build.rs(任何 cargo build/打包都同步,

--- a/pinvou3-app/tests/codex_acp_platform_contract.test.js
+++ b/pinvou3-app/tests/codex_acp_platform_contract.test.js
@@ -12,6 +12,7 @@ const windows = read(...featureRoot, "platform", "windows.rs");
 const linux = read(...featureRoot, "platform", "linux.rs");
 const macos = read(...featureRoot, "platform", "macos.rs");
 const prepareBridge = read("scripts", "prepare-codex-bridge-runtime.sh");
+const runDev = read("run-dev.sh");
 
 for (const os of ["windows", "linux", "macos"]) {
   assert.match(
@@ -55,6 +56,16 @@ assert.match(prepareBridge, /npm_ci_for_target "\$ACP_ROOT" darwin arm64/);
 assert.match(prepareBridge, /npm_ci_for_target "\$ACP_X64_ROOT" darwin x64/);
 assert.match(prepareBridge, /claude-agent-sdk-darwin-arm64/);
 assert.match(prepareBridge, /claude-agent-sdk-darwin-x64/);
+assert.match(
+  runDev,
+  /if \[ "\$OS_NAME" = "Linux" \] \|\| \[ "\$OS_NAME" = "Darwin" \]; then\s+\.\/scripts\/prepare-codex-bridge-runtime\.sh\s+fi/,
+  "dev startup must delegate the complete ACP Bridge readiness check to the preparation script",
+);
+assert.doesNotMatch(
+  runDev,
+  /BRIDGE_(?:NODE|ENTRY)=/,
+  "dev startup must not duplicate a partial Bridge readiness check",
+);
 assert.match(feature, /run_brew\(&\["install", "--cask", "codex"\]\)/);
 assert.match(feature, /run_brew\(&\["upgrade", "--cask", "codex"\]\)/);
 assert.doesNotMatch(feature, /brew (?:install|upgrade) codex/);


### PR DESCRIPTION
## 背景

同步接入 Claude Code 的最新代码后，开发工作区可能仍保留被 Git 忽略的旧 Codex-only Bridge。run-dev.sh 只检查 Node 和 Codex 入口，会误判旧 Runtime 已就绪，导致 Claude Code 显示 Agent 尚未就绪。

## 变更

- Linux/macOS 开发启动统一调用完整 Bridge 准备脚本，由单一入口校验 Codex、Claude adapter、Claude 原生 Runtime 和 Node
- 增加契约断言，禁止 run-dev.sh 再次维护不完整的 Bridge 就绪检查

## 实际验证

- bash -n pinvou3-app/run-dev.sh pinvou3-app/scripts/prepare-codex-bridge-runtime.sh
- npm --prefix pinvou3-app run test:codex-acp
- python3 scripts/architecture-guard.py
- git diff --check
- 本地重建并验证 Node 22.22.0、Codex ACP 1.1.5、Claude ACP 0.62.0、Claude Code 2.1.219
- 重复执行准备命令可直接复用现有完整 Runtime，开发应用已正常启动，Claude 登录状态正常

## 风险

仅影响 Linux/macOS 开发启动流程。完整 Runtime 已存在时准备脚本会快速退出；正式打包行为不变。