### PR TITLE
fix(markdown): 完善代码高亮性能与主题覆盖

### DIFF
--- a/pinvou3-app/package-lock.json
+++ b/pinvou3-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.7.1",
       "dependencies": {
         "dompurify": "^3.4.12",
+        "highlight.js": "^11.11.1",
         "marked": "^13.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1384,6 +1385,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ignore": {

--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -69,7 +69,7 @@
     "test:design-runtime": "node tests/design_runtime_logic.test.js",
     "test:design-changes": "node tests/design_changes_logic.test.js",
     "test:scene-capabilities": "node tests/scene_capabilities_logic.test.js",
-    "test": "npm run test:update-notice && npm run test:diff-parser && npm run test:marketplace-oauth && npm run test:composer-tools && npm run test:codex-acp && npm run test:model-reasoning && npm run test:session-management && npm run test:pinvou-mode-state && npm run test:design-runtime && npm run test:design-changes && npm run test:scene-capabilities && npm run test:chat-input-limit && npm run test:chat-error-isolation && npm run test:attachment-drop && npm run test:voice-input && npm run test:voice-asr-cancel && npm run test:bridge-protocol && npm run test:web-access-contract && npm run test:web-access-desktop-proxy && npm run test:web-asset-base-path && npm run test:ui-language && npm run test:web-bootstrap && npm run test:api-key-gate && npm run test:artifact-deliverable && npm run test:scheduled && npm run test:windows-runtime && npm run test:workflow-scheduler-contract && npm run test:tauri-layout && npm run test:tauri-effective-config && npm run test:web-template-packaging && npm run test:macos-phase2 && npm run test:pet-animation && npm run test:pet-registry && npm run test:pet-active && npm run test:pet-selector-contract && npm run test:pet-state && npm run test:pet-card-state && npm run test:pet-reply && npm run test:pet-scheduled-notice && npm run test:pet-interaction && npm run test:pet-activation-guard && npm run test:pet-navigation && npm run test:pet-bootstrap && npm run validate:pet-assets",
+    "test": "npm run test:update-notice && npm run test:diff-parser && npm run test:markdown && npm run test:marketplace-oauth && npm run test:composer-tools && npm run test:codex-acp && npm run test:model-reasoning && npm run test:session-management && npm run test:pinvou-mode-state && npm run test:design-runtime && npm run test:design-changes && npm run test:scene-capabilities && npm run test:chat-input-limit && npm run test:chat-error-isolation && npm run test:attachment-drop && npm run test:voice-input && npm run test:voice-asr-cancel && npm run test:bridge-protocol && npm run test:web-access-contract && npm run test:web-access-desktop-proxy && npm run test:web-asset-base-path && npm run test:ui-language && npm run test:web-bootstrap && npm run test:api-key-gate && npm run test:artifact-deliverable && npm run test:scheduled && npm run test:windows-runtime && npm run test:workflow-scheduler-contract && npm run test:tauri-layout && npm run test:tauri-effective-config && npm run test:web-template-packaging && npm run test:macos-phase2 && npm run test:pet-animation && npm run test:pet-registry && npm run test:pet-active && npm run test:pet-selector-contract && npm run test:pet-state && npm run test:pet-card-state && npm run test:pet-reply && npm run test:pet-scheduled-notice && npm run test:pet-interaction && npm run test:pet-activation-guard && npm run test:pet-navigation && npm run test:pet-bootstrap && npm run validate:pet-assets",
     "test:ui-smoke": "node tests/ui_smoke.js",
     "test:settings-ui": "node tests/settings_ui_smoke.js",
     "test:kb-smoke": "node tests/kb_smoke.js",
@@ -78,7 +78,7 @@
     "test:design-mode-entry-smoke": "node tests/design_mode_entry_smoke.js",
     "test:bridge-smoke": "npm run test:ui-smoke && npm run test:settings-ui && npm run test:kb-smoke && npm run test:composer-tools-smoke && npm run test:design-mode-entry-smoke && npm run test:tool-store",
     "test:webui": "npm run build:web && node ../remote-control-relay/test/web-ui.smoke.cjs",
-    "test:markdown": "node tests/render_markdown_smoke.js",
+    "test:markdown": "node tests/render_markdown_smoke.js && node tests/markdown_syntax_highlight.test.mjs",
     "test:user-journey": "../scripts/run-user-journey-tests.sh",
     "sync:version": "node ../scripts/sync-version.mjs"
   },
@@ -91,6 +91,7 @@
   },
   "dependencies": {
     "dompurify": "^3.4.12",
+    "highlight.js": "^11.11.1",
     "marked": "^13.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -14,6 +14,7 @@ import { dict, LANG_TO_TAG, SEARCH_KEY_PROVIDERS, TAG_TO_LANG } from '../shared/
 import { formatSessionDate, localDateKey, formatDateGroupLabel } from '../shared/date-utils.js';
 import { runSessionBatch, sessionRoute } from '../shared/session-management.js';
 import { can, isWeb } from '../shared/platform.js';
+import { installGlobalMarkdownRenderer } from '../shared/markdown-renderer.js';
 import { KnowledgeView } from '../features/knowledge/KnowledgeView.jsx';
 import { MonitorView } from '../features/monitor/MonitorView.jsx';
 import { SettingsView, WebAccessModal } from '../features/settings/SettingsView.jsx';
@@ -50,6 +51,7 @@ import { PinvouSummonCard } from '../features/tools/tool-renderers.jsx';
 import { CardPoolView, Lanyard, PersonaEditorModal } from '../features/personas/Personas.jsx';
 import { WorkflowView } from '../features/workflow/WorkflowView.jsx';
 
+installGlobalMarkdownRenderer(window);
 window.__PINVOU_STARTUP__.mark('app:main_module_body_enter');
 
 let appFirstRenderMarked = false;

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
+import { renderMarkdown } from '../../shared/markdown-renderer.js';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -108,10 +107,7 @@ function localizedSemanticLabel(value, copy) {
 }
 
 export function ConversationMarkdown({ text, className = '', onOpenExternal }) {
-  const html = useMemo(() => DOMPurify.sanitize(marked.parse(String(text || '')), {
-    USE_PROFILES: { html: true },
-    FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed'],
-  }), [text]);
+  const html = useMemo(() => renderMarkdown(text), [text]);
   const openLink = (event) => {
     const anchor = event.target && event.target.closest && event.target.closest('a[href]');
     if (!anchor) return;

--- a/pinvou3-app/src/features/personas/Personas.jsx
+++ b/pinvou3-app/src/features/personas/Personas.jsx
@@ -125,7 +125,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
               <p className="text-[12px] uppercase mb-2" style={{ color:'#8E8E93' }}>{t.cpFullBody}</p>
               {body===null
                 ? <div className="text-[14px] py-8 text-center" style={{ color:'#8E8E93' }}>{t.cpBodyLoading}</div>
-                : <div className="persona-body text-[14px] leading-relaxed" style={{ color: isDark?'#C7C7CC':'#1C1C1E' }} dangerouslySetInnerHTML={{ __html: bridge.rendering.renderMarkdown ? bridge.rendering.renderMarkdown(body) : body }} />}
+                : <div className={`persona-body text-[14px] leading-relaxed ${isDark ? 'dark-code' : 'light-code'}`} style={{ color: isDark?'#C7C7CC':'#1C1C1E' }} dangerouslySetInnerHTML={{ __html: bridge.rendering.renderMarkdown ? bridge.rendering.renderMarkdown(body) : body }} />}
             </div>
             {/* 加持/取消 */}
             <div className="p-4 shrink-0" style={{ borderTop:'1px solid '+(isDark?'#38383A':'rgba(198,198,200,.5)') }}>

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -108,6 +108,9 @@
     return html.replace(DANGEROUS_TAGS_RE, function (_, inner) { return "&lt;" + inner + "&gt;"; });
   }
   function renderMarkdown(text) {
+    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
+      return window.PinvouMarkdownRenderer.renderMarkdown(text);
+    }
     if (!window.marked || !window.DOMPurify) return escapeHtml(text);
     var html = neutralizeRawDangerousTags(marked.parse(text || ""));
     return DOMPurify.sanitize(html, {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -56,6 +56,9 @@
     return html.replace(DANGEROUS_TAGS_RE, function (_, inner) { return "&lt;" + inner + "&gt;"; });
   }
   function renderMarkdown(text) {
+    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
+      return window.PinvouMarkdownRenderer.renderMarkdown(text);
+    }
     if (!window.marked || !window.DOMPurify) return escapeHtml(text);
     var html = neutralizeRawDangerousTags(marked.parse(text || ""));
     return DOMPurify.sanitize(html, {

--- a/pinvou3-app/src/shared/markdown-renderer.js
+++ b/pinvou3-app/src/shared/markdown-renderer.js
@@ -1,0 +1,73 @@
+import createDOMPurify from 'dompurify';
+import { Marked } from 'marked';
+import { escapeCodeHtml, highlightCode } from './syntax-highlighter.js';
+
+const DANGEROUS_TAGS_RE = /<(\/?(?:script|style|iframe|object|embed|link|meta)\b[^>]*)>/giu;
+const SANITIZE_OPTIONS = {
+  USE_PROFILES: { html: true },
+  FORBID_TAGS: ['style', 'iframe', 'object', 'embed', 'link', 'meta'],
+  FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
+};
+
+let purifier;
+function getPurifier() {
+  if (purifier) return purifier;
+  if (typeof createDOMPurify.sanitize === 'function') {
+    purifier = createDOMPurify;
+  } else if (typeof window !== 'undefined') {
+    purifier = createDOMPurify(window);
+  }
+  return purifier;
+}
+
+function neutralizeRawDangerousTags(html) {
+  return html.replace(DANGEROUS_TAGS_RE, (_, inner) => `&lt;${inner}&gt;`);
+}
+
+function fencedCodeIsClosed(token) {
+  const opening = String(token.raw || '').match(/^\s*(`{3,}|~{3,})/u);
+  if (!opening) return true;
+  const fence = opening[1];
+  const closing = new RegExp(`(?:^|\\n)\\s*${fence[0]}{${fence.length},}\\s*$`, 'u');
+  return closing.test(String(token.raw || '').trimEnd());
+}
+
+const markdown = new Marked({
+  gfm: true,
+  breaks: true,
+  headerIds: false,
+  mangle: false,
+});
+
+markdown.use({
+  useNewRenderer: true,
+  renderer: {
+    code(token) {
+      const result = highlightCode(token.text, token.lang, {
+        allowAutoDetect: fencedCodeIsClosed(token),
+      });
+      const language = escapeCodeHtml(result.language);
+      const languageId = escapeCodeHtml(result.languageId);
+      const label = escapeCodeHtml(result.label);
+      return `<pre class="pinvou-code-block" data-language="${label}" data-language-id="${languageId}"><code class="hljs language-${language}">${result.html}</code></pre>\n`;
+    },
+  },
+});
+
+export function renderMarkdownMarkup(text) {
+  return neutralizeRawDangerousTags(markdown.parse(String(text || '')));
+}
+
+export function renderMarkdown(text) {
+  const html = renderMarkdownMarkup(text);
+  const domPurify = getPurifier();
+  if (!domPurify || typeof domPurify.sanitize !== 'function') {
+    return escapeCodeHtml(String(text || ''));
+  }
+  return domPurify.sanitize(html, SANITIZE_OPTIONS);
+}
+
+export function installGlobalMarkdownRenderer(target = window) {
+  target.PinvouMarkdownRenderer = Object.freeze({ renderMarkdown });
+  return target.PinvouMarkdownRenderer;
+}

--- a/pinvou3-app/src/shared/markdown-renderer.js
+++ b/pinvou3-app/src/shared/markdown-renderer.js
@@ -43,8 +43,10 @@ markdown.use({
   useNewRenderer: true,
   renderer: {
     code(token) {
+      const fenceClosed = fencedCodeIsClosed(token);
       const result = highlightCode(token.text, token.lang, {
-        allowAutoDetect: fencedCodeIsClosed(token),
+        allowHighlight: fenceClosed,
+        allowAutoDetect: fenceClosed,
       });
       const language = escapeCodeHtml(result.language);
       const languageId = escapeCodeHtml(result.languageId);

--- a/pinvou3-app/src/shared/syntax-highlighter.js
+++ b/pinvou3-app/src/shared/syntax-highlighter.js
@@ -1,0 +1,253 @@
+import hljs from 'highlight.js/lib/core';
+import accesslog from 'highlight.js/lib/languages/accesslog';
+import apache from 'highlight.js/lib/languages/apache';
+import awk from 'highlight.js/lib/languages/awk';
+import bash from 'highlight.js/lib/languages/bash';
+import c from 'highlight.js/lib/languages/c';
+import clojure from 'highlight.js/lib/languages/clojure';
+import cmake from 'highlight.js/lib/languages/cmake';
+import coffeescript from 'highlight.js/lib/languages/coffeescript';
+import cpp from 'highlight.js/lib/languages/cpp';
+import csharp from 'highlight.js/lib/languages/csharp';
+import css from 'highlight.js/lib/languages/css';
+import dart from 'highlight.js/lib/languages/dart';
+import diff from 'highlight.js/lib/languages/diff';
+import dns from 'highlight.js/lib/languages/dns';
+import dockerfile from 'highlight.js/lib/languages/dockerfile';
+import dos from 'highlight.js/lib/languages/dos';
+import elixir from 'highlight.js/lib/languages/elixir';
+import erlang from 'highlight.js/lib/languages/erlang';
+import fsharp from 'highlight.js/lib/languages/fsharp';
+import go from 'highlight.js/lib/languages/go';
+import gradle from 'highlight.js/lib/languages/gradle';
+import graphql from 'highlight.js/lib/languages/graphql';
+import groovy from 'highlight.js/lib/languages/groovy';
+import handlebars from 'highlight.js/lib/languages/handlebars';
+import haskell from 'highlight.js/lib/languages/haskell';
+import http from 'highlight.js/lib/languages/http';
+import ini from 'highlight.js/lib/languages/ini';
+import java from 'highlight.js/lib/languages/java';
+import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import julia from 'highlight.js/lib/languages/julia';
+import kotlin from 'highlight.js/lib/languages/kotlin';
+import latex from 'highlight.js/lib/languages/latex';
+import less from 'highlight.js/lib/languages/less';
+import lisp from 'highlight.js/lib/languages/lisp';
+import lua from 'highlight.js/lib/languages/lua';
+import makefile from 'highlight.js/lib/languages/makefile';
+import markdown from 'highlight.js/lib/languages/markdown';
+import matlab from 'highlight.js/lib/languages/matlab';
+import mipsasm from 'highlight.js/lib/languages/mipsasm';
+import nginx from 'highlight.js/lib/languages/nginx';
+import nim from 'highlight.js/lib/languages/nim';
+import objectivec from 'highlight.js/lib/languages/objectivec';
+import ocaml from 'highlight.js/lib/languages/ocaml';
+import perl from 'highlight.js/lib/languages/perl';
+import pgsql from 'highlight.js/lib/languages/pgsql';
+import php from 'highlight.js/lib/languages/php';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+import powershell from 'highlight.js/lib/languages/powershell';
+import profile from 'highlight.js/lib/languages/profile';
+import properties from 'highlight.js/lib/languages/properties';
+import protobuf from 'highlight.js/lib/languages/protobuf';
+import python from 'highlight.js/lib/languages/python';
+import q from 'highlight.js/lib/languages/q';
+import qml from 'highlight.js/lib/languages/qml';
+import r from 'highlight.js/lib/languages/r';
+import reasonml from 'highlight.js/lib/languages/reasonml';
+import ruby from 'highlight.js/lib/languages/ruby';
+import rust from 'highlight.js/lib/languages/rust';
+import sas from 'highlight.js/lib/languages/sas';
+import scala from 'highlight.js/lib/languages/scala';
+import scheme from 'highlight.js/lib/languages/scheme';
+import scss from 'highlight.js/lib/languages/scss';
+import shell from 'highlight.js/lib/languages/shell';
+import sql from 'highlight.js/lib/languages/sql';
+import stata from 'highlight.js/lib/languages/stata';
+import swift from 'highlight.js/lib/languages/swift';
+import tcl from 'highlight.js/lib/languages/tcl';
+import typescript from 'highlight.js/lib/languages/typescript';
+import vbnet from 'highlight.js/lib/languages/vbnet';
+import wasm from 'highlight.js/lib/languages/wasm';
+import x86asm from 'highlight.js/lib/languages/x86asm';
+import xml from 'highlight.js/lib/languages/xml';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+const LANGUAGE_DEFINITIONS = [
+  ['accesslog', accesslog], ['apache', apache], ['awk', awk], ['bash', bash],
+  ['c', c], ['clojure', clojure], ['cmake', cmake], ['coffeescript', coffeescript],
+  ['cpp', cpp], ['csharp', csharp], ['css', css], ['dart', dart], ['diff', diff],
+  ['dns', dns], ['dockerfile', dockerfile], ['dos', dos], ['elixir', elixir],
+  ['erlang', erlang], ['fsharp', fsharp], ['go', go], ['gradle', gradle],
+  ['graphql', graphql], ['groovy', groovy], ['handlebars', handlebars],
+  ['haskell', haskell], ['http', http], ['ini', ini], ['java', java],
+  ['javascript', javascript], ['json', json], ['julia', julia], ['kotlin', kotlin],
+  ['latex', latex], ['less', less], ['lisp', lisp], ['lua', lua],
+  ['makefile', makefile], ['markdown', markdown], ['matlab', matlab],
+  ['mipsasm', mipsasm], ['nginx', nginx], ['nim', nim], ['objectivec', objectivec],
+  ['ocaml', ocaml], ['perl', perl], ['pgsql', pgsql], ['php', php],
+  ['plaintext', plaintext], ['powershell', powershell], ['profile', profile],
+  ['properties', properties], ['protobuf', protobuf], ['python', python], ['q', q],
+  ['qml', qml], ['r', r], ['reasonml', reasonml], ['ruby', ruby], ['rust', rust],
+  ['sas', sas], ['scala', scala], ['scheme', scheme], ['scss', scss],
+  ['shell', shell], ['sql', sql], ['stata', stata], ['swift', swift], ['tcl', tcl],
+  ['typescript', typescript], ['vbnet', vbnet], ['wasm', wasm],
+  ['x86asm', x86asm], ['xml', xml], ['yaml', yaml],
+];
+
+for (const [name, definition] of LANGUAGE_DEFINITIONS) {
+  hljs.registerLanguage(name, definition);
+}
+
+const EXPLICIT_ALIASES = {
+  javascript: ['js', 'jsx', 'mjs', 'cjs'],
+  typescript: ['ts', 'tsx', 'mts', 'cts'],
+  python: ['py', 'py3'],
+  csharp: ['cs', 'c#'],
+  cpp: ['c++', 'cc', 'cxx', 'hpp'],
+  objectivec: ['objc', 'objective-c'],
+  fsharp: ['fs', 'f#'],
+  bash: ['sh', 'zsh'],
+  powershell: ['ps1', 'pwsh'],
+  dos: ['bat', 'cmd'],
+  yaml: ['yml'],
+  markdown: ['md', 'mdown'],
+  protobuf: ['proto'],
+  dockerfile: ['docker'],
+  makefile: ['make'],
+  x86asm: ['asm', 'assembly'],
+  xml: ['html', 'xhtml', 'svg', 'vue', 'svelte'],
+  plaintext: ['text', 'txt', 'plain'],
+  pgsql: ['postgres', 'postgresql'],
+  properties: ['props'],
+  handlebars: ['hbs'],
+};
+
+for (const [languageName, aliases] of Object.entries(EXPLICIT_ALIASES)) {
+  hljs.registerAliases(aliases, { languageName });
+}
+
+const DISPLAY_NAMES = {
+  accesslog: 'Access Log', apache: 'Apache', bash: 'Shell', c: 'C', cpp: 'C++',
+  csharp: 'C#', cmake: 'CMake', coffeescript: 'CoffeeScript', css: 'CSS',
+  diff: 'Diff', dockerfile: 'Dockerfile', dos: 'Batch', fsharp: 'F#', go: 'Go',
+  graphql: 'GraphQL', html: 'HTML', http: 'HTTP', ini: 'INI / TOML',
+  java: 'Java', javascript: 'JavaScript', json: 'JSON', kotlin: 'Kotlin',
+  latex: 'LaTeX', less: 'Less', makefile: 'Makefile', markdown: 'Markdown',
+  mipsasm: 'MIPS Assembly', nginx: 'Nginx', objectivec: 'Objective-C',
+  pgsql: 'PostgreSQL', php: 'PHP', plaintext: 'Text', powershell: 'PowerShell',
+  protobuf: 'Protocol Buffers', python: 'Python', qml: 'QML', r: 'R',
+  reasonml: 'ReasonML', ruby: 'Ruby', rust: 'Rust', scss: 'SCSS', sql: 'SQL',
+  typescript: 'TypeScript', vbnet: 'VB.NET', wasm: 'WebAssembly',
+  x86asm: 'x86 Assembly', xml: 'HTML / XML', yaml: 'YAML',
+};
+
+const AUTO_DETECT_LANGUAGES = [
+  'javascript', 'typescript', 'python', 'java', 'c', 'cpp', 'csharp', 'go', 'rust',
+  'bash', 'powershell', 'sql', 'json', 'yaml', 'xml', 'css', 'php', 'ruby',
+];
+
+export const MAX_HIGHLIGHT_SOURCE_BYTES = 128 * 1024;
+
+export const supportedSyntaxLanguages = Object.freeze(
+  LANGUAGE_DEFINITIONS.map(([name]) => name),
+);
+
+export function escapeCodeHtml(value) {
+  return String(value).replace(/[&<>"']/g, character => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]);
+}
+
+function utf8ByteLength(value) {
+  if (value.length > MAX_HIGHLIGHT_SOURCE_BYTES) return value.length;
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function languageToken(languageHint) {
+  return String(languageHint || '')
+    .trim()
+    .split(/\s+/u, 1)[0]
+    .replace(/^\{?\.?/u, '')
+    .replace(/\}?$/u, '')
+    .toLowerCase();
+}
+
+export function normalizeSyntaxLanguage(languageHint) {
+  const token = languageToken(languageHint);
+  if (!token) return '';
+  const language = hljs.getLanguage(token);
+  if (!language) return token;
+  const canonical = LANGUAGE_DEFINITIONS.find(([name]) => hljs.getLanguage(name) === language);
+  return canonical ? canonical[0] : token;
+}
+
+function displayName(language, originalHint) {
+  const original = languageToken(originalHint);
+  if (original === 'vue') return 'Vue';
+  if (original === 'svelte') return 'Svelte';
+  if (original === 'tsx') return 'TSX';
+  if (original === 'jsx') return 'JSX';
+  if (original === 'html' || original === 'xhtml') return 'HTML';
+  if (original === 'svg') return 'SVG';
+  if (original === 'toml') return 'TOML';
+  return DISPLAY_NAMES[language] || language.replace(/(^|[-_])([a-z])/gu, (_, separator, letter) => `${separator ? ' ' : ''}${letter.toUpperCase()}`);
+}
+
+export function highlightCode(code, languageHint, options = {}) {
+  const source = String(code || '');
+  const originalHint = languageToken(languageHint);
+  const normalized = normalizeSyntaxLanguage(originalHint);
+  const explicitLanguage = originalHint && hljs.getLanguage(originalHint) ? normalized : '';
+
+  if (utf8ByteLength(source) > MAX_HIGHLIGHT_SOURCE_BYTES) {
+    return {
+      html: escapeCodeHtml(source),
+      language: 'plaintext',
+      languageId: 'plaintext',
+      label: explicitLanguage
+        ? displayName(explicitLanguage, originalHint)
+        : (originalHint ? originalHint.toUpperCase() : 'Text'),
+      highlighted: false,
+      oversized: true,
+    };
+  }
+
+  try {
+    if (explicitLanguage) {
+      const result = hljs.highlight(source, { language: explicitLanguage, ignoreIllegals: true });
+      return {
+        html: result.value,
+        language: explicitLanguage,
+        languageId: originalHint || explicitLanguage,
+        label: displayName(explicitLanguage, originalHint),
+        highlighted: true,
+      };
+    }
+
+    const allowAutoDetect = options.allowAutoDetect !== false;
+    if (!originalHint && allowAutoDetect && source.length >= 20 && source.length <= 50_000) {
+      const result = hljs.highlightAuto(source, AUTO_DETECT_LANGUAGES);
+      if (result.language && result.relevance >= 3) {
+        return {
+          html: result.value,
+          language: result.language,
+          languageId: result.language,
+          label: displayName(result.language, ''),
+          highlighted: true,
+        };
+      }
+    }
+  } catch (_) {
+    // Invalid or partially streamed code must remain readable as plain text.
+  }
+
+  return {
+    html: escapeCodeHtml(source),
+    language: 'plaintext',
+    languageId: 'plaintext',
+    label: originalHint ? originalHint.toUpperCase() : 'Text',
+    highlighted: false,
+  };
+}

--- a/pinvou3-app/src/shared/syntax-highlighter.js
+++ b/pinvou3-app/src/shared/syntax-highlighter.js
@@ -74,6 +74,48 @@ import x86asm from 'highlight.js/lib/languages/x86asm';
 import xml from 'highlight.js/lib/languages/xml';
 import yaml from 'highlight.js/lib/languages/yaml';
 
+function genericLog(hljsApi) {
+  const httpMethod = {
+    scope: 'keyword',
+    begin: /\b(?:GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|CONNECT|TRACE)\b/u,
+  };
+  const requestPath = {
+    scope: 'string',
+    begin: /\/[A-Za-z0-9._~!$&'()*+,;=:@%/?#-]*/u,
+  };
+  const errorStatus = { scope: 'deletion', begin: /\b[45]\d{2}\b/u };
+  const normalStatus = { scope: 'literal', begin: /\b[123]\d{2}\b/u };
+
+  return {
+    name: 'Log',
+    aliases: ['logs'],
+    case_insensitive: true,
+    contains: [
+      {
+        scope: 'meta',
+        begin: /\b\d{4}-\d{2}-\d{2}(?:[T ][0-2]\d:[0-5]\d:[0-5]\d(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?/u,
+      },
+      { scope: 'meta', begin: /\[[^\]\r\n]*(?:\d{2}:){2}\d{2}[^\]\r\n]*\]/u },
+      { scope: 'deletion', begin: /\b(?:FATAL|CRITICAL|ERROR|ERR)\b/u },
+      { scope: 'warning', begin: /\b(?:WARN|WARNING)\b/u },
+      { scope: 'built_in', begin: /\b(?:TRACE|DEBUG|INFO|NOTICE)\b/u },
+      errorStatus,
+      normalStatus,
+      httpMethod,
+      { scope: 'attr', begin: /\b[A-Za-z_][\w.-]*(?==)/u },
+      requestPath,
+      {
+        scope: 'string',
+        begin: /"/u,
+        end: /"/u,
+        contains: [httpMethod, requestPath, errorStatus, normalStatus],
+      },
+      hljsApi.APOS_STRING_MODE,
+      hljsApi.NUMBER_MODE,
+    ],
+  };
+}
+
 const LANGUAGE_DEFINITIONS = [
   ['accesslog', accesslog], ['apache', apache], ['awk', awk], ['bash', bash],
   ['c', c], ['clojure', clojure], ['cmake', cmake], ['coffeescript', coffeescript],
@@ -94,6 +136,7 @@ const LANGUAGE_DEFINITIONS = [
   ['shell', shell], ['sql', sql], ['stata', stata], ['swift', swift], ['tcl', tcl],
   ['typescript', typescript], ['vbnet', vbnet], ['wasm', wasm],
   ['x86asm', x86asm], ['xml', xml], ['yaml', yaml],
+  ['log', genericLog],
 ];
 
 for (const [name, definition] of LANGUAGE_DEFINITIONS) {
@@ -141,6 +184,7 @@ const DISPLAY_NAMES = {
   reasonml: 'ReasonML', ruby: 'Ruby', rust: 'Rust', scss: 'SCSS', sql: 'SQL',
   typescript: 'TypeScript', vbnet: 'VB.NET', wasm: 'WebAssembly',
   x86asm: 'x86 Assembly', xml: 'HTML / XML', yaml: 'YAML',
+  log: 'Log',
 };
 
 const AUTO_DETECT_LANGUAGES = [
@@ -149,6 +193,9 @@ const AUTO_DETECT_LANGUAGES = [
 ];
 
 export const MAX_HIGHLIGHT_SOURCE_BYTES = 128 * 1024;
+const MAX_CACHED_SOURCE_BYTES = 64 * 1024;
+const MAX_HIGHLIGHT_CACHE_ENTRIES = 24;
+const highlightCache = new Map();
 
 export const supportedSyntaxLanguages = Object.freeze(
   LANGUAGE_DEFINITIONS.map(([name]) => name),
@@ -163,6 +210,36 @@ export function escapeCodeHtml(value) {
 function utf8ByteLength(value) {
   if (value.length > MAX_HIGHLIGHT_SOURCE_BYTES) return value.length;
   return new TextEncoder().encode(value).byteLength;
+}
+
+function plainTextResult(source, originalHint, explicitLanguage, extra = {}) {
+  return {
+    html: escapeCodeHtml(source),
+    language: 'plaintext',
+    languageId: 'plaintext',
+    label: explicitLanguage
+      ? displayName(explicitLanguage, originalHint)
+      : (originalHint ? originalHint.toUpperCase() : 'Text'),
+    highlighted: false,
+    ...extra,
+  };
+}
+
+function cachedHighlight(key) {
+  const value = highlightCache.get(key);
+  if (!value) return null;
+  highlightCache.delete(key);
+  highlightCache.set(key, value);
+  return value;
+}
+
+function rememberHighlight(key, value, sourceBytes) {
+  if (sourceBytes > MAX_CACHED_SOURCE_BYTES) return value;
+  highlightCache.set(key, value);
+  while (highlightCache.size > MAX_HIGHLIGHT_CACHE_ENTRIES) {
+    highlightCache.delete(highlightCache.keys().next().value);
+  }
+  return value;
 }
 
 function languageToken(languageHint) {
@@ -200,54 +277,50 @@ export function highlightCode(code, languageHint, options = {}) {
   const originalHint = languageToken(languageHint);
   const normalized = normalizeSyntaxLanguage(originalHint);
   const explicitLanguage = originalHint && hljs.getLanguage(originalHint) ? normalized : '';
+  const sourceBytes = utf8ByteLength(source);
 
-  if (utf8ByteLength(source) > MAX_HIGHLIGHT_SOURCE_BYTES) {
-    return {
-      html: escapeCodeHtml(source),
-      language: 'plaintext',
-      languageId: 'plaintext',
-      label: explicitLanguage
-        ? displayName(explicitLanguage, originalHint)
-        : (originalHint ? originalHint.toUpperCase() : 'Text'),
-      highlighted: false,
-      oversized: true,
-    };
+  if (sourceBytes > MAX_HIGHLIGHT_SOURCE_BYTES) {
+    return plainTextResult(source, originalHint, explicitLanguage, { oversized: true });
+  }
+
+  if (options.allowHighlight === false) {
+    return plainTextResult(source, originalHint, explicitLanguage, { deferred: true });
   }
 
   try {
     if (explicitLanguage) {
+      const cacheKey = `explicit\u0000${explicitLanguage}\u0000${source}`;
+      const cached = cachedHighlight(cacheKey);
+      if (cached) return cached;
       const result = hljs.highlight(source, { language: explicitLanguage, ignoreIllegals: true });
-      return {
+      return rememberHighlight(cacheKey, {
         html: result.value,
         language: explicitLanguage,
         languageId: originalHint || explicitLanguage,
         label: displayName(explicitLanguage, originalHint),
         highlighted: true,
-      };
+      }, sourceBytes);
     }
 
     const allowAutoDetect = options.allowAutoDetect !== false;
     if (!originalHint && allowAutoDetect && source.length >= 20 && source.length <= 50_000) {
+      const cacheKey = `auto\u0000${source}`;
+      const cached = cachedHighlight(cacheKey);
+      if (cached) return cached;
       const result = hljs.highlightAuto(source, AUTO_DETECT_LANGUAGES);
       if (result.language && result.relevance >= 3) {
-        return {
+        return rememberHighlight(cacheKey, {
           html: result.value,
           language: result.language,
           languageId: result.language,
           label: displayName(result.language, ''),
           highlighted: true,
-        };
+        }, sourceBytes);
       }
     }
   } catch (_) {
     // Invalid or partially streamed code must remain readable as plain text.
   }
 
-  return {
-    html: escapeCodeHtml(source),
-    language: 'plaintext',
-    languageId: 'plaintext',
-    label: originalHint ? originalHint.toUpperCase() : 'Text',
-    highlighted: false,
-  };
+  return plainTextResult(source, originalHint, explicitLanguage);
 }

--- a/pinvou3-app/src/styles/base.css
+++ b/pinvou3-app/src/styles/base.css
@@ -31,18 +31,20 @@
     .msg-md li { margin:0.2em 0; line-height:1.6; }
     .msg-md code { font-family:"JetBrains Mono","SF Mono",Consolas,monospace; font-size:0.88em; padding:0.15em 0.4em; border-radius:6px; }
     .msg-md pre { margin:0.6em 0; padding:1em; border-radius:12px; overflow-x:auto; font-size:0.88em; line-height:1.5; }
-    .msg-md pre code { padding:0; background:none; }
+    .msg-md pre > code { display:block; padding:0; background:transparent; color:inherit; }
     .msg-md blockquote { border-left:3px solid rgba(128,128,128,0.4); padding-left:1em; margin:0.5em 0; opacity:0.85; }
     .msg-md a { text-decoration:underline; }
     .msg-md table { border-collapse:collapse; margin:0.5em 0; font-size:0.92em; }
     .msg-md th,.msg-md td { border:1px solid rgba(128,128,128,0.3); padding:0.4em 0.8em; }
 
     /* Dark theme code blocks */
-    .dark-code .msg-md code { background:rgba(255,255,255,0.08); color:#E3E3E3; }
-    .dark-code .msg-md pre { background:rgba(0,0,0,0.3); color:#E3E3E3; }
+    .dark-code .msg-md :not(pre) > code { background:rgba(255,255,255,0.08); color:#E3E3E3; }
+    .dark-code .msg-md pre { background:#16181d; color:#E3E3E3; }
+    .dark-code .msg-md pre > code { background:transparent; color:inherit; }
     /* Light theme code blocks */
-    .light-code .msg-md code { background:rgba(0,0,0,0.06); color:#1F1F1F; }
-    .light-code .msg-md pre { background:rgba(0,0,0,0.04); color:#1F1F1F; }
+    .light-code .msg-md :not(pre) > code { background:rgba(0,0,0,0.06); color:#1F1F1F; }
+    .light-code .msg-md pre { background:#F6F8FA; color:#1F2328; }
+    .light-code .msg-md pre > code { background:transparent; color:inherit; }
 
     /* Codex ACP: scoped Markdown layout (Tailwind preflight removes native list styles). */
     .codex-markdown > :first-child { margin-top:0; }
@@ -72,11 +74,11 @@
     .codex-markdown code {
       padding:.12em .36em;
       border-radius:5px;
-      background:rgba(0,0,0,.055);
       font-family:"JetBrains Mono","SF Mono",Consolas,monospace;
       font-size:.88em;
     }
-    .dark .codex-markdown code { background:rgba(255,255,255,.09); }
+    .codex-markdown :not(pre) > code { background:rgba(0,0,0,.055); }
+    .dark .codex-markdown :not(pre) > code { background:rgba(255,255,255,.09); }
     .codex-markdown pre {
       margin:.7em 0;
       padding:.85em 1em;
@@ -91,7 +93,8 @@
       border-color:rgba(255,255,255,.08);
       background:rgba(0,0,0,.28);
     }
-    .codex-markdown pre code { padding:0; background:none; }
+    .codex-markdown pre > code { display:block; padding:0; background:transparent; color:inherit; }
+    .dark .codex-markdown pre > code { background:transparent; color:inherit; }
     .codex-markdown blockquote {
       margin:.65em 0;
       padding:.1em 0 .1em 1em;
@@ -116,6 +119,254 @@
       padding:.4em .7em;
       border:1px solid rgba(128,128,128,.25);
       text-align:left;
+    }
+
+    /* Shared fenced-code presentation and syntax colors. */
+    .light-code .msg-md,
+    .codex-markdown {
+      --pinvou-code-border:rgba(31,35,40,.14);
+      --pinvou-code-divider:rgba(31,35,40,.10);
+      --pinvou-code-label:#57606A;
+      --pinvou-hl-comment:#6E7781;
+      --pinvou-hl-keyword:#CF222E;
+      --pinvou-hl-title:#8250DF;
+      --pinvou-hl-string:#0A3069;
+      --pinvou-hl-number:#0550AE;
+      --pinvou-hl-built-in:#953800;
+      --pinvou-hl-attribute:#116329;
+      --pinvou-hl-property:#0550AE;
+      --pinvou-hl-parameter:#9A6700;
+      --pinvou-hl-meta:#8250DF;
+      --pinvou-hl-punctuation:#8C959F;
+      --pinvou-hl-operator:#57606A;
+      --pinvou-hl-addition:#116329;
+      --pinvou-hl-deletion:#A40E26;
+      --pinvou-hl-addition-bg:rgba(46,160,67,.13);
+      --pinvou-hl-deletion-bg:rgba(255,129,130,.16);
+      --pinvou-hl-quote-bg:rgba(84,174,255,.09);
+    }
+    .dark-code .msg-md,
+    .dark .codex-markdown {
+      --pinvou-code-border:rgba(240,246,252,.16);
+      --pinvou-code-divider:rgba(240,246,252,.12);
+      --pinvou-code-label:#8B949E;
+      --pinvou-hl-comment:#8B949E;
+      --pinvou-hl-keyword:#FF7B72;
+      --pinvou-hl-title:#D2A8FF;
+      --pinvou-hl-string:#A5D6FF;
+      --pinvou-hl-number:#79C0FF;
+      --pinvou-hl-built-in:#FFA657;
+      --pinvou-hl-attribute:#7EE787;
+      --pinvou-hl-property:#79C0FF;
+      --pinvou-hl-parameter:#E3B341;
+      --pinvou-hl-meta:#D2A8FF;
+      --pinvou-hl-punctuation:#6E7681;
+      --pinvou-hl-operator:#C9D1D9;
+      --pinvou-hl-addition:#7EE787;
+      --pinvou-hl-deletion:#FFA198;
+      --pinvou-hl-addition-bg:rgba(46,160,67,.18);
+      --pinvou-hl-deletion-bg:rgba(248,81,73,.18);
+      --pinvou-hl-quote-bg:rgba(56,139,253,.12);
+    }
+    .msg-md pre.pinvou-code-block,
+    .codex-markdown pre.pinvou-code-block {
+      position:relative;
+      padding:2.55rem 1rem 1rem;
+      border:1px solid var(--pinvou-code-border, rgba(128,128,128,.2));
+      tab-size:4;
+      white-space:pre;
+    }
+    .msg-md pre.pinvou-code-block::before,
+    .codex-markdown pre.pinvou-code-block::before {
+      content:attr(data-language);
+      position:absolute;
+      top:0;
+      right:0;
+      left:0;
+      height:1.85rem;
+      box-sizing:border-box;
+      padding:0 .85rem;
+      border-bottom:1px solid var(--pinvou-code-divider, rgba(128,128,128,.16));
+      color:var(--pinvou-code-label, #6E7781);
+      font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
+      font-size:11px;
+      font-weight:600;
+      line-height:1.85rem;
+      letter-spacing:.02em;
+      user-select:none;
+    }
+    .hljs-comment,.hljs-quote { color:var(--pinvou-hl-comment, #6E7781); font-style:italic; }
+    .hljs-keyword,.hljs-selector-tag,.hljs-literal,.hljs-section,.hljs-link { color:var(--pinvou-hl-keyword, #CF222E); }
+    .hljs-title,.hljs-title.class_,.hljs-title.function_,.hljs-name,.hljs-type { color:var(--pinvou-hl-title, #8250DF); }
+    .hljs-string,.hljs-regexp,.hljs-symbol,.hljs-bullet { color:var(--pinvou-hl-string, #0A3069); }
+    .hljs-number,.hljs-variable,.hljs-template-variable { color:var(--pinvou-hl-number, #0550AE); }
+    .hljs-built_in,.hljs-builtin-name { color:var(--pinvou-hl-built-in, #953800); }
+    .hljs-attr,.hljs-attribute,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id { color:var(--pinvou-hl-attribute, #116329); }
+    .hljs-property { color:var(--pinvou-hl-property, #0550AE); }
+    .hljs-params { color:var(--pinvou-hl-parameter, #9A6700); }
+    .hljs-meta { color:var(--pinvou-hl-meta, #8250DF); }
+    .hljs-punctuation { color:var(--pinvou-hl-punctuation, #8C959F); }
+    .hljs-operator { color:var(--pinvou-hl-operator, #57606A); }
+    .hljs-addition { color:var(--pinvou-hl-addition, #116329); }
+    .hljs-deletion { color:var(--pinvou-hl-deletion, #A40E26); }
+    .hljs-emphasis { font-style:italic; }
+    .hljs-strong { font-weight:700; }
+
+    /* Language-specific refinements built on the shared token theme. */
+    code.language-diff .hljs-addition,
+    code.language-diff .hljs-deletion {
+      display:inline-block;
+      min-width:100%;
+      box-sizing:border-box;
+      font-weight:650;
+    }
+    code.language-diff .hljs-addition { background:var(--pinvou-hl-addition-bg); }
+    code.language-diff .hljs-deletion { background:var(--pinvou-hl-deletion-bg); }
+
+    code.language-json .hljs-attr {
+      color:var(--pinvou-hl-property);
+      font-weight:650;
+    }
+    code.language-json .hljs-punctuation { opacity:.64; }
+    code.language-json .hljs-literal { font-weight:600; }
+
+    code:is(.language-yaml,.language-ini) .hljs-attr {
+      color:var(--pinvou-hl-property);
+      font-weight:650;
+    }
+    code:is(.language-yaml,.language-ini) .hljs-section {
+      color:var(--pinvou-hl-title);
+      font-weight:700;
+    }
+    code:is(.language-yaml,.language-ini) .hljs-literal { font-weight:600; }
+
+    code:is(.language-bash,.language-shell,.language-powershell) .hljs-built_in {
+      color:var(--pinvou-hl-title);
+      font-weight:650;
+    }
+    code:is(.language-bash,.language-shell,.language-powershell) .hljs-variable {
+      color:var(--pinvou-hl-number);
+      font-weight:600;
+    }
+    code:is(.language-bash,.language-shell,.language-powershell) .hljs-operator {
+      color:var(--pinvou-hl-operator);
+      font-weight:700;
+    }
+    code:is(.language-bash,.language-shell,.language-powershell) .hljs-meta {
+      color:var(--pinvou-code-label);
+      font-weight:500;
+    }
+
+    code:is(.language-sql,.language-pgsql) .hljs-keyword { font-weight:750; }
+    code:is(.language-sql,.language-pgsql) .hljs-built_in {
+      color:var(--pinvou-hl-title);
+      font-weight:650;
+    }
+    code:is(.language-sql,.language-pgsql) :is(.hljs-meta,.hljs-variable) {
+      color:var(--pinvou-hl-parameter);
+      font-weight:600;
+    }
+
+    code.language-xml .hljs-tag { color:var(--pinvou-hl-punctuation); }
+    code.language-xml .hljs-name {
+      color:var(--pinvou-hl-title);
+      font-weight:650;
+    }
+    code.language-xml .hljs-attr {
+      color:var(--pinvou-hl-attribute);
+      font-weight:600;
+    }
+    pre:is([data-language-id="vue"],[data-language-id="svelte"]) code.language-xml .hljs-name {
+      color:var(--pinvou-hl-built-in);
+      font-weight:700;
+    }
+    pre:is([data-language-id="vue"],[data-language-id="svelte"]) code.language-xml .hljs-attr {
+      color:var(--pinvou-hl-meta);
+    }
+
+    code:is(.language-javascript,.language-typescript) .hljs-title.class_ { font-weight:750; }
+    code:is(.language-javascript,.language-typescript) .hljs-title.function_ { font-weight:650; }
+    code:is(.language-javascript,.language-typescript) :is(.hljs-type,.hljs-meta) {
+      color:var(--pinvou-hl-meta);
+      font-weight:600;
+    }
+
+    code.language-python .hljs-meta {
+      color:var(--pinvou-hl-meta);
+      font-weight:650;
+    }
+    code.language-python .hljs-built_in { font-weight:650; }
+    code.language-python .hljs-title.class_ { font-weight:750; }
+    code.language-python .hljs-title.function_ { font-weight:650; }
+
+    code:is(.language-java,.language-csharp,.language-kotlin) .hljs-meta {
+      color:var(--pinvou-hl-meta);
+      font-weight:650;
+    }
+    code:is(.language-java,.language-csharp,.language-kotlin) :is(.hljs-type,.hljs-title.class_) {
+      color:var(--pinvou-hl-title);
+      font-weight:700;
+    }
+    code:is(.language-java,.language-csharp,.language-kotlin) :is(.hljs-title.function_,.hljs-function > .hljs-title) {
+      font-weight:650;
+    }
+
+    code:is(.language-c,.language-cpp) .hljs-meta {
+      color:var(--pinvou-hl-meta);
+      font-weight:600;
+    }
+    code:is(.language-c,.language-cpp) :is(.hljs-type,.hljs-title.class_,.hljs-class .hljs-title) {
+      color:var(--pinvou-hl-title);
+      font-weight:700;
+    }
+
+    code:is(.language-go,.language-rust) .hljs-type {
+      color:var(--pinvou-hl-title);
+      font-weight:650;
+    }
+    code:is(.language-go,.language-rust) :is(.hljs-title.class_,.hljs-title.function_,.hljs-function > .hljs-title) {
+      font-weight:700;
+    }
+    code.language-rust :is(.hljs-symbol,.hljs-built_in) {
+      color:var(--pinvou-hl-meta);
+      font-weight:650;
+    }
+
+    code.language-markdown .hljs-section {
+      color:var(--pinvou-hl-title);
+      font-weight:750;
+    }
+    code.language-markdown .hljs-quote {
+      display:inline-block;
+      min-width:100%;
+      box-sizing:border-box;
+      padding-left:.65em;
+      border-left:3px solid var(--pinvou-hl-comment);
+      background:var(--pinvou-hl-quote-bg);
+    }
+    code.language-markdown .hljs-link {
+      color:var(--pinvou-hl-number);
+      text-decoration:underline;
+      text-underline-offset:2px;
+    }
+
+    code.language-dockerfile > .hljs-keyword {
+      color:var(--pinvou-hl-keyword);
+      font-weight:750;
+      letter-spacing:.02em;
+    }
+
+    code.language-accesslog {
+      font-variant-numeric:tabular-nums;
+    }
+    code.language-accesslog .hljs-keyword {
+      color:var(--pinvou-hl-keyword);
+      font-weight:750;
+    }
+    code.language-accesslog .hljs-string { color:var(--pinvou-hl-string); }
+    code.language-accesslog .hljs-number {
+      color:var(--pinvou-hl-number);
+      font-weight:600;
     }
 
     /* Tool card styles */

--- a/pinvou3-app/src/styles/base.css
+++ b/pinvou3-app/src/styles/base.css
@@ -38,13 +38,25 @@
     .msg-md th,.msg-md td { border:1px solid rgba(128,128,128,0.3); padding:0.4em 0.8em; }
 
     /* Dark theme code blocks */
-    .dark-code .msg-md :not(pre) > code { background:rgba(255,255,255,0.08); color:#E3E3E3; }
-    .dark-code .msg-md pre { background:#16181d; color:#E3E3E3; }
-    .dark-code .msg-md pre > code { background:transparent; color:inherit; }
+    .dark-code .msg-md :not(pre) > code,
+    .msg-md.dark-code :not(pre) > code,
+    .persona-body.dark-code :not(pre) > code { background:rgba(255,255,255,0.08); color:#E3E3E3; }
+    .dark-code .msg-md pre,
+    .msg-md.dark-code pre,
+    .persona-body.dark-code pre { background:#16181d; color:#E3E3E3; }
+    .dark-code .msg-md pre > code,
+    .msg-md.dark-code pre > code,
+    .persona-body.dark-code pre > code { background:transparent; color:inherit; }
     /* Light theme code blocks */
-    .light-code .msg-md :not(pre) > code { background:rgba(0,0,0,0.06); color:#1F1F1F; }
-    .light-code .msg-md pre { background:#F6F8FA; color:#1F2328; }
-    .light-code .msg-md pre > code { background:transparent; color:inherit; }
+    .light-code .msg-md :not(pre) > code,
+    .msg-md.light-code :not(pre) > code,
+    .persona-body.light-code :not(pre) > code { background:rgba(0,0,0,0.06); color:#1F1F1F; }
+    .light-code .msg-md pre,
+    .msg-md.light-code pre,
+    .persona-body.light-code pre { background:#F6F8FA; color:#1F2328; }
+    .light-code .msg-md pre > code,
+    .msg-md.light-code pre > code,
+    .persona-body.light-code pre > code { background:transparent; color:inherit; }
 
     /* Codex ACP: scoped Markdown layout (Tailwind preflight removes native list styles). */
     .codex-markdown > :first-child { margin-top:0; }
@@ -123,6 +135,8 @@
 
     /* Shared fenced-code presentation and syntax colors. */
     .light-code .msg-md,
+    .msg-md.light-code,
+    .persona-body.light-code,
     .codex-markdown {
       --pinvou-code-border:rgba(31,35,40,.14);
       --pinvou-code-divider:rgba(31,35,40,.10);
@@ -141,11 +155,14 @@
       --pinvou-hl-operator:#57606A;
       --pinvou-hl-addition:#116329;
       --pinvou-hl-deletion:#A40E26;
+      --pinvou-hl-warning:#9A6700;
       --pinvou-hl-addition-bg:rgba(46,160,67,.13);
       --pinvou-hl-deletion-bg:rgba(255,129,130,.16);
       --pinvou-hl-quote-bg:rgba(84,174,255,.09);
     }
     .dark-code .msg-md,
+    .msg-md.dark-code,
+    .persona-body.dark-code,
     .dark .codex-markdown {
       --pinvou-code-border:rgba(240,246,252,.16);
       --pinvou-code-divider:rgba(240,246,252,.12);
@@ -164,11 +181,13 @@
       --pinvou-hl-operator:#C9D1D9;
       --pinvou-hl-addition:#7EE787;
       --pinvou-hl-deletion:#FFA198;
+      --pinvou-hl-warning:#E3B341;
       --pinvou-hl-addition-bg:rgba(46,160,67,.18);
       --pinvou-hl-deletion-bg:rgba(248,81,73,.18);
       --pinvou-hl-quote-bg:rgba(56,139,253,.12);
     }
     .msg-md pre.pinvou-code-block,
+    .persona-body pre.pinvou-code-block,
     .codex-markdown pre.pinvou-code-block {
       position:relative;
       padding:2.55rem 1rem 1rem;
@@ -177,6 +196,7 @@
       white-space:pre;
     }
     .msg-md pre.pinvou-code-block::before,
+    .persona-body pre.pinvou-code-block::before,
     .codex-markdown pre.pinvou-code-block::before {
       content:attr(data-language);
       position:absolute;
@@ -195,22 +215,23 @@
       letter-spacing:.02em;
       user-select:none;
     }
-    .hljs-comment,.hljs-quote { color:var(--pinvou-hl-comment, #6E7781); font-style:italic; }
-    .hljs-keyword,.hljs-selector-tag,.hljs-literal,.hljs-section,.hljs-link { color:var(--pinvou-hl-keyword, #CF222E); }
-    .hljs-title,.hljs-title.class_,.hljs-title.function_,.hljs-name,.hljs-type { color:var(--pinvou-hl-title, #8250DF); }
-    .hljs-string,.hljs-regexp,.hljs-symbol,.hljs-bullet { color:var(--pinvou-hl-string, #0A3069); }
-    .hljs-number,.hljs-variable,.hljs-template-variable { color:var(--pinvou-hl-number, #0550AE); }
-    .hljs-built_in,.hljs-builtin-name { color:var(--pinvou-hl-built-in, #953800); }
-    .hljs-attr,.hljs-attribute,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id { color:var(--pinvou-hl-attribute, #116329); }
-    .hljs-property { color:var(--pinvou-hl-property, #0550AE); }
-    .hljs-params { color:var(--pinvou-hl-parameter, #9A6700); }
-    .hljs-meta { color:var(--pinvou-hl-meta, #8250DF); }
-    .hljs-punctuation { color:var(--pinvou-hl-punctuation, #8C959F); }
-    .hljs-operator { color:var(--pinvou-hl-operator, #57606A); }
-    .hljs-addition { color:var(--pinvou-hl-addition, #116329); }
-    .hljs-deletion { color:var(--pinvou-hl-deletion, #A40E26); }
-    .hljs-emphasis { font-style:italic; }
-    .hljs-strong { font-weight:700; }
+    .pinvou-code-block .hljs-comment,.pinvou-code-block .hljs-quote { color:var(--pinvou-hl-comment, #6E7781); font-style:italic; }
+    .pinvou-code-block .hljs-keyword,.pinvou-code-block .hljs-selector-tag,.pinvou-code-block .hljs-literal,.pinvou-code-block .hljs-section,.pinvou-code-block .hljs-link { color:var(--pinvou-hl-keyword, #CF222E); }
+    .pinvou-code-block .hljs-title,.pinvou-code-block .hljs-title.class_,.pinvou-code-block .hljs-title.function_,.pinvou-code-block .hljs-name,.pinvou-code-block .hljs-type { color:var(--pinvou-hl-title, #8250DF); }
+    .pinvou-code-block .hljs-string,.pinvou-code-block .hljs-regexp,.pinvou-code-block .hljs-symbol,.pinvou-code-block .hljs-bullet { color:var(--pinvou-hl-string, #0A3069); }
+    .pinvou-code-block .hljs-number,.pinvou-code-block .hljs-variable,.pinvou-code-block .hljs-template-variable { color:var(--pinvou-hl-number, #0550AE); }
+    .pinvou-code-block .hljs-built_in,.pinvou-code-block .hljs-builtin-name { color:var(--pinvou-hl-built-in, #953800); }
+    .pinvou-code-block .hljs-attr,.pinvou-code-block .hljs-attribute,.pinvou-code-block .hljs-selector-attr,.pinvou-code-block .hljs-selector-class,.pinvou-code-block .hljs-selector-id { color:var(--pinvou-hl-attribute, #116329); }
+    .pinvou-code-block .hljs-property { color:var(--pinvou-hl-property, #0550AE); }
+    .pinvou-code-block .hljs-params { color:var(--pinvou-hl-parameter, #9A6700); }
+    .pinvou-code-block .hljs-meta { color:var(--pinvou-hl-meta, #8250DF); }
+    .pinvou-code-block .hljs-punctuation { color:var(--pinvou-hl-punctuation, #8C959F); }
+    .pinvou-code-block .hljs-operator { color:var(--pinvou-hl-operator, #57606A); }
+    .pinvou-code-block .hljs-addition { color:var(--pinvou-hl-addition, #116329); }
+    .pinvou-code-block .hljs-deletion { color:var(--pinvou-hl-deletion, #A40E26); }
+    .pinvou-code-block .hljs-warning { color:var(--pinvou-hl-warning, #9A6700); }
+    .pinvou-code-block .hljs-emphasis { font-style:italic; }
+    .pinvou-code-block .hljs-strong { font-weight:700; }
 
     /* Language-specific refinements built on the shared token theme. */
     code.language-diff .hljs-addition,
@@ -356,17 +377,22 @@
       letter-spacing:.02em;
     }
 
-    code.language-accesslog {
+    code:is(.language-accesslog,.language-log) {
       font-variant-numeric:tabular-nums;
     }
-    code.language-accesslog .hljs-keyword {
+    code:is(.language-accesslog,.language-log) .hljs-keyword {
       color:var(--pinvou-hl-keyword);
       font-weight:750;
     }
-    code.language-accesslog .hljs-string { color:var(--pinvou-hl-string); }
-    code.language-accesslog .hljs-number {
+    code:is(.language-accesslog,.language-log) .hljs-string { color:var(--pinvou-hl-string); }
+    code:is(.language-accesslog,.language-log) .hljs-number {
       color:var(--pinvou-hl-number);
       font-weight:600;
+    }
+    code.language-log .hljs-warning { font-weight:700; }
+    code.language-log .hljs-deletion {
+      color:var(--pinvou-hl-deletion);
+      font-weight:750;
     }
 
     /* Tool card styles */

--- a/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
+++ b/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { renderMarkdownMarkup } from '../src/shared/markdown-renderer.js';
+import {
+  highlightCode,
+  MAX_HIGHLIGHT_SOURCE_BYTES,
+  normalizeSyntaxLanguage,
+  supportedSyntaxLanguages,
+} from '../src/shared/syntax-highlighter.js';
+
+const testRoot = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(testRoot, '..');
+const readApp = (...parts) => fs.readFileSync(path.join(appRoot, ...parts), 'utf8');
+
+assert.ok(
+  supportedSyntaxLanguages.length >= 70,
+  `expected broad syntax coverage, found ${supportedSyntaxLanguages.length} languages`,
+);
+for (const language of [
+  'javascript', 'typescript', 'python', 'java', 'c', 'cpp', 'csharp', 'go', 'rust',
+  'kotlin', 'swift', 'dart', 'php', 'ruby', 'bash', 'powershell', 'sql', 'json',
+  'yaml', 'ini', 'dockerfile', 'cmake', 'nginx', 'haskell', 'elixir', 'r', 'julia',
+  'x86asm', 'wasm', 'xml', 'css', 'markdown', 'diff',
+]) {
+  assert.ok(supportedSyntaxLanguages.includes(language), `missing syntax language: ${language}`);
+}
+
+for (const [alias, canonical] of [
+  ['js', 'javascript'], ['jsx', 'javascript'], ['tsx', 'typescript'], ['py', 'python'],
+  ['cs', 'csharp'], ['c++', 'cpp'], ['ps1', 'powershell'], ['yml', 'yaml'],
+  ['toml', 'ini'], ['vue', 'xml'], ['svelte', 'xml'], ['html', 'xml'],
+]) {
+  assert.equal(normalizeSyntaxLanguage(alias), canonical, `${alias} alias must resolve to ${canonical}`);
+}
+
+const python = renderMarkdownMarkup([
+  '```python',
+  'def heap_sort(arr):',
+  '    return sorted(arr)',
+  '```',
+].join('\n'));
+assert.match(python, /class="pinvou-code-block" data-language="Python"/u);
+assert.match(python, /data-language-id="python"/u);
+assert.match(python, /class="hljs language-python"/u);
+assert.match(python, /hljs-keyword">def</u);
+assert.match(python, /hljs-title function_">heap_sort</u);
+
+const tsx = renderMarkdownMarkup('```tsx\nconst App = () => <main>Hello</main>;\n```');
+assert.match(tsx, /data-language="TSX"/u);
+assert.match(tsx, /data-language-id="tsx"/u);
+assert.match(tsx, /class="hljs language-typescript"/u);
+assert.match(tsx, /hljs-keyword">const</u);
+
+const html = renderMarkdownMarkup('```html\n<main><script>const ready = true;</script><style>.app { color: red; }</style></main>\n```');
+assert.match(html, /data-language-id="html"/u);
+assert.match(html, /class="language-javascript"/u);
+assert.match(html, /class="language-css"/u);
+
+const vue = renderMarkdownMarkup('```vue\n<UserCard v-if="user" :name="user.name">{{ user.name }}</UserCard>\n```');
+assert.match(vue, /data-language-id="vue"/u);
+assert.match(vue, /class="hljs language-xml"/u);
+assert.match(vue, /hljs-name">UserCard</u);
+assert.match(vue, /hljs-attr">v-if</u);
+
+const diff = renderMarkdownMarkup('```diff\n-oldValue\n+newValue\n```');
+assert.match(diff, /hljs-deletion">-oldValue</u);
+assert.match(diff, /hljs-addition">\+newValue</u);
+
+const json = renderMarkdownMarkup('```json\n{"enabled": true}\n```');
+assert.match(json, /hljs-attr">&quot;enabled&quot;</u);
+assert.match(json, /hljs-punctuation">\{/u);
+
+const sql = renderMarkdownMarkup('```sql\nSELECT COUNT\(\*\) FROM users WHERE id = :id;\n```');
+assert.match(sql, /hljs-keyword">SELECT</u);
+assert.match(sql, /hljs-built_in">COUNT</u);
+
+const autoDetected = renderMarkdownMarkup('```\ndef greet(name):\n    return f"Hello {name}"\n```');
+assert.match(autoDetected, /data-language="Python"/u);
+assert.match(autoDetected, /hljs-keyword">def</u);
+
+const incompleteStream = renderMarkdownMarkup('```\ndef greet(name):\n    return name');
+assert.match(incompleteStream, /data-language="Text"/u);
+assert.doesNotMatch(incompleteStream, /hljs-keyword/u);
+
+const unsupported = renderMarkdownMarkup('```unknown-lang\n<script>alert("x")</script>\n```');
+assert.match(unsupported, /class="hljs language-plaintext"/u);
+assert.match(unsupported, /&lt;script&gt;/u);
+assert.doesNotMatch(unsupported, /<script>/u);
+
+const oversizedJavaScript = highlightCode(
+  `const value = 1;\n${'x'.repeat(MAX_HIGHLIGHT_SOURCE_BYTES)}`,
+  'javascript',
+);
+assert.equal(oversizedJavaScript.language, 'plaintext');
+assert.equal(oversizedJavaScript.languageId, 'plaintext');
+assert.equal(oversizedJavaScript.label, 'JavaScript');
+assert.equal(oversizedJavaScript.highlighted, false);
+assert.equal(oversizedJavaScript.oversized, true);
+assert.doesNotMatch(oversizedJavaScript.html, /hljs-keyword/u);
+
+const oversizedUtf8 = highlightCode(
+  '中'.repeat(Math.ceil(MAX_HIGHLIGHT_SOURCE_BYTES / 3) + 1),
+  'python',
+);
+assert.equal(oversizedUtf8.language, 'plaintext');
+assert.equal(oversizedUtf8.oversized, true);
+
+const dangerousRawHtml = renderMarkdownMarkup('before <script>alert("x")</script> after');
+assert.match(dangerousRawHtml, /&lt;script&gt;/u);
+assert.doesNotMatch(dangerousRawHtml, /<script>/u);
+
+const css = readApp('src', 'styles', 'base.css');
+assert.match(css, /\.dark-code \.msg-md :not\(pre\) > code/u);
+assert.match(css, /\.light-code \.msg-md :not\(pre\) > code/u);
+assert.match(css, /\.dark-code \.msg-md pre > code \{ background:transparent; color:inherit; \}/u);
+assert.match(css, /\.msg-md pre\.pinvou-code-block::before/u);
+assert.match(css, /\.hljs-keyword/u);
+for (const selector of [
+  'code.language-diff .hljs-addition',
+  'code.language-json .hljs-punctuation',
+  'code:is(.language-yaml,.language-ini) .hljs-attr',
+  'code:is(.language-bash,.language-shell,.language-powershell) .hljs-built_in',
+  'code:is(.language-sql,.language-pgsql) .hljs-keyword',
+  'code.language-xml .hljs-name',
+  'pre:is([data-language-id="vue"],[data-language-id="svelte"])',
+  'code:is(.language-javascript,.language-typescript) .hljs-title.class_',
+  'code.language-python .hljs-meta',
+  'code:is(.language-java,.language-csharp,.language-kotlin) .hljs-meta',
+  'code:is(.language-c,.language-cpp) .hljs-meta',
+  'code:is(.language-go,.language-rust) .hljs-type',
+  'code.language-markdown .hljs-quote',
+  'code.language-dockerfile > .hljs-keyword',
+  'code.language-accesslog .hljs-number',
+]) {
+  assert.ok(css.includes(selector), `missing language-specific style: ${selector}`);
+}
+
+for (const bridgePath of [
+  ['src', 'platform', 'tauri', 'bridge.js'],
+  ['src', 'platform', 'web', 'bridge.js'],
+]) {
+  assert.match(
+    readApp(...bridgePath),
+    /window\.PinvouMarkdownRenderer\.renderMarkdown\(text\)/u,
+    `${bridgePath.join('/')} must delegate to the shared renderer`,
+  );
+}
+assert.match(
+  readApp('src', 'features', 'conversation', 'ConversationTimeline.jsx'),
+  /import \{ renderMarkdown \} from '\.\.\/\.\.\/shared\/markdown-renderer\.js'/u,
+);
+console.log('Markdown syntax highlighting contract: ok');

--- a/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
+++ b/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
@@ -16,7 +16,7 @@ const appRoot = path.resolve(testRoot, '..');
 const readApp = (...parts) => fs.readFileSync(path.join(appRoot, ...parts), 'utf8');
 
 assert.ok(
-  supportedSyntaxLanguages.length >= 70,
+  supportedSyntaxLanguages.length >= 75,
   `expected broad syntax coverage, found ${supportedSyntaxLanguages.length} languages`,
 );
 for (const language of [
@@ -24,6 +24,7 @@ for (const language of [
   'kotlin', 'swift', 'dart', 'php', 'ruby', 'bash', 'powershell', 'sql', 'json',
   'yaml', 'ini', 'dockerfile', 'cmake', 'nginx', 'haskell', 'elixir', 'r', 'julia',
   'x86asm', 'wasm', 'xml', 'css', 'markdown', 'diff',
+  'log',
 ]) {
   assert.ok(supportedSyntaxLanguages.includes(language), `missing syntax language: ${language}`);
 }
@@ -31,7 +32,7 @@ for (const language of [
 for (const [alias, canonical] of [
   ['js', 'javascript'], ['jsx', 'javascript'], ['tsx', 'typescript'], ['py', 'python'],
   ['cs', 'csharp'], ['c++', 'cpp'], ['ps1', 'powershell'], ['yml', 'yaml'],
-  ['toml', 'ini'], ['vue', 'xml'], ['svelte', 'xml'], ['html', 'xml'],
+  ['toml', 'ini'], ['vue', 'xml'], ['svelte', 'xml'], ['html', 'xml'], ['logs', 'log'],
 ]) {
   assert.equal(normalizeSyntaxLanguage(alias), canonical, `${alias} alias must resolve to ${canonical}`);
 }
@@ -85,6 +86,28 @@ const incompleteStream = renderMarkdownMarkup('```\ndef greet(name):\n    return
 assert.match(incompleteStream, /data-language="Text"/u);
 assert.doesNotMatch(incompleteStream, /hljs-keyword/u);
 
+const incompleteExplicitStream = renderMarkdownMarkup('```python\ndef greet(name):\n    return name');
+assert.match(incompleteExplicitStream, /data-language="Python"/u);
+assert.match(incompleteExplicitStream, /data-language-id="plaintext"/u);
+assert.match(incompleteExplicitStream, /class="hljs language-plaintext"/u);
+assert.doesNotMatch(incompleteExplicitStream, /hljs-keyword/u);
+
+const genericLog = renderMarkdownMarkup([
+  '```log',
+  '2026-07-30T10:00:00+08:00 INFO GET /api/users status=200',
+  '2026-07-30T10:00:01+08:00 WARN retry status=429',
+  '2026-07-30T10:00:02+08:00 ERROR request failed status=500',
+  '```',
+].join('\n'));
+assert.match(genericLog, /data-language="Log"/u);
+assert.match(genericLog, /class="hljs language-log"/u);
+assert.match(genericLog, /hljs-built_in">INFO</u);
+assert.match(genericLog, /hljs-warning">WARN</u);
+assert.match(genericLog, /hljs-deletion">ERROR</u);
+assert.match(genericLog, /hljs-keyword">GET</u);
+assert.match(genericLog, /hljs-string">\/api\/users</u);
+assert.match(genericLog, /hljs-attr">status</u);
+
 const unsupported = renderMarkdownMarkup('```unknown-lang\n<script>alert("x")</script>\n```');
 assert.match(unsupported, /class="hljs language-plaintext"/u);
 assert.match(unsupported, /&lt;script&gt;/u);
@@ -108,6 +131,16 @@ const oversizedUtf8 = highlightCode(
 assert.equal(oversizedUtf8.language, 'plaintext');
 assert.equal(oversizedUtf8.oversized, true);
 
+const cachedSource = 'const cacheProbe = () => 42;';
+const cachedFirst = highlightCode(cachedSource, 'javascript');
+const cachedSecond = highlightCode(cachedSource, 'javascript');
+assert.strictEqual(cachedSecond, cachedFirst, 'completed code highlight should use the bounded cache');
+for (let index = 1; index <= 24; index += 1) {
+  highlightCode(`const boundedCacheProbe${index} = ${index};`, 'javascript');
+}
+const cachedAfterEviction = highlightCode(cachedSource, 'javascript');
+assert.notStrictEqual(cachedAfterEviction, cachedFirst, 'highlight cache must evict its least-recently-used entry');
+
 const dangerousRawHtml = renderMarkdownMarkup('before <script>alert("x")</script> after');
 assert.match(dangerousRawHtml, /&lt;script&gt;/u);
 assert.doesNotMatch(dangerousRawHtml, /<script>/u);
@@ -115,9 +148,12 @@ assert.doesNotMatch(dangerousRawHtml, /<script>/u);
 const css = readApp('src', 'styles', 'base.css');
 assert.match(css, /\.dark-code \.msg-md :not\(pre\) > code/u);
 assert.match(css, /\.light-code \.msg-md :not\(pre\) > code/u);
-assert.match(css, /\.dark-code \.msg-md pre > code \{ background:transparent; color:inherit; \}/u);
+assert.match(css, /\.msg-md\.dark-code pre > code/u);
+assert.match(css, /\.msg-md\.light-code pre > code/u);
+assert.match(css, /\.persona-body\.dark-code/u);
+assert.match(css, /\.persona-body\.light-code/u);
 assert.match(css, /\.msg-md pre\.pinvou-code-block::before/u);
-assert.match(css, /\.hljs-keyword/u);
+assert.match(css, /\.pinvou-code-block \.hljs-keyword/u);
 for (const selector of [
   'code.language-diff .hljs-addition',
   'code.language-json .hljs-punctuation',
@@ -133,7 +169,8 @@ for (const selector of [
   'code:is(.language-go,.language-rust) .hljs-type',
   'code.language-markdown .hljs-quote',
   'code.language-dockerfile > .hljs-keyword',
-  'code.language-accesslog .hljs-number',
+  'code:is(.language-accesslog,.language-log) .hljs-number',
+  'code.language-log .hljs-warning',
 ]) {
   assert.ok(css.includes(selector), `missing language-specific style: ${selector}`);
 }
@@ -151,5 +188,9 @@ for (const bridgePath of [
 assert.match(
   readApp('src', 'features', 'conversation', 'ConversationTimeline.jsx'),
   /import \{ renderMarkdown \} from '\.\.\/\.\.\/shared\/markdown-renderer\.js'/u,
+);
+assert.match(
+  readApp('src', 'features', 'personas', 'Personas.jsx'),
+  /isDark \? 'dark-code' : 'light-code'/u,
 );
 console.log('Markdown syntax highlighting contract: ok');

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -225,6 +225,101 @@ async function expand(page) {
     JSON.stringify(visualShell),
   );
 
+  const markdownHighlight = await page.evaluate(() => {
+    const render = window.PinvouMarkdownRenderer && window.PinvouMarkdownRenderer.renderMarkdown;
+    if (typeof render !== 'function') return { found: false };
+
+    const fixture = document.createElement('section');
+    fixture.style.cssText = 'position:fixed;left:-10000px;top:0;width:720px;visibility:hidden;';
+    document.body.appendChild(fixture);
+    const markdown = [
+      '```json',
+      '{"enabled": true, "message": "hello"}',
+      '```',
+      '',
+      '```diff',
+      '-oldValue',
+      '+newValue',
+      '```',
+    ].join('\n');
+
+    function addSample(mode, structure) {
+      const wrapper = document.createElement('div');
+      let content;
+      if (structure === 'nested') {
+        wrapper.className = `${mode}-code`;
+        content = document.createElement('div');
+        content.className = 'msg-md';
+        wrapper.appendChild(content);
+      } else if (structure === 'persona') {
+        content = wrapper;
+        content.className = `persona-body ${mode}-code`;
+      } else {
+        content = wrapper;
+        content.className = `msg-md ${mode}-code`;
+      }
+      content.innerHTML = render(markdown);
+      fixture.appendChild(wrapper);
+      const pre = content.querySelector('pre[data-language-id="json"]');
+      const stringToken = pre && pre.querySelector('.hljs-string');
+      const attrToken = pre && pre.querySelector('.hljs-attr');
+      const addition = content.querySelector('.language-diff .hljs-addition');
+      return {
+        languageId: pre && pre.dataset.languageId,
+        stringColor: stringToken && getComputedStyle(stringToken).color,
+        attrColor: attrToken && getComputedStyle(attrToken).color,
+        preBackground: pre && getComputedStyle(pre).backgroundColor,
+        label: pre && getComputedStyle(pre, '::before').content,
+        diffBackground: addition && getComputedStyle(addition).backgroundColor,
+      };
+    }
+
+    const lightNested = addSample('light', 'nested');
+    const lightSame = addSample('light', 'same');
+    const darkNested = addSample('dark', 'nested');
+    const darkSame = addSample('dark', 'same');
+    const darkPersona = addSample('dark', 'persona');
+
+    const sanitized = document.createElement('div');
+    sanitized.innerHTML = render([
+      '<img src="x" onerror="window.__MARKDOWN_XSS__=true">',
+      '<script>window.__MARKDOWN_XSS__=true</script>',
+      '',
+      '```json',
+      '{"safe": true}',
+      '```',
+    ].join('\n'));
+    const sanitizedPre = sanitized.querySelector('pre[data-language-id="json"]');
+    const security = {
+      noScriptElement: !sanitized.querySelector('script'),
+      noEventAttribute: !sanitized.querySelector('img')?.hasAttribute('onerror'),
+      noExecution: window.__MARKDOWN_XSS__ !== true,
+      dataAttributePreserved: sanitizedPre?.dataset.languageId === 'json',
+      highlightMarkupPreserved: !!sanitizedPre?.querySelector('.hljs-attr'),
+    };
+    fixture.remove();
+    return { found: true, lightNested, lightSame, darkNested, darkSame, darkPersona, security };
+  });
+  const transparent = value => !value || value === 'rgba(0, 0, 0, 0)' || value === 'transparent';
+  rec(
+    'Markdown highlighting uses sanitized DOM and consistent computed themes',
+    markdownHighlight.found
+      && Object.values(markdownHighlight.security || {}).every(Boolean)
+      && markdownHighlight.lightNested.languageId === 'json'
+      && markdownHighlight.lightNested.stringColor === markdownHighlight.lightSame.stringColor
+      && markdownHighlight.lightNested.attrColor === markdownHighlight.lightSame.attrColor
+      && markdownHighlight.darkNested.stringColor === markdownHighlight.darkSame.stringColor
+      && markdownHighlight.darkNested.attrColor === markdownHighlight.darkSame.attrColor
+      && markdownHighlight.darkSame.stringColor === markdownHighlight.darkPersona.stringColor
+      && markdownHighlight.darkSame.attrColor === markdownHighlight.darkPersona.attrColor
+      && markdownHighlight.darkSame.stringColor !== markdownHighlight.lightSame.stringColor
+      && markdownHighlight.darkSame.preBackground === markdownHighlight.darkPersona.preBackground
+      && !transparent(markdownHighlight.darkSame.diffBackground)
+      && !transparent(markdownHighlight.lightSame.diffBackground)
+      && String(markdownHighlight.darkPersona.label).includes('JSON'),
+    JSON.stringify(markdownHighlight),
+  );
+
   // ① 启动落草稿页(僵尸 run 不劫持)
   const st = await page.evaluate(() => {
     const s = window.TauriBridge.state.getMany(['chat', 'workflow', 'vllm']);


### PR DESCRIPTION
## 概述

完善桌面端与远程访问端的 Markdown 围栏代码高亮，并修复独立评审发现的流式渲染性能、主题作用域、通用日志支持和测试真实性问题。完成后，常用语言代码块具备一致的语言标签、明暗主题和专项样式，未闭合流式内容及超大代码块能够稳定降级。

## 背景

原有 Markdown 渲染只负责解析和安全清洗，没有对代码关键字、类型、字符串、注释等进行语法着色；同时内联代码样式会覆盖围栏代码背景，形成逐行深色条，影响代码可读性。

首次实现后，独立评审进一步发现四类问题：显式声明语言但尚未闭合的流式代码仍会在每次增量中重复高亮；工作流、可编辑 Markdown 和专家正文使用“主题类与正文类同元素”的结构，原选择器无法覆盖；通用 `log` 围栏仍按纯文本显示；测试只验证字符串输出和 CSS 文本，没有经过真实浏览器中的 DOMPurify 与计算样式路径。本 PR 一并修复这些问题并补齐回归测试。

## 变更

- 新增共享 Markdown 渲染入口，统一 `marked` 解析、危险原始标签中和、DOMPurify 清洗和围栏代码输出，桌面端、远程访问端及会话时间线复用相同行为。
- 使用 `highlight.js core` 静态注册 74 种官方语法，并增加一套内置通用日志 grammar；补充 JavaScript、TypeScript、Python、C++、PowerShell、Vue、Svelte 等常见别名。
- 仅在代码围栏闭合后执行显式高亮或自动识别；流式未闭合代码保留原语言标签但按纯文本渲染，避免每个增量重复解析和颜色反复变化。
- 对单个代码块设置 128 KiB UTF-8 字节上限，超限、未知语言或高亮异常时安全降级为纯文本；对不超过 64 KiB 的完成结果使用最多 24 项的 LRU 缓存，降低重复渲染开销并限制内存占用。
- 修正内联代码与围栏代码的 CSS 作用域，兼容“主题类包裹正文”和“主题类与正文同元素”两种结构，并覆盖普通消息、工作流、可编辑 Markdown、Codex 会话与专家正文。
- 在通用明暗主题上增加 Diff/Patch、JSON、YAML/TOML/INI、Shell/PowerShell、SQL/PostgreSQL、HTML/XML、Vue/Svelte、JavaScript/TypeScript、Python、Java/C#/Kotlin、C/C++、Go/Rust、Markdown、Dockerfile、Access Log 和通用日志的专项层次。
- 通用日志可区分时间、日志等级、HTTP 方法、路径、键名和状态码；警告与错误采用独立颜色及字重，Diff 新增/删除行保留淡绿/淡红背景。
- 高亮 token 样式限定在 Pinvou 代码块内，避免影响其他使用相同 class 名称的页面元素；宠物独立窗口继续使用原有轻量 Markdown 路径，不加载完整语法包。
- 补充语言覆盖、别名、流式围栏、UTF-8 上限、通用日志、缓存命中与 LRU 淘汰、危险 HTML 中和及样式契约测试。
- 在真实 Chromium 中执行共享渲染器与 DOMPurify，验证脚本和事件属性被移除、高亮标记及 `data-language-id` 被保留，并比对嵌套/同元素/专家正文的实际计算颜色、背景和语言标题。

## 影响面

- 影响桌面端和远程访问端的助手消息、Codex 会话、工作流 Markdown、Markdown 产物编辑预览及专家正文中的代码块显示。
- 不改变普通文本、模型输出内容、后端协议、CodeWhale 子模块或平台运行时；未知语言和异常输入仍以转义后的纯文本展示。
- 74 种官方语法采用静态打包以保证离线可用和首屏无异步闪烁，主前端 bundle 会增大；构建仍存在仓库已有的大 chunk 提示。
- Vue/Svelte 复用 XML grammar，TOML 复用 INI grammar，PostgreSQL 复用 SQL grammar，专项效果受对应 grammar 的 token 粒度限制。

## 验证

- `npm test`：通过，包含 Markdown 高亮、最新主线附件交互及全部现有单元/平台契约测试。
- `npm run test:bridge-smoke`：通过；UI 42 项、设置 34 项、知识库 10 项、Composer 8 项、设计模式 29 项、工具商店 39 项全部通过。
- `npm run test:webui`：通过，31 项桌面/移动 WebUI 旅程全部通过。
- `npm run lint:ui`：通过。
- `npm run check:architecture`：通过，无新增架构债务；仅输出仓库已有的大文件建议警告。
- `npm run build:ui`：通过；仅输出仓库已有的经典脚本与大 chunk 提示。
- `npm audit --omit=dev`：通过，生产依赖 0 个漏洞。
- 70,279 字节未闭合 Python 流式代码诊断：单次渲染由约 15.31 ms 降至约 0.37 ms。
- `git diff --check origin/main...HEAD`：通过。
- 两条分支提交均包含有效 `Signed-off-by`，分支已同步最新 `origin/main`，主线附件功能及其测试在冲突处理中完整保留。