### PR TITLE
fix(ci): 公开运行时发布不再依赖凭据

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -20,8 +20,8 @@ name: release-packages
 #
 # 签名:Windows nsis 不签名(config/platforms/windows 无证书配置);macOS ad-hoc
 # (signingIdentity="-",用户首次安装需 xattr -dr com.apple.quarantine)。
-# Windows 正式发布依赖受保护的 windows-release Environment 及其只读
-# PINVOU3_WINDOWS_RUNTIME_TOKEN；任何 PR job 都不引用该凭据。
+# Windows 正式发布仍进入 windows-release Environment。运行时仓库已公开，
+# checkout 后不保留凭据，后续按锁定 gitlink 匿名拉取运行时和 Git LFS 对象。
 
 on:
   push:
@@ -282,18 +282,9 @@ jobs:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v7
         with:
-          # 私有运行时由初始化脚本按锁文件精确拉取。
+          # 公开运行时由初始化脚本按锁文件精确拉取；不向跨仓库 submodule 传递 job token。
           submodules: false
-          token: ${{ secrets.PINVOU3_WINDOWS_RUNTIME_TOKEN || github.token }}
-
-      - name: 检查 Windows 私有运行时凭据
-        env:
-          WINDOWS_RUNTIME_TOKEN: ${{ secrets.PINVOU3_WINDOWS_RUNTIME_TOKEN }}
-        run: |
-          if [[ -z "$WINDOWS_RUNTIME_TOKEN" ]]; then
-            echo "::error::正式 Windows 发布缺少 PINVOU3_WINDOWS_RUNTIME_TOKEN，拒绝生成不完整发布。"
-            exit 1
-          fi
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -317,7 +308,7 @@ jobs:
         working-directory: pinvou3-app
         run: npm ci --prefer-offline --no-audit
 
-      - name: 初始化 Windows 私有运行时
+      - name: 初始化 Windows 独立运行时
         working-directory: pinvou3-app
         run: npm run runtime:windows:init
 

--- a/docs/windows-private-runtime-submodule.md
+++ b/docs/windows-private-runtime-submodule.md
@@ -1,25 +1,27 @@
-# Windows 私有运行时 submodule
+# Windows 独立运行时 submodule
 
 ## 目标
 
 Windows 分支只维护代码、安装器模板和 submodule gitlink。Poppler、Tesseract、Python、
-Node.js、Pandoc、ONNX Runtime、ASR 引擎、7-Zip 和 VC Runtime 存放在私有仓库：
+Node.js、Pandoc、ONNX Runtime、ASR 引擎、7-Zip 和 VC Runtime 存放在公开仓库：
 
 ```text
 https://github.com/Pinvou/pinvou3-windows-runtime.git
 ```
 
-主仓库不保存这些二进制，也不在基础 `tauri.conf.json` 中硬编码私有资源路径。
+主仓库不保存这些大型二进制，也不在基础 `tauri.conf.json` 中硬编码平台资源路径。
+`private-runtimes/windows` 是为保持 gitlink、缓存和构建脚本兼容而保留的历史路径名，
+不代表当前仓库可见性。
 
 ## 目录和版本锁定
 
 主仓库引用：
 
 ```text
-private-runtimes/windows  -> 私有仓库的确定 commit
+private-runtimes/windows  -> 公开运行时仓库的确定 commit
 ```
 
-私有仓库的 `payload/` 按组件保存资源。Poppler、Tesseract、ASR、7-Zip 分别使用一个
+运行时仓库的 `payload/` 按组件保存资源。Poppler、Tesseract、ASR、7-Zip 分别使用一个
 确定性 ZIP；Python、Node.js、Pandoc、ONNX Runtime 继续使用各自的上游组件包；
 VC Runtime 保持独立文件。二进制由 Git LFS 管理。
 
@@ -31,10 +33,10 @@ VC Runtime 保持独立文件。二进制由 Git LFS 管理。
 主仓库 `pinvou3-app/src-tauri/config/platforms/windows/runtime/x86_64.lock.json` 再锁定：
 
 - submodule URL、路径和 commit；
-- 私有 manifest 路径及 SHA-256；
+- runtime manifest 路径及 SHA-256；
 - 目标平台 `windows-x86_64`。
 
-因此版本完整性由三层保证：主仓库 gitlink、主仓库 lock、私有文件级 manifest。
+因此版本完整性由三层保证：主仓库 gitlink、主仓库 lock、运行时文件级 manifest。
 
 ## 初始化和构建
 
@@ -46,7 +48,7 @@ npm run runtime:windows:stage
 npm run build:nsis
 ```
 
-私有 submodule 配置为 `update = none`，普通的递归 submodule 初始化只处理公共底座，
+运行时 submodule 配置为 `update = none`，普通的递归 submodule 初始化只处理公共底座，
 Windows 构建机通过 `runtime:windows:init` 显式覆盖该策略并拉取 Git LFS 对象。
 
 ### Jenkins 子模块准备
@@ -60,7 +62,7 @@ npm --prefix pinvou3-app run runtime:windows:init
 
 `CodeWhale` 当前没有嵌套 submodule，因此不需要 `--recursive`。`runtime:windows:init` 会比较主仓库 gitlink 与本地 runtime
 commit；一致且工作树中不存在 LFS pointer 时，跳过 submodule update 和 `git lfs pull`。脚本输出的
-`PINVOU3_WINDOWS_RUNTIME_CACHE_KEY=pinvou3-windows-runtime-<commit>` 可作为 Jenkins 缓存键，缓存私有 runtime checkout、
+`PINVOU3_WINDOWS_RUNTIME_CACHE_KEY=pinvou3-windows-runtime-<commit>` 可作为 Jenkins 缓存键，缓存 runtime checkout、
 Git LFS objects 和 `pinvou3-app/src-tauri/target/windows-runtime`。
 
 Jenkins 的 `CheckoutSubmodule` 阶段只负责准备 submodule，不再单独执行 `runtime:windows:validate`。后续直接运行
@@ -74,21 +76,21 @@ npm --prefix pinvou3-app run runtime:windows:cache-key
 ```
 
 建议缓存 `.git/modules/private-runtimes/windows/lfs/objects` 与 `pinvou3-app/src-tauri/target/windows-runtime`；前者避免重复下载
-LFS 对象，后者复用已验证、已展开的安装资源。每次构建都会按私有 manifest 重新核对源文件 SHA-256；复用 staging 前还会按
+LFS 对象，后者复用已验证、已展开的安装资源。每次构建都会按 runtime manifest 重新核对源文件 SHA-256；复用 staging 前还会按
 `.verified-stage.json` 对全部会进入构建链路的展开文件重新核对路径、大小和 SHA-256，缓存内容发生缺失或修改时自动回退到原子 staging。
 
 主仓库 checkout 的 refspec、tag 获取和 shallow clone 由 Jenkins SCM 插件控制，不在仓库脚本内。发布 Job 应启用
 `Honor refspec on initial clone`、`No tags`，并把 refspec 限制为实际构建分支或 MR ref；不要在每次构建中抓取全部分支和 tag。
 
-GitHub Actions 构建 Windows NSIS 时，需要创建受保护的 GitHub Environment
-`windows-release`，并在该 Environment 内配置 Secret
-`PINVOU3_WINDOWS_RUNTIME_TOKEN`。不要把该凭据配置成仓库或组织 Secret。该凭据只需对主仓库和
-`Pinvou/pinvou3-windows-runtime` 具有 `Contents: read` 权限；Environment 应限制为受保护的
-`main` 分支，并按发布策略配置 required reviewers。
+GitHub Actions 构建 Windows NSIS 时仍进入 `windows-release` Environment，作为正式发布边界；
+job 自身只允许 `main`，Environment 可按发布策略进一步配置 protected branch 和 required reviewers。
+运行时仓库已公开，不需要仓库级、组织级或 Environment Secret。checkout 设置
+`persist-credentials: false`，初始化脚本按锁定 URL、gitlink 和 manifest 匿名拉取运行时及
+Git LFS 对象。
 
-所有 PR（包括同仓 PR）都只运行不引用私有凭据的 Windows 打包契约测试。只有 `main` 的发布链路
-push 或在 `main` 上执行的 `workflow_dispatch` 才能进入 `windows-release` 构建正式 NSIS。
-受保护构建缺少该 Secret 时会明确失败，避免产生缺少 Windows 产物的不完整发布。
+所有 PR（包括同仓 PR）只运行不拉取大型运行时的 Windows 打包契约测试。只有 `main` 的发布链路
+push 或在 `main` 上执行的 `workflow_dispatch` 才能进入 `windows-release` 构建正式 NSIS；
+运行时缺失、gitlink 不一致或 LFS 对象未物化时仍会明确失败，避免产生不完整发布。
 
 `scripts/tauri/build.js` 是项目内 `tauri build` / `tauri bundle` 的统一入口：Windows
 构建前自动执行 staging，所有平台都会加载对应 config overlay，并在调用 Tauri CLI 前
@@ -99,10 +101,10 @@ resolver 只负责验证、展开运行时并生成 `target/windows-runtime/runt
 `scripts/tauri/windows-installer.js` 只在目标包含 NSIS 时消费 descriptor 中的 VC Runtime。
 Codex Bridge 同样从 descriptor 取得已锁定 Node，不反向解析 Tauri 资源映射。
 
-迁移验证阶段可设置 `PINVOU3_WINDOWS_RUNTIME_ROOT` 指向相同 commit 的本地私有仓库；
+迁移验证阶段可设置 `PINVOU3_WINDOWS_RUNTIME_ROOT` 指向相同 commit 的本地运行时仓库；
 正式发布不得用它绕过主仓库锁定的 submodule。
 
-普通开发和检查不需要私有仓库：
+普通开发和检查不需要初始化运行时仓库：
 
 ```powershell
 cd pinvou3-app/src-tauri
@@ -114,7 +116,7 @@ cargo check
 1. 在临时目录展开并修改对应组件；
 2. 使用 `scripts/pack-component.ps1` 重新生成对应的确定性 ZIP；
 3. 执行 `scripts/update-manifest.ps1`；
-4. 提交并推送私有仓库，只有变更组件产生新的 LFS 对象；
+4. 提交并推送运行时仓库，只有变更组件产生新的 LFS 对象；
 5. 主仓库更新 submodule gitlink；
 6. 更新主仓库 lock 中的 commit 和 manifest SHA-256；
 7. 从干净 checkout 验证 staging 和安装包。
@@ -124,7 +126,7 @@ lock。若 Git LFS 没有拉取成功，resolver 会识别 pointer 文件并在�
 
 ## 多平台扩展
 
-macOS 私有运行时应使用独立路径和仓库，例如：
+macOS 平台运行时应使用独立路径和仓库，例如：
 
 ```text
 private-runtimes/windows

--- a/pinvou3-app/scripts/tauri/windows-runtime.js
+++ b/pinvou3-app/scripts/tauri/windows-runtime.js
@@ -132,7 +132,7 @@ function stageWindowsRuntime({
   if (child.error) throw child.error;
   if (child.status !== 0) {
     throw new Error(
-      `Windows 私有运行时 staging 失败（退出码 ${child.status ?? "unknown"}）`,
+      `Windows 独立运行时 staging 失败（退出码 ${child.status ?? "unknown"}）`,
     );
   }
   const runtime = describeWindowsRuntime();

--- a/pinvou3-app/src-tauri/config/README.md
+++ b/pinvou3-app/src-tauri/config/README.md
@@ -13,7 +13,7 @@ config/
 ```
 
 - `tauri.conf.json`：对应平台的安装包目标、资源映射和安装器参数；macOS 额外把主窗口覆盖为原生顶栏（`decorations: true` + `titleBarStyle: "Overlay"` + `hiddenTitle`，系统红绿灯替代前端自绘三键）。
-- `windows/runtime/x86_64.lock.json`：锁定 Windows 私有 runtime 的 submodule commit、manifest 与目标架构；实际资源映射由 staging 后生成的 overlay 提供。
+- `windows/runtime/x86_64.lock.json`：锁定 Windows 独立 runtime 的 submodule commit、manifest 与目标架构；实际资源映射由 staging 后生成的 overlay 提供。
 
 `--config` overlay 按 JSON Merge Patch 合并：对象合并、**数组整体替换**。因此 macOS overlay 中的
 `app.windows` 是基础配置主窗口定义的完整拷贝，改动基础配置 `app.windows` 字段时必须同步此处。
@@ -21,7 +21,7 @@ config/
 `scripts/tauri/build.js` 根据当前操作系统在 **build / bundle** 时加载 `platforms/<os>/tauri.conf.json`
 （Linux/Windows 的 dev 刻意不注入 packaging overlay，见 `tests/tauri_effective_config.test.js`）；macOS
 例外：原生顶栏定义在 overlay 里，因此 dev（`npm run dev` 与 `run-dev.sh` 两条入口）都会以 `--config`
-带上同一份 overlay，保证 dev 与打包产物顶栏一致。公共配置不得引用私有签名工具或私有运行时。
+带上同一份 overlay，保证 dev 与打包产物顶栏一致。公共配置不得引用私有签名工具或直接硬编码大型平台运行时。
 
 Windows 例外由统一构建入口先验证并 staging `private-runtimes/windows`，再加载
 `target/windows-runtime/tauri.generated.conf.json`；Node、VC Runtime 和 ASR 模型交付策略通过同目录的

--- a/pinvou3-app/src-tauri/packaging/README.md
+++ b/pinvou3-app/src-tauri/packaging/README.md
@@ -1,6 +1,6 @@
 # 平台打包目录
 
-这里仅保存社区构建需要的可审查安装资源；大型或私有运行时不得提交到本目录。
+这里仅保存社区构建需要的可审查安装资源；大型运行时不得直接提交到本目录。
 
 ```text
 packaging/
@@ -9,7 +9,7 @@ packaging/
 ├─ macos/                  # 社区版打包配置
 └─ windows/
    ├─ nsis/                # 最小化 NSIS 安装 hook
-   └─ runtime/             # 私有 runtime 的锁校验、descriptor 与原子 staging 脚本
+   └─ runtime/             # 独立 runtime 的锁校验、descriptor 与原子 staging 脚本
 ```
 
 公共构建编排位于 `../../scripts/tauri/`：
@@ -19,7 +19,8 @@ packaging/
 - `windows-runtime.js`：读取 runtime descriptor，不感知安装器细节。
 - `windows-installer.js`：按 bundle 目标准备 NSIS 专属资源。
 
-工具市场不在构建期注入共享 API Key。社区构建不包含私有运行时或官方签名工具。
+工具市场不在构建期注入共享 API Key。社区构建从公开、锁定的独立仓库取得 Windows 运行时，
+不包含私有凭据或官方签名工具。
 
 平台脚本不得修改其他平台的资源树；所有生成物必须写入 `src-tauri/target/`。Windows
 安装包通过 `private-runtimes/windows` 的锁定 gitlink 合入运行时，协议和初始化方式见

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
@@ -1,8 +1,8 @@
-# Windows 私有运行时
+# Windows 独立运行时
 
-Windows 私有运行时不存放在主仓库的 `resources/` 或 `packaging/` 中。主仓库只保留：
+Windows 大型运行时存放在独立的公开仓库，不直接提交到主仓库的 `resources/` 或 `packaging/`。主仓库只保留：
 
-- `../../../config/platforms/windows/runtime/x86_64.lock.json`：锁定私有 submodule commit 和 manifest SHA-256；
+- `../../../config/platforms/windows/runtime/x86_64.lock.json`：锁定 runtime submodule commit 和 manifest SHA-256；
 - `scripts/resolve-runtime.ps1`：校验 submodule、manifest、ZIP 内部清单，原子 staging 并生成 runtime descriptor；
 - `scripts/stage-runtime.ps1`：供构建入口调用的轻量包装。
 
@@ -14,13 +14,13 @@ npm run runtime:windows:validate
 npm run runtime:windows:stage
 ```
 
-`runtime:windows:init` 只在当前 checkout 与主仓库 gitlink 不一致时更新私有 submodule；gitlink 未变化时直接复用。
+`runtime:windows:init` 只在当前 checkout 与主仓库 gitlink 不一致时更新 runtime submodule；gitlink 未变化时直接复用。
 脚本会检查受 LFS 管理的实际文件，只有仍存在 pointer 时才按路径执行 `git lfs pull`，并输出
 `pinvou3-windows-runtime-<commit>` 形式的 Jenkins 缓存键。
 
 校验内容包括 submodule commit、gitlink、origin URL、工作树状态、manifest SHA-256、文件大小与 SHA-256，以及受管理 ZIP 解压后的逐文件清单。
 
-每次构建都会按私有 manifest 复核源文件的大小和 SHA-256。staging 内的 `.verified-lock` 绑定 runtime commit、manifest
+每次构建都会按 runtime manifest 复核源文件的大小和 SHA-256。staging 内的 `.verified-lock` 绑定 runtime commit、manifest
 SHA-256、lock 文件 SHA-256 和目标平台，`.verified-stage.json` 则记录全部展开文件的路径、大小和 SHA-256；任一暂存产物变化
 或使用 `-Force`，都会自动回退到原子 staging。已验证并解包的 payload 以及 ASR 主模型不会留在 staging 中。
 
@@ -32,6 +32,6 @@ src-tauri/target/windows-runtime/<commit>-<manifest-sha>/
 
 生成的 Tauri overlay 位于 `src-tauri/target/windows-runtime/tauri.generated.conf.json`，构建工具路径和安装器输入由同目录的
 `runtime-descriptor.json` 描述。ASR 主模型采用首次启用时下载策略，不进入安装资源映射；VC Runtime 只作为通用组件展开，
-由 NSIS installer adapter 按目标消费。公共 `tauri.conf.json` 不引用私有资源，因此未初始化私有 submodule 时仍可执行 `cargo check`。
+由 NSIS installer adapter 按目标消费。公共 `tauri.conf.json` 不引用大型运行时资源，因此未初始化 runtime submodule 时仍可执行 `cargo check`。
 
 `PINVOU3_WINDOWS_RUNTIME_ROOT` 只用于本地迁移或故障排查，且目标仓库的 commit 必须与 lock 完全一致；正式 CI 和发布始终使用 submodule 默认路径。

--- a/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
+++ b/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
@@ -308,10 +308,11 @@ assert.doesNotMatch(
 
 assert.match(windowsBuildJob, /github\.ref == 'refs\/heads\/main'/);
 assert.match(windowsBuildJob, /environment:\s*\n\s*name: windows-release/);
-assert.match(windowsBuildJob, /PINVOU3_WINDOWS_RUNTIME_TOKEN/);
-assert.match(
+assert.match(windowsBuildJob, /persist-credentials:\s*false/);
+assert.doesNotMatch(
   windowsBuildJob,
-  /正式 Windows 发布缺少 PINVOU3_WINDOWS_RUNTIME_TOKEN/,
+  /PINVOU3_WINDOWS_RUNTIME_TOKEN|secrets\./,
+  "public Windows runtime builds must not depend on cross-repository credentials",
 );
 assert.match(windowsBuildJob, /npm run runtime:windows:init/);
 assert.doesNotMatch(
@@ -351,4 +352,4 @@ assert.match(
   /build_required: \$\{\{ steps\.release\.outputs\.build_required \}\}/,
 );
 
-console.log("Windows private runtime packaging contract: ok");
+console.log("Windows runtime packaging contract: ok");


### PR DESCRIPTION
## 背景

0.7.2 合并后触发的 `release-packages` 在 Windows NSIS job 立即失败：`windows-release` Environment 中没有 `PINVOU3_WINDOWS_RUNTIME_TOKEN`，工作流主动拒绝继续构建。

现场核对发现 `Pinvou/pinvou3-windows-runtime` 当前已经是公开仓库，匿名读取 `main` ref 正常；继续要求跨仓库 Secret 不仅没有必要，也会让正式发布依赖一项过时配置。

## 变更

- Windows 正式发布 checkout 不再引用 `PINVOU3_WINDOWS_RUNTIME_TOKEN`。
- 设置 `persist-credentials: false`，不把 job token 传给后续跨仓库 submodule；初始化脚本按锁定 URL、gitlink 和 manifest 匿名拉取公开 runtime 与 Git LFS 对象。
- 保留 `windows-release` Environment 和仅允许 `main` 的 job 条件，发布边界不变。
- 更新 Windows runtime 打包契约：强制公开 runtime 构建不得引用 `secrets.*`，并必须关闭凭据持久化。
- 同步运行时、平台配置和打包文档；保留 `private-runtimes/windows` 历史路径以避免破坏 gitlink、缓存和脚本兼容性。

## 影响与风险

- 只影响 `main` 上的 Windows NSIS 正式构建；Linux、macOS 和普通 PR 验证路径不变。
- runtime 的 gitlink、lock、manifest 和文件 SHA-256 校验完全保留，缺失、版本不符或 LFS pointer 未物化仍会明确失败。
- Windows 原生 ACP 冒烟只能在 Windows runner 上执行，本地 Linux 未运行，交由 PR CI 验证。

## 验证

- `npm --prefix pinvou3-app run test:windows-runtime`：通过。
- `python3 scripts/tests/test_ci_gate_policy.py`：8 个用例通过。
- `node scripts/sync-version.mjs --check`：0.7.2 版本落点一致。
- `python3 scripts/architecture-guard.py`：通过，无新增架构债务。
- `./scripts/fork-guard.sh --fast`：通过。
- `git diff --check`：通过。
- 清空 Git credential helper 和 GitHub extra header 后，匿名 `git ls-remote` 公开 runtime 的 `main` ref：通过。

## 发布恢复

本 PR 合并后，需要在最新 `main` 上重新执行一次 `release-packages` 的 `workflow_dispatch`，生成完整的 0.7.2 四平台 artifacts；旧失败运行仍使用旧 workflow，不应直接重跑。
