### PR TITLE
fix(windows): 避免误判 Git 进度输出

### DIFF
--- a/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/init-submodule.ps1
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/init-submodule.ps1
@@ -16,8 +16,20 @@ function Invoke-Git {
     [string]$FailureMessage
   )
 
-  $output = & git -C $WorkingDirectory @Arguments 2>&1
-  if ($LASTEXITCODE -ne 0) {
+  $output = @()
+  $exitCode = 1
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    # Windows PowerShell 5.1 can turn normal native stderr progress into a
+    # terminating NativeCommandError while ErrorActionPreference is Stop.
+    $ErrorActionPreference = "Continue"
+    $output = @(& git -C $WorkingDirectory @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+
+  if ($exitCode -ne 0) {
     throw "$FailureMessage $($output -join ' ')"
   }
   return @($output)

--- a/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
+++ b/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
@@ -136,6 +136,11 @@ assert.doesNotMatch(runtimeScript, /Stage-NsisBootstrapper/u);
 assert.match(initScript, /git lfs pull/);
 assert.match(initScript, /--include=/);
 assert.match(initScript, /pinvou3-windows-runtime-\$expectedCommit/);
+assert.match(initScript, /\$previousErrorActionPreference = \$ErrorActionPreference/);
+assert.match(initScript, /\$ErrorActionPreference = "Continue"/);
+assert.match(initScript, /\$exitCode = \$LASTEXITCODE/);
+assert.match(initScript, /\$ErrorActionPreference = \$previousErrorActionPreference/);
+assert.match(initScript, /if \(\$exitCode -ne 0\)/);
 
 assert.match(runtimeWrapper, /runtime-descriptor\.json/);
 assert.match(runtimeWrapper, /cleanupLegacyWindowsNodeStaging/);


### PR DESCRIPTION
## 背景

0.7.2 发布工作流的 Windows x86_64 NSIS 任务在初始化 runtime submodule 时失败。实际 submodule 已成功注册，但 Windows PowerShell 5.1 在严格错误模式下把 Git 写入 stderr 的正常进度信息识别为 `NativeCommandError`，导致脚本在读取 Git 退出码前退出。

失败现场：`release-packages` run 30530233952，Windows job 90832226389。

## 变更

- 执行原生 Git 命令期间临时允许捕获 stderr，执行后恢复全局严格错误模式
- 仅依据 Git 的真实退出码判断成功或失败
- 补充 Windows runtime 打包契约断言，防止回退到直接受 stderr 影响的判断

## 验证

- `npm --prefix pinvou3-app run test:windows-runtime`
- `python3 scripts/tests/test_ci_gate_policy.py`
- `node scripts/sync-version.mjs --check`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `git diff --check`

## 已知风险

本地没有 Windows PowerShell 5.1 环境，完整 Windows runtime 初始化与 NSIS 构建需要合并后通过正式 `release-packages` 工作流复核。