### PR TITLE
fix(chat): 修复中断后会话同步阻塞

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1058,7 +1058,8 @@
               resolvedPlanTickets[key].push(String(item.planId));
             });
             var liveChatItems = rawLiveChatItems.filter(function (item) {
-              if (!item || item.type === "user" || item.type === "assistant") return false;
+              if (!item || item.type === "user") return false;
+              if (item.type === "assistant") return item.interruptedDisplayOnly === true;
               if (item.turnErrorNotice && !item.legacyConversationOnly) return false;
               // 后台 Shell 在 chat:done 后仍继续运行；持久化 transcript 只有工具结果文本，
               // 没有 taskId/background/liveOutput，权威重载时必须保留实时卡片并按 toolId 合并。

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -129,6 +129,14 @@
           afterMessageIndex = Number(candidate.messageIndex);
         }
       }
+      // 没有任何 user 气泡时无法锚定轮次;若把全部历史 assistant 项都标记为
+      // 仅展示,下次权威重载会在末尾追加整段历史的重复副本。此时放弃保留,
+      // 退化为修复前行为(重载后消失),但必须清空 pending 以免污染下一轮。
+      if (userItemIndex < 0) {
+        context.pendingAssistantText = "";
+        context.pendingAssistantBlocks = [];
+        return;
+      }
       for (var itemIndex = userItemIndex + 1; itemIndex < state.chatItems.length; itemIndex++) {
         var item = state.chatItems[itemIndex];
         if (!item || item.type !== "assistant" || !item.html) continue;

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -114,6 +114,31 @@
       }]);
       state.activeTurnTimelineId = null;
     }
+
+    function preserveInterruptedAssistantPresentation() {
+      var userItemIndex = -1;
+      var afterMessageIndex = -1;
+      var afterUserOrdinal = -1;
+      for (var index = 0; index < state.chatItems.length; index++) {
+        var candidate = state.chatItems[index];
+        if (!candidate || candidate.type !== "user") continue;
+        afterUserOrdinal += 1;
+        userItemIndex = index;
+        afterMessageIndex = -1;
+        if (Number.isFinite(Number(candidate.messageIndex))) {
+          afterMessageIndex = Number(candidate.messageIndex);
+        }
+      }
+      for (var itemIndex = userItemIndex + 1; itemIndex < state.chatItems.length; itemIndex++) {
+        var item = state.chatItems[itemIndex];
+        if (!item || item.type !== "assistant" || !item.html) continue;
+        item.interruptedDisplayOnly = true;
+        item.afterMessageIndex = afterMessageIndex;
+        item.afterUserOrdinal = afterUserOrdinal;
+      }
+      context.pendingAssistantText = "";
+      context.pendingAssistantBlocks = [];
+    }
     var markTurnDirtyArtifact = context.markTurnDirtyArtifact;
     var trackArtifact = context.trackArtifact;
     var untrackArtifact = context.untrackArtifact;
@@ -631,7 +656,11 @@
           });
         }
       }
-      flushAssistantMessageToHistory();
+      var terminalStatus = String(e.payload && e.payload.status || "").toLowerCase();
+      var interrupted = terminalStatus === "interrupted" ||
+        terminalStatus === "cancelled" || terminalStatus === "canceled";
+      if (interrupted) preserveInterruptedAssistantPresentation();
+      else flushAssistantMessageToHistory();
       // 本 turn 写/改过的产物 → 末尾补一张成品卡(带召唤图标),让 Boss 就近召唤 pinvou。
       // present 过的复用其 title/desc;AI 没 present 的兜底用文件名补首卡(否则没召唤入口=这次的 bug)。
       // 本 turn 刚 present_artifact 出过卡的跳过,不重复。edit/append 改多次也只补一张。

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -538,6 +538,45 @@
   function mergeHydratedChatItems(liveChatItems, liveCurrentStreamId) {
     var remappedCurrentStreamId = 0;
     var availableByKey = Object.create(null);
+    function interruptedDisplayRange(item) {
+      if (!item || item.interruptedDisplayOnly !== true) return null;
+      var anchorIndex = -1;
+      var nextUserIndex = -1;
+      var afterMessageIndex = Number(item.afterMessageIndex);
+      if (Number.isFinite(afterMessageIndex) && afterMessageIndex >= 0) {
+        for (var index = 0; index < state.chatItems.length; index++) {
+          var candidate = state.chatItems[index];
+          if (!candidate || candidate.type !== "user") continue;
+          var candidateMessageIndex = Number(candidate.messageIndex);
+          if (candidateMessageIndex === afterMessageIndex) anchorIndex = index;
+          else if (anchorIndex >= 0 && candidateMessageIndex > afterMessageIndex) {
+            nextUserIndex = index;
+            break;
+          }
+        }
+      }
+      var afterUserOrdinal = Number(item.afterUserOrdinal);
+      if (anchorIndex < 0 && Number.isInteger(afterUserOrdinal) && afterUserOrdinal >= 0) {
+        var userOrdinal = -1;
+        for (var fallbackIndex = 0; fallbackIndex < state.chatItems.length; fallbackIndex++) {
+          var fallback = state.chatItems[fallbackIndex];
+          if (!fallback || fallback.type !== "user") continue;
+          userOrdinal += 1;
+          if (userOrdinal === afterUserOrdinal) anchorIndex = fallbackIndex;
+          else if (userOrdinal > afterUserOrdinal) {
+            nextUserIndex = fallbackIndex;
+            break;
+          }
+        }
+      }
+      if (anchorIndex < 0) {
+        return { start: state.chatItems.length, end: state.chatItems.length };
+      }
+      return {
+        start: anchorIndex + 1,
+        end: nextUserIndex >= 0 ? nextUserIndex : state.chatItems.length,
+      };
+    }
     state.chatItems.forEach(function (item, index) {
       var key = hydratedChatItemKey(item);
       if (!key) return;
@@ -546,8 +585,21 @@
     });
     (liveChatItems || []).forEach(function (item) {
       var key = hydratedChatItemKey(item);
-      var matches = key && availableByKey[key];
-      var existingIndex = matches && matches.length ? matches.shift() : -1;
+      var range = interruptedDisplayRange(item);
+      var existingIndex = -1;
+      if (range) {
+        for (var rangeIndex = range.start; rangeIndex < range.end; rangeIndex++) {
+          var rangeItem = state.chatItems[rangeIndex];
+          if (rangeItem && rangeItem.interruptedDisplayOnly !== true &&
+              hydratedChatItemKey(rangeItem) === key) {
+            existingIndex = rangeIndex;
+            break;
+          }
+        }
+      } else {
+        var matches = key && availableByKey[key];
+        existingIndex = matches && matches.length ? matches.shift() : -1;
+      }
       if (existingIndex >= 0) {
         var existingId = state.chatItems[existingIndex].id;
         state.chatItems[existingIndex] = Object.assign({}, state.chatItems[existingIndex], item, {
@@ -558,7 +610,14 @@
       }
       var clone = Object.assign({}, item, { id: ++context.itemIdSeq });
       if (item && item.id === liveCurrentStreamId) remappedCurrentStreamId = clone.id;
-      state.chatItems.push(clone);
+      if (range && range.end < state.chatItems.length) {
+        state.chatItems.splice(range.end, 0, clone);
+        Object.keys(availableByKey).forEach(function (availableKey) {
+          availableByKey[availableKey] = availableByKey[availableKey].map(function (index) {
+            return index >= range.end ? index + 1 : index;
+          });
+        });
+      } else state.chatItems.push(clone);
     });
     return remappedCurrentStreamId;
   }

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1304,7 +1304,8 @@
               resolvedPlanTickets[key].push(String(item.planId));
             });
             var liveChatItems = rawLiveChatItems.filter(function (item) {
-              if (!item || item.type === "user" || item.type === "assistant" || item.type === "tool") return false;
+              if (!item || item.type === "user" || item.type === "tool") return false;
+              if (item.type === "assistant") return item.interruptedDisplayOnly === true;
               if (item.turnErrorNotice && !item.legacyConversationOnly) return false;
               // Plan cards need semantic matching by their plan snapshot. Their
               // generic hydration key includes ticket/action state and would
@@ -2545,6 +2546,45 @@
   function mergeHydratedChatItems(liveChatItems, liveCurrentStreamId) {
     var remappedCurrentStreamId = 0;
     var availableByKey = Object.create(null);
+    function interruptedDisplayRange(item) {
+      if (!item || item.interruptedDisplayOnly !== true) return null;
+      var anchorIndex = -1;
+      var nextUserIndex = -1;
+      var afterMessageIndex = Number(item.afterMessageIndex);
+      if (Number.isFinite(afterMessageIndex) && afterMessageIndex >= 0) {
+        for (var index = 0; index < state.chatItems.length; index++) {
+          var candidate = state.chatItems[index];
+          if (!candidate || candidate.type !== "user") continue;
+          var candidateMessageIndex = Number(candidate.messageIndex);
+          if (candidateMessageIndex === afterMessageIndex) anchorIndex = index;
+          else if (anchorIndex >= 0 && candidateMessageIndex > afterMessageIndex) {
+            nextUserIndex = index;
+            break;
+          }
+        }
+      }
+      var afterUserOrdinal = Number(item.afterUserOrdinal);
+      if (anchorIndex < 0 && Number.isInteger(afterUserOrdinal) && afterUserOrdinal >= 0) {
+        var userOrdinal = -1;
+        for (var fallbackIndex = 0; fallbackIndex < state.chatItems.length; fallbackIndex++) {
+          var fallback = state.chatItems[fallbackIndex];
+          if (!fallback || fallback.type !== "user") continue;
+          userOrdinal += 1;
+          if (userOrdinal === afterUserOrdinal) anchorIndex = fallbackIndex;
+          else if (userOrdinal > afterUserOrdinal) {
+            nextUserIndex = fallbackIndex;
+            break;
+          }
+        }
+      }
+      if (anchorIndex < 0) {
+        return { start: state.chatItems.length, end: state.chatItems.length };
+      }
+      return {
+        start: anchorIndex + 1,
+        end: nextUserIndex >= 0 ? nextUserIndex : state.chatItems.length,
+      };
+    }
     state.chatItems.forEach(function (item, index) {
       var key = hydratedChatItemKey(item);
       if (!key) return;
@@ -2553,8 +2593,21 @@
     });
     (liveChatItems || []).forEach(function (item) {
       var key = hydratedChatItemKey(item);
-      var matches = key && availableByKey[key];
-      var existingIndex = matches && matches.length ? matches.shift() : -1;
+      var range = interruptedDisplayRange(item);
+      var existingIndex = -1;
+      if (range) {
+        for (var rangeIndex = range.start; rangeIndex < range.end; rangeIndex++) {
+          var rangeItem = state.chatItems[rangeIndex];
+          if (rangeItem && rangeItem.interruptedDisplayOnly !== true &&
+              hydratedChatItemKey(rangeItem) === key) {
+            existingIndex = rangeIndex;
+            break;
+          }
+        }
+      } else {
+        var matches = key && availableByKey[key];
+        existingIndex = matches && matches.length ? matches.shift() : -1;
+      }
       if (existingIndex >= 0) {
         var existingId = state.chatItems[existingIndex].id;
         state.chatItems[existingIndex] = Object.assign({}, state.chatItems[existingIndex], item, {
@@ -2565,7 +2618,14 @@
       }
       var clone = Object.assign({}, item, { id: ++itemIdSeq });
       if (item && item.id === liveCurrentStreamId) remappedCurrentStreamId = clone.id;
-      state.chatItems.push(clone);
+      if (range && range.end < state.chatItems.length) {
+        state.chatItems.splice(range.end, 0, clone);
+        Object.keys(availableByKey).forEach(function (availableKey) {
+          availableByKey[availableKey] = availableByKey[availableKey].map(function (index) {
+            return index >= range.end ? index + 1 : index;
+          });
+        });
+      } else state.chatItems.push(clone);
     });
     return remappedCurrentStreamId;
   }
@@ -4584,6 +4644,31 @@
     state.activeTurnTimelineId = null;
   }
 
+  function preserveInterruptedAssistantPresentation() {
+    var userItemIndex = -1;
+    var afterMessageIndex = -1;
+    var afterUserOrdinal = -1;
+    for (var index = 0; index < state.chatItems.length; index++) {
+      var candidate = state.chatItems[index];
+      if (!candidate || candidate.type !== "user") continue;
+      afterUserOrdinal += 1;
+      userItemIndex = index;
+      afterMessageIndex = -1;
+      if (Number.isFinite(Number(candidate.messageIndex))) {
+        afterMessageIndex = Number(candidate.messageIndex);
+      }
+    }
+    for (var itemIndex = userItemIndex + 1; itemIndex < state.chatItems.length; itemIndex++) {
+      var item = state.chatItems[itemIndex];
+      if (!item || item.type !== "assistant" || !item.html) continue;
+      item.interruptedDisplayOnly = true;
+      item.afterMessageIndex = afterMessageIndex;
+      item.afterUserOrdinal = afterUserOrdinal;
+    }
+    pendingAssistantText = "";
+    pendingAssistantBlocks = [];
+  }
+
   listen("chat:turn_started", function (e) { onSessionEvent(e, function () {
     state.busy = true;
     if (!state.thinking.active) startThinking();
@@ -4995,7 +5080,11 @@
           });
         }
       }
-      flushAssistantMessageToHistory();
+      var terminalStatus = String(e.payload && e.payload.status || "").toLowerCase();
+      var interrupted = terminalStatus === "interrupted" ||
+        terminalStatus === "cancelled" || terminalStatus === "canceled";
+      if (interrupted) preserveInterruptedAssistantPresentation();
+      else flushAssistantMessageToHistory();
       // 本 turn 写/改过的产物 → 末尾补一张成品卡(带召唤图标),让 Boss 就近召唤 pinvou。
       // present 过的复用其 title/desc;AI 没 present 的兜底用文件名补首卡(否则没召唤入口=这次的 bug)。
       // 本 turn 刚 present_artifact 出过卡的跳过,不重复。edit/append 改多次也只补一张。

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4658,6 +4658,14 @@
         afterMessageIndex = Number(candidate.messageIndex);
       }
     }
+    // 没有任何 user 气泡时无法锚定轮次;若把全部历史 assistant 项都标记为
+    // 仅展示,下次权威重载会在末尾追加整段历史的重复副本。此时放弃保留,
+    // 退化为修复前行为(重载后消失),但必须清空 pending 以免污染下一轮。
+    if (userItemIndex < 0) {
+      pendingAssistantText = "";
+      pendingAssistantBlocks = [];
+      return;
+    }
     for (var itemIndex = userItemIndex + 1; itemIndex < state.chatItems.length; itemIndex++) {
       var item = state.chatItems[itemIndex];
       if (!item || item.type !== "assistant" || !item.html) continue;

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -80,7 +80,7 @@ const protocolSources = {
 const expectedProtocolHashes = {
   orchestration: '6d8e2a818ea4edbae35035903c5322a500ff4ede75158b8038cd2a172755c853',
   artifacts: '35eeb5ac596f039f62d3d1b97aef98306b2b8e8cd02fd13c1a172ca48d920048',
-  chat: '279ae806ccada26b4895c8b32d05f651762267e06834374dad9648b0fd547a4a',
+  chat: '7dac0045b97cae91fd142482f712dd72cc4e61df51d9fd7a707b9f384a153ae2',
   dependencies: '53dc5f9fa4245b065c27904068fa15d8fee0492abf21f0cbc1d91f5dd0a89bb9',
   interaction: 'db1647d6c406d6c34c1ac33a914797bfb3effde0c5d5b2670581a3cc35aa6993',
   knowledge: 'f1e6bf2e21474ba5573e9411e5c5e32d63ecdb0517b42320232ccd0940a59b69',

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -25,6 +25,10 @@ const tauriBridge = tauriBridgeFeatureNames
   .map(name => fs.readFileSync(path.join(__dirname, '..', 'src', 'platform', 'tauri', 'bridge', `${name}.js`), 'utf8'))
   .concat(fs.readFileSync(path.join(__dirname, '..', 'src', 'platform', 'tauri', 'bridge.js'), 'utf8'))
   .join('\n');
+const webBridge = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'platform', 'web', 'bridge.js'),
+  'utf8'
+);
 const scheduledTasksRust = fs.readFileSync(path.join(__dirname, '..', 'src-tauri', 'src', 'features', 'scheduled', 'tasks.rs'), 'utf8');
 const enginePoolRust = fs.readFileSync(path.join(__dirname, '..', 'src-tauri', 'src', 'features', 'assistant', 'engine_pool.rs'), 'utf8');
 const scheduledTaskPromptRust = scheduledTasksRust.slice(
@@ -457,6 +461,13 @@ assert.ok(
   /fn should_sync_session\(_is_scheduled: bool, _has_messages: bool\)[\s\S]{0,520}\n\s*true\s*\n}/.test(enginePoolRust) &&
     /should_sync_session\(is_scheduled, !saved\.messages\.is_empty\(\)\)/.test(enginePoolRust),
   'every Session must SyncSession even when its durable message list is empty'
+);
+assert.ok(
+  tauriBridge.includes('preserveInterruptedAssistantPresentation') &&
+    webBridge.includes('preserveInterruptedAssistantPresentation') &&
+    tauriBridge.includes('item.interruptedDisplayOnly = true') &&
+    webBridge.includes('item.interruptedDisplayOnly = true'),
+  'desktop and Web bridges must share the display-only interrupted response behavior'
 );
 assert.ok(
   /请一次只问我一个问题[\s\S]*1\.[\s\S]*2\./.test(scheduledTaskPromptRust) &&
@@ -1212,6 +1223,172 @@ async function authoritativeHydrateDropsReplayedAssistantTail() {
     (JSON.stringify(assistantItems).match(/answer tail/g) || []).length,
     1,
     "the mid-turn replay tail must not be appended after the authoritative full answer"
+  );
+}
+
+async function interruptedTurnRetainsDisplayOnlyPartial() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var sessionId = "chat-interrupted-display-only";
+  var durableMessages = [];
+  harness.handlers.create_session = function () {
+    return { id: sessionId, title: "New chat", transcript_revision: "empty" };
+  };
+  harness.handlers.list_sessions = function () {
+    return [{ id: sessionId, title: "Interrupted display", message_count: durableMessages.length }];
+  };
+  harness.handlers.load_session = function () {
+    return {
+      metadata: {
+        id: sessionId,
+        title: "Interrupted display",
+        message_count: durableMessages.length,
+      },
+      messages: JSON.parse(JSON.stringify(durableMessages)),
+      artifacts: [],
+      transcript_revision: "display-" + durableMessages.length,
+    };
+  };
+
+  await bridge.sessions.createNewSession();
+  await bridge.chat.sendMessage("first question");
+  durableMessages = [
+    { role: "user", content: [{ type: "text", text: "first question" }] },
+  ];
+  await harness.emit("chat:delta", { session_id: sessionId, text: "partial reply" });
+  await harness.emit("chat:done", {
+    session_id: sessionId,
+    status: "Interrupted",
+    error: null,
+  });
+  await tick();
+  await tick();
+
+  var interruptedState = bridge.state.get("chat");
+  assert.strictEqual(
+    interruptedState.messages.some(function (message) {
+      return JSON.stringify(message).includes("partial reply");
+    }),
+    false,
+    "an interrupted partial response must not enter the authoritative message list"
+  );
+  assert.ok(
+    interruptedState.chatItems.some(function (item) {
+      return item.type === "assistant" && item.interruptedDisplayOnly === true &&
+        String(item.html || "").includes("partial reply");
+    }),
+    "the interrupted partial response must remain visible after authority reconciliation"
+  );
+
+  await bridge.chat.sendMessage("follow up");
+  var followupState = bridge.state.get("chat");
+  var firstUserIndex = followupState.chatItems.findIndex(function (item) {
+    return item.type === "user" && item.text === "first question";
+  });
+  var partialIndex = followupState.chatItems.findIndex(function (item) {
+    return item.type === "assistant" && item.interruptedDisplayOnly === true;
+  });
+  var followupIndex = followupState.chatItems.findIndex(function (item) {
+    return item.type === "user" && item.text === "follow up";
+  });
+  assert.ok(
+    firstUserIndex >= 0 && firstUserIndex < partialIndex && partialIndex < followupIndex,
+    "the display-only partial must stay in its original turn when the user continues"
+  );
+
+  durableMessages = [
+    { role: "user", content: [{ type: "text", text: "first question" }] },
+    { role: "user", content: [{ type: "text", text: "follow up" }] },
+    { role: "assistant", content: [{ type: "text", text: "complete follow-up" }] },
+  ];
+  await harness.emit("chat:delta", { session_id: sessionId, text: "complete follow-up" });
+  await harness.emit("chat:done", {
+    session_id: sessionId,
+    status: "Completed",
+    error: null,
+  });
+  await tick();
+  await tick();
+
+  var completedState = bridge.state.get("chat");
+  var completedPartialIndex = completedState.chatItems.findIndex(function (item) {
+    return item.type === "assistant" && item.interruptedDisplayOnly === true &&
+      String(item.html || "").includes("partial reply");
+  });
+  var completedFollowupIndex = completedState.chatItems.findIndex(function (item) {
+    return item.type === "user" && item.text === "follow up";
+  });
+  assert.ok(
+    completedPartialIndex >= 0 && completedPartialIndex < completedFollowupIndex,
+    "later authoritative refreshes must not move the interrupted partial into another turn"
+  );
+  assert.strictEqual(
+    completedState.messages.some(function (message) {
+      return JSON.stringify(message).includes("partial reply");
+    }),
+    false,
+    "later turns must not promote the display-only partial into model context"
+  );
+}
+
+async function remoteInterruptedTurnKeepsItsDisplayPosition() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var sessionId = "chat-remote-interrupted-display";
+  var durableMessages = [
+    { role: "user", content: [{ type: "text", text: "older question" }] },
+    { role: "assistant", content: [{ type: "text", text: "remote partial reply" }] },
+  ];
+  harness.handlers.load_session = function () {
+    return {
+      metadata: {
+        id: sessionId,
+        title: "Remote interrupted display",
+        message_count: durableMessages.length,
+      },
+      messages: JSON.parse(JSON.stringify(durableMessages)),
+      artifacts: [],
+      transcript_revision: "remote-" + durableMessages.length,
+    };
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await harness.emit("chat:user_message", {
+    session_id: sessionId,
+    content: "remote question",
+    operation: "append",
+    base_transcript_revision: "remote-2",
+  });
+  await harness.emit("chat:turn_started", { session_id: sessionId });
+  durableMessages = durableMessages.concat([
+    { role: "user", content: [{ type: "text", text: "remote question" }] },
+  ]);
+  await harness.emit("chat:delta", {
+    session_id: sessionId,
+    text: "remote partial reply",
+  });
+  await harness.emit("chat:done", {
+    session_id: sessionId,
+    status: "Interrupted",
+    error: null,
+  });
+  await tick();
+  await tick();
+
+  var chatItems = bridge.state.get("chat").chatItems;
+  var olderUserIndex = chatItems.findIndex(function (item) {
+    return item.type === "user" && item.text === "older question";
+  });
+  var remoteUserIndex = chatItems.findIndex(function (item) {
+    return item.type === "user" && item.text === "remote question";
+  });
+  var partialIndex = chatItems.findIndex(function (item) {
+    return item.type === "assistant" && item.interruptedDisplayOnly === true &&
+      String(item.html || "").includes("remote partial reply");
+  });
+  assert.ok(
+    olderUserIndex >= 0 && olderUserIndex < remoteUserIndex && remoteUserIndex < partialIndex,
+    "a remote interrupted partial must stay after the remote user turn, not an older turn"
   );
 }
 
@@ -3153,6 +3330,8 @@ Promise.resolve()
   .then(scheduledDoneBeforeBufferCreatesTerminalTombstone)
   .then(authoritativeTurnSyncDoesNotCrossSessions)
   .then(authoritativeHydrateDropsReplayedAssistantTail)
+  .then(interruptedTurnRetainsDisplayOnlyPartial)
+  .then(remoteInterruptedTurnKeepsItsDisplayPosition)
   .then(completedTurnWaitsForAssistantInAuthoritySnapshot)
   .then(remoteAcceptPlanConvergesAcrossClients)
   .then(activePlanSurvivesUnrelatedTerminalHydrate)

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -1392,6 +1392,90 @@ async function remoteInterruptedTurnKeepsItsDisplayPosition() {
   );
 }
 
+async function interruptedTurnWithoutUserItemDropsPartial() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var sessionId = "chat-interrupted-no-user-anchor";
+  var durableMessages = [
+    { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+  ];
+  harness.handlers.list_sessions = function () {
+    return [{ id: sessionId, title: "Unanchored interrupt", message_count: durableMessages.length }];
+  };
+  harness.handlers.load_session = function () {
+    return {
+      metadata: {
+        id: sessionId,
+        title: "Unanchored interrupt",
+        message_count: durableMessages.length,
+      },
+      messages: JSON.parse(JSON.stringify(durableMessages)),
+      artifacts: [],
+      transcript_revision: "no-user-" + durableMessages.length,
+    };
+  };
+
+  // transcript 里没有任何 user 消息(无 user 气泡、无法锚定轮次)的中断:
+  // 不得把全部历史 assistant 项标记为仅展示,否则权威重载会在末尾复活它们,
+  // 复制出整段历史的重复副本。
+  await bridge.sessions.switchToSession(sessionId);
+  await harness.emit("chat:turn_started", { session_id: sessionId });
+  await harness.emit("chat:delta", { session_id: sessionId, text: "orphan partial" });
+  await harness.emit("chat:done", {
+    session_id: sessionId,
+    status: "Interrupted",
+    error: null,
+  });
+  await tick();
+  await tick();
+
+  var unanchoredState = bridge.state.get("chat");
+  assert.ok(
+    !unanchoredState.chatItems.some(function (item) {
+      return item.interruptedDisplayOnly === true;
+    }),
+    "without any user turn anchor, nothing may be marked display-only"
+  );
+  assert.strictEqual(
+    unanchoredState.chatItems.filter(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("old reply");
+    }).length,
+    1,
+    "authority reconciliation must not duplicate the unanchored history"
+  );
+  assert.ok(
+    !unanchoredState.chatItems.some(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("orphan partial");
+    }),
+    "an unanchorable interrupted partial must not be resurrected by authority reconciliation"
+  );
+
+  durableMessages = [
+    { role: "assistant", content: [{ type: "text", text: "old reply" }] },
+    { role: "user", content: [{ type: "text", text: "next question" }] },
+    { role: "assistant", content: [{ type: "text", text: "clean reply" }] },
+  ];
+  await bridge.chat.sendMessage("next question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "clean reply" });
+  await harness.emit("chat:done", {
+    session_id: sessionId,
+    status: "Completed",
+    error: null,
+  });
+  await tick();
+  await tick();
+
+  var followupState = bridge.state.get("chat");
+  var assistantMessages = followupState.messages.filter(function (message) {
+    return message.role === "assistant";
+  });
+  assert.ok(
+    assistantMessages.length > 0 &&
+      !JSON.stringify(assistantMessages).includes("orphan partial"),
+    "the dropped partial must not leak into the next authoritative assistant message"
+  );
+}
+
 async function completedTurnWaitsForAssistantInAuthoritySnapshot() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
@@ -3332,6 +3416,7 @@ Promise.resolve()
   .then(authoritativeHydrateDropsReplayedAssistantTail)
   .then(interruptedTurnRetainsDisplayOnlyPartial)
   .then(remoteInterruptedTurnKeepsItsDisplayPosition)
+  .then(interruptedTurnWithoutUserItemDropsPartial)
   .then(completedTurnWaitsForAssistantInAuthoritySnapshot)
   .then(remoteAcceptPlanConvergesAcrossClients)
   .then(activePlanSurvivesUnrelatedTerminalHydrate)


### PR DESCRIPTION
## 背景

用户中断流式回复时，旧前端会把已经显示但尚未被 Engine 确认的助手正文写入本地 `state.messages`。终态处理随后把这条临时正文设置为 `remoteExpectedAssistantKey`，要求权威 transcript 必须包含它。

Engine 当前不会持久化中断的半截助手正文，因此该 key 永远无法在权威快照中出现。同步屏障持续失败，`remoteTurnActive` 无法清除，用户下一次发送会被“该会话仍在同步另一端完成的回合”拦截。

## 变更

- 识别 `Interrupted` / `Cancelled` 终态，不再把尚未确认的半截助手正文写入 `state.messages`
- 让权威同步只等待 Engine 实际能够提供的消息，从而正常清除同步状态并允许继续发送
- 已显示的半截正文仅作为当前客户端展示项保留，并锚定到原用户轮次
- 权威 transcript 重载时进行同轮去重，避免与历史中的相同正文错误合并
- 桌面端与远程 WebUI 保持相同行为；正常完成、失败、工具及 reasoning 链路不变

## 实现边界

- 不修改 Rust、CodeWhale、Engine 消息、存储格式或前端事件协议
- 中断的半截正文不会进入下一轮模型上下文，也不会写入磁盘 transcript
- 展示项只保留在当前客户端内存中；重启应用或强制重新加载后不保证保留
- 将中断正文原子纳入权威上下文的 Engine 能力另行跟踪：Hmbown/CodeWhale#5000

## 验证

- 自动化覆盖：中断后权威重载、继续发送、后续完成轮次、跨轮同文案以及桌面/Web 实现一致性
- 用户桌面端手工验证：中断后可正常继续发送，未再出现权威同步阻塞；半截正文仍留在原轮次
- 检查落盘 transcript：中断半截正文未进入权威消息
- `npm run test:scheduled`
- `npm run test:bridge-protocol`
- `npm run test:chat-error-isolation`
- `npm run test:session-management`
- `npm run test:web-access-contract`
- `npm run test:web-access-desktop-proxy`
- `npm run lint:ui`
- `npm run build:ui`
- `npm run build:web`
- `python3 scripts/architecture-guard.py`（通过，仅存量大文件 advisory）
- `git diff --check origin/main...HEAD`

## 已知限制

本 PR 修复的是中断后错误的权威同步阻塞，并保留当前客户端的可见正文；有意不解决“中断半截正文进入权威上下文/跨重启持久化”。在上游 Engine 提供原子语义前，Pinvou 不做异步全量 `SyncSession` 回灌。