### PR TITLE
fix(acp): 持久化新会话配置并完善代码模式恢复

### DIFF
--- a/docs/codex-acp.md
+++ b/docs/codex-acp.md
@@ -60,13 +60,24 @@ Reasoning 使用事件时间戳显示耗时；完成的工具步骤默认折叠�
 `session-agents.json`，ACP `session/new`、`session/load` 或进程重连后会先重新应用，
 再把会话标记为可发送。配置应用期间和 Turn 运行期间不能发送另一项配置修改。
 
+ACP 的配置作用域是单个 session，不提供跨 session 默认值。Pinvou 会把用户成功选择的
+模型、权限模式、推理强度等配置按 Agent 写入 `acp-agent-defaults.json`；新建该 Agent
+会话后，根据 Agent 实际上报的可选项重新应用。历史会话仍使用自己的 session 配置，
+不会被后来修改的新会话默认值覆盖。旧版本升级时会从该 Agent 最近的有效会话迁移一次。
+
+应用被直接关闭时，旧进程中的 ACP Prompt 无法在新进程重新挂接。Pinvou 启动恢复会把
+`acp-timeline.jsonl` 中只有 `turn_started`、没有 `turn_completed` 的遗留 Turn 收口为
+`Interrupted`；对应的运行中工具、权限和输入项显示为已取消。恢复后的会话保留原历史和
+工作目录，并可继续发送新消息，不会永久停在“处理中”。
+
 Codex 自己上报的 `/skills`、`/mcp` 等命令可直接在输入框使用。开发时也可用
 `PINVOU3_CODEX_ACP_BIN=/absolute/path/to/codex-acp` 覆盖运行时。
 
 ## 数据位置
 
 - `~/.pinvou3/session-agents.json`：pinvou 会话与 ACP session ID / model /
-  用户确认权限模式的轻量索引。
+  用户确认配置的轻量索引。
+- `~/.pinvou3/acp-agent-defaults.json`：每个 ACP Agent 的新会话默认配置。
 - `~/.pinvou3/sessions/<id>/acp-state.json`：Agent、capability、model、mode、config 和最后状态。
 - `~/.pinvou3/sessions/<id>/acp-timeline.jsonl`：按 `seq` 追加的完整 ACP 事件时间线。
 - `~/.pinvou3/sessions/<id>/workspace/`：仅临时 Codex 会话使用的执行目录。

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -106,6 +106,40 @@ impl EventBridge {
         }
     }
 
+    /// 把 timeline 中只开始、未结束的旧回合收口为已中断。
+    ///
+    /// ACP prompt future 和当前 turn 只存在于宿主进程内；应用被直接关闭后，Agent
+    /// 会话虽然可以恢复，但旧 prompt 已无法重新挂接。继续把这种回合展示为 running
+    /// 会让前端永久停在“处理中”，而恢复后的 session/cancel 也没有旧 turn 可取消。
+    ///
+    /// 本方法只处理当前 timeline 已存在的孤儿回合。正常的同进程活跃回合仍由
+    /// `prompt()` 返回后调用 `finish_turn()` 收口。
+    pub fn interrupt_orphaned_turns(&self, reason: &str) -> usize {
+        let events = match load_timeline(&self.pinvou_session_id) {
+            Ok(events) => events,
+            Err(error) => {
+                eprintln!(
+                    "[pinvou3-app] inspect orphaned ACP turns failed for {}: {error:#}",
+                    self.pinvou_session_id
+                );
+                return 0;
+            }
+        };
+        let orphaned = orphaned_turn_ids(&events);
+        for turn_id in &orphaned {
+            self.emit_with_turn(
+                Some(turn_id.clone()),
+                "turn_completed",
+                json!({
+                    "status": "Interrupted",
+                    "error": null,
+                    "recoveryReason": reason,
+                }),
+            );
+        }
+        orphaned.len()
+    }
+
     pub fn handle(&self, notification: SessionNotification) {
         let meta = serde_json::to_value(notification.meta).unwrap_or(Value::Null);
         match notification.update {
@@ -257,6 +291,29 @@ fn is_terminal(status: ToolCallStatus) -> bool {
     matches!(status, ToolCallStatus::Completed | ToolCallStatus::Failed)
 }
 
+fn orphaned_turn_ids(events: &[AcpEventEnvelope]) -> Vec<String> {
+    let mut open = HashMap::<String, u64>::new();
+    let mut ordered = events.iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|event| event.seq);
+    for envelope in ordered {
+        let Some(turn_id) = envelope.turn_id.as_ref() else {
+            continue;
+        };
+        match envelope.event.event_type.as_str() {
+            "turn_started" => {
+                open.entry(turn_id.clone()).or_insert(envelope.seq);
+            }
+            "turn_completed" => {
+                open.remove(turn_id);
+            }
+            _ => {}
+        }
+    }
+    let mut orphaned = open.into_iter().collect::<Vec<_>>();
+    orphaned.sort_by_key(|(_, started_seq)| *started_seq);
+    orphaned.into_iter().map(|(turn_id, _)| turn_id).collect()
+}
+
 fn timeline_path(session_id: &str) -> Result<PathBuf> {
     session_file_path(session_id, TIMELINE_FILE)
 }
@@ -358,6 +415,20 @@ pub fn load_timeline(session_id: &str) -> Result<Vec<AcpEventEnvelope>> {
 mod tests {
     use super::*;
 
+    fn event(seq: u64, turn_id: Option<&str>, event_type: &str) -> AcpEventEnvelope {
+        AcpEventEnvelope {
+            version: EVENT_VERSION,
+            session_id: "session-1".into(),
+            turn_id: turn_id.map(str::to_string),
+            seq,
+            timestamp: format!("2026-01-01T00:00:{seq:02}Z"),
+            event: AcpEvent {
+                event_type: event_type.into(),
+                data: json!({}),
+            },
+        }
+    }
+
     #[test]
     fn timeline_rejects_path_traversal() {
         assert!(timeline_path("../escape").is_err());
@@ -382,5 +453,28 @@ mod tests {
         assert_eq!(value["version"], 1);
         assert_eq!(value["sessionId"], "session-1");
         assert_eq!(value["event"]["type"], "tool_call");
+    }
+
+    #[test]
+    fn orphaned_turns_are_detected_in_start_order_and_recovery_is_idempotent() {
+        let mut events = vec![
+            event(1, Some("turn-completed"), "turn_started"),
+            event(2, Some("turn-orphan-1"), "turn_started"),
+            event(3, Some("turn-completed"), "turn_completed"),
+            event(4, None, "cancel_requested"),
+            event(5, Some("turn-orphan-2"), "turn_started"),
+        ];
+        assert_eq!(
+            orphaned_turn_ids(&events),
+            vec!["turn-orphan-1", "turn-orphan-2"],
+            "global cancel events must not accidentally close a persisted turn"
+        );
+
+        events.push(event(6, Some("turn-orphan-1"), "turn_completed"));
+        events.push(event(7, Some("turn-orphan-2"), "turn_completed"));
+        assert!(
+            orphaned_turn_ids(&events).is_empty(),
+            "re-running recovery after terminal events must be a no-op"
+        );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -12,7 +12,7 @@ mod runtime;
 mod store;
 pub(crate) mod workspace;
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -51,10 +51,10 @@ use runtime::{
     install_managed_codex, is_managed_newer_than, resolve_codex_path, system_codex_incompatible,
     ResolvedCodex, MANAGED_CODEX_VERSION, MIN_CODEX_VERSION,
 };
-use store::SessionAgentRecord;
 pub use store::{
     validate_codex_project_workspace, AgentBackend, CodexWorkspaceKind, SessionAgentStore,
 };
+use store::{AcpConfigDefaultsStore, SessionAgentRecord};
 
 pub const CODEX_ACP_VERSION: &str = "1.1.5";
 pub const CODEX_ACP_SESSION_MODEL: &str = "Codex (ACP)";
@@ -114,16 +114,60 @@ fn backend_for_acp_state(state: &Value) -> Result<AgentBackend> {
 }
 
 fn acp_mode_from_state(state: &Value) -> Option<String> {
-    state["session"]["modes"]["currentModeId"]
-        .as_str()
+    acp_config_values_from_state(state)
+        .remove("mode")
         .or_else(|| {
-            state["session"]["config_options"]
-                .as_array()?
-                .iter()
-                .find(|option| option["id"].as_str() == Some("mode"))?["currentValue"]
+            state["session"]["modes"]["currentModeId"]
                 .as_str()
+                .map(str::to_string)
         })
-        .map(str::to_string)
+}
+
+fn acp_config_values_from_state(state: &Value) -> HashMap<String, String> {
+    state["session"]["config_options"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|option| {
+            Some((
+                option["id"].as_str()?.to_string(),
+                option["currentValue"].as_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn saved_config_values(record: &SessionAgentRecord) -> HashMap<String, String> {
+    let mut values = record.acp_config_values.clone();
+    if let Some(model_id) = &record.acp_model_id {
+        values
+            .entry("model".to_string())
+            .or_insert_with(|| model_id.clone());
+    }
+    if let Some(mode_id) = &record.acp_mode_id {
+        values
+            .entry("mode".to_string())
+            .or_insert_with(|| mode_id.clone());
+    }
+    values
+}
+
+fn load_acp_config_values_from_state(
+    session_id: &str,
+    expected_backend: AgentBackend,
+) -> Result<HashMap<String, String>> {
+    let state_path = crate::platform::paths::sessions_root()
+        .join(session_id)
+        .join("acp-state.json");
+    let state: Value = serde_json::from_slice(
+        &std::fs::read(&state_path)
+            .with_context(|| format!("读取 {} 失败", state_path.display()))?,
+    )
+    .with_context(|| format!("解析 {} 失败", state_path.display()))?;
+    if backend_for_acp_state(&state)? != expected_backend {
+        bail!("acp-state.json 的 Agent 与会话元数据不匹配");
+    }
+    Ok(acp_config_values_from_state(&state))
 }
 
 fn acp_recovery_record(
@@ -176,6 +220,7 @@ fn acp_recovery_record(
             .as_str()
             .map(str::to_string),
         acp_mode_id: acp_mode_from_state(state),
+        acp_config_values: acp_config_values_from_state(state),
         workspace_kind,
         workspace_path: (workspace_kind == CodexWorkspaceKind::Project).then_some(workspace_path),
     })
@@ -480,8 +525,9 @@ impl AcpSession {
             model_id,
         )
         .await?;
+        let current_model = current_config_value(&options, "model");
         *self.config_options.write() = options;
-        *self.current_model.write() = Some(model_id.to_string());
+        *self.current_model.write() = current_model;
         Ok(())
     }
 
@@ -495,7 +541,9 @@ impl AcpSession {
             value_id,
         )
         .await?;
+        let current_model = current_config_value(&options, "model");
         *self.config_options.write() = options;
+        *self.current_model.write() = current_model;
         Ok(())
     }
 }
@@ -507,6 +555,7 @@ pub struct AcpPool {
     pending_permissions: Arc<Mutex<HashMap<String, PendingPermission>>>,
     pending_elicitations: Arc<Mutex<HashMap<String, PendingElicitation>>>,
     agents: SessionAgentStore,
+    config_defaults: AcpConfigDefaultsStore,
     acp_metadata_backends: Arc<parking_lot::RwLock<HashMap<String, AgentBackend>>>,
     session_store: SessionStore,
     installing: Arc<AtomicBool>,
@@ -590,12 +639,50 @@ impl AcpPool {
                 ),
             }
         }
+        let config_defaults = AcpConfigDefaultsStore::load_or_empty();
+        // 旧版本只保存了 session 级状态。按更新时间从新到旧，为每个 Agent
+        // 迁移最近一次成功配置，使升级后的第一个新会话也能继承用户选择。
+        for item in &metadata {
+            let Some(backend) = acp_metadata_backends.get(&item.id).copied() else {
+                continue;
+            };
+            if config_defaults.has_backend(backend) {
+                continue;
+            }
+            let values = load_acp_config_values_from_state(&item.id, backend)
+                .unwrap_or_else(|_| saved_config_values(&agents.get(&item.id)));
+            match config_defaults.set_all_if_absent(backend, values) {
+                Ok(true) => eprintln!(
+                    "[pinvou3-app] migrated {} ACP defaults from session {}",
+                    backend.display_name(),
+                    item.id
+                ),
+                Ok(false) => {}
+                Err(error) => eprintln!(
+                    "[pinvou3-app] failed to migrate {} ACP defaults: {error:#}",
+                    backend.display_name()
+                ),
+            }
+        }
+        // 新进程无法继续持有上次进程里的 ACP prompt future。恢复原 Agent session
+        // 只恢复对话上下文，不会重新挂接当时正在等待的 prompt；因此必须在任何
+        // runtime lazy spawn 之前，把 timeline 中遗留的 running 回合收口。
+        for session_id in acp_metadata_backends.keys() {
+            let bridge = EventBridge::new(app.clone(), session_id.clone());
+            let interrupted = bridge.interrupt_orphaned_turns("application_restarted");
+            if interrupted > 0 {
+                eprintln!(
+                    "[pinvou3-app] interrupted {interrupted} orphaned ACP turn(s) for {session_id}"
+                );
+            }
+        }
         Ok(Self {
             app,
             sessions: Arc::new(Mutex::new(HashMap::new())),
             pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             pending_elicitations: Arc::new(Mutex::new(HashMap::new())),
             agents,
+            config_defaults,
             acp_metadata_backends: Arc::new(parking_lot::RwLock::new(acp_metadata_backends)),
             session_store,
             installing: Arc::new(AtomicBool::new(false)),
@@ -1609,10 +1696,23 @@ impl AcpPool {
         self.cancel_pending_permissions(session_id).await;
         self.cancel_pending_elicitations(session_id).await;
         if let Some(runtime) = self.sessions.lock().await.get(session_id).cloned() {
-            runtime.cancel();
-            runtime
-                .bridge
-                .emit("cancel_requested", json!({ "status": "cancelling" }));
+            if runtime.busy.load(Ordering::Acquire) {
+                runtime.cancel();
+                runtime
+                    .bridge
+                    .emit("cancel_requested", json!({ "status": "cancelling" }));
+            } else {
+                // session 已恢复但当前进程没有活跃 prompt 时，session/cancel 无法
+                // 命中旧进程的 turn。直接收口持久化孤儿回合，让停止操作可恢复且幂等。
+                runtime
+                    .bridge
+                    .interrupt_orphaned_turns("cancel_without_active_prompt");
+            }
+        } else {
+            // 正常 UI 加载会先 lazy spawn runtime；这里仍为启动失败或竞态保留兜底，
+            // 避免“停止”在没有内存 runtime 时静默无效。
+            EventBridge::new(self.app.clone(), session_id.to_string())
+                .interrupt_orphaned_turns("cancel_without_runtime");
         }
     }
 
@@ -1636,11 +1736,48 @@ impl AcpPool {
             .info(pending_permissions, pending_elicitations))
     }
 
+    fn remember_config_choice(
+        &self,
+        session_id: &str,
+        runtime: &AcpSession,
+        config_id: &str,
+        value_id: &str,
+    ) {
+        let backend = self.backend(session_id);
+        let mut errors = Vec::new();
+        if let Err(error) = self
+            .agents
+            .set_acp_config_value(session_id, config_id, value_id)
+        {
+            errors.push(format!("会话配置: {error:#}"));
+        }
+        if let Err(error) = self.config_defaults.set(backend, config_id, value_id) {
+            errors.push(format!("新会话默认值: {error:#}"));
+        }
+        if !errors.is_empty() {
+            let message = errors.join("；");
+            eprintln!(
+                "[pinvou3-app] failed to persist {} ACP config {}={}: {}",
+                backend.display_name(),
+                config_id,
+                value_id,
+                message
+            );
+            runtime.bridge.emit(
+                "config_persistence_failed",
+                json!({
+                    "configId": config_id,
+                    "valueId": value_id,
+                    "message": message,
+                }),
+            );
+        }
+    }
+
     pub async fn set_model(&self, session_id: &str, model_id: &str) -> Result<CodexAcpSessionInfo> {
         let runtime = self.get_or_spawn(session_id).await?;
         runtime.set_model(model_id).await?;
-        self.agents
-            .set_acp_model(session_id, Some(model_id.to_string()))?;
+        self.remember_config_choice(session_id, &runtime, "model", model_id);
         let info = runtime.info(
             self.pending_permissions_for(session_id).await,
             self.pending_elicitations_for(session_id).await,
@@ -1683,10 +1820,7 @@ impl AcpPool {
             );
             return Err(error);
         }
-        if config_id == "mode" {
-            self.agents
-                .set_acp_mode(session_id, Some(value_id.to_string()))?;
-        }
+        self.remember_config_choice(session_id, &runtime, config_id, value_id);
         runtime.bridge.emit(
             "config_change_applied",
             json!({ "configId": config_id, "valueId": value_id }),
@@ -1728,8 +1862,7 @@ impl AcpPool {
             );
             return Err(error);
         }
-        self.agents
-            .set_acp_mode(session_id, Some(mode_id.to_string()))?;
+        self.remember_config_choice(session_id, &runtime, "mode", mode_id);
         runtime.bridge.emit(
             "config_change_applied",
             json!({ "configId": "mode", "valueId": mode_id }),
@@ -2274,6 +2407,11 @@ impl AcpPool {
         };
 
         let saved = self.agents.get(pinvou_session_id);
+        let desired_config_values = if saved.acp_session_id.is_some() {
+            saved_config_values(&saved)
+        } else {
+            self.config_defaults.get(backend)
+        };
         let (acp_session_id, mut mode_state, mut config_options) =
             if initialized.agent_capabilities.load_session {
                 if let Some(saved_id) = saved.acp_session_id.clone() {
@@ -2303,24 +2441,24 @@ impl AcpPool {
             } else {
                 new_acp_session(&connection, &workspace, backend).await?
             };
-        if let Some(mode_id) = saved.acp_mode_id.as_deref() {
-            apply_saved_mode(
-                &connection,
-                &acp_session_id,
-                &mut mode_state,
-                &mut config_options,
-                mode_id,
-            )
-            .await
-            .with_context(|| format!("恢复 {} 权限模式 {mode_id} 失败", backend.display_name()))?;
-        }
+        restore_config_values(
+            &connection,
+            &acp_session_id,
+            &mut mode_state,
+            &mut config_options,
+            &desired_config_values,
+            backend,
+        )
+        .await;
         let current_model_id = current_config_value(&config_options, "model");
         let models = codex_models(&config_options);
+        let config_values = config_values_from_options(&config_options, &mode_state);
         let prompt_capabilities = initialized.agent_capabilities.prompt_capabilities.clone();
         self.agents.set_acp_session(
             pinvou_session_id,
             acp_session_id.clone(),
             current_model_id.clone(),
+            config_values,
         )?;
         persist_acp_state(
             pinvou_session_id,
@@ -2463,14 +2601,14 @@ fn config_option_supports(
 async fn apply_config_option(
     connection: &ConnectionTo<Agent>,
     acp_session_id: &str,
-    options: &mut [SessionConfigOption],
+    options: &mut Vec<SessionConfigOption>,
     config_id: &str,
     value_id: &str,
 ) -> Result<()> {
     if !config_option_supports(options, config_id, value_id) {
         bail!("ACP 配置项或取值不存在: {config_id}={value_id}");
     }
-    connection
+    let response = connection
         .send_request(SetSessionConfigOptionRequest::new(
             acp_session_id.to_string(),
             config_id.to_string(),
@@ -2479,14 +2617,9 @@ async fn apply_config_option(
         .block_task()
         .await
         .context("ACP session/set_config_option 失败")?;
-    for option in options {
-        if option.id.to_string() != config_id {
-            continue;
-        }
-        if let SessionConfigKind::Select(select) = &mut option.kind {
-            select.current_value = value_id.to_string().into();
-        }
-    }
+    // ACP 规定响应包含完整的最新配置集。配置项之间可能联动，必须以 Agent
+    // 返回值整体替换，不能只在本地手工修改当前字段。
+    *options = response.config_options;
     Ok(())
 }
 
@@ -2494,7 +2627,7 @@ async fn apply_saved_mode(
     connection: &ConnectionTo<Agent>,
     acp_session_id: &str,
     modes: &mut Option<SessionModeState>,
-    config_options: &mut [SessionConfigOption],
+    config_options: &mut Vec<SessionConfigOption>,
     mode_id: &str,
 ) -> Result<()> {
     if config_options
@@ -2527,6 +2660,106 @@ async fn apply_saved_mode(
     Ok(())
 }
 
+async fn restore_config_values(
+    connection: &ConnectionTo<Agent>,
+    acp_session_id: &str,
+    modes: &mut Option<SessionModeState>,
+    config_options: &mut Vec<SessionConfigOption>,
+    values: &HashMap<String, String>,
+    backend: AgentBackend,
+) {
+    let mut desired = values.iter().collect::<Vec<_>>();
+    desired.sort_by(|(left, _), (right, _)| {
+        let priority = |config_id: &str| match config_id {
+            "model" => 0,
+            "mode" => 1,
+            _ => 2,
+        };
+        priority(left)
+            .cmp(&priority(right))
+            .then_with(|| left.cmp(right))
+    });
+    let mut failed = HashSet::new();
+
+    // 某些 Agent 会根据 model/mode 改变后续可选项。最多多跑两轮，让 Agent
+    // 返回的完整配置集稳定下来，同时避免互斥配置导致无限来回设置。
+    for _ in 0..3 {
+        let mut progress = false;
+        for (config_id, value_id) in &desired {
+            if failed.contains(config_id.as_str())
+                || current_config_value(config_options, config_id) == Some((*value_id).clone())
+            {
+                continue;
+            }
+            if !config_option_supports(config_options, config_id, value_id) {
+                continue;
+            }
+            match apply_config_option(
+                connection,
+                acp_session_id,
+                config_options,
+                config_id,
+                value_id,
+            )
+            .await
+            {
+                Ok(()) => progress = true,
+                Err(error) => {
+                    failed.insert((*config_id).clone());
+                    eprintln!(
+                        "[pinvou3-app] skipped {} saved ACP config {}={}: {error:#}",
+                        backend.display_name(),
+                        config_id,
+                        value_id
+                    );
+                }
+            }
+        }
+        if !progress {
+            break;
+        }
+    }
+
+    if let Some(mode_id) = values.get("mode") {
+        let has_config_mode = config_options
+            .iter()
+            .any(|option| option.id.to_string() == "mode");
+        if !has_config_mode
+            && modes
+                .as_ref()
+                .is_some_and(|state| state.current_mode_id.to_string() != mode_id.as_str())
+        {
+            if let Err(error) =
+                apply_saved_mode(connection, acp_session_id, modes, config_options, mode_id).await
+            {
+                eprintln!(
+                    "[pinvou3-app] skipped {} saved ACP mode {}: {error:#}",
+                    backend.display_name(),
+                    mode_id
+                );
+            }
+        }
+    }
+
+    for (config_id, value_id) in desired {
+        if config_id == "mode"
+            && !config_options
+                .iter()
+                .any(|option| option.id.to_string() == "mode")
+        {
+            continue;
+        }
+        if current_config_value(config_options, config_id) != Some(value_id.clone()) {
+            eprintln!(
+                "[pinvou3-app] {} ACP no longer supports saved config {}={}",
+                backend.display_name(),
+                config_id,
+                value_id
+            );
+        }
+    }
+}
+
 fn current_config_value(options: &[SessionConfigOption], config_id: &str) -> Option<String> {
     options.iter().find_map(|option| {
         if option.id.to_string() != config_id {
@@ -2537,6 +2770,30 @@ fn current_config_value(options: &[SessionConfigOption], config_id: &str) -> Opt
             _ => None,
         }
     })
+}
+
+fn config_values_from_options(
+    options: &[SessionConfigOption],
+    modes: &Option<SessionModeState>,
+) -> HashMap<String, String> {
+    let mut values = options
+        .iter()
+        .filter_map(|option| {
+            let SessionConfigKind::Select(select) = &option.kind else {
+                return None;
+            };
+            Some((option.id.to_string(), select.current_value.to_string()))
+        })
+        .collect::<HashMap<_, _>>();
+    if !values.contains_key("mode") {
+        if let Some(mode_id) = modes
+            .as_ref()
+            .map(|state| state.current_mode_id.to_string())
+        {
+            values.insert("mode".to_string(), mode_id);
+        }
+    }
+    values
 }
 
 fn codex_models(options: &[SessionConfigOption]) -> Vec<CodexAcpModel> {
@@ -3217,11 +3474,20 @@ mod tests {
             "session": {
                 "session_id": "acp-session",
                 "current_model_id": "kimi-test",
-                "modes": null,
-                "config_options": [{
-                    "id": "mode",
-                    "currentValue": "auto",
-                }],
+                "modes": {
+                    "currentModeId": "stale-agent-mode",
+                    "availableModes": [],
+                },
+                "config_options": [
+                    {
+                        "id": "mode",
+                        "currentValue": "auto",
+                    },
+                    {
+                        "id": "reasoning_effort",
+                        "currentValue": "high",
+                    }
+                ],
             },
         });
         let temporary = Path::new("/tmp/pinvou-session-workspace");
@@ -3239,6 +3505,10 @@ mod tests {
         assert_eq!(recovered.acp_session_id.as_deref(), Some("acp-session"));
         assert_eq!(recovered.acp_model_id.as_deref(), Some("kimi-test"));
         assert_eq!(recovered.acp_mode_id.as_deref(), Some("auto"));
+        assert_eq!(
+            recovered.acp_config_values.get("reasoning_effort"),
+            Some(&"high".to_string())
+        );
         assert_eq!(recovered.workspace_kind, CodexWorkspaceKind::Project);
         assert_eq!(recovered.workspace_path, Some(project));
 

--- a/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
@@ -7,7 +7,8 @@ use anyhow::{Context, Result};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 
-const STORE_VERSION: u32 = 4;
+const STORE_VERSION: u32 = 5;
+const CONFIG_DEFAULTS_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
@@ -86,6 +87,12 @@ pub struct SessionAgentRecord {
     /// `agent`，所以 Pinvou 必须在运行时就绪前重新应用该期望值。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acp_mode_id: Option<String>,
+    /// 当前 Pinvou 会话最后一次确认成功的 ACP 配置。
+    ///
+    /// `model` / `mode` 仍保留独立字段用于兼容旧版本；其余 Agent 动态上报的
+    /// 配置项统一保存在这里，恢复同一会话时不会被 Agent 默认值覆盖。
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub acp_config_values: HashMap<String, String>,
     /// ACP Agent 的执行目录类型。旧记录没有该字段时按临时会话兼容。
     #[serde(default)]
     pub workspace_kind: CodexWorkspaceKind,
@@ -179,6 +186,7 @@ impl SessionAgentStore {
                 record.acp_session_id = None;
                 record.acp_model_id = None;
                 record.acp_mode_id = None;
+                record.acp_config_values.clear();
                 record.workspace_kind = CodexWorkspaceKind::Temporary;
                 record.workspace_path = None;
             }
@@ -226,12 +234,22 @@ impl SessionAgentStore {
         session_id: &str,
         acp_session_id: String,
         model_id: Option<String>,
+        config_values: HashMap<String, String>,
     ) -> Result<()> {
         {
             let mut records = self.records.write();
             let record = records.entry(session_id.to_string()).or_default();
             record.acp_session_id = Some(acp_session_id);
-            record.acp_model_id = model_id;
+            record.acp_model_id = model_id
+                .clone()
+                .or_else(|| config_values.get("model").cloned());
+            record.acp_mode_id = config_values.get("mode").cloned();
+            record.acp_config_values = config_values;
+            if let Some(model_id) = model_id {
+                record
+                    .acp_config_values
+                    .insert("model".to_string(), model_id);
+            }
         }
         self.persist()
     }
@@ -240,7 +258,17 @@ impl SessionAgentStore {
         {
             let mut records = self.records.write();
             let record = records.entry(session_id.to_string()).or_default();
-            record.acp_model_id = model_id;
+            record.acp_model_id = model_id.clone();
+            match model_id {
+                Some(model_id) => {
+                    record
+                        .acp_config_values
+                        .insert("model".to_string(), model_id);
+                }
+                None => {
+                    record.acp_config_values.remove("model");
+                }
+            }
         }
         self.persist()
     }
@@ -249,7 +277,36 @@ impl SessionAgentStore {
         {
             let mut records = self.records.write();
             let record = records.entry(session_id.to_string()).or_default();
-            record.acp_mode_id = mode_id;
+            record.acp_mode_id = mode_id.clone();
+            match mode_id {
+                Some(mode_id) => {
+                    record.acp_config_values.insert("mode".to_string(), mode_id);
+                }
+                None => {
+                    record.acp_config_values.remove("mode");
+                }
+            }
+        }
+        self.persist()
+    }
+
+    pub fn set_acp_config_value(
+        &self,
+        session_id: &str,
+        config_id: &str,
+        value_id: &str,
+    ) -> Result<()> {
+        {
+            let mut records = self.records.write();
+            let record = records.entry(session_id.to_string()).or_default();
+            record
+                .acp_config_values
+                .insert(config_id.to_string(), value_id.to_string());
+            if config_id == "model" {
+                record.acp_model_id = Some(value_id.to_string());
+            } else if config_id == "mode" {
+                record.acp_mode_id = Some(value_id.to_string());
+            }
         }
         self.persist()
     }
@@ -293,6 +350,122 @@ impl SessionAgentStore {
         let value = AgentStoreFile {
             version: STORE_VERSION,
             sessions: self.records.read().clone(),
+        };
+        fs::write(&tmp, serde_json::to_vec_pretty(&value)?)?;
+        fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct AcpConfigDefaultsFile {
+    #[serde(default = "config_defaults_version")]
+    version: u32,
+    #[serde(default)]
+    agents: HashMap<AgentBackend, HashMap<String, String>>,
+}
+
+fn config_defaults_version() -> u32 {
+    CONFIG_DEFAULTS_VERSION
+}
+
+/// 用户为每个 ACP Agent 选择的新会话默认配置。
+///
+/// ACP 只定义 session 级配置，不负责跨 session 持久化；Pinvou 作为 client 将
+/// 用户成功应用过的配置按 Agent 隔离保存，并在新建 session 后重新应用。
+#[derive(Clone)]
+pub struct AcpConfigDefaultsStore {
+    path: PathBuf,
+    records: Arc<RwLock<HashMap<AgentBackend, HashMap<String, String>>>>,
+}
+
+impl AcpConfigDefaultsStore {
+    pub fn load() -> Result<Self> {
+        let path = crate::platform::paths::pinvou3_home().join("acp-agent-defaults.json");
+        let records = if path.exists() {
+            let raw = fs::read_to_string(&path)
+                .with_context(|| format!("读取 {} 失败", path.display()))?;
+            serde_json::from_str::<AcpConfigDefaultsFile>(&raw)
+                .with_context(|| format!("解析 {} 失败", path.display()))?
+                .agents
+        } else {
+            HashMap::new()
+        };
+        Ok(Self {
+            path,
+            records: Arc::new(RwLock::new(records)),
+        })
+    }
+
+    /// 默认值文件损坏不能阻断 Agent 启动；保留原文件，下一次用户成功修改配置时
+    /// 会重新生成可用内容。
+    pub fn load_or_empty() -> Self {
+        match Self::load() {
+            Ok(store) => store,
+            Err(error) => {
+                let path = crate::platform::paths::pinvou3_home().join("acp-agent-defaults.json");
+                eprintln!(
+                    "[pinvou3-app] ACP agent defaults unavailable, starting empty: {error:#}"
+                );
+                Self {
+                    path,
+                    records: Arc::new(RwLock::new(HashMap::new())),
+                }
+            }
+        }
+    }
+
+    pub fn get(&self, backend: AgentBackend) -> HashMap<String, String> {
+        self.records
+            .read()
+            .get(&backend)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn has_backend(&self, backend: AgentBackend) -> bool {
+        self.records.read().contains_key(&backend)
+    }
+
+    pub fn set(&self, backend: AgentBackend, config_id: &str, value_id: &str) -> Result<()> {
+        if !backend.is_acp() {
+            anyhow::bail!("不能为非 ACP Agent 保存配置默认值");
+        }
+        self.records
+            .write()
+            .entry(backend)
+            .or_default()
+            .insert(config_id.to_string(), value_id.to_string());
+        self.persist()
+    }
+
+    pub fn set_all_if_absent(
+        &self,
+        backend: AgentBackend,
+        values: HashMap<String, String>,
+    ) -> Result<bool> {
+        if !backend.is_acp() || values.is_empty() {
+            return Ok(false);
+        }
+        {
+            let mut records = self.records.write();
+            if records.contains_key(&backend) {
+                return Ok(false);
+            }
+            records.insert(backend, values);
+        }
+        self.persist()?;
+        Ok(true)
+    }
+
+    fn persist(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = self.path.with_extension("json.tmp");
+        let value = AcpConfigDefaultsFile {
+            version: CONFIG_DEFAULTS_VERSION,
+            agents: self.records.read().clone(),
         };
         fs::write(&tmp, serde_json::to_vec_pretty(&value)?)?;
         fs::rename(&tmp, &self.path)?;
@@ -355,6 +528,7 @@ mod tests {
         assert_eq!(record.workspace_kind, CodexWorkspaceKind::Temporary);
         assert_eq!(record.workspace_path, None);
         assert_eq!(record.acp_mode_id, None);
+        assert!(record.acp_config_values.is_empty());
     }
 
     #[test]
@@ -392,7 +566,7 @@ mod tests {
             )
             .unwrap();
         store
-            .set_acp_session("session-1", "acp-1".to_string(), None)
+            .set_acp_session("session-1", "acp-1".to_string(), None, HashMap::new())
             .unwrap();
         assert!(store
             .set_acp_workspace(
@@ -439,6 +613,10 @@ mod tests {
                     acp_session_id: Some("acp-session-1".to_string()),
                     acp_model_id: Some("gpt-test".to_string()),
                     acp_mode_id: Some("agent".to_string()),
+                    acp_config_values: HashMap::from([(
+                        "reasoning_effort".to_string(),
+                        "high".to_string(),
+                    )]),
                     workspace_kind: CodexWorkspaceKind::Project,
                     workspace_path: Some(root.clone()),
                 },
@@ -451,6 +629,10 @@ mod tests {
         assert_eq!(recovered.acp_session_id.as_deref(), Some("acp-session-1"));
         assert_eq!(recovered.workspace_kind, CodexWorkspaceKind::Project);
         assert_eq!(recovered.workspace_path.as_deref(), Some(root.as_path()));
+        assert_eq!(
+            recovered.acp_config_values.get("reasoning_effort"),
+            Some(&"high".to_string())
+        );
         fs::remove_dir_all(&root).unwrap();
     }
 
@@ -473,6 +655,70 @@ mod tests {
         assert_eq!(
             value["sessions"]["session-1"]["acp_mode_id"],
             "agent-full-access"
+        );
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn generic_acp_config_is_persisted_with_the_session_record() {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-acp-config-store-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("session-agents.json");
+        let store = SessionAgentStore {
+            path: path.clone(),
+            records: Arc::new(RwLock::new(HashMap::new())),
+        };
+        store
+            .set_acp_config_value("session-1", "reasoning_effort", "high")
+            .unwrap();
+
+        let persisted: AgentStoreFile = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(
+            persisted.sessions["session-1"].acp_config_values["reasoning_effort"],
+            "high"
+        );
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn acp_defaults_are_isolated_by_agent_and_not_overwritten_by_migration() {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-acp-defaults-store-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("acp-agent-defaults.json");
+        let store = AcpConfigDefaultsStore {
+            path: path.clone(),
+            records: Arc::new(RwLock::new(HashMap::new())),
+        };
+        store
+            .set(AgentBackend::CodexAcp, "mode", "agent-full-access")
+            .unwrap();
+        store
+            .set(AgentBackend::ClaudeAcp, "mode", "default")
+            .unwrap();
+        assert!(!store
+            .set_all_if_absent(
+                AgentBackend::CodexAcp,
+                HashMap::from([("mode".to_string(), "agent".to_string())]),
+            )
+            .unwrap());
+
+        let persisted: AcpConfigDefaultsFile =
+            serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(
+            persisted.agents[&AgentBackend::CodexAcp]["mode"],
+            "agent-full-access"
+        );
+        assert_eq!(
+            persisted.agents[&AgentBackend::ClaudeAcp]["mode"],
+            "default"
         );
         fs::remove_dir_all(&root).unwrap();
     }

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -2058,7 +2058,9 @@ function workspaceDisplayName(path) {
           <div className={`flex-1 flex flex-col relative min-w-0 overflow-hidden ${activeTheme === 'dark' ? 'bg-[#131314]' : 'bg-white'} ${isCompactShell ? '' : 'rounded-tl-[28px]'}`}>
 
             {/* Gemini Style Background Glow */}
-            {(currentView === 'chat' || (currentView === 'scheduled' && bs && bs.scheduledRunContext)) && (
+            {(currentView === 'chat'
+              || currentView === 'codex'
+              || (currentView === 'scheduled' && bs && bs.scheduledRunContext)) && (
               activeTheme === 'light' ? (
                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[1200px] h-[800px] bg-[radial-gradient(ellipse_at_center,_rgba(232,240,254,0.8)_0%,_transparent_60%)] pointer-events-none z-0"></div>
               ) : (

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1833,8 +1833,8 @@ export function CodexAcpView({
           </div>
         )}
 
-        <div className="shrink-0 px-6 pb-5 pt-2">
-          <div className="w-full max-w-[920px] mx-auto">
+        <div className={`shrink-0 px-6 pt-2 ${activeId ? 'pb-5' : 'pb-[60px]'}`}>
+          <div className={`w-full mx-auto ${activeId ? 'max-w-[920px]' : 'max-w-[800px]'}`}>
             {!activeId && (
               <HomeModeSwitcher
                 mode="code"

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1815,25 +1815,24 @@ export function CodexAcpView({
           </div>
         </div>
 
-        {showScrollBottom && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-[106px] z-20 flex justify-center">
-            <button
-              type="button"
-              onClick={scrollConversationToBottom}
-              aria-label={pending.length || pendingElicitations.length ? codexCopy.attentionLatest : codexCopy.latest}
-              title={pending.length || pendingElicitations.length ? codexCopy.attentionLatest : codexCopy.latest}
-              className={`pointer-events-auto w-9 h-9 rounded-full flex items-center justify-center shadow-lg backdrop-blur transition-all hover:-translate-y-0.5 active:translate-y-0 border ${
-                pending.length || pendingElicitations.length
-                  ? 'bg-amber-500/95 text-white border-amber-400'
-                  : 'bg-white/95 dark:bg-[#2B2C2F]/95 text-[#1F1F1F] dark:text-[#E3E3E3] border-black/10 dark:border-white/10'
-              }`}
-            >
-              <ChevronDown size={15} />
-            </button>
-          </div>
-        )}
-
-        <div className={`shrink-0 px-6 pt-2 ${activeId ? 'pb-5' : 'pb-[60px]'}`}>
+        <div className={`relative shrink-0 px-6 pt-2 ${activeId ? 'pb-5' : 'pb-[60px]'}`}>
+          {showScrollBottom && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-full z-20 flex justify-center pb-2">
+              <button
+                type="button"
+                onClick={scrollConversationToBottom}
+                aria-label={pending.length || pendingElicitations.length ? codexCopy.attentionLatest : codexCopy.latest}
+                title={pending.length || pendingElicitations.length ? codexCopy.attentionLatest : codexCopy.latest}
+                className={`pointer-events-auto w-9 h-9 rounded-full flex items-center justify-center shadow-lg backdrop-blur transition-all hover:-translate-y-0.5 active:translate-y-0 border ${
+                  pending.length || pendingElicitations.length
+                    ? 'bg-amber-500/95 text-white border-amber-400'
+                    : 'bg-white/95 dark:bg-[#2B2C2F]/95 text-[#1F1F1F] dark:text-[#E3E3E3] border-black/10 dark:border-white/10'
+                }`}
+              >
+                <ChevronDown size={15} />
+              </button>
+            </div>
+          )}
           <div className={`w-full mx-auto ${activeId ? 'max-w-[920px]' : 'max-w-[800px]'}`}>
             {!activeId && (
               <HomeModeSwitcher

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -112,24 +112,30 @@ function normalizeTurnItems(turn) {
       };
     }
     if (block.type === 'tool') {
+      const status = block.tool && block.tool.status || 'pending';
       return {
         ...block,
         type: toolItemType(block.tool),
-        status: block.tool && block.tool.status || 'pending',
+        status: turn.completedAt && !isTerminalToolStatus(status) ? 'cancelled' : status,
+        completedAt: block.completedAt || turn.completedAt || null,
       };
     }
     if (block.type === 'permission') {
       return {
         ...block,
-        status: block.permission.resolved ? 'completed' : 'waiting',
-        completedAt: block.permission.resolvedAt || null,
+        status: block.permission.resolved
+          ? 'completed'
+          : turn.completedAt ? 'cancelled' : 'waiting',
+        completedAt: block.permission.resolvedAt || turn.completedAt || null,
       };
     }
     if (block.type === 'elicitation') {
       return {
         ...block,
-        status: block.elicitation.resolved ? 'completed' : 'waiting',
-        completedAt: block.elicitation.resolvedAt || null,
+        status: block.elicitation.resolved
+          ? 'completed'
+          : turn.completedAt ? 'cancelled' : 'waiting',
+        completedAt: block.elicitation.resolvedAt || turn.completedAt || null,
       };
     }
     if (block.type === 'plan') {
@@ -320,7 +326,8 @@ export function projectAcpTimeline(input) {
   }
 
   for (const turn of turns) {
-    turn.waitingInput = turn.elicitations.some(elicitation => !elicitation.resolved);
+    turn.waitingInput = !turn.completedAt
+      && turn.elicitations.some(elicitation => !elicitation.resolved);
     turn.items = normalizeTurnItems(turn);
     turn.presentation = presentTurnItems(turn.items);
     const operations = turn.items.filter(item => (

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -461,8 +461,10 @@ try {
     && codexView.includes('if (movingUp) autoScrollRef.current = false')
     && codexView.includes('if (autoScrollRef.current)')
     && codexView.includes('scrollConversationToBottom')
-    && codexView.includes('codexCopy.latest'),
-  'Codex streaming must pause auto-follow while the user reads history and expose an explicit return action');
+    && codexView.includes('codexCopy.latest')
+    && codexView.includes('bottom-full')
+    && !codexView.includes('bottom-[106px]'),
+  'Codex streaming must pause auto-follow and place the return action above, not over, the composer');
   assert.ok(!codexView.includes('<JsonBlock'), 'raw ACP JSON must not leak into normal command UI');
   assert.ok(codexView.includes("invoke('codex_acp_prompt', {")
     && codexView.includes('attachments: readyAttachments.map(attachment => attachment.result)')

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -124,6 +124,36 @@ try {
   assert.equal(pendingInputTurn.waitingInput, true);
   assert.equal(pendingInputTurn.items[0].status, 'waiting');
 
+  const interruptedTurn = projectAcpTimeline([
+    event(16, 'turn_started', { status: 'running' }, 'turn-interrupted'),
+    event(17, 'tool_call', { update: {
+      toolCallId: 'tool-interrupted',
+      title: '执行长任务',
+      kind: 'execute',
+      status: 'in_progress',
+    } }, 'turn-interrupted'),
+    event(18, 'permission_requested', {
+      toolCallId: 'permission-interrupted',
+      request: { options: [] },
+    }, 'turn-interrupted'),
+    event(19, 'elicitation_requested', {
+      elicitationId: 'input-interrupted',
+      request: { mode: 'form', requestedSchema: { type: 'object', properties: {} } },
+    }, 'turn-interrupted'),
+    event(20, 'turn_completed', {
+      status: 'Interrupted',
+      error: null,
+      recoveryReason: 'application_restarted',
+    }, 'turn-interrupted'),
+  ]).turns[0];
+  assert.equal(interruptedTurn.status, 'Interrupted');
+  assert.equal(interruptedTurn.waitingInput, false);
+  assert.deepEqual(
+    interruptedTurn.items.map(item => item.status),
+    ['cancelled', 'cancelled', 'cancelled'],
+    'terminal recovery must not leave tool, permission, or input items visually running',
+  );
+
   const commandEvents = [
     event(20, 'user_message', { content: [{ type: 'text', text: '检查 PR' }] }, 'turn-command'),
     event(21, 'turn_started', { status: 'running' }, 'turn-command'),
@@ -261,6 +291,10 @@ try {
   const runtime = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'mod.rs'), 'utf8');
   assert.ok(runtime.includes('self.session_store.touch_activity(session_id)'),
     'an accepted ACP turn must persist the session activity timestamp before it starts');
+  assert.ok(runtime.includes('interrupt_orphaned_turns("application_restarted")')
+    && runtime.includes('cancel_without_active_prompt')
+    && runtime.includes('runtime.busy.load(Ordering::Acquire)'),
+  'app restart and stale stop must close orphaned ACP turns without cancelling an idle runtime');
   assert.ok(runtime.includes('LoadSessionRequest::new(saved_id.clone(), workspace.clone())'));
   assert.ok(runtime.includes('NewSessionRequest::new(workspace)'));
   assert.ok(runtime.includes('会话绑定的项目目录已不可用'), 'missing projects must not silently fall back');


### PR DESCRIPTION
## 背景

ACP 的配置项只作用于当前 session。此前用户在 Codex 中选择 Full Access、模型或推理强度后，新建 Agent 会话仍可能回到 Agent 默认值；应用异常退出时，历史时间线也可能残留永久“处理中”的回合。代码模式首屏的背景、输入区尺寸及“回到最新”按钮位置同时与工作模式不一致。

## 变更

- 新增按 Agent 隔离的 `~/.pinvou3/acp-agent-defaults.json`，保存用户成功应用的模型、权限模式、推理强度等新会话默认值
- 历史会话继续保存自己的完整 ACP 配置；新会话创建后按 Agent 默认值校验并重新应用，旧版本首次升级时从最近有效会话迁移
- 按 ACP 协议使用 `session/set_config_option` 返回的完整配置集更新本地状态，避免配置联动后状态失真
- 应用重启或停止空闲 runtime 时，将无法重新挂接的孤儿回合收口为 `Interrupted`，同步取消未结束的工具、权限和输入状态
- 代码模式首屏加入渐变背景，调整草稿输入区宽度和底部间距；“回到最新”按钮锚定到输入区上方，不再覆盖输入框

## 与 #112 的关系

#112 主要负责前端体验：草稿态配置预展示/主动预选、配置项移到底栏以及自定义下拉浮层。本 PR 负责后端跨会话持久化和恢复，是实际配置值的真相源。

两者可以共存：

- 未主动修改草稿配置时，由本 PR 的后端默认值保证新会话继承 Full Access 等选择
- 用户在 #112 的草稿态主动预选时，显式选择覆盖默认值；现有 setter 成功后会由本 PR 保存为下一次默认值
- #112 的 `localStorage` 可继续作为草稿界面的选项快照，不承担实际跨会话持久化职责

已使用本 PR 当前 head 与 #112 当前 head `1c0fdeae` 执行合并树检查，无文本冲突。

## 实际验证

- `cargo test --no-default-features --features local-embed codex_acp:: --lib`：52 项通过
- `npm run test:codex-acp`：4 个 ACP 契约测试通过
- `npx eslint src/app/main.jsx src/features/codex/CodexAcpView.jsx src/features/codex/acp-state.js`：通过
- `python3 scripts/architecture-guard.py`：通过（仅既有大文件提示）
- `git diff --check`：通过

## 已知边界

- Agent 已删除或不再支持的旧配置值会跳过并记录诊断，不阻断新会话创建
- 当前只持久化前端可选择的字符串型配置项；ACP 后续新增其他值类型时需扩展命令参数和存储结构
- 本 PR 不修改登录凭据，也不会把 Token、Cookie 等敏感信息写入配置默认值文件
