### PR TITLE
test(markdown): 补全脚本标签大小写断言

### DIFF
--- a/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
+++ b/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
@@ -111,7 +111,7 @@ assert.match(genericLog, /hljs-attr">status</u);
 const unsupported = renderMarkdownMarkup('```unknown-lang\n<script>alert("x")</script>\n```');
 assert.match(unsupported, /class="hljs language-plaintext"/u);
 assert.match(unsupported, /&lt;script&gt;/u);
-assert.doesNotMatch(unsupported, /<script>/u);
+assert.doesNotMatch(unsupported, /<script>/iu);
 
 const oversizedJavaScript = highlightCode(
   `const value = 1;\n${'x'.repeat(MAX_HIGHLIGHT_SOURCE_BYTES)}`,
@@ -143,7 +143,7 @@ assert.notStrictEqual(cachedAfterEviction, cachedFirst, 'highlight cache must ev
 
 const dangerousRawHtml = renderMarkdownMarkup('before <script>alert("x")</script> after');
 assert.match(dangerousRawHtml, /&lt;script&gt;/u);
-assert.doesNotMatch(dangerousRawHtml, /<script>/u);
+assert.doesNotMatch(dangerousRawHtml, /<script>/iu);
 
 const css = readApp('src', 'styles', 'base.css');
 assert.match(css, /\.dark-code \.msg-md :not\(pre\) > code/u);


### PR DESCRIPTION
## 背景

CodeQL 告警 #13、#14 指向两处仅匹配小写 script 标签的测试断言。

## 变更

- 将两处原始 script 标签断言改为大小写不敏感匹配。
- 仅增强测试约束，不修改生产运行时行为。

## 验证

- `python3 scripts/architecture-guard.py`
- `npm --prefix pinvou3-app test`
- `git diff --check origin/main...HEAD`

## 已知风险

仅涉及测试正则，无产品行为和兼容性变化。