### PR TITLE
Potential fix for code scanning alert no. 13: Bad HTML filtering regexp

### DIFF
--- a/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
+++ b/pinvou3-app/tests/markdown_syntax_highlight.test.mjs
@@ -111,7 +111,7 @@ assert.match(genericLog, /hljs-attr">status</u);
 const unsupported = renderMarkdownMarkup('```unknown-lang\n<script>alert("x")</script>\n```');
 assert.match(unsupported, /class="hljs language-plaintext"/u);
 assert.match(unsupported, /&lt;script&gt;/u);
-assert.doesNotMatch(unsupported, /<script>/u);
+assert.doesNotMatch(unsupported, /<script>/iu);
 
 const oversizedJavaScript = highlightCode(
   `const value = 1;\n${'x'.repeat(MAX_HIGHLIGHT_SOURCE_BYTES)}`,


### PR DESCRIPTION
Potential fix for [https://github.com/Pinvou/pinvou-agent/security/code-scanning/13](https://github.com/Pinvou/pinvou-agent/security/code-scanning/13)

Use a case-insensitive regex for the “no script tag” assertion in the test.  
Specifically, in `pinvou3-app/tests/markdown_syntax_highlight.test.mjs` at the assertion on line 114, replace `/\<script\>/u` with `/\<script\>/iu` so uppercase/mixed-case `<script>` tags are also rejected by the test.

No new methods or structural refactors are needed. No imports are required. This is a one-line test-hardening fix that preserves existing behavior while improving the correctness of HTML tag filtering validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
