### PR TITLE
fix(codex): 修复 Windows 下 ACP 项目目录路径形态导致相对读取失败

### DIFF
--- a/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/store.rs
@@ -483,7 +483,12 @@ pub fn validate_codex_project_workspace(path: &Path) -> Result<PathBuf> {
     if !canonical.is_dir() {
         anyhow::bail!("Codex 工作目录必须是文件夹: {}", canonical.display());
     }
-    Ok(canonical)
+    // Windows 的 canonicalize 返回 \\?\ 前缀的 verbatim 路径；ACP agent（如 kimi acp）的
+    // 工作目录校验不识别该形式，会把一切相对路径误判为“工作目录之外”而拒绝读取。
+    // 统一归一化为常规盘符路径（非 Windows 平台为恒等映射）。
+    Ok(crate::platform::os::platform_compat_path(
+        &canonical.to_string_lossy(),
+    ))
 }
 
 #[cfg(test)]
@@ -539,9 +544,19 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&root);
         fs::create_dir_all(&root).unwrap();
+        let validated = validate_codex_project_workspace(&root).unwrap();
+        assert!(validated.is_dir());
         assert_eq!(
-            validate_codex_project_workspace(&root).unwrap(),
+            validated.canonicalize().unwrap(),
             root.canonicalize().unwrap()
+        );
+        // 回归断言：交给 ACP agent 的工作目录不得保留 \\?\ verbatim 前缀，
+        // 否则 kimi acp 会把相对路径误判为“工作目录之外”。该断言全平台有效——
+        // 非 Windows 的 canonicalize 本就不产生该前缀，Windows 上由 platform_compat_path 归一化。
+        assert!(
+            !validated.to_string_lossy().starts_with(r"\\?\"),
+            "validated workspace must not keep the verbatim prefix: {}",
+            validated.display()
         );
         assert!(validate_codex_project_workspace(&root.join("missing")).is_err());
         fs::remove_dir_all(&root).unwrap();


### PR DESCRIPTION
## 背景

Windows 上 pinvou 记录项目工作目录时使用 `canonicalize()`，得到带 `\\?\` 前缀的 verbatim 路径（如 `\\?\D:\work\proj`）。该路径作为进程 cwd 和 ACP `session/new` 的 cwd 传给 agent 后，kimi acp（0.30.0）的工作目录校验不识别该形态，把所有相对路径误判为“工作目录之外”，报 `"xxx" is not an absolute path...`，agent 只能全程改用绝对路径。

## 根因验证（ACP 直连对照实验）

手写 ACP 客户端直连本机 kimi acp 0.30.0：

- cwd 传常规 `D:\...`：`session/new`、`session/load` 下相对路径 Read 均正常；
- cwd 传 `\\?\D:\...`：相对路径 Read 100% 失败，错误文案与实际遇到的一致。

另实测 Node v24：`path`/`fs` 直接读写对 verbatim 路径自洽，但 `fs.realpathSync(verbatim)` 抛 EISDIR——node 系 agent（claude 适配层）存在同类隐患；codex 核心为 Rust，verbatim 是其原生 canonical 形态，不受影响。统一发常规路径可同时规避这三类问题。

## 变更

- `validate_codex_project_workspace`：canonicalize 后经既有 `platform_compat_path` 归一化（Windows 脱 `\\?\` 前缀；非 Windows 恒等），会话存储与 spawn / `session/new` 的 cwd 均为常规盘符路径
- 复用 `file_ingest.rs` 已验证的同款归一化手法，无新增依赖
- 存量 verbatim 会话无需迁移：启动时经同一函数重新校验自动获得常规路径
- 单测补充回归断言（全平台有效，避免在 feature 代码引入 `cfg(windows)`）

## 实际验证

- `cargo clippy --lib --no-deps` 通过（仅 CodeWhale 上游既有 warning）
- `cargo fmt --check` 通过
- `cargo test --lib --no-run` 编译通过；本机 Windows 测试二进制存在既有启动故障（0xc0000139，与本次改动无关，最小 cargo 项目正常），测试执行依赖 Linux CI
- `npm run test:codex-acp`（4 个契约测试）通过
- `python3 scripts/architecture-guard.py` 通过
- 已在真实应用中实测确认 kimi 相对路径读取恢复正常

## 已知风险

- 对 codex / claude 的免疫判断为架构层面推断（本机未登录，无法端到端实测），但两者只会因“收到更常规的路径”而更安全，不会因此变更差
- `to_string_lossy` 对极端非 UTF-8 路径有损（与仓内既有用法一致）