### PR TITLE
fix(settings): 修复添加模型弹窗 Coding Plan 分组误显示为 OpenAI 兼容

### DIFF
--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -1763,13 +1763,13 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
         <div className="space-y-4">
           {catalogGroups.map(group => (
             <section key={group.key}>
-              <div className={catalogSectionTitleClass}>{presetProviderLabel(group.preset, t)}</div>
+              <div className={catalogSectionTitleClass}>{group.providerKind === PROVIDER_KIND_CODING_PLAN ? group.title : presetProviderLabel(group.preset, t)}</div>
               <div className={catalogGroupClass}>
                 {group.items.map(item => {
                   const active = preset === group.preset && model === item.model && !item.custom;
-                  const itemTitle = item.custom ? settingsCopy.customModelTitle(presetProviderLabel(group.preset, t)) : item.title;
+                  const itemTitle = item.custom ? (settingsCopy.customModelTitles[group.key] || settingsCopy.customModelTitle(presetProviderLabel(group.preset, t))) : item.title;
                   const itemDescription = item.custom
-                    ? (group.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (group.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc))
+                    ? (group.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (group.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (group.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc)))
                     : (settingsCopy.modelDescriptions[item.desc] || item.desc);
                   return (
                     <button

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -1221,14 +1221,17 @@ const dict = {
     dict.zh.uiSettingsDetail.customModelTitles = {
       glm:'自定义 GLM 模型', qwen:'自定义通义模型',
       openai_compatible:'自定义兼容模型', glm_coding_plan:'自定义 GLM Coding Plan 模型',
+      tencent_coding_plan:'自定义腾讯云 Coding Plan 模型', kimi_coding_plan:'自定义 Kimi Coding Plan 模型',
     };
     dict.en.uiSettingsDetail.customModelTitles = {
       glm:'Custom GLM model', qwen:'Custom Qwen model',
       openai_compatible:'Custom compatible model', glm_coding_plan:'Custom GLM Coding Plan model',
+      tencent_coding_plan:'Custom Tencent Cloud Coding Plan model', kimi_coding_plan:'Custom Kimi Coding Plan model',
     };
     dict.ja.uiSettingsDetail.customModelTitles = {
       glm:'カスタム GLM モデル', qwen:'カスタム Qwen モデル',
       openai_compatible:'カスタム互換モデル', glm_coding_plan:'カスタム GLM Coding Plan モデル',
+      tencent_coding_plan:'カスタム Tencent Cloud Coding Plan モデル', kimi_coding_plan:'カスタム Kimi Coding Plan モデル',
     };
     dict.zh.uiToolDetails.flow = {
       incomplete:name=>`${name}接入未完成`, connected:name=>`已连接${name}`, connecting:name=>`正在接入${name}`,


### PR DESCRIPTION
## 背景

预存问题（#23 起，非 PR #110 引入）：添加模型弹窗的目录选择器（`renderCatalogPicker`）按 `preset` 渲染分组标题与自定义模型项，而三个 Coding Plan 分组（智谱 `glm_coding_plan`、腾讯云 `tencent_coding_plan`、Kimi `kimi_coding_plan`）的 `preset` 均为 `openai_compatible`，导致：

- 三个分组的组标题都显示为「OpenAI 兼容」，无法区分；
- 自定义模型项标题都显示为「自定义兼容模型」口径，丢失供应商语境；
- 自定义项描述用了通用兼容接口文案，而非 Coding Plan 专用文案。

本 PR 基于 #119（`fix/i18n-web-memory-status`）叠加，复用其引入的 `customModelTitles`/`customCodingPlanDesc` 词条；#119 合并后本 PR  diff 只剩自身一个 commit。

## 变更

- `SettingsView.jsx` `renderCatalogPicker`：
  - Coding Plan 分组的组标题改用分组自身 `title`（zh 来自 `MODEL_CATALOG`，en/ja 经 `providerCatalog` overlay 本地化），其余分组仍按 `preset` 标签渲染，行为不变；
  - 自定义项标题接入 `settingsCopy.customModelTitles[group.key]`（与 #119 编辑弹窗同一词典），未列出的分组回退原逻辑；
  - Coding Plan 自定义项描述改用 `customCodingPlanDesc`（「手动填写 Coding Plan 模型 ID」），与目录数据原口径一致。
- `i18n.js`：`customModelTitles` 三语补齐 `tencent_coding_plan`、`kimi_coding_plan` 两个 key（zh 与 `MODEL_CATALOG` 条目原标题逐字一致）；同时使 #119 的编辑弹窗对这两个供应商的自定义项也能显示专用标题。

## 实际验证

- `npx eslint` 涉及文件零错误；`test:ui-language` 三语覆盖检查通过；`npm test` 全量通过。
- `test:settings-ui` smoke 34/34 全过（含 ⑥ 添加模型目录分组、⑥.1a/⑥.1b Coding Plan 表单与保存、④ 编辑模型弹窗等相关项）。

## 已知风险

- 改动仅限添加/编辑模型弹窗的文案选择逻辑，不涉及保存数据格式；smoke ⑥.1b 已验证保存的 `provider_kind`/`base_url` 等字段不受影响。
- 依赖 #119 的词条，需在其合并后合并（或合并时自动包含）。