### PR TITLE
fix(prompt): 修复 bundle 技能提示词错误并登记 fork 提示词审查

### DIFF
--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -198,6 +198,15 @@ diff /tmp/pre-sync-prompt.txt /tmp/post-sync-prompt.txt
 
 ## 5. Sync 历史
 
+### LLM-facing 提示词文本审查修复（2026-08-02）
+
+- fork 侧改动经 `Pinvou/CodeWhale#4`（分支 `fix/prompt-text-audit`，基线 `pinvou-v0.9.0-r2`）提交；合入发布新标签后，父仓再更新 gitlink 对齐。
+- 纯提示词文本变更，零代码行为变化；fork 指纹锚点全部保留，`forkguard_blocklist_golden` 等结果式 golden 不受影响；两处既有测试断言随文本修正同步更新（`rlm.rs` 的错误示例 `SOURCE`→`content`、`prompts.rs` 的 edit_file 不再引用被 pinvou3 工具面隐藏的 apply_patch）。
+- fork-distinct 文件中的文本修复（shell.rs T2、automation.rs T4、subagent T5、skills/mod.rs T3、tool_catalog.rs T2）只校正描述与既有实现的一致性，不新增 fork 语义，无需新增指纹。
+- 生产层改动限于 bundle 内 wecomcli-doc / wecomcli-smartsheet / lark-task 三个 SKILL.md 的自相矛盾与笔误修复，以及 `runtime_bundle/platform/mod.rs` 两条过时注释；instructions.md、base.md、kb_tool.rs、ima.rs 审查后无需改动。
+- 上游通用的文本-实现漂移（如 grep_files 虚假的 `.gitignore` 声明、agents/message 虚构的 "natural resume"、delegate 技能错误的 model_strength 默认值、wecomcli-doc 矛盾）已列入回馈上游候选。
+- 验证：`cargo check -p codewhale-tui`、`cargo test -p codewhale-tui forkguard_ --lib` 及 tools/prompts/skills 模块测试、`cargo check`（pinvou3-tauri lib）、`./scripts/fork-guard.sh --fast`。
+
 ### v0.9.0 r2 append_file inline diff（2026-07-30）
 
 - `Pinvou/CodeWhale#2` 以 squash commit `cb93e0f4466d60e306252ed08bbbe214f2def752` 合入 `pinvou3-clean`，并发布不可变标签 `pinvou-v0.9.0-r2`。

--- a/pinvou3-app/src-tauri/resources/common/bundle/skills/lark-task/SKILL.md
+++ b/pinvou3-app/src-tauri/resources/common/bundle/skills/lark-task/SKILL.md
@@ -68,7 +68,7 @@ lark-cli task <resource> <method> [flags] # 调用 API
   - `create` — 创建任务
   - `delete` — 删除任务
   - `get` — 获取任务详情
-  - `list` — 列取任务列表
+  - `list` — 获取任务列表
   - `patch` — 更新任务
 
 ### tasklists

--- a/pinvou3-app/src-tauri/resources/common/bundle/wecom-skills/wecomcli-doc/SKILL.md
+++ b/pinvou3-app/src-tauri/resources/common/bundle/wecom-skills/wecomcli-doc/SKILL.md
@@ -24,7 +24,7 @@ metadata:
 | `https://doc.weixin.qq.com/smartsheet/*` | **智能表格**（doc_type=10） | 参阅 `wecomcli-smartsheet` skill |
 | `https://doc.weixin.qq.com/smartpage/*` | **智能文档**（原名智能主页） | `smartpage_export_task` → `smartpage_get_export_result` |
 
-> ⚠️ `/sheet/`（表格）与 `/smartsheet/`（智能表格）是不同品类；读取都用 `get_doc_content`，智能表格的结构/记录管理见 `wecomcli-smartsheet` skill。
+> ⚠️ `/sheet/`（表格）与 `/smartsheet/`（智能表格）是不同品类；表格读取用 `get_doc_content`，智能表格的读取与结构/记录管理见 `wecomcli-smartsheet` skill。
 
 ## 调用方式
 
@@ -57,7 +57,7 @@ wecom-cli doc <tool_name> '<json_params>'
 
 ### get_doc_content
 
-获取**文档 / 表格（在线表格） / 智能表格**的完整内容数据，统一以 Markdown 格式返回。采用**异步轮询机制**：首次调用无需传 `task_id`，接口返回 `task_id`；若 `task_done` 为 false，需携带该 `task_id` 再次调用，直到 `task_done` 为 true 时返回完整内容。
+获取**文档 / 表格（在线表格）**的完整内容数据，统一以 Markdown 格式返回。采用**异步轮询机制**：首次调用无需传 `task_id`，接口返回 `task_id`；若 `task_done` 为 false，需携带该 `task_id` 再次调用，直到 `task_done` 为 true 时返回完整内容。
 
 > 适用 URL：`/doc/*`、`/sheet/*`。`/smartsheet/*`（智能表格）不适用，请改用 `wecomcli-smartsheet` skill；`/smartpage/*`（智能文档）不适用，请改用 `smartpage_export_task`。
 
@@ -127,7 +127,7 @@ wecom-cli doc edit_doc_content '{"docid": "DOCID", "content": "# 标题\n\n正�
 
 创建智能文档（原名智能主页），支持传入标题和多个子页面。每个子页面可指定标题、内容类型和本地文件路径。创建成功返回 docid 和 url。
 
-> ⚠️ **特殊语法**：此命令必须使用 `+smartpage_create`（带 `+` 前缀），加号不可省略；该 `+` 仅适用于此命令，不要泛化到其他 `doc` 子命令。
+> ⚠️ **特殊语法**：此命令必须使用 `+smartpage_create`（带 `+` 前缀），加号不可省略；不要自行给其他 `doc` 子命令加 `+`，带 `+` 的命令（如此命令及 smartsheet 的 `+smartsheet_add_records_auto_file` / `+smartsheet_update_records_auto_file`）必须原样保留加号。
 
 ```bash
 wecom-cli doc +smartpage_create '{"title": "项目概览", "pages": [{"page_title": "需求文档", "content_type": 1, "page_filepath": "/path/to/requirements.md"}]}'

--- a/pinvou3-app/src-tauri/resources/common/bundle/wecom-skills/wecomcli-smartsheet/SKILL.md
+++ b/pinvou3-app/src-tauri/resources/common/bundle/wecom-skills/wecomcli-smartsheet/SKILL.md
@@ -208,7 +208,7 @@ wecom-cli doc smartsheet_update_records '{"docid": "DOCID", "sheet_id": "SHEETID
 更新一行或多行记录，单次建议在 500 行内。与 `smartsheet_update_records` 不同之处在于，可支持本地路径传入图片、文件。对于需要更新记录中的图片或文件，请使用此接口。传入后台后，后台将自动存储并转换为 `image_url`。
 
 ```bash
-wecom-cli doc +smartsheet_update_records_auto_file '{"docid": "DOCID", "sheet_id": "SHEETID", "key_type": "CELL_VALUE_KEY_TYPE_FIELD_TITLE", "records": [{"record_id": "RECORDID", "values": {"values":{"图片":[{"image_path":"/path/to/image.jpg"}],"文件":[{"file_path":"/path/to/file.txt"}]}}}]}'
+wecom-cli doc +smartsheet_update_records_auto_file '{"docid": "DOCID", "sheet_id": "SHEETID", "key_type": "CELL_VALUE_KEY_TYPE_FIELD_TITLE", "records": [{"record_id": "RECORDID", "values": {"图片":[{"image_path":"/path/to/image.jpg"}],"文件":[{"file_path":"/path/to/file.txt"}]}}]}'
 ```
 
 ### 删除记录

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -109,17 +109,17 @@ pub const INSTRUCTIONS_MD: &str =
 const VISUAL_DESIGN_SKILL_MD: &str =
     include_str!("../../../../resources/common/bundle/skills/visual-design/SKILL.md");
 
-/// pinvou3 版 base prompt（Constitution / 工具纪律 / embedder-aware / 删 RLM·Toolbox·V4），
-/// 编译期内嵌。通过底座 `prompts::set_base_prompt_override` 注入，替换底座的上游
-/// `BASE_PROMPT`。这样 pinvou3 的 prompt 定制活在 app,CodeWhale submodule 的
-/// base.md 回退上游原文（fork drift 归零）。
+/// pinvou3 版 base prompt，编译期内嵌。通过底座 `prompts::set_base_prompt_override`
+/// 注入，替换底座的上游 `BASE_PROMPT`。这样 pinvou3 的 prompt 定制活在 app,
+/// CodeWhale submodule 的 base.md 回退上游原文（fork drift 归零）。
+/// 注：base.md 已折叠为自述空壳，实际静态文案由本文件的 composer（见下）输出，
+/// 工具纪律与语言要求分别由 instructions.md 与 `LOCALE_PREAMBLE_*` 承载。
 pub const BASE_PROMPT_MD: &str = include_str!("../../../../resources/common/bundle/base.md");
 
 /// pinvou3 版简体中文 locale 前导段（替换底座 `LOCALE_PREAMBLE_ZH_HANS`）。
 /// 瘦身依据:底座原文的动机是防 thinking 漂英文(上游 #1118)——pinvou3 生产
-/// `reasoning_effort=off` 无 thinking,该 failure mode 不存在;回复语言已由
-/// base.md §Language("match the latest user message")管,这里只补
-/// "判断不了时的默认语言"。closer 同理。
+/// `reasoning_effort=off` 无 thinking,该 failure mode 不存在;回复语言由
+/// 用户消息驱动,这里只补"判断不了时的默认语言"。closer 同理。
 pub const LOCALE_PREAMBLE_ZH_HANS: &str = "## 语言要求\n\n\
 pinvou3 界面语言为简体中文。跟随用户消息的语言回复;无法判断时用简体中文。\
 代码、路径、工具名、URL 保持原样。";


### PR DESCRIPTION
## 背景

配合 fork 侧的 LLM-facing 提示词文本系统审查（Pinvou/CodeWhale#4，约 50 处工具/技能提示词修复），本 PR 包含生产层（pinvou3-app bundle）的提示词修复与 fork 登记。全部为提示词文本/注释变更，零代码行为变化。

## 变更

- `wecomcli-doc/SKILL.md`：三处自相矛盾——`get_doc_content` 误称适用智能表格（与同文路由表 :62/:81 及参考文档矛盾，实际 `/smartsheet/*` 不适用）；「`+` 前缀仅此命令，不要泛化」的绝对化表述会诱导模型剥掉 smartsheet 的 `+smartsheet_add_records_auto_file` / `+smartsheet_update_records_auto_file` 两条命令必须保留的加号
- `wecomcli-smartsheet/SKILL.md`：`+smartsheet_update_records_auto_file` 示例 JSON 的 `values` 双重嵌套笔误
- `lark-task/SKILL.md`：「列取任务列表」→「获取任务列表」笔误
- `runtime_bundle/platform/mod.rs`：两条过时注释（base.md 已折叠为空壳、`§Language` 引用已不存在），仅注释非 LLM-facing
- `docs/fork-modifications.md` §5：登记本次两层提示词审查（fork 侧走 Pinvou/CodeWhale#4，合入发标签后再对齐 gitlink）

instructions.md、base.md、kb_tool.rs、ima.rs 及其余 15 个 bundle SKILL.md 审查后确认无需改动。

## 验证

- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib` 通过
- `./scripts/fork-guard.sh --fast` 指纹层全过
- bundle 相关测试仅有 SKILL.md 存在性断言，无文本断言受影响
- fork 侧：`cargo check -p codewhale-tui`、`forkguard_` 34 项、tools/prompts/skills 模块测试均过（详见 Pinvou/CodeWhale#4）

## 已知风险

- 仅提示词文本变化；wecomcli 两处修复与参考文档逐项核对过。wecomcli-doc / wecomcli-smartsheet 的矛盾修复属上游 wecom-cli skills 的通用缺陷，建议后续回馈上游。

Signed-off-by: asto <asto18089@126.com>