### PR TITLE
refactor(remote-control): 拆分文件访问边界

### DIFF
--- a/docs/remote-control-phase1-architecture.md
+++ b/docs/remote-control-phase1-architecture.md
@@ -203,7 +203,7 @@ Session 索引后再发送 `state_ready=true`，桌面才重放初始化窗口�
   与 `web_access_discard_attachment`
   时才显示"从此设备上传"入口（`deviceFileUpload` 语义能力）；旧桌面实例自动回落为
   原有的单入口远程文件浏览；
-- 浏览器本机上传走分块 RPC：单块 ≤ 256 KiB（对齐 `MAX_ARTIFACT_CHUNK_BYTES`，base64
+- 浏览器本机上传走分块 RPC：单块 ≤ 256 KiB（对齐 `MAX_TRANSFER_CHUNK_BYTES`，base64
   后仍在 1 MiB RPC 请求上限内），单文件 ≤ `file_ingest::MAX_FILE_BYTES`（20 MiB，超限
   在传输前拒绝），桌面内存缓冲最多 4 个、总量 64 MiB、闲置 10 分钟过期，取消命令幂等。
   Relay 只转发分块帧，不保存任何内容。最后一块提交时字节落入

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -6,7 +6,7 @@ use std::io::{BufWriter, Write};
 use tauri::{AppHandle, State, WebviewWindow};
 
 use crate::features::assistant::engine_pool::EnginePool;
-use crate::features::remote_control::manager;
+use crate::features::remote_control::{file_access, manager, MAX_TRANSFER_CHUNK_BYTES};
 use crate::features::remote_control::{
     RelaySettingsInfo, RemoteControlManager, WebAccessInfo, WebAccessStatus,
 };
@@ -132,8 +132,8 @@ pub fn web_access_publish_event(
 #[tauri::command]
 pub fn web_access_list_host_files(
     path: Option<String>,
-) -> Result<manager::HostFileListing, String> {
-    manager::list_host_files(path)
+) -> Result<file_access::HostFileListing, String> {
+    file_access::list_host_files(path)
 }
 
 /// WebUI navigation owns an independent selected Session. These wrappers
@@ -292,7 +292,7 @@ pub async fn web_access_upload_attachment_chunk(
     let data = base64::engine::general_purpose::STANDARD
         .decode(data_base64)
         .map_err(|error| format!("decode attachment upload chunk: {error}"))?;
-    if data.len() > manager::MAX_ARTIFACT_CHUNK_BYTES {
+    if data.len() > MAX_TRANSFER_CHUNK_BYTES {
         return Err("attachment upload chunk exceeds 256 KiB".into());
     }
     let Some((file_name, bytes)) = manager
@@ -365,7 +365,7 @@ pub async fn web_access_read_conversation_attachment_chunk(
     offset: u64,
     limit: Option<usize>,
     store: State<'_, SessionStore>,
-) -> Result<manager::ArtifactChunk, String> {
+) -> Result<file_access::ArtifactChunk, String> {
     let path = super::files::resolve_conversation_attachment_path(
         &store,
         &session_id,
@@ -374,7 +374,7 @@ pub async fn web_access_read_conversation_attachment_chunk(
         &basename,
         &display_text,
     )?;
-    manager::read_resolved_file_chunk(&path, offset, limit)
+    file_access::read_resolved_file_chunk(&path, offset, limit)
 }
 
 /// Materialize a draft Web conversation and admit its first turn as one
@@ -584,7 +584,7 @@ pub async fn web_access_save_session_messages_chunk(
     let data = base64::engine::general_purpose::STANDARD
         .decode(data_base64)
         .map_err(|error| format!("decode Session upload chunk: {error}"))?;
-    if data.len() > manager::MAX_ARTIFACT_CHUNK_BYTES {
+    if data.len() > MAX_TRANSFER_CHUNK_BYTES {
         return Err("Session upload chunk exceeds 256 KiB".into());
     }
     let completed = manager.append_web_session_upload(
@@ -668,8 +668,8 @@ pub fn web_access_read_artifact_chunk(
     offset: u64,
     limit: Option<usize>,
     store: State<'_, SessionStore>,
-) -> Result<manager::ArtifactChunk, String> {
-    manager::read_artifact_chunk(&store, &path, &session_id, offset, limit)
+) -> Result<file_access::ArtifactChunk, String> {
+    file_access::read_artifact_chunk(&store, &path, &session_id, offset, limit)
 }
 
 /// Merge only settings that remain visible and meaningful in WebUI. Hidden
@@ -687,7 +687,7 @@ fn scoped_artifact_path(
     session_id: &str,
     path: &str,
 ) -> Result<String, String> {
-    manager::resolve_session_artifact_path(store, session_id, path)
+    file_access::resolve_session_artifact_path(store, session_id, path)
         .map(|resolved| resolved.to_string_lossy().into_owned())
 }
 

--- a/pinvou3-app/src-tauri/src/features/remote_control/file_access.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/file_access.rs
@@ -1,0 +1,341 @@
+//! Remote Web host-file browsing and Session-owned artifact access.
+//!
+//! This module owns path authorization and bounded file reads. Relay lifecycle,
+//! RPC dispatch, streaming, and upload state remain in [`super::manager`].
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+use serde::Serialize;
+
+use super::platform;
+use super::MAX_TRANSFER_CHUNK_BYTES;
+use crate::features::sessions::SessionStore;
+use crate::platform::paths;
+
+const MAX_HOST_ENTRIES: usize = 5_000;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostFileEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostFileRoot {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostFileListing {
+    pub path: String,
+    pub parent: Option<String>,
+    pub entries: Vec<HostFileEntry>,
+    pub roots: Vec<HostFileRoot>,
+}
+
+pub fn list_host_files(requested: Option<String>) -> Result<HostFileListing, String> {
+    let requested = requested
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(paths::user_home_dir);
+    let directory =
+        crate::features::files::file_ingest::validate_browsable_path(&requested.to_string_lossy())?;
+    if !directory.is_dir() {
+        return Err(format!(
+            "host path is not a directory: {}",
+            directory.display()
+        ));
+    }
+    let mut entries = Vec::new();
+    let read_dir = std::fs::read_dir(&directory)
+        .map_err(|error| format!("list host path {}: {error}", directory.display()))?;
+    for entry in read_dir.take(MAX_HOST_ENTRIES) {
+        let Ok(entry) = entry else { continue };
+        let entry_path = entry.path();
+        let Ok(authorized_path) = crate::features::files::file_ingest::validate_browsable_path(
+            &entry_path.to_string_lossy(),
+        ) else {
+            continue;
+        };
+        let Ok(metadata) = std::fs::metadata(&authorized_path) else {
+            continue;
+        };
+        let is_dir = metadata.is_dir();
+        entries.push(HostFileEntry {
+            name: entry.file_name().to_string_lossy().into_owned(),
+            path: platform::display_path(&authorized_path),
+            is_dir,
+            size: (!is_dir).then_some(metadata.len()),
+        });
+    }
+    entries.sort_by(|left, right| {
+        right
+            .is_dir
+            .cmp(&left.is_dir)
+            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+    });
+    Ok(HostFileListing {
+        path: platform::display_path(&directory),
+        parent: directory.parent().and_then(|parent| {
+            crate::features::files::file_ingest::validate_browsable_path(&parent.to_string_lossy())
+                .ok()
+                .map(|path| platform::display_path(&path))
+        }),
+        entries,
+        roots: host_roots(),
+    })
+}
+
+fn host_roots() -> Vec<HostFileRoot> {
+    let home = paths::user_home_dir();
+    vec![HostFileRoot {
+        name: "Home".to_string(),
+        path: platform::display_path(&home),
+    }]
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactChunk {
+    pub name: String,
+    pub size: u64,
+    pub offset: u64,
+    pub data_base64: String,
+    pub eof: bool,
+}
+
+pub fn read_artifact_chunk(
+    store: &SessionStore,
+    path: &str,
+    session_id: &str,
+    offset: u64,
+    limit: Option<usize>,
+) -> Result<ArtifactChunk, String> {
+    let session_id = require_explicit_session_id(session_id)?;
+    let limit = limit.unwrap_or(MAX_TRANSFER_CHUNK_BYTES);
+    if limit == 0 || limit > MAX_TRANSFER_CHUNK_BYTES {
+        return Err(format!(
+            "artifact chunk limit must be between 1 and {MAX_TRANSFER_CHUNK_BYTES}"
+        ));
+    }
+    let resolved = resolve_session_artifact_path(store, session_id, path)?;
+    read_resolved_file_chunk_with_limit(&resolved, offset, limit)
+}
+
+pub(crate) fn read_resolved_file_chunk(
+    resolved: &Path,
+    offset: u64,
+    limit: Option<usize>,
+) -> Result<ArtifactChunk, String> {
+    let limit = limit.unwrap_or(MAX_TRANSFER_CHUNK_BYTES);
+    if limit == 0 || limit > MAX_TRANSFER_CHUNK_BYTES {
+        return Err(format!(
+            "artifact chunk limit must be between 1 and {MAX_TRANSFER_CHUNK_BYTES}"
+        ));
+    }
+    read_resolved_file_chunk_with_limit(resolved, offset, limit)
+}
+
+fn read_resolved_file_chunk_with_limit(
+    resolved: &Path,
+    offset: u64,
+    limit: usize,
+) -> Result<ArtifactChunk, String> {
+    let mut file = File::open(resolved)
+        .map_err(|error| format!("open artifact {}: {error}", resolved.display()))?;
+    let size = file
+        .metadata()
+        .map_err(|error| format!("stat artifact {}: {error}", resolved.display()))?
+        .len();
+    if offset > size {
+        return Err(format!("artifact offset {offset} exceeds file size {size}"));
+    }
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|error| format!("seek artifact {}: {error}", resolved.display()))?;
+    let mut data = vec![0_u8; limit];
+    let read = file
+        .read(&mut data)
+        .map_err(|error| format!("read artifact {}: {error}", resolved.display()))?;
+    data.truncate(read);
+    Ok(ArtifactChunk {
+        name: resolved
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("artifact")
+            .to_string(),
+        size,
+        offset,
+        data_base64: base64::engine::general_purpose::STANDARD.encode(data),
+        eof: offset.saturating_add(read as u64) >= size,
+    })
+}
+
+fn require_explicit_session_id(session_id: &str) -> Result<&str, String> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Err("sessionId is required to download an artifact".to_string());
+    }
+    Ok(session_id)
+}
+
+/// Resolve only files owned by the selected Session. For ordinary Sessions,
+/// their isolated workspace and private artifacts directory are both owned by
+/// that Session. Scheduled Sessions share a wider workspace, so only explicitly
+/// recorded deliverables and their private artifacts directory are accepted.
+pub(crate) fn resolve_session_artifact_path(
+    store: &SessionStore,
+    session_id: &str,
+    requested: &str,
+) -> Result<PathBuf, String> {
+    crate::features::sessions::validate_session_id(session_id)
+        .map_err(|error| format!("invalid Session id: {error:#}"))?;
+    let saved = store
+        .load(session_id)
+        .map_err(|error| format!("load Session {session_id}: {error:#}"))?;
+    let requested = requested.trim();
+    if requested.is_empty() {
+        return Err("missing artifact path".to_string());
+    }
+    let workspace = store
+        .execution_workspace(session_id)
+        .map_err(|error| format!("resolve session workspace: {error:#}"))?;
+    let scheduled = store.scheduled_profile(session_id).is_some();
+    let artifacts = paths::session_artifacts_dir(session_id);
+    let workspace_root = workspace
+        .canonicalize()
+        .map_err(|error| format!("resolve session workspace: {error}"))?;
+    let artifacts_root = artifacts.canonicalize().ok();
+    let scheduled_artifacts = if scheduled {
+        saved
+            .artifacts
+            .into_iter()
+            .filter_map(|artifact| artifact.storage_path.canonicalize().ok())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    let mut candidates = Vec::new();
+    let requested_path = Path::new(requested);
+    if requested_path.is_absolute() {
+        candidates.push(requested_path.to_path_buf());
+    } else {
+        candidates.push(workspace.join(requested));
+        candidates.push(artifacts.join(requested));
+        if let Some(tail) = path_after_segment(requested, "workspace") {
+            candidates.push(workspace.join(tail));
+        }
+        if let Some(tail) = path_after_segment(requested, "artifacts") {
+            candidates.push(artifacts.join(tail));
+        }
+    }
+    for candidate in candidates {
+        let Ok(canonical) = candidate.canonicalize() else {
+            continue;
+        };
+        if !canonical.is_file() {
+            continue;
+        }
+        let in_private_artifacts = artifacts_root
+            .as_ref()
+            .is_some_and(|root| canonical.starts_with(root));
+        let authorized = if scheduled {
+            in_private_artifacts || scheduled_artifacts.iter().any(|path| path == &canonical)
+        } else {
+            canonical.starts_with(&workspace_root) || in_private_artifacts
+        };
+        if authorized {
+            return Ok(canonical);
+        }
+    }
+    Err(format!(
+        "artifact path not found in Session {session_id}: {requested}"
+    ))
+}
+
+fn path_after_segment(path: &str, segment: &str) -> Option<PathBuf> {
+    let normalized = path.replace('\\', "/");
+    let mut parts = normalized.split('/').filter(|part| !part.is_empty());
+    while let Some(part) = parts.next() {
+        if part == segment {
+            let tail = parts.collect::<Vec<_>>().join("/");
+            return (!tail.is_empty()).then(|| PathBuf::from(tail));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_file_listing_accepts_the_default_home_directory() {
+        let listing = list_host_files(None).expect("default home directory should be browsable");
+
+        assert!(!listing.path.is_empty());
+        assert!(
+            listing.roots.iter().any(|root| root.path == listing.path),
+            "home root should match the initial listing path"
+        );
+    }
+
+    #[test]
+    fn artifact_segment_helper_never_retains_parent_prefix() {
+        assert_eq!(
+            path_after_segment("ignored/workspace/reports/a.pdf", "workspace"),
+            Some(PathBuf::from("reports/a.pdf"))
+        );
+        assert_eq!(path_after_segment("workspace", "workspace"), None);
+    }
+
+    #[test]
+    fn artifact_chunk_limit_is_exactly_256_kib() {
+        assert_eq!(MAX_TRANSFER_CHUNK_BYTES, 262_144);
+    }
+
+    #[test]
+    fn artifact_chunk_requires_an_explicit_session_id() {
+        assert_eq!(
+            require_explicit_session_id("  ").unwrap_err(),
+            "sessionId is required to download an artifact"
+        );
+        assert_eq!(
+            require_explicit_session_id(" session-1 ").unwrap(),
+            "session-1"
+        );
+    }
+
+    #[test]
+    fn resolved_file_chunks_preserve_offset_limit_and_eof() {
+        let directory = std::env::temp_dir().join(format!(
+            "pinvou-remote-file-access-{}-{}",
+            std::process::id(),
+            crate::features::remote_control::short_token(12)
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("artifact.bin");
+        std::fs::write(&path, b"abcdef").unwrap();
+
+        let first = read_resolved_file_chunk(&path, 2, Some(3)).unwrap();
+        assert_eq!(first.name, "artifact.bin");
+        assert_eq!(first.size, 6);
+        assert_eq!(first.offset, 2);
+        assert_eq!(first.data_base64, "Y2Rl");
+        assert!(!first.eof);
+
+        let last = read_resolved_file_chunk(&path, 5, Some(3)).unwrap();
+        assert_eq!(last.data_base64, "Zg==");
+        assert!(last.eof);
+
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use base64::Engine as _;
 use fs2::FileExt as _;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -42,8 +41,6 @@ const MAX_RPC_COMMAND_BYTES: usize = 128;
 const MAX_RPC_REQUEST_BYTES: usize = 1024 * 1024;
 const MAX_RPC_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 const RPC_LEDGER_VERSION: u8 = 1;
-const MAX_HOST_ENTRIES: usize = 5_000;
-pub const MAX_ARTIFACT_CHUNK_BYTES: usize = 256 * 1024;
 /// 会话分块单独放大：首开会话在高延迟链路上按 256KB 串行拉取过慢。
 /// 上限受 `MAX_RPC_RESPONSE_BYTES`（2MiB）约束，base64 膨胀后仍需留出 JSON 外壳余量。
 pub const MAX_SESSION_CHUNK_BYTES: usize = 1024 * 1024;
@@ -4033,262 +4030,6 @@ fn new_stream_epoch() -> String {
     format!("epoch_{}", crate::features::remote_control::short_token(24))
 }
 
-#[derive(Debug, Clone, Serialize)]
-pub struct HostFileEntry {
-    pub name: String,
-    pub path: String,
-    pub is_dir: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<u64>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct HostFileRoot {
-    pub name: String,
-    pub path: String,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct HostFileListing {
-    pub path: String,
-    pub parent: Option<String>,
-    pub entries: Vec<HostFileEntry>,
-    pub roots: Vec<HostFileRoot>,
-}
-
-pub fn list_host_files(requested: Option<String>) -> Result<HostFileListing, String> {
-    let requested = requested
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .unwrap_or_else(paths::user_home_dir);
-    let directory =
-        crate::features::files::file_ingest::validate_browsable_path(&requested.to_string_lossy())?;
-    if !directory.is_dir() {
-        return Err(format!(
-            "host path is not a directory: {}",
-            directory.display()
-        ));
-    }
-    let mut entries = Vec::new();
-    let read_dir = std::fs::read_dir(&directory)
-        .map_err(|error| format!("list host path {}: {error}", directory.display()))?;
-    for entry in read_dir.take(MAX_HOST_ENTRIES) {
-        let Ok(entry) = entry else { continue };
-        let entry_path = entry.path();
-        let Ok(authorized_path) = crate::features::files::file_ingest::validate_browsable_path(
-            &entry_path.to_string_lossy(),
-        ) else {
-            continue;
-        };
-        let Ok(metadata) = std::fs::metadata(&authorized_path) else {
-            continue;
-        };
-        let is_dir = metadata.is_dir();
-        entries.push(HostFileEntry {
-            name: entry.file_name().to_string_lossy().into_owned(),
-            path: platform::display_path(&authorized_path),
-            is_dir,
-            size: (!is_dir).then_some(metadata.len()),
-        });
-    }
-    entries.sort_by(|left, right| {
-        right
-            .is_dir
-            .cmp(&left.is_dir)
-            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
-    });
-    Ok(HostFileListing {
-        path: platform::display_path(&directory),
-        parent: directory.parent().and_then(|parent| {
-            crate::features::files::file_ingest::validate_browsable_path(&parent.to_string_lossy())
-                .ok()
-                .map(|path| platform::display_path(&path))
-        }),
-        entries,
-        roots: host_roots(),
-    })
-}
-
-fn host_roots() -> Vec<HostFileRoot> {
-    let home = paths::user_home_dir();
-    vec![HostFileRoot {
-        name: "Home".to_string(),
-        path: platform::display_path(&home),
-    }]
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ArtifactChunk {
-    pub name: String,
-    pub size: u64,
-    pub offset: u64,
-    pub data_base64: String,
-    pub eof: bool,
-}
-
-pub fn read_artifact_chunk(
-    store: &SessionStore,
-    path: &str,
-    session_id: &str,
-    offset: u64,
-    limit: Option<usize>,
-) -> Result<ArtifactChunk, String> {
-    let session_id = require_explicit_session_id(session_id)?;
-    let limit = limit.unwrap_or(MAX_ARTIFACT_CHUNK_BYTES);
-    if limit == 0 || limit > MAX_ARTIFACT_CHUNK_BYTES {
-        return Err(format!(
-            "artifact chunk limit must be between 1 and {MAX_ARTIFACT_CHUNK_BYTES}"
-        ));
-    }
-    let resolved = resolve_session_artifact_path(store, session_id, path)?;
-    read_resolved_file_chunk_with_limit(&resolved, offset, limit)
-}
-
-pub(crate) fn read_resolved_file_chunk(
-    resolved: &Path,
-    offset: u64,
-    limit: Option<usize>,
-) -> Result<ArtifactChunk, String> {
-    let limit = limit.unwrap_or(MAX_ARTIFACT_CHUNK_BYTES);
-    if limit == 0 || limit > MAX_ARTIFACT_CHUNK_BYTES {
-        return Err(format!(
-            "artifact chunk limit must be between 1 and {MAX_ARTIFACT_CHUNK_BYTES}"
-        ));
-    }
-    read_resolved_file_chunk_with_limit(resolved, offset, limit)
-}
-
-fn read_resolved_file_chunk_with_limit(
-    resolved: &Path,
-    offset: u64,
-    limit: usize,
-) -> Result<ArtifactChunk, String> {
-    let mut file = File::open(resolved)
-        .map_err(|error| format!("open artifact {}: {error}", resolved.display()))?;
-    let size = file
-        .metadata()
-        .map_err(|error| format!("stat artifact {}: {error}", resolved.display()))?
-        .len();
-    if offset > size {
-        return Err(format!("artifact offset {offset} exceeds file size {size}"));
-    }
-    file.seek(SeekFrom::Start(offset))
-        .map_err(|error| format!("seek artifact {}: {error}", resolved.display()))?;
-    let mut data = vec![0_u8; limit];
-    let read = file
-        .read(&mut data)
-        .map_err(|error| format!("read artifact {}: {error}", resolved.display()))?;
-    data.truncate(read);
-    Ok(ArtifactChunk {
-        name: resolved
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("artifact")
-            .to_string(),
-        size,
-        offset,
-        data_base64: base64::engine::general_purpose::STANDARD.encode(data),
-        eof: offset.saturating_add(read as u64) >= size,
-    })
-}
-
-fn require_explicit_session_id(session_id: &str) -> Result<&str, String> {
-    let session_id = session_id.trim();
-    if session_id.is_empty() {
-        return Err("sessionId is required to download an artifact".to_string());
-    }
-    Ok(session_id)
-}
-
-/// Resolve only files owned by the selected Session. For ordinary Sessions,
-/// their isolated workspace and private artifacts directory are both owned by
-/// that Session. Scheduled Sessions share a wider workspace, so only explicitly
-/// recorded deliverables and their private artifacts directory are accepted.
-pub(crate) fn resolve_session_artifact_path(
-    store: &SessionStore,
-    session_id: &str,
-    requested: &str,
-) -> Result<PathBuf, String> {
-    crate::features::sessions::validate_session_id(session_id)
-        .map_err(|error| format!("invalid Session id: {error:#}"))?;
-    let saved = store
-        .load(session_id)
-        .map_err(|error| format!("load Session {session_id}: {error:#}"))?;
-    let requested = requested.trim();
-    if requested.is_empty() {
-        return Err("missing artifact path".to_string());
-    }
-    let workspace = store
-        .execution_workspace(session_id)
-        .map_err(|error| format!("resolve session workspace: {error:#}"))?;
-    let scheduled = store.scheduled_profile(session_id).is_some();
-    let artifacts = paths::session_artifacts_dir(session_id);
-    let workspace_root = workspace
-        .canonicalize()
-        .map_err(|error| format!("resolve session workspace: {error}"))?;
-    let artifacts_root = artifacts.canonicalize().ok();
-    let scheduled_artifacts = if scheduled {
-        saved
-            .artifacts
-            .into_iter()
-            .filter_map(|artifact| artifact.storage_path.canonicalize().ok())
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
-
-    let mut candidates = Vec::new();
-    let requested_path = Path::new(requested);
-    if requested_path.is_absolute() {
-        candidates.push(requested_path.to_path_buf());
-    } else {
-        candidates.push(workspace.join(requested));
-        candidates.push(artifacts.join(requested));
-        if let Some(tail) = path_after_segment(requested, "workspace") {
-            candidates.push(workspace.join(tail));
-        }
-        if let Some(tail) = path_after_segment(requested, "artifacts") {
-            candidates.push(artifacts.join(tail));
-        }
-    }
-    for candidate in candidates {
-        let Ok(canonical) = candidate.canonicalize() else {
-            continue;
-        };
-        if !canonical.is_file() {
-            continue;
-        }
-        let in_private_artifacts = artifacts_root
-            .as_ref()
-            .is_some_and(|root| canonical.starts_with(root));
-        let authorized = if scheduled {
-            in_private_artifacts || scheduled_artifacts.iter().any(|path| path == &canonical)
-        } else {
-            canonical.starts_with(&workspace_root) || in_private_artifacts
-        };
-        if authorized {
-            return Ok(canonical);
-        }
-    }
-    Err(format!(
-        "artifact path not found in Session {session_id}: {requested}"
-    ))
-}
-
-fn path_after_segment(path: &str, segment: &str) -> Option<PathBuf> {
-    let normalized = path.replace('\\', "/");
-    let mut parts = normalized.split('/').filter(|part| !part.is_empty());
-    while let Some(part) = parts.next() {
-        if part == segment {
-            let tail = parts.collect::<Vec<_>>().join("/");
-            return (!tail.is_empty()).then(|| PathBuf::from(tail));
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4361,17 +4102,6 @@ mod tests {
         assert_eq!(
             DEFAULT_RELAY_WS_URL,
             "ws://127.0.0.1:8787/pinvou3/remote/ws"
-        );
-    }
-
-    #[test]
-    fn host_file_listing_accepts_the_default_home_directory() {
-        let listing = list_host_files(None).expect("default home directory should be browsable");
-
-        assert!(!listing.path.is_empty());
-        assert!(
-            listing.roots.iter().any(|root| root.path == listing.path),
-            "home root should match the initial listing path"
         );
     }
 
@@ -5307,32 +5037,6 @@ mod tests {
         assert!(link.contains("#endpoint=ep_test&token=a%2Bb%2Fc"));
         assert!(link.contains("relay=ws%3A%2F%2F127.0.0.1%3A8787%2Fws%3Fx%3D1"));
         assert!(!link.contains("never-in-url"));
-    }
-
-    #[test]
-    fn artifact_segment_helper_never_retains_parent_prefix() {
-        assert_eq!(
-            path_after_segment("ignored/workspace/reports/a.pdf", "workspace"),
-            Some(PathBuf::from("reports/a.pdf"))
-        );
-        assert_eq!(path_after_segment("workspace", "workspace"), None);
-    }
-
-    #[test]
-    fn artifact_chunk_limit_is_exactly_256_kib() {
-        assert_eq!(MAX_ARTIFACT_CHUNK_BYTES, 262_144);
-    }
-
-    #[test]
-    fn artifact_chunk_requires_an_explicit_session_id() {
-        assert_eq!(
-            require_explicit_session_id("  ").unwrap_err(),
-            "sessionId is required to download an artifact"
-        );
-        assert_eq!(
-            require_explicit_session_id(" session-1 ").unwrap(),
-            "session-1"
-        );
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/remote_control/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod file_access;
 pub(crate) mod manager;
 mod platform;
 mod protocol;
@@ -5,6 +6,8 @@ mod relay_client;
 
 pub use manager::{RelaySettingsInfo, RemoteControlManager};
 pub use protocol::{WebAccessInfo, WebAccessStatus};
+
+pub(crate) const MAX_TRANSFER_CHUNK_BYTES: usize = 256 * 1024;
 
 use rand::distr::Alphanumeric;
 use rand::Rng;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -7091,7 +7091,7 @@
   // ── 浏览器本机文件上传 ──────────────────────────────────────────
   // 「从此设备上传」入口:文件按 256KB 分块经 Relay 转发(Relay 只转发不保存),
   // 桌面端最后一块落盘 + ingest 后返回与桌面文件附件相同的 WebAttachmentSummary。
-  var DEVICE_UPLOAD_CHUNK_BYTES = 256 * 1024;      // 对齐桌面 MAX_ARTIFACT_CHUNK_BYTES
+  var DEVICE_UPLOAD_CHUNK_BYTES = 256 * 1024;      // 对齐桌面 MAX_TRANSFER_CHUNK_BYTES
   var DEVICE_UPLOAD_MAX_BYTES = 20 * 1024 * 1024;  // 对齐 file_ingest::MAX_FILE_BYTES
   var DEVICE_UPLOAD_CANCELLED = new Error("device-upload-cancelled");
 

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -100,7 +100,7 @@ assert.match(chatView, /bridge\.attachments\.uploadDeviceFiles\(files\)/);
 assert.match(chatView, /bridge\.attachments\.pickAndAttach\(\)/,
   'the desktop-instance picker entry must keep using the existing remote browser');
 assert.match(webBridge, /DEVICE_UPLOAD_CHUNK_BYTES = 256 \* 1024/,
-  'upload chunks must stay aligned with the desktop MAX_ARTIFACT_CHUNK_BYTES limit');
+  'upload chunks must stay aligned with the desktop MAX_TRANSFER_CHUNK_BYTES limit');
 assert.match(webBridge, /DEVICE_UPLOAD_MAX_BYTES = 20 \* 1024 \* 1024/,
   'the browser preflight must mirror file_ingest::MAX_FILE_BYTES');
 assert.match(webBridge, /web_access_abort_attachment_upload/,


### PR DESCRIPTION
## 依赖关系

- Depends on #140
- 传递依赖：#140 对 #133/#137 的行数门禁做纠偏，并保留 #134/#136 已完成的拆分
- 合入顺序：`#140` → 本 PR
- 原因：本批按 #140 新增的定性模块化公约实施，并以其最新 head 作为精确父分支
- #140 合入后，将本 PR 的 base 切回 `main`，安全同步最新主线并重跑 required gate 后再合入

## 背景

`remote_control/manager.rs` 同时承担 Relay 生命周期、RPC、事件流、上传状态，以及主机文件浏览和 Session 产物授权读取。后两者具有独立的路径授权、分块读取和序列化边界，不应继续由连接管理器持有。

## 变更

- 新增 `remote_control/file_access.rs`，集中负责：
  - WebUI 主机文件浏览及可浏览路径校验
  - Session 所有权范围内的产物路径解析
  - 有界文件分块读取、base64 编码及 EOF 计算
- Tauri command 层显式区分 `file_access` 与 `manager`，命令名、参数和序列化响应保持不变
- 将 256 KiB 分块上限提升为远控模块共享的传输约束，避免错误归属于文件访问或连接管理器
- 将原有 4 项相关测试迁入新模块，并新增真实文件分块读取回归，覆盖 offset、limit、base64 内容和 EOF
- CodeWhale gitlink及底座行为不变

## 实际验证

- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib features::remote_control`（63 项通过）
- `cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib app::commands::protocol_tests`（24 项通过）
- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --all-targets`
- `python3 scripts/architecture-guard.py --base-ref origin/fix/remove-line-count-gate`
- `python3 scripts/architecture-guard.py --base-ref origin/main`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`（33 项通过）
- `npm --prefix pinvou3-app run test:bridge-protocol`
- `./scripts/fork-guard.sh --fast`

## 已知风险

- 本 PR 是堆叠 PR，不能先于 #140 合入。
- 当前只迁移文件访问职责，不调整授权范围、Relay 协议、Tauri command 协议或上传生命周期。
- Rust 内部类型路径从 `manager::*` 调整为 `file_access::*`，调用点均在同一 crate 内且已完成全目标编译；对前端序列化结构无影响。
- 构建仍输出 CodeWhale 既有的 22 条可见性/未使用警告，本批未修改 CodeWhale，也未新增同类警告。
