### PR TITLE
refactor(rust): Wave 1 共享原语抽取与重复收敛

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/chat.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/chat.rs
@@ -53,9 +53,7 @@ pub async fn chat(
     }
     // 多 session 并发:消息显式路由到指定 session(前端传 session_id);兼容旧前端时
     // 回退到全局 active_id。每条消息按各自 session 取 mode/phase/skill,送到对应 engine。
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     if acp_pool.is_acp(&sid) {
         return Err("ACP 代码会话必须通过独立代码页面发送".to_string());
     }

--- a/pinvou3-app/src-tauri/src/app/commands/interaction.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/interaction.rs
@@ -11,9 +11,7 @@ pub async fn compact_now(
     pool: State<'_, EnginePool>,
     store: State<'_, SessionStore>,
 ) -> Result<(), String> {
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     pool.compact_now(&sid)
         .await
         .map_err(|e| format!("compact_now: {e:?}"))
@@ -321,9 +319,7 @@ pub async fn submit_user_input(
     pool: State<'_, EnginePool>,
     store: State<'_, SessionStore>,
 ) -> Result<(), String> {
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     let response = UserInputResponse { answers };
     pool.submit_user_input(&sid, tool_call_id, response)
         .await
@@ -339,9 +335,7 @@ pub async fn add_run_materials(
     paths: Vec<String>,
     store: State<'_, SessionStore>,
 ) -> Result<Vec<String>, String> {
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -383,9 +377,7 @@ pub async fn cancel_user_input(
     pool: State<'_, EnginePool>,
     store: State<'_, SessionStore>,
 ) -> Result<(), String> {
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     pool.cancel_user_input(&sid, tool_call_id)
         .await
         .map_err(|e| format!("cancel_user_input: {e:?}"))
@@ -442,9 +434,7 @@ pub async fn summon_pinvou(
     store: State<'_, SessionStore>,
     pool: State<'_, EnginePool>,
 ) -> Result<crate::features::review::PinvouReview, String> {
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     let session = store
         .load(&sid)
         .map_err(|e| format!("summon_pinvou load({sid}): {e:?}"))?;

--- a/pinvou3-app/src-tauri/src/app/commands/memory.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/memory.rs
@@ -813,9 +813,7 @@ pub async fn edit_last_turn(
     if new_message.trim().is_empty() {
         return Err("empty new_message".into());
     }
-    let sid = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
+    let sid = require_active_sid(session_id, &store)?;
     let reservation = pool
         .reserve_turn(&sid)
         .map_err(|e| format!("reserve edit_last_turn: {e:#}"))?;
@@ -827,6 +825,7 @@ pub async fn edit_last_turn(
         new_message.clone(),
     );
     let display_message = user_display_message(new_message);
+
     // 定时会话不走 ensure_chat_session:编辑重发与继续追问同路,EnginePool 内部
     // 按 scheduled_profile 做 turn gate;会话管理类命令(删除/改名/归档)仍然拒绝。
     pool.edit_last_turn_reserved(&sid, full, display_message, reservation)

--- a/pinvou3-app/src-tauri/src/app/commands/prelude.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/prelude.rs
@@ -46,3 +46,55 @@ macro_rules! sync_command_passthrough {
 
 pub(super) use async_command_passthrough;
 pub(super) use sync_command_passthrough;
+
+/// 解析当前会话 id：优先入参，否则取 store.active_id()。
+///
+/// 收敛原本散落在 workflows/interaction/memory/chat 共 14 处的
+/// `session_id.or_else(|| store.active_id()).ok_or_else(|| "no active session")`
+/// 惯用法。行为保持不变：入参非空用入参，否则回退活跃会话，仍无则报错。
+pub(super) fn require_active_sid(
+    session_id: Option<String>,
+    store: &SessionStore,
+) -> Result<String, String> {
+    session_id
+        .or_else(|| store.active_id())
+        .ok_or_else(|| "no active session".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 无入参且 store 无活跃会话 → Err("no active session")。
+    /// 有入参 → Ok(入参)，忽略 store 活跃态。
+    #[test]
+    fn require_active_sid_resolves_explicit_then_active_then_err() {
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        std::env::set_var("PINVOU3_HOME", "/tmp/pinvou3-require-active-sid-test");
+        let store = SessionStore::boot().expect("boot SessionStore");
+
+        // 1) 入参为 Some：直接返回，不看 store。
+        assert_eq!(
+            require_active_sid(Some("explicit-1".into()), &store),
+            Ok("explicit-1".to_string())
+        );
+
+        // 2) 入参为 None 且无活跃会话 → 报错（empty-store 分支）。
+        assert_eq!(
+            require_active_sid(None, &store),
+            Err("no active session".to_string())
+        );
+
+        // 3) 入参为 None 且 store 有活跃会话 → 回退 active_id。
+        store.set_active(Some("active-1".into()));
+        assert_eq!(require_active_sid(None, &store), Ok("active-1".to_string()));
+
+        // 4) 入参非空时即便 store 有活跃会话，也只用入参。
+        assert_eq!(
+            require_active_sid(Some("explicit-2".into()), &store),
+            Ok("explicit-2".to_string())
+        );
+    }
+}

--- a/pinvou3-app/src-tauri/src/app/commands/prelude.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/prelude.rs
@@ -65,6 +65,39 @@ pub(super) fn require_active_sid(
 mod tests {
     use super::*;
 
+    /// `PINVOU3_HOME` 的进程级测试隔离守卫:保存旧值 → 切到 `temp_dir()` 下唯一目录 →
+    /// Drop 时恢复旧值并删除目录。覆盖成功 / 失败 / panic 路径,避免硬编码 `/tmp`
+    /// (Windows 不可用) 与测试间环境泄漏。
+    struct PinvouHomeGuard {
+        prev: Option<String>,
+        dir: std::path::PathBuf,
+    }
+
+    impl PinvouHomeGuard {
+        fn new(label: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "pinvou3-{}-test-{}-{}",
+                label,
+                std::process::id(),
+                crate::platform::paths::tests::unique_suffix()
+            ));
+            let _ = std::fs::create_dir_all(&dir);
+            let prev = std::env::var("PINVOU3_HOME").ok();
+            std::env::set_var("PINVOU3_HOME", &dir);
+            Self { prev, dir }
+        }
+    }
+
+    impl Drop for PinvouHomeGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => std::env::set_var("PINVOU3_HOME", v),
+                None => std::env::remove_var("PINVOU3_HOME"),
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
     /// 无入参且 store 无活跃会话 → Err("no active session")。
     /// 有入参 → Ok(入参)，忽略 store 活跃态。
     #[test]
@@ -72,7 +105,7 @@ mod tests {
         let _g = crate::platform::paths::tests::ENV_LOCK
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        std::env::set_var("PINVOU3_HOME", "/tmp/pinvou3-require-active-sid-test");
+        let _home = PinvouHomeGuard::new("require-active-sid");
         let store = SessionStore::boot().expect("boot SessionStore");
 
         // 1) 入参为 Some：直接返回，不看 store。

--- a/pinvou3-app/src-tauri/src/app/commands/workflows.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/workflows.rs
@@ -10,18 +10,6 @@
 /// `EngineConfig.skills_dir` 注入。当前用 skiplist 软隔离，工作量小、效果一致。
 const WORKFLOW_HIDDEN_SKILLS: &[&str] = &["pinvou-review-plan", "pinvou-review-final"];
 
-/// 既有 Python 调度器与新的 CodeWhale 多智能体运行必须保持数据隔离。
-///
-fn resolve_legacy_scheduler_session(
-    session_id: Option<String>,
-    store: &SessionStore,
-) -> Result<String, String> {
-    let session_id = session_id
-        .or_else(|| store.active_id())
-        .ok_or_else(|| "no active session".to_string())?;
-    Ok(session_id)
-}
-
 /// 工作流视图卡片渲染需要的 skill 摘要 — 跟 CodeWhale runtime_api 的
 /// `SkillEntry` 不同,这里额外把 phases / demo 元数据序列化给前端 (底座
 /// 没把这俩字段暴露到 REST,所以 pinvou3-app 自己读 SkillRegistry 拼)。
@@ -377,7 +365,7 @@ pub async fn kick_workflow(
 ) -> Result<String, String> {
     // 取本次工作流对应的 session(前端显式传;回退 active)。每个工作流 = 一个 session,
     // 绝不能匹配错——harness_phase / 项目目录全都按这个 sid 走。
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let ws = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -516,7 +504,7 @@ pub async fn retry_workflow_role(
     pool: State<'_, EnginePool>,
     app: AppHandle,
 ) -> Result<String, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let ws = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -1109,7 +1097,7 @@ pub async fn cancel_workflow_role(
     session_id: Option<String>,
     store: State<'_, SessionStore>,
 ) -> Result<serde_json::Value, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -1170,7 +1158,7 @@ pub async fn stop_workflow(
     pool: State<'_, EnginePool>,
     app: AppHandle,
 ) -> Result<serde_json::Value, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -1220,7 +1208,7 @@ pub async fn approve_workflow_gate(
     pool: State<'_, EnginePool>,
     app: tauri::AppHandle,
 ) -> Result<serde_json::Value, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -1264,7 +1252,7 @@ pub async fn reject_workflow_gate(
     pool: State<'_, EnginePool>,
     app: tauri::AppHandle,
 ) -> Result<serde_json::Value, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
@@ -1304,7 +1292,7 @@ pub async fn get_workflow_state(
     session_id: Option<String>,
     store: State<'_, SessionStore>,
 ) -> Result<serde_json::Value, String> {
-    let sid = resolve_legacy_scheduler_session(session_id, &store)?;
+    let sid = require_active_sid(session_id, &store)?;
     let workspace = store
         .ledger_root(&sid)
         .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;

--- a/pinvou3-app/src-tauri/src/features/assistant/audit.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/audit.rs
@@ -31,18 +31,6 @@ pub fn append(ws: &Path, kind: &str, role: &str, detail: serde_json::Value) {
     }
 }
 
-/// 审计字段截断（≤600 字节，UTF-8 char 边界安全）。
-pub fn clip(s: &str) -> &str {
-    if s.len() <= 600 {
-        return s;
-    }
-    let mut end = 600;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,14 +84,5 @@ mod tests {
         // 写失败只打日志不 panic —— 审计绝不能弄死工作流
         let dir = std::path::PathBuf::from("/nonexistent_dir_for_audit_test");
         append(&dir, "x", "y", serde_json::json!({}));
-    }
-
-    #[test]
-    fn clip_respects_utf8_boundary() {
-        let s = "中".repeat(300); // 900 字节
-        let c = clip(&s);
-        assert!(c.len() <= 600);
-        assert!(c.chars().all(|ch| ch == '中')); // 没切出半个字符
-        assert_eq!(clip("short"), "short");
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -1704,7 +1704,7 @@ pub(crate) fn emit_workflow_blocked(
         workspace,
         "blocked",
         "",
-        json!({ "message": crate::features::assistant::audit::clip(message) }),
+        json!({ "message": crate::platform::strings::truncate_utf8(message, 600) }),
     );
     let warmup_report = serde_json::from_str::<serde_json::Value>(message).ok();
     let display_message = warmup_report
@@ -1849,7 +1849,7 @@ pub(crate) async fn apply_harness_action(
                 &ws,
                 "human_gate",
                 &role_id,
-                json!({ "role_name": &role_name, "description": crate::features::assistant::audit::clip(&description) }),
+                json!({ "role_name": &role_name, "description": crate::platform::strings::truncate_utf8(&description, 600) }),
             );
             let _ = app.emit(
                 "workflow:gate_approval",
@@ -1896,7 +1896,7 @@ pub(crate) async fn apply_harness_action(
                 &ws,
                 "blocked",
                 "",
-                json!({ "message": crate::features::assistant::audit::clip(&message) }),
+                json!({ "message": crate::platform::strings::truncate_utf8(&message, 600) }),
             );
             let warmup_report = serde_json::from_str::<serde_json::Value>(&message).ok();
             let _ = app.emit(
@@ -2495,7 +2495,7 @@ fn spawn_event_forwarder(
                                 &role,
                                 json!({
                                     "agent_id": agent_id,
-                                    "summary": crate::features::assistant::audit::clip(&summary),
+                                    "summary": crate::platform::strings::truncate_utf8(&summary, 600),
                                 }),
                             );
                         }
@@ -2508,7 +2508,7 @@ fn spawn_event_forwarder(
                                 &role,
                                 json!({
                                     "agent_id": agent_id,
-                                    "error": crate::features::assistant::audit::clip(&error),
+                                    "error": crate::platform::strings::truncate_utf8(&error, 600),
                                 }),
                             );
                         }

--- a/pinvou3-app/src-tauri/src/features/assistant/harness.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/harness.rs
@@ -24,22 +24,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::platform::paths;
-
-/// 按 UTF-8 char 边界向下取整截断 `s` 到 ≤ `max_bytes` 字节，返回前缀切片。
-/// 直接 `&s[..max_bytes]` 在 max_bytes 落在多字节字符(中文)中间时会 panic——
-/// 角色产出几乎全是中文,曾导致 build_review_prompt 在 spawn_blocking 里 panic
-/// → turn 崩溃 → engine busy flag 永不复位 → 卡死(P0 根因)。所有按字节切中文的
-/// 地方都必须走这里。
-fn truncate_on_char_boundary(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
+use crate::platform::strings;
 
 // ── 调度器 JSON 结构 ──
 // 这些 struct 镜像 Python scheduler.py 产出的 JSON schema;部分字段(all_actionable、
@@ -870,7 +855,7 @@ fn run_python_with_timeout(args: &[&str], cwd: &Path, timeout_secs: u64) -> Resu
         eprintln!(
             "[harness] {program} exit={} stderr={}",
             output.status,
-            truncate_on_char_boundary(&stderr, 300)
+            strings::truncate_utf8(&stderr, 300)
         );
     }
 
@@ -896,7 +881,7 @@ fn subprocess_failure_detail(stdout: &str, stderr: &str) -> String {
         (false, true) => stdout.to_string(),
         (false, false) => format!("stderr:\n{stderr}\nstdout:\n{stdout}"),
     };
-    truncate_on_char_boundary(&detail, 4000).to_string()
+    strings::truncate_utf8(&detail, 4000).to_string()
 }
 
 fn run_scheduler(project: &Path, args: &[&str]) -> Result<String, String> {
@@ -1011,7 +996,7 @@ pub(crate) fn model_auth_failure_reason(error: &str) -> Option<String> {
         .lines()
         .map(str::trim)
         .find(|line| !line.is_empty())
-        .map(|line| truncate_on_char_boundary(line, 400).to_string())
+        .map(|line| strings::truncate_utf8(line, 400).to_string())
 }
 
 /// 把 SubAgent 的失败信封整理成可持久化、可展示的诊断文本。
@@ -1029,12 +1014,12 @@ fn failure_detail(error: &str) -> String {
     } else {
         detail
     };
-    truncate_on_char_boundary(&detail, 4000).to_string()
+    strings::truncate_utf8(&detail, 4000).to_string()
 }
 
 fn failure_summary(detail: &str) -> String {
     let summary = detail.lines().take(6).collect::<Vec<_>>().join(" | ");
-    truncate_on_char_boundary(&summary, 800).to_string()
+    strings::truncate_utf8(&summary, 800).to_string()
 }
 
 fn failure_category(detail: &str) -> &'static str {
@@ -1233,7 +1218,7 @@ fn parse_decision(json: &str) -> Result<SchedulerDecision, String> {
     serde_json::from_str(json).map_err(|e| {
         format!(
             "parse scheduler: {e}\nraw: {}",
-            truncate_on_char_boundary(json, 200)
+            strings::truncate_utf8(json, 200)
         )
     })
 }
@@ -2994,39 +2979,6 @@ mod tests {
         ));
 
         let _ = std::fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn truncate_never_panics_on_chinese_char_boundary() {
-        // 复现 P0 根因:大纲是中文,直接 &s[..2000] 会切在多字节字符中间 panic。
-        // 构造一个 byte 2000 恰好落在 '压'(3 字节)中间的串。
-        let mut s = String::from("# 中国人口发展趋势分析 — 大纲\n");
-        while s.len() < 2100 {
-            s.push_str("总人口降至14.09亿，老龄化压力持续加大；");
-        }
-        assert!(s.len() > 2000);
-        // 直接字节切片会 panic;helper 必须安全返回 ≤2000 的合法 UTF-8 前缀。
-        let out = truncate_on_char_boundary(&s, 2000);
-        assert!(out.len() <= 2000);
-        assert!(s.starts_with(out));
-        // 返回值本身必须是合法 UTF-8(能再被切片/打印而不 panic)。
-        let _ = format!("{out}...");
-    }
-
-    #[test]
-    fn truncate_returns_whole_string_when_under_limit() {
-        let s = "短中文串";
-        assert_eq!(truncate_on_char_boundary(s, 2000), s);
-    }
-
-    #[test]
-    fn truncate_handles_boundary_exactly_at_limit() {
-        // max_bytes 恰为 char 边界时不应回退。
-        let s = "abcd压"; // "abcd"=4 字节, '压'=3 字节
-        assert_eq!(truncate_on_char_boundary(s, 4), "abcd");
-        // max_bytes 落在 '压' 中间(5,6)→ 回退到 4。
-        assert_eq!(truncate_on_char_boundary(s, 5), "abcd");
-        assert_eq!(truncate_on_char_boundary(s, 6), "abcd");
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::features::connectors::connector_cli::{self as cc, CliCtx, ConnectorConn};
+use crate::features::connectors::skill_gate::ConnectorSkillGate;
 
 const ID: &str = "dingtalk";
 const DINGTALK_CTX: CliCtx = CliCtx {
@@ -400,22 +401,30 @@ pub async fn dingtalk_logout() -> Result<Value, String> {
 
 // ─────────────────────── 钉钉 skill 门控(对齐飞书 / 企微)───────────────────────
 
-fn dingtalk_disabled_path() -> std::path::PathBuf {
-    crate::platform::paths::pinvou3_home().join("dingtalk_disabled")
+/// 钉钉技能门控:停用标志文件机制走 [`ConnectorSkillGate`] 默认实现,
+/// `apply_skills` 指向 `apply_dingtalk_skills`。
+struct DingtalkGate;
+impl ConnectorSkillGate for DingtalkGate {
+    fn id(&self) -> &'static str {
+        ID
+    }
+    fn disabled_filename(&self) -> &'static str {
+        "dingtalk_disabled"
+    }
+    fn apply_skills(&self, visible: bool) -> Result<(), String> {
+        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
+            .apply_dingtalk_skills(visible)
+            .map_err(|e| format!("更新钉钉技能失败: {e}"))
+    }
 }
+const GATE: DingtalkGate = DingtalkGate;
 
 pub fn is_dingtalk_disabled() -> bool {
-    dingtalk_disabled_path().exists()
+    GATE.is_disabled()
 }
 
 fn set_dingtalk_disabled_flag(disabled: bool) -> Result<(), String> {
-    let p = dingtalk_disabled_path();
-    if disabled {
-        std::fs::write(&p, b"1").map_err(|e| format!("保存钉钉技能停用状态失败: {e}"))?;
-    } else if p.exists() {
-        std::fs::remove_file(&p).map_err(|e| format!("清除钉钉技能停用状态失败: {e}"))?;
-    }
-    Ok(())
+    GATE.set_disabled_flag(disabled)
 }
 
 pub fn dingtalk_skills_should_show() -> bool {
@@ -424,9 +433,7 @@ pub fn dingtalk_skills_should_show() -> bool {
 pub async fn dingtalk_apply_skills() -> Result<Value, String> {
     let show = tokio::task::spawn_blocking(|| -> Result<bool, String> {
         let show = dingtalk_skills_should_show();
-        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_dingtalk_skills(show)
-            .map_err(|e| format!("更新钉钉技能失败: {e}"))?;
+        GATE.apply_skills(show)?;
         Ok(show)
     })
     .await
@@ -437,9 +444,7 @@ pub async fn set_dingtalk_enabled(enabled: bool) -> Result<Value, String> {
     let show = tokio::task::spawn_blocking(move || -> Result<bool, String> {
         set_dingtalk_disabled_flag(!enabled)?;
         let show = dingtalk_skills_should_show();
-        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_dingtalk_skills(show)
-            .map_err(|e| format!("更新钉钉技能失败: {e}"))?;
+        GATE.apply_skills(show)?;
         Ok(show)
     })
     .await

--- a/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/dingtalk.rs
@@ -408,6 +408,9 @@ impl ConnectorSkillGate for DingtalkGate {
     fn id(&self) -> &'static str {
         ID
     }
+    fn display_name(&self) -> &'static str {
+        "钉钉"
+    }
     fn disabled_filename(&self) -> &'static str {
         "dingtalk_disabled"
     }

--- a/pinvou3-app/src-tauri/src/features/connectors/feishu.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/feishu.rs
@@ -21,6 +21,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::features::connectors::connector_cli::{self as cc, CliCtx, ConnectorConn};
+use crate::features::connectors::skill_gate::ConnectorSkillGate;
 
 /// 连接器 id(事件前缀 + ConnectorConn 槽位键)。
 const ID: &str = "feishu";
@@ -306,22 +307,31 @@ pub async fn feishu_logout() -> Result<Value, String> {
 // 规则:**已连接(user:ready) 且 未手动停用** 才写技能;否则删掉(省 token / 关闭)。
 // 手动停用标志:`~/.pinvou3/feishu_disabled` 文件存在 = 停用。与连接状态正交。
 
-fn feishu_disabled_path() -> std::path::PathBuf {
-    crate::platform::paths::pinvou3_home().join("feishu_disabled")
+/// 飞书技能门控:停用标志文件机制走 [`ConnectorSkillGate`] 默认实现,
+/// `apply_skills` 指向 `apply_feishu_skills`。
+struct FeishuGate;
+impl ConnectorSkillGate for FeishuGate {
+    fn id(&self) -> &'static str {
+        ID
+    }
+    fn disabled_filename(&self) -> &'static str {
+        "feishu_disabled"
+    }
+    fn apply_skills(&self, visible: bool) -> Result<(), String> {
+        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
+            .apply_feishu_skills(visible)
+            .map_err(|e| format!("更新飞书技能失败: {e}"))
+    }
 }
+const GATE: FeishuGate = FeishuGate;
 
 /// 用户是否手动停用了飞书技能。
 pub fn is_feishu_disabled() -> bool {
-    feishu_disabled_path().exists()
+    GATE.is_disabled()
 }
 
-fn set_feishu_disabled_flag(disabled: bool) {
-    let p = feishu_disabled_path();
-    if disabled {
-        let _ = std::fs::write(&p, b"1");
-    } else {
-        let _ = std::fs::remove_file(&p);
-    }
+fn set_feishu_disabled_flag(disabled: bool) -> Result<(), String> {
+    GATE.set_disabled_flag(disabled)
 }
 
 /// 飞书技能此刻该不该出现在 skills_dir:**未手动停用 且 已连接**。
@@ -333,30 +343,31 @@ pub fn feishu_skills_should_show() -> bool {
 /// 按当前"应否可见"状态写 / 删技能文件,并广播刷新在跑会话(当前对话即时生效)。
 /// 前端在 **连接成功 / 断开 / 切开关** 后调,统一收口。
 pub async fn feishu_apply_skills() -> Result<Value, String> {
-    let show = tokio::task::spawn_blocking(|| {
+    let show = tokio::task::spawn_blocking(|| -> Result<bool, String> {
         let show = feishu_skills_should_show();
-        let _ = crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_feishu_skills(show);
-        show
+        GATE.apply_skills(show)?;
+        Ok(show)
     })
     .await
-    .map_err(|e| format!("spawn_blocking: {e}"))?;
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
     // 技能写盘即可——连接成功弹窗已引导「新建对话」,新会话 spawn 时自然扫到飞书技能;
     // 不再原地广播刷新当前对话(故不依赖子模块 Op::RefreshSystemPrompt)。
     Ok(json!({ "visible": show }))
 }
 
 /// composer 飞书开关:`enabled` → 写停用标志 → 按规则增删技能 → 广播刷新。
+///
+/// 注:停用标志写盘此前用 `let _ =` 静默忽略失败,现统一为 `Result` 传播
+/// (Wave 1 批准的契约面变更)。
 pub async fn set_feishu_enabled(enabled: bool) -> Result<Value, String> {
-    let show = tokio::task::spawn_blocking(move || {
-        set_feishu_disabled_flag(!enabled);
+    let show = tokio::task::spawn_blocking(move || -> Result<bool, String> {
+        set_feishu_disabled_flag(!enabled)?;
         let show = feishu_skills_should_show();
-        let _ = crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_feishu_skills(show);
-        show
+        GATE.apply_skills(show)?;
+        Ok(show)
     })
     .await
-    .map_err(|e| format!("spawn_blocking: {e}"))?;
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
     Ok(json!({ "ok": true, "visible": show }))
 }
 

--- a/pinvou3-app/src-tauri/src/features/connectors/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/mod.rs
@@ -4,5 +4,6 @@ pub(crate) mod feishu;
 pub(crate) mod ima;
 mod native_installer;
 mod platform;
+pub(crate) mod skill_gate;
 pub(crate) mod tmeet;
 pub(crate) mod wecom;

--- a/pinvou3-app/src-tauri/src/features/connectors/native_installer.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/native_installer.rs
@@ -189,7 +189,8 @@ fn download_verified(artifact: &Artifact, destination: &Path) -> Result<(), Stri
         let _ = fs::remove_file(&partial);
         return Err("连接器归档超过 128 MiB 安全上限".to_string());
     }
-    let actual = sha256_file(&partial).map_err(|e| format!("读取下载文件失败: {e}"))?;
+    let actual = crate::platform::hashing::sha256_file(&partial)
+        .map_err(|e| format!("读取下载文件失败: {e}"))?;
     if actual != artifact.archive_sha256 {
         let _ = fs::remove_file(&partial);
         return Err(format!(
@@ -267,21 +268,7 @@ fn read_limited(reader: &mut impl Read, max: u64) -> io::Result<Vec<u8>> {
 }
 
 fn file_sha256_matches(path: &Path, expected: &str) -> bool {
-    sha256_file(path).is_ok_and(|actual| actual == expected)
-}
-
-fn sha256_file(path: &Path) -> io::Result<String> {
-    let mut file = File::open(path)?;
-    let mut digest = Sha256::new();
-    let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-    }
-    Ok(crate::platform::encoding::hex_lower(&digest.finalize()))
+    crate::platform::hashing::sha256_file(path).is_ok_and(|actual| actual == expected)
 }
 
 fn sha256_bytes(bytes: &[u8]) -> String {

--- a/pinvou3-app/src-tauri/src/features/connectors/skill_gate.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/skill_gate.rs
@@ -28,6 +28,12 @@ pub(crate) trait ConnectorSkillGate {
     /// `Pinvou3Bundle::apply_*_skills`。返回 `Result` 以传播写盘失败。
     fn apply_skills(&self, visible: bool) -> Result<(), String>;
 
+    /// 用户可见的中文产品名(如「腾讯会议」「钉钉」),用于错误文案。
+    /// 默认回退到 `id()`(ASCII),各连接器按需覆盖以保留原中文文案。
+    fn display_name(&self) -> &'static str {
+        self.id()
+    }
+
     /// 停用标志文件完整路径:`~/.pinvou3/<disabled_filename>`。
     fn disabled_path(&self) -> PathBuf {
         crate::platform::paths::pinvou3_home().join(self.disabled_filename())
@@ -42,11 +48,11 @@ pub(crate) trait ConnectorSkillGate {
     /// 写盘失败传播给调用方,不再静默 `let _ =` 忽略。
     fn set_disabled_flag(&self, disabled: bool) -> Result<(), String> {
         let p = self.disabled_path();
-        let id = self.id();
+        let name = self.display_name();
         if disabled {
-            std::fs::write(&p, b"1").map_err(|e| format!("保存{id}技能停用状态失败: {e}"))?;
+            std::fs::write(&p, b"1").map_err(|e| format!("保存{name}技能停用状态失败: {e}"))?;
         } else if p.exists() {
-            std::fs::remove_file(&p).map_err(|e| format!("清除{id}技能停用状态失败: {e}"))?;
+            std::fs::remove_file(&p).map_err(|e| format!("清除{name}技能停用状态失败: {e}"))?;
         }
         Ok(())
     }

--- a/pinvou3-app/src-tauri/src/features/connectors/skill_gate.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/skill_gate.rs
@@ -1,0 +1,145 @@
+//! 技能门控 trait —— 4 连接器(tmeet/dingtalk/feishu/wecom)共享的
+//! 「停用标志文件 + 应用技能」机制。
+//!
+//! 收敛前,四个连接器各自复制了一份几乎相同的四元组:
+//! `*_disabled_path` / `is_*_disabled` / `set_*_disabled_flag` / `apply_*_skills`。
+//! 本 trait 把「停用标志文件」的路径解析 / 读存在性 / 写删往返抽成默认实现,
+//! 各连接器只需提供 `id` / `disabled_filename` / `apply_skills`(指向各自的
+//! `Pinvou3Bundle::apply_*_skills`)。
+//!
+//! 停用语义:`~/.pinvou3/<id>_disabled` 文件**存在** = 用户手动停用该连接器技能,
+//! 与连接状态(auth)正交。`set_disabled_flag` 统一返回 `Result<(), String>`:
+//! 停用标志写盘失败必须传播给调用方(此前 feishu/wecom 用 `let _ =` 静默忽略,
+//! Wave 1 显式批准的契约面变更)。
+
+use std::path::PathBuf;
+
+/// 单个 CLI 连接器的技能门控抽象。
+///
+/// 实现者提供三项连接器特有信息,即可复用默认的标志文件读写实现。
+pub(crate) trait ConnectorSkillGate {
+    /// 连接器 id(事件前缀 / 日志标签,如 `"tmeet"`)。
+    fn id(&self) -> &'static str;
+
+    /// 停用标志文件名(如 `"tmeet_disabled"`)。
+    fn disabled_filename(&self) -> &'static str;
+
+    /// 按 `visible` 增 / 删本连接器的技能文件 —— 调各自的
+    /// `Pinvou3Bundle::apply_*_skills`。返回 `Result` 以传播写盘失败。
+    fn apply_skills(&self, visible: bool) -> Result<(), String>;
+
+    /// 停用标志文件完整路径:`~/.pinvou3/<disabled_filename>`。
+    fn disabled_path(&self) -> PathBuf {
+        crate::platform::paths::pinvou3_home().join(self.disabled_filename())
+    }
+
+    /// 是否被手动停用(停用标志文件存在即停用)。
+    fn is_disabled(&self) -> bool {
+        self.disabled_path().exists()
+    }
+
+    /// 写(`true`)/ 删(`false`)停用标志文件。统一返回 `Result<(), String>`:
+    /// 写盘失败传播给调用方,不再静默 `let _ =` 忽略。
+    fn set_disabled_flag(&self, disabled: bool) -> Result<(), String> {
+        let p = self.disabled_path();
+        let id = self.id();
+        if disabled {
+            std::fs::write(&p, b"1").map_err(|e| format!("保存{id}技能停用状态失败: {e}"))?;
+        } else if p.exists() {
+            std::fs::remove_file(&p).map_err(|e| format!("清除{id}技能停用状态失败: {e}"))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::paths::tests::ENV_LOCK;
+
+    /// 用一个最小 fake 实现驱动默认实现:验证 `is_disabled` / `set_disabled_flag`
+    /// 在临时 `PINVOU3_HOME` 下的读写往返(置停用→存在;复位→消失;幂等)。
+    struct FakeGate;
+    impl ConnectorSkillGate for FakeGate {
+        fn id(&self) -> &'static str {
+            "fake"
+        }
+        fn disabled_filename(&self) -> &'static str {
+            "fake_disabled"
+        }
+        fn apply_skills(&self, _visible: bool) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn disabled_flag_roundtrip_through_default_impl() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = format!(
+            "{}/pinvou3-skillgate-test-{}-{}",
+            std::env::temp_dir().display(),
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let previous = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &tmp);
+        let _ = std::fs::create_dir_all(crate::platform::paths::pinvou3_home());
+
+        let gate = FakeGate;
+
+        // 默认(无文件)= 未停用;设 false 在无文件时也应幂等成功。
+        assert!(!gate.is_disabled());
+        gate.set_disabled_flag(false).unwrap();
+        assert!(!gate.is_disabled());
+
+        // 置停用 → 文件落盘 → is_disabled 命中。
+        gate.set_disabled_flag(true).unwrap();
+        assert!(gate.is_disabled());
+
+        // 重复置停用幂等(覆盖写不报错)。
+        gate.set_disabled_flag(true).unwrap();
+        assert!(gate.is_disabled());
+
+        // 复位 → 文件删 → 未停用。
+        gate.set_disabled_flag(false).unwrap();
+        assert!(!gate.is_disabled());
+
+        match previous {
+            Some(value) => std::env::set_var("PINVOU3_HOME", value),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// `disabled_path` 跟随 `PINVOU3_HOME`,且文件名由 `disabled_filename` 决定。
+    #[test]
+    fn disabled_path_is_derived_from_pinvou3_home() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = format!(
+            "{}/pinvou3-skillgate-path-{}-{}",
+            std::env::temp_dir().display(),
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        let previous = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let gate = FakeGate;
+        assert_eq!(
+            gate.disabled_path(),
+            crate::platform::paths::pinvou3_home().join("fake_disabled")
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("PINVOU3_HOME", value),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::features::connectors::connector_cli::{self as cc, CliCtx, ConnectorConn};
+use crate::features::connectors::skill_gate::ConnectorSkillGate;
 
 const ID: &str = "tmeet";
 const TMEET_NPM_SPEC: &str = "@tencentcloud/tmeet@1.0.13";
@@ -411,22 +412,30 @@ pub async fn tmeet_logout() -> Result<Value, String> {
 
 // ─────────────────────── 腾讯会议 skill 门控 ────────────────────────
 
-fn tmeet_disabled_path() -> std::path::PathBuf {
-    crate::platform::paths::pinvou3_home().join("tmeet_disabled")
+/// 腾讯会议技能门控:停用标志文件机制走 [`ConnectorSkillGate`] 默认实现,
+/// `apply_skills` 指向 `apply_tmeet_skills`。
+struct TmeetGate;
+impl ConnectorSkillGate for TmeetGate {
+    fn id(&self) -> &'static str {
+        ID
+    }
+    fn disabled_filename(&self) -> &'static str {
+        "tmeet_disabled"
+    }
+    fn apply_skills(&self, visible: bool) -> Result<(), String> {
+        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
+            .apply_tmeet_skills(visible)
+            .map_err(|e| format!("更新腾讯会议技能失败: {e}"))
+    }
 }
+const GATE: TmeetGate = TmeetGate;
 
 pub fn is_tmeet_disabled() -> bool {
-    tmeet_disabled_path().exists()
+    GATE.is_disabled()
 }
 
 fn set_tmeet_disabled_flag(disabled: bool) -> Result<(), String> {
-    let p = tmeet_disabled_path();
-    if disabled {
-        std::fs::write(&p, b"1").map_err(|e| format!("保存腾讯会议技能停用状态失败: {e}"))?;
-    } else if p.exists() {
-        std::fs::remove_file(&p).map_err(|e| format!("清除腾讯会议技能停用状态失败: {e}"))?;
-    }
-    Ok(())
+    GATE.set_disabled_flag(disabled)
 }
 
 pub fn tmeet_skills_should_show() -> bool {
@@ -436,9 +445,7 @@ pub fn tmeet_skills_should_show() -> bool {
 pub async fn tmeet_apply_skills() -> Result<Value, String> {
     let show = tokio::task::spawn_blocking(|| -> Result<bool, String> {
         let show = tmeet_skills_should_show();
-        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_tmeet_skills(show)
-            .map_err(|e| format!("更新腾讯会议技能失败: {e}"))?;
+        GATE.apply_skills(show)?;
         Ok(show)
     })
     .await
@@ -450,9 +457,7 @@ pub async fn set_tmeet_enabled(enabled: bool) -> Result<Value, String> {
     let show = tokio::task::spawn_blocking(move || -> Result<bool, String> {
         set_tmeet_disabled_flag(!enabled)?;
         let show = tmeet_skills_should_show();
-        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_tmeet_skills(show)
-            .map_err(|e| format!("更新腾讯会议技能失败: {e}"))?;
+        GATE.apply_skills(show)?;
         Ok(show)
     })
     .await

--- a/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/tmeet.rs
@@ -419,6 +419,9 @@ impl ConnectorSkillGate for TmeetGate {
     fn id(&self) -> &'static str {
         ID
     }
+    fn display_name(&self) -> &'static str {
+        "腾讯会议"
+    }
     fn disabled_filename(&self) -> &'static str {
         "tmeet_disabled"
     }

--- a/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Manager};
 
 use crate::features::connectors::connector_cli::{self as cc, CliCtx, ConnectorConn};
+use crate::features::connectors::skill_gate::ConnectorSkillGate;
 
 /// 连接器 id(事件前缀 + ConnectorConn 槽位键 + 停用标志名)。
 const ID: &str = "wecom";
@@ -212,21 +213,30 @@ pub async fn wecom_logout() -> Result<Value, String> {
 // 规则:**已连接(ready) 且 未手动停用** 才写技能;否则删掉(省 token / 关闭)。
 // 手动停用标志:`~/.pinvou3/wecom_disabled` 文件存在 = 停用。与连接状态正交。
 
-fn wecom_disabled_path() -> std::path::PathBuf {
-    crate::platform::paths::pinvou3_home().join("wecom_disabled")
+/// 企微技能门控:停用标志文件机制走 [`ConnectorSkillGate`] 默认实现,
+/// `apply_skills` 指向 `apply_wecom_skills`。
+struct WecomGate;
+impl ConnectorSkillGate for WecomGate {
+    fn id(&self) -> &'static str {
+        ID
+    }
+    fn disabled_filename(&self) -> &'static str {
+        "wecom_disabled"
+    }
+    fn apply_skills(&self, visible: bool) -> Result<(), String> {
+        crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
+            .apply_wecom_skills(visible)
+            .map_err(|e| format!("更新企微技能失败: {e}"))
+    }
 }
+const GATE: WecomGate = WecomGate;
 
 pub fn is_wecom_disabled() -> bool {
-    wecom_disabled_path().exists()
+    GATE.is_disabled()
 }
 
-fn set_wecom_disabled_flag(disabled: bool) {
-    let p = wecom_disabled_path();
-    if disabled {
-        let _ = std::fs::write(&p, b"1");
-    } else {
-        let _ = std::fs::remove_file(&p);
-    }
+fn set_wecom_disabled_flag(disabled: bool) -> Result<(), String> {
+    GATE.set_disabled_flag(disabled)
 }
 
 /// 企微技能此刻该不该出现在 skills_dir:**未手动停用 且 已连接**。
@@ -237,28 +247,29 @@ pub fn wecom_skills_should_show() -> bool {
 
 /// 按当前"应否可见"状态写 / 删技能文件。前端在连接成功 / 断开 / 切开关后调。
 pub async fn wecom_apply_skills() -> Result<Value, String> {
-    let show = tokio::task::spawn_blocking(|| {
+    let show = tokio::task::spawn_blocking(|| -> Result<bool, String> {
         let show = wecom_skills_should_show();
-        let _ = crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_wecom_skills(show);
-        show
+        GATE.apply_skills(show)?;
+        Ok(show)
     })
     .await
-    .map_err(|e| format!("spawn_blocking: {e}"))?;
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
     Ok(json!({ "visible": show }))
 }
 
 /// composer 企微开关:写停用标志 → 按规则增删技能。
+///
+/// 注:停用标志写盘此前用 `let _ =` 静默忽略失败,现统一为 `Result` 传播
+/// (Wave 1 批准的契约面变更)。
 pub async fn set_wecom_enabled(enabled: bool) -> Result<Value, String> {
-    let show = tokio::task::spawn_blocking(move || {
-        set_wecom_disabled_flag(!enabled);
+    let show = tokio::task::spawn_blocking(move || -> Result<bool, String> {
+        set_wecom_disabled_flag(!enabled)?;
         let show = wecom_skills_should_show();
-        let _ = crate::features::runtime_bundle::platform::Pinvou3Bundle::paths()
-            .apply_wecom_skills(show);
-        show
+        GATE.apply_skills(show)?;
+        Ok(show)
     })
     .await
-    .map_err(|e| format!("spawn_blocking: {e}"))?;
+    .map_err(|e| format!("spawn_blocking: {e}"))??;
     Ok(json!({ "ok": true, "visible": show }))
 }
 
@@ -313,13 +324,13 @@ mod tests {
         let _ = std::fs::create_dir_all(crate::platform::paths::pinvou3_home());
 
         // 默认(无文件)= 未停用
-        set_wecom_disabled_flag(false);
+        set_wecom_disabled_flag(false).unwrap();
         assert!(!is_wecom_disabled());
         // 置停用 → 文件在 → 停用
-        set_wecom_disabled_flag(true);
+        set_wecom_disabled_flag(true).unwrap();
         assert!(is_wecom_disabled());
         // 复位 → 文件删 → 未停用
-        set_wecom_disabled_flag(false);
+        set_wecom_disabled_flag(false).unwrap();
         assert!(!is_wecom_disabled());
 
         std::env::remove_var("PINVOU3_HOME");

--- a/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
@@ -43,6 +43,69 @@ pub struct IngestResult {
     pub warning: Option<String>,
 }
 
+impl IngestResult {
+    /// 缺工具/不支持时的占位结果（warning 文案，无 markdown）。
+    ///
+    /// 字段默认与既有字面量逐字段一致：`markdown: None`、`token_estimate: 0`、
+    /// `warning: Some(warning)`，`path` 由 `path.to_string_lossy()` 还原（与各
+    /// ingest 函数顶部预计算的 `path_str` 等价）。
+    pub fn warning(
+        kind: &str,
+        basename: &str,
+        path: &Path,
+        byte_size: u64,
+        warning: impl Into<String>,
+    ) -> Self {
+        IngestResult {
+            kind: kind.into(),
+            basename: basename.into(),
+            path: path.to_string_lossy().into(),
+            markdown: None,
+            token_estimate: 0,
+            byte_size,
+            warning: Some(warning.into()),
+        }
+    }
+
+    /// 已生成 markdown 的正常结果。
+    ///
+    /// `token_estimate` 由 `estimate_tokens(&markdown)` 推导，`warning: None`。
+    /// 仅适用于「成功提取正文且无任何告警」的结果；同时带有正文和告警（如编码转换、
+    /// OCR 误差提示）的结果无法用本构造器表达，仍需保留字面量。
+    pub fn with_markdown(
+        kind: &str,
+        basename: &str,
+        path: &Path,
+        byte_size: u64,
+        markdown: String,
+    ) -> Self {
+        let token_estimate = estimate_tokens(&markdown);
+        IngestResult {
+            kind: kind.into(),
+            basename: basename.into(),
+            path: path.to_string_lossy().into(),
+            markdown: Some(markdown),
+            token_estimate,
+            byte_size,
+            warning: None,
+        }
+    }
+
+    /// 仅占位、无内容无警告（极少用）。`markdown: None`、`token_estimate: 0`、
+    /// `warning: None`。典型用例：图片附件登记元数据（kind="image"）。
+    pub fn placeholder(kind: &str, basename: &str, path: &Path, byte_size: u64) -> Self {
+        IngestResult {
+            kind: kind.into(),
+            basename: basename.into(),
+            path: path.to_string_lossy().into(),
+            markdown: None,
+            token_estimate: 0,
+            byte_size,
+            warning: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 pub struct SystemTools {
     pub pandoc: bool,
@@ -263,31 +326,27 @@ pub fn ingest(path: &Path) -> IngestResult {
     let meta = match std::fs::metadata(path) {
         Ok(m) => m,
         Err(e) => {
-            return IngestResult {
-                kind: "missing".into(),
-                basename,
-                path: path_str,
-                markdown: None,
-                token_estimate: 0,
-                byte_size: 0,
-                warning: Some(format!("文件不存在: {e}")),
-            };
+            return IngestResult::warning(
+                "missing",
+                &basename,
+                path,
+                0,
+                format!("文件不存在: {e}"),
+            );
         }
     };
     let byte_size = meta.len();
     if byte_size > MAX_FILE_BYTES {
-        return IngestResult {
-            kind: "oversize".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            "oversize",
+            &basename,
+            path,
             byte_size,
-            warning: Some(format!(
+            format!(
                 "文件 {:.1} MB 超过 20 MB 上限,请拆分或裁剪",
                 byte_size as f64 / 1024.0 / 1024.0
-            )),
-        };
+            ),
+        );
     }
 
     let ext = path
@@ -301,11 +360,11 @@ pub fn ingest(path: &Path) -> IngestResult {
         "text" => ingest_text(path, basename, path_str, byte_size),
         "pdf" => ingest_pdf(path, basename, path_str, byte_size),
         // 文字文档：pandoc 原生支持 docx/odt。
-        "doc_pandoc" => ingest_pandoc(path, basename, path_str, byte_size, &ext),
+        "doc_pandoc" => ingest_pandoc(path, basename, byte_size, &ext),
         // 文字文档：pandoc 吃不下，LibreOffice 转纯文本（doc/rtf/wps）。
-        "doc_office" => ingest_office_text(path, basename, path_str, byte_size, &ext),
+        "doc_office" => ingest_office_text(path, basename, byte_size, &ext),
         // 演示：LibreOffice 转 PDF 再 pdftotext（pptx/ppt/odp/dps）。
-        "presentation" => ingest_presentation(path, basename, path_str, byte_size, &ext),
+        "presentation" => ingest_presentation(path, basename, byte_size, &ext),
         // 表格：LibreOffice 转 CSV（xlsx/ods/xls/et）—— pandoc 不支持表格输入。
         "spreadsheet" => ingest_spreadsheet(path, basename, path_str, byte_size, &ext),
         "image" => ingest_image(path, basename, path_str, byte_size),
@@ -384,15 +443,13 @@ fn ingest_text(path: &Path, basename: String, path_str: String, byte_size: u64) 
     let bytes = match std::fs::read(path) {
         Ok(b) => b,
         Err(e) => {
-            return IngestResult {
-                kind: "text".into(),
-                basename,
-                path: path_str,
-                markdown: None,
-                token_estimate: 0,
+            return IngestResult::warning(
+                "text",
+                &basename,
+                path,
                 byte_size,
-                warning: Some(format!("读取失败(可能不是文本): {e}")),
-            };
+                format!("读取失败(可能不是文本): {e}"),
+            );
         }
     };
     // 内容侧安全兜底:已知文本扩展名也可能被塞了私钥(如把 id_rsa 改名 id_rsa.txt),
@@ -416,15 +473,13 @@ fn ingest_text(path: &Path, basename: String, path_str: String, byte_size: u64) 
 fn ingest_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> IngestResult {
     let tools = system_tools();
     if !tools.pdftotext {
-        return IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            "pdf",
+            &basename,
+            path,
             byte_size,
-            warning: Some(crate::platform::os::pdf_text_missing_message().into()),
-        };
+            crate::platform::os::pdf_text_missing_message(),
+        );
     }
     // pdftotext -layout <path> -  → stdout
     let out = pdf_tool_command("pdftotext")
@@ -440,59 +495,38 @@ fn ingest_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -
             if content.trim().is_empty() {
                 return ocr_pdf(path, basename, path_str, byte_size);
             }
-            let tokens = estimate_tokens(&content);
-            IngestResult {
-                kind: "pdf".into(),
-                basename,
-                path: path_str,
-                markdown: Some(content),
-                token_estimate: tokens,
-                byte_size,
-                warning: None,
-            }
+            IngestResult::with_markdown("pdf", &basename, path, byte_size, content)
         }
-        Ok(o) => IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        Ok(o) => IngestResult::warning(
+            "pdf",
+            &basename,
+            path,
             byte_size,
-            warning: Some(format!(
+            format!(
                 "pdftotext 失败: {}",
                 String::from_utf8_lossy(&o.stderr).trim()
-            )),
-        },
-        Err(e) => IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+            ),
+        ),
+        Err(e) => IngestResult::warning(
+            "pdf",
+            &basename,
+            path,
             byte_size,
-            warning: Some(format!("pdftotext 调用失败: {e}")),
-        },
+            format!("pdftotext 调用失败: {e}"),
+        ),
     }
 }
 
-fn ingest_pandoc(
-    path: &Path,
-    basename: String,
-    path_str: String,
-    byte_size: u64,
-    label: &str,
-) -> IngestResult {
+fn ingest_pandoc(path: &Path, basename: String, byte_size: u64, label: &str) -> IngestResult {
     let tools = system_tools();
     if !tools.pandoc {
-        return IngestResult {
-            kind: label.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            label,
+            &basename,
+            path,
             byte_size,
-            warning: Some(crate::platform::os::pandoc_missing_message().into()),
-        };
+            crate::platform::os::pandoc_missing_message(),
+        );
     }
     let out = pandoc_tool_command()
         .arg("-t")
@@ -502,38 +536,22 @@ fn ingest_pandoc(
     match out {
         Ok(o) if o.status.success() => {
             let content = String::from_utf8_lossy(&o.stdout).into_owned();
-            let tokens = estimate_tokens(&content);
-            IngestResult {
-                kind: label.into(),
-                basename,
-                path: path_str,
-                markdown: Some(content),
-                token_estimate: tokens,
-                byte_size,
-                warning: None,
-            }
+            IngestResult::with_markdown(label, &basename, path, byte_size, content)
         }
-        Ok(o) => IngestResult {
-            kind: label.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        Ok(o) => IngestResult::warning(
+            label,
+            &basename,
+            path,
             byte_size,
-            warning: Some(format!(
-                "pandoc 失败: {}",
-                String::from_utf8_lossy(&o.stderr).trim()
-            )),
-        },
-        Err(e) => IngestResult {
-            kind: label.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+            format!("pandoc 失败: {}", String::from_utf8_lossy(&o.stderr).trim()),
+        ),
+        Err(e) => IngestResult::warning(
+            label,
+            &basename,
+            path,
             byte_size,
-            warning: Some(format!("pandoc 调用失败: {e}")),
-        },
+            format!("pandoc 调用失败: {e}"),
+        ),
     }
 }
 
@@ -906,35 +924,10 @@ pub fn pdf_to_png_data_uris(path: &Path, max_pages: u32) -> Result<(Vec<String>,
 }
 
 /// 文字类文档（.doc/.rtf + WPS .wps）：pandoc 吃不下，用 LibreOffice 转纯文本。
-fn ingest_office_text(
-    path: &Path,
-    basename: String,
-    path_str: String,
-    byte_size: u64,
-    kind: &str,
-) -> IngestResult {
+fn ingest_office_text(path: &Path, basename: String, byte_size: u64, kind: &str) -> IngestResult {
     match libreoffice_convert_text(path, "txt:Text (encoded):UTF8", "txt") {
-        Ok(content) => {
-            let tokens = estimate_tokens(&content);
-            IngestResult {
-                kind: kind.into(),
-                basename,
-                path: path_str,
-                markdown: Some(content),
-                token_estimate: tokens,
-                byte_size,
-                warning: None,
-            }
-        }
-        Err(e) => IngestResult {
-            kind: kind.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
-            byte_size,
-            warning: Some(e),
-        },
+        Ok(content) => IngestResult::with_markdown(kind, &basename, path, byte_size, content),
+        Err(e) => IngestResult::warning(kind, &basename, path, byte_size, e),
     }
 }
 
@@ -1034,56 +1027,23 @@ fn spreadsheet_text_from_bytes(bytes: Vec<u8>) -> Result<String, String> {
 /// 演示类（.pptx/.ppt/.odp + WPS .dps）：LibreOffice **没有 Impress→txt 导出**
 /// （实测无产出），所以先转 PDF 再用 pdftotext 抽每页文字（标题/要点/中文都保留）。
 /// 自己转出的 PDF 必有文字层，不需要扫描件 OCR 兜底。
-fn ingest_presentation(
-    path: &Path,
-    basename: String,
-    path_str: String,
-    byte_size: u64,
-    kind: &str,
-) -> IngestResult {
+fn ingest_presentation(path: &Path, basename: String, byte_size: u64, kind: &str) -> IngestResult {
     let tools = system_tools();
     if !tools.libreoffice || !tools.pdftotext {
-        return IngestResult {
-            kind: kind.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            kind,
+            &basename,
+            path,
             byte_size,
-            warning: Some(crate::platform::os::presentation_pdf_missing_message().into()),
-        };
+            crate::platform::os::presentation_pdf_missing_message(),
+        );
     }
     match libreoffice_presentation_text(path) {
         Ok(content) if !content.trim().is_empty() => {
-            let tokens = estimate_tokens(&content);
-            IngestResult {
-                kind: kind.into(),
-                basename,
-                path: path_str,
-                markdown: Some(content),
-                token_estimate: tokens,
-                byte_size,
-                warning: None,
-            }
+            IngestResult::with_markdown(kind, &basename, path, byte_size, content)
         }
-        Ok(_) => IngestResult {
-            kind: kind.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
-            byte_size,
-            warning: Some("演示文稿未提取到文字".into()),
-        },
-        Err(e) => IngestResult {
-            kind: kind.into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
-            byte_size,
-            warning: Some(e),
-        },
+        Ok(_) => IngestResult::warning(kind, &basename, path, byte_size, "演示文稿未提取到文字"),
+        Err(e) => IngestResult::warning(kind, &basename, path, byte_size, e),
     }
 }
 
@@ -1146,15 +1106,7 @@ fn libreoffice_presentation_text(path: &Path) -> Result<String, String> {
 /// markdown 留空(不预解析像素),token_estimate=0(视觉 token 量取决于分辨率,
 /// 不在此处解码估算,UI 计数会略低,属已知局限)。
 fn ingest_image(_path: &Path, basename: String, path_str: String, byte_size: u64) -> IngestResult {
-    IngestResult {
-        kind: "image".into(),
-        basename,
-        path: path_str,
-        markdown: None,
-        token_estimate: 0,
-        byte_size,
-        warning: None,
-    }
+    IngestResult::placeholder("image", &basename, Path::new(&path_str), byte_size)
 }
 
 /// 对单张图片跑 tesseract，识别文字到 stdout。`tesseract <img> - -l <langs>`。
@@ -1195,16 +1147,17 @@ pub fn ocr_image_for_kb(path: &Path) -> Option<String> {
 fn ocr_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> IngestResult {
     const PDF_OCR_MAX_PAGES: u32 = 30;
     let tools = system_tools();
+    // 构造器从 &Path 还原 path 字符串；path_str 来自上游 path.to_string_lossy()，
+    // 用 Path::new(&path_str) 复用同一字符串视图，保证 path 字段逐字节一致。
+    let result_path = Path::new(&path_str);
     if !tools.tesseract || !tools.pdftoppm {
-        return IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            "pdf",
+            &basename,
+            result_path,
             byte_size,
-            warning: Some(crate::platform::os::pdf_ocr_missing_message().into()),
-        };
+            crate::platform::os::pdf_ocr_missing_message(),
+        );
     }
 
     // 临时目录：每次唯一，避免并发冲突。
@@ -1214,15 +1167,13 @@ fn ocr_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> I
         .unwrap_or(0);
     let tmpdir = std::env::temp_dir().join(format!("pinvou3-pdfocr-{ts}"));
     if let Err(e) = std::fs::create_dir_all(&tmpdir) {
-        return IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str,
-            markdown: None,
-            token_estimate: 0,
+        return IngestResult::warning(
+            "pdf",
+            &basename,
+            result_path,
             byte_size,
-            warning: Some(format!("创建临时目录失败: {e}")),
-        };
+            format!("创建临时目录失败: {e}"),
+        );
     }
 
     let prefix = tmpdir.join("page");
@@ -1250,15 +1201,13 @@ fn ocr_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> I
             pages.sort();
 
             if pages.is_empty() {
-                IngestResult {
-                    kind: "pdf".into(),
-                    basename,
-                    path: path_str.clone(),
-                    markdown: None,
-                    token_estimate: 0,
+                IngestResult::warning(
+                    "pdf",
+                    &basename,
+                    result_path,
                     byte_size,
-                    warning: Some("PDF 无文字层，且 pdftoppm 未产出可识别页".into()),
-                }
+                    "PDF 无文字层，且 pdftoppm 未产出可识别页",
+                )
             } else {
                 let mut parts = Vec::new();
                 for (idx, page) in pages.iter().enumerate() {
@@ -1276,16 +1225,16 @@ fn ocr_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> I
                     ));
                 }
                 if content.trim().is_empty() {
-                    IngestResult {
-                        kind: "pdf".into(),
-                        basename,
-                        path: path_str.clone(),
-                        markdown: None,
-                        token_estimate: 0,
+                    IngestResult::warning(
+                        "pdf",
+                        &basename,
+                        result_path,
                         byte_size,
-                        warning: Some("扫描件 OCR 未识别到文字".into()),
-                    }
+                        "扫描件 OCR 未识别到文字",
+                    )
                 } else {
+                    // 同时带 markdown 与 warning（OCR 误差提示），不符合任何构造器，
+                    // 保留字面量 —— 这是「正文 + 告警」的特例。
                     let tokens = estimate_tokens(&content);
                     IngestResult {
                         kind: "pdf".into(),
@@ -1299,27 +1248,23 @@ fn ocr_pdf(path: &Path, basename: String, path_str: String, byte_size: u64) -> I
                 }
             }
         }
-        Ok(o) => IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str.clone(),
-            markdown: None,
-            token_estimate: 0,
+        Ok(o) => IngestResult::warning(
+            "pdf",
+            &basename,
+            result_path,
             byte_size,
-            warning: Some(format!(
+            format!(
                 "pdftoppm 转图失败: {}",
                 String::from_utf8_lossy(&o.stderr).trim()
-            )),
-        },
-        Err(e) => IngestResult {
-            kind: "pdf".into(),
-            basename,
-            path: path_str.clone(),
-            markdown: None,
-            token_estimate: 0,
+            ),
+        ),
+        Err(e) => IngestResult::warning(
+            "pdf",
+            &basename,
+            result_path,
             byte_size,
-            warning: Some(format!("pdftoppm 调用失败: {e}")),
-        },
+            format!("pdftoppm 调用失败: {e}"),
+        ),
     };
 
     let _ = std::fs::remove_dir_all(&tmpdir);
@@ -1334,14 +1279,8 @@ fn ingest_archive(path: &Path, basename: String, path_str: String, byte_size: u6
     const MAX_ENTRIES: usize = 50;
     const MAX_TOTAL_BYTES: u64 = 100 * 1024 * 1024; // 解压后总量上限，防压缩炸弹
 
-    let mk_err = |msg: String| IngestResult {
-        kind: "archive".into(),
-        basename: basename.clone(),
-        path: path_str.clone(),
-        markdown: None,
-        token_estimate: 0,
-        byte_size,
-        warning: Some(msg),
+    let mk_err = |msg: String| {
+        IngestResult::warning("archive", &basename, Path::new(&path_str), byte_size, msg)
     };
 
     if !system_tools().sevenzip {
@@ -1430,16 +1369,7 @@ fn ingest_archive(path: &Path, basename: String, path_str: String, byte_size: u6
         files.len(),
         sections.join("\n")
     );
-    let tokens = estimate_tokens(&content);
-    IngestResult {
-        kind: "archive".into(),
-        basename,
-        path: path_str,
-        markdown: Some(content),
-        token_estimate: tokens,
-        byte_size,
-        warning: None,
-    }
+    IngestResult::with_markdown("archive", &basename, path, byte_size, content)
 }
 
 /// `7z l -slt` 列出条目，返回 (文件数, 解压后总字节)。用于解压前的炸弹预检。
@@ -1937,46 +1867,37 @@ if atts:
 /// 音视频：本地语音转录（whisper 等）尚未部署到 GB10，先优雅降级，明确告知用户
 /// 「未处理」而非臆测内容。真正转录留作未来独立能力（见 process.md）。
 fn media_placeholder(basename: String, path_str: String, byte_size: u64) -> IngestResult {
-    IngestResult {
-        kind: "media".into(),
-        basename,
-        path: path_str,
-        markdown: None,
-        token_estimate: 0,
+    IngestResult::warning(
+        "media",
+        &basename,
+        Path::new(&path_str),
         byte_size,
-        warning: Some(
-            "检测到音视频文件，当前暂不支持本地语音转录。\
-             可改为提供文字稿，或口述其中要点。"
-                .into(),
-        ),
-    }
+        "检测到音视频文件，当前暂不支持本地语音转录。\
+             可改为提供文字稿，或口述其中要点。",
+    )
 }
 
 fn binary_placeholder(basename: String, path_str: String, byte_size: u64) -> IngestResult {
-    IngestResult {
-        kind: "binary".into(),
-        basename,
-        path: path_str,
-        markdown: None,
-        token_estimate: 0,
+    IngestResult::warning(
+        "binary",
+        &basename,
+        Path::new(&path_str),
         byte_size,
-        warning: Some("不支持的文件类型(二进制)".into()),
-    }
+        "不支持的文件类型(二进制)",
+    )
 }
 
 /// 私钥 / 密钥库文件的占位:与 binary_placeholder 同为 markdown=None,但文案明确说明
 /// 「为防泄露而拒绝读取」,便于用户理解为什么内容没被读入。kind 用 "binary" 以复用
 /// 前端既有分类展示(无需新增前端分支),靠 warning 区分原因。
 fn secret_placeholder(basename: String, path_str: String, byte_size: u64) -> IngestResult {
-    IngestResult {
-        kind: "binary".into(),
-        basename,
-        path: path_str,
-        markdown: None,
-        token_estimate: 0,
+    IngestResult::warning(
+        "binary",
+        &basename,
+        Path::new(&path_str),
         byte_size,
-        warning: Some("检测到密钥/私钥文件,为防止泄露给 LLM 已拒绝读取内容".into()),
-    }
+        "检测到密钥/私钥文件,为防止泄露给 LLM 已拒绝读取内容",
+    )
 }
 
 /// 内容侧私钥检测:捕获改了名 / 无扩展名 / 套了 .txt 外壳的私钥(如 `id_rsa`、
@@ -2045,15 +1966,13 @@ fn sniff_text_or_binary(
         Ok(b) => b,
         // 读失败(权限/TOCTOU 等)如实上报,不要误报成「不支持的二进制类型」。
         Err(e) => {
-            return IngestResult {
-                kind: "binary".into(),
-                basename,
-                path: path_str,
-                markdown: None,
-                token_estimate: 0,
+            return IngestResult::warning(
+                "binary",
+                &basename,
+                path,
                 byte_size,
-                warning: Some(format!("文件读取失败: {e}")),
-            };
+                format!("文件读取失败: {e}"),
+            );
         }
     };
     // 内容侧安全兜底:无扩展名 / 改名的私钥(id_rsa、server-key 等)在此拦截。
@@ -2304,6 +2223,69 @@ fn normalize_validated_path(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ingest_result_constructors_match_equivalent_literals() {
+        // 构造器产出必须与等价字面量逐字段相等（含 None 默认值）。
+        // 任一字段默认值被构造器静默改变即视为 bug。
+        let tmp = std::env::temp_dir().join("pinvou3-ctor-equiv-test.txt");
+        std::fs::write(&tmp, "hello").unwrap();
+        let basename = "ctor-equiv-test.txt".to_string();
+        let path_str = tmp.to_string_lossy().to_string();
+
+        // warning()：markdown None、token_estimate 0、warning Some。
+        let via_ctor = IngestResult::warning("text", &basename, &tmp, 5, "缺工具");
+        let literal = IngestResult {
+            kind: "text".into(),
+            basename: basename.clone(),
+            path: path_str.clone(),
+            markdown: None,
+            token_estimate: 0,
+            byte_size: 5,
+            warning: Some("缺工具".into()),
+        };
+        assert_eq!(via_ctor.kind, literal.kind);
+        assert_eq!(via_ctor.basename, literal.basename);
+        assert_eq!(
+            via_ctor.path, literal.path,
+            "path 必须由 to_string_lossy 还原"
+        );
+        assert_eq!(via_ctor.markdown, literal.markdown);
+        assert_eq!(via_ctor.token_estimate, literal.token_estimate);
+        assert_eq!(via_ctor.byte_size, literal.byte_size);
+        assert_eq!(via_ctor.warning, literal.warning);
+
+        // with_markdown()：markdown Some、token_estimate=estimate_tokens、warning None。
+        let md = "# 标题\n正文内容".to_string();
+        let via_ctor = IngestResult::with_markdown("pdf", &basename, &tmp, 5, md.clone());
+        let literal = IngestResult {
+            kind: "pdf".into(),
+            basename: basename.clone(),
+            path: path_str.clone(),
+            markdown: Some(md.clone()),
+            token_estimate: estimate_tokens(&md),
+            byte_size: 5,
+            warning: None,
+        };
+        assert_eq!(via_ctor.kind, literal.kind);
+        assert_eq!(via_ctor.path, literal.path);
+        assert_eq!(via_ctor.markdown, literal.markdown);
+        assert_eq!(via_ctor.token_estimate, literal.token_estimate);
+        assert_eq!(via_ctor.byte_size, literal.byte_size);
+        assert_eq!(via_ctor.warning, literal.warning);
+
+        // placeholder()：markdown None、token_estimate 0、warning None。
+        let via_ctor = IngestResult::placeholder("image", &basename, &tmp, 5);
+        assert_eq!(via_ctor.kind, "image");
+        assert_eq!(via_ctor.basename, basename);
+        assert_eq!(via_ctor.path, path_str);
+        assert!(via_ctor.markdown.is_none());
+        assert_eq!(via_ctor.token_estimate, 0);
+        assert_eq!(via_ctor.byte_size, 5);
+        assert!(via_ctor.warning.is_none());
+
+        std::fs::remove_file(&tmp).ok();
+    }
 
     #[test]
     fn classify_extensions() {

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -7,13 +7,12 @@
 //!
 //! 进度事件 `kb_model:progress`：`{ stage: download|verify|extract|done, downloaded, total, ready }`。
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use super::KnowledgeService;
 
@@ -303,7 +302,8 @@ pub async fn kb_model_download(
                 "kb_model:progress",
                 serde_json::json!({ "stage": "verify" }),
             );
-            let got = sha256_file(&part2)?;
+            let got = crate::platform::hashing::sha256_file(&part2)
+                .map_err(|e| format!("读校验文件失败: {e}"))?;
             if !got.eq_ignore_ascii_case(&exp) {
                 let _ = std::fs::remove_file(&part2);
                 return Err(format!(
@@ -484,23 +484,6 @@ impl Drop for DownloadGuard {
     fn drop(&mut self) {
         DOWNLOADING.store(false, Ordering::SeqCst);
     }
-}
-
-fn sha256_file(path: &Path) -> Result<String, String> {
-    let mut f = std::fs::File::open(path).map_err(|e| format!("打开校验文件失败: {e}"))?;
-    let mut hasher = Sha256::new();
-    let mut buf = vec![0u8; 1024 * 1024];
-    loop {
-        let n = f
-            .read(&mut buf)
-            .map_err(|e| format!("读校验文件失败: {e}"))?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let digest = hasher.finalize();
-    Ok(crate::platform::encoding::hex_lower(&digest))
 }
 
 fn extract_targz(targz: &Path, dest: &Path) -> Result<(), String> {

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -7,7 +7,6 @@
 //!
 //! 进度事件 `kb_model:progress`：`{ stage: download|verify|extract|done, downloaded, total, ready }`。
 
-use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -246,72 +245,67 @@ pub async fn kb_model_download(
         .unwrap_or_else(|| dir.clone());
     std::fs::create_dir_all(&parent).map_err(|e| format!("创建目录失败: {e}"))?;
     let part = parent.join("bge-m3.tar.gz.part");
+    // 校验通过后 helper 把 .part 原子 rename 成干净的归档名(随后解压、解压完删除)。
+    let archive = parent.join("bge-m3.tar.gz");
 
-    // ── 1. 流式下载 → .part ───────────────────────────────────────
+    // ── 1. 流式下载 → .part → sha256 校验 → rename 为干净归档 ─────────
+    //     复用 platform::download helper(下载/取消/进度/校验/原子提升);解压+部署
+    //     是 KB 专属的第二阶段,留在下面 spawn_blocking。
     let url = std::env::var("PINVOU3_KB_MODEL_URL").unwrap_or_else(|_| MODEL_URL.to_string());
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .user_agent("pinvou3-kb/1.0")
-        .build()
-        .map_err(|e| format!("HTTP client 构建失败: {e}"))?;
-    let mut resp = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| format!("连接模型源失败: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("模型源响应异常: {e}"))?;
-    let total = resp
-        .content_length()
-        .filter(|n| *n > 0)
-        .unwrap_or(MODEL_TARGZ_SIZE);
-    let mut file = std::fs::File::create(&part).map_err(|e| format!("创建文件失败: {e}"))?;
-    let mut downloaded: u64 = 0;
-    let mut last_emit: u64 = 0;
-    while let Some(chunk) = resp.chunk().await.map_err(|e| format!("下载中断: {e}"))? {
-        if CANCEL.load(Ordering::Relaxed) {
-            drop(file);
-            let _ = std::fs::remove_file(&part);
-            return Err("已取消".into());
-        }
-        file.write_all(&chunk)
-            .map_err(|e| format!("写盘失败: {e}"))?;
-        downloaded += chunk.len() as u64;
-        if downloaded - last_emit >= 2_097_152 || (total > 0 && downloaded >= total) {
-            last_emit = downloaded;
-            let _ = app.emit(
+    let expected = std::env::var("PINVOU3_KB_MODEL_SHA256")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| (!MODEL_SHA256.is_empty()).then(|| MODEL_SHA256.to_string()));
+    // helper 的 expected_sha256 空串=跳过校验(dev 本地包),与原逻辑一致。
+    let expected_sha256: &str = expected.as_deref().unwrap_or("");
+    let _ = app.emit(
+        "kb_model:progress",
+        serde_json::json!({ "stage": "verify" }),
+    );
+    // 进度节流:每 2 MiB 或到达 total 才 emit(与原实现一致)。helper 的 on_progress
+    // 是 `Fn`,节流状态用 Arc<Mutex> 承载;total 由 helper 透传(真实 Content-Length
+    // 或缺失时回退 max_bytes=MODEL_TARGZ_SIZE)。
+    let app_clone = app.clone();
+    let last_emit = std::sync::Arc::new(std::sync::Mutex::new(0u64));
+    let last_emit_clone = std::sync::Arc::clone(&last_emit);
+    let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |downloaded: u64, t: u64| {
+        let mut guard = match last_emit_clone.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if downloaded - *guard >= 2_097_152 || (t > 0 && downloaded >= t) {
+            *guard = downloaded;
+            drop(guard);
+            let _ = app_clone.emit(
                 "kb_model:progress",
-                serde_json::json!({ "stage": "download", "downloaded": downloaded, "total": total }),
+                serde_json::json!({ "stage": "download", "downloaded": downloaded, "total": t }),
             );
         }
-    }
-    drop(file);
+    });
+    let is_cancelled: Box<dyn Fn() -> bool + Send> = Box::new(|| CANCEL.load(Ordering::Relaxed));
+    let req = crate::platform::download::DownloadRequest {
+        url: &url,
+        dest: &archive,
+        part: &part,
+        expected_sha256,
+        max_bytes: MODEL_TARGZ_SIZE,
+        is_cancelled,
+        on_progress,
+    };
+    crate::platform::download::download_to_part_with_verify(req)
+        .await
+        .map_err(|err| {
+            if err == "已取消" {
+                err
+            } else {
+                format!("模型下载/校验失败: {err}")
+            }
+        })?;
 
-    // ── 2. sha256 校验 + 3. 解压部署（CPU/IO 重，挪 spawn_blocking）───
-    let part2 = part.clone();
+    // ── 2. 解压部署（CPU/IO 重，挪 spawn_blocking）────────────────
     let dir2 = dir.clone();
     let app2 = app.clone();
     tokio::task::spawn_blocking(move || -> Result<(), String> {
-        // 校验：const 或 env 给了 sha256 才校验（占位空串=跳过，dev 用本地包时方便）。
-        let expected = std::env::var("PINVOU3_KB_MODEL_SHA256")
-            .ok()
-            .filter(|s| !s.trim().is_empty())
-            .or_else(|| (!MODEL_SHA256.is_empty()).then(|| MODEL_SHA256.to_string()));
-        if let Some(exp) = expected {
-            let _ = app2.emit(
-                "kb_model:progress",
-                serde_json::json!({ "stage": "verify" }),
-            );
-            let got = crate::platform::hashing::sha256_file(&part2)
-                .map_err(|e| format!("读校验文件失败: {e}"))?;
-            if !got.eq_ignore_ascii_case(&exp) {
-                let _ = std::fs::remove_file(&part2);
-                return Err(format!(
-                    "模型校验失败(sha256 不匹配): 期望 {exp:.12} 实际 {got:.12}"
-                ));
-            }
-        }
-        // 解压到临时目录再原子换入（避免半包污染落点）。
         let _ = app2.emit(
             "kb_model:progress",
             serde_json::json!({ "stage": "extract" }),
@@ -319,11 +313,14 @@ pub async fn kb_model_download(
         let tmp = dir2.with_extension("tmp");
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).map_err(|e| format!("创建解压目录失败: {e}"))?;
-        extract_targz(&part2, &tmp)?;
+        extract_targz(&archive, &tmp)?;
         if !model_directory_is_complete(&tmp) {
             let _ = std::fs::remove_dir_all(&tmp);
             return Err("解压结果缺少完整的 ONNX 模型或 tokenizer 配置".into());
         }
+        // 解压完成后清理已校验归档(helper 把 .part rename 成此干净名;dir 换入
+        // 留给后续候选 embedding 验证 + deploy_validated_model 原子提升)。
+        let _ = std::fs::remove_file(&archive);
         Ok(())
     })
     .await

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -278,8 +278,8 @@ pub async fn kb_model_download(
             );
         }
     });
-    let is_cancelled: Box<dyn Fn() -> bool + Send + Sync> =
-        Box::new(|| CANCEL.load(Ordering::Relaxed));
+    let is_cancelled: std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static> =
+        std::sync::Arc::new(|| CANCEL.load(Ordering::Relaxed));
     // `verify` 事件恢复到重构前时点:下载成功后、sha256 校验开始前 emit(helper 在
     // sync_all 后、sha256_file 前调用此闭包)。原实现仅在 sha256 存在时 emit
     // (空串跳过校验的 dev 兜底不发 verify),这里保持一致。frontend 据此从下载进度

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -258,10 +258,6 @@ pub async fn kb_model_download(
         .or_else(|| (!MODEL_SHA256.is_empty()).then(|| MODEL_SHA256.to_string()));
     // helper 的 expected_sha256 空串=跳过校验(dev 本地包),与原逻辑一致。
     let expected_sha256: &str = expected.as_deref().unwrap_or("");
-    let _ = app.emit(
-        "kb_model:progress",
-        serde_json::json!({ "stage": "verify" }),
-    );
     // 进度节流:每 2 MiB 或到达 total 才 emit(与原实现一致)。helper 的 on_progress
     // 是 `Fn`,节流状态用 Arc<Mutex> 承载;total 由 helper 透传(真实 Content-Length
     // 或缺失时回退 max_bytes=MODEL_TARGZ_SIZE)。
@@ -283,6 +279,20 @@ pub async fn kb_model_download(
         }
     });
     let is_cancelled: Box<dyn Fn() -> bool + Send> = Box::new(|| CANCEL.load(Ordering::Relaxed));
+    // `verify` 事件恢复到重构前时点:下载成功后、sha256 校验开始前 emit(helper 在
+    // sync_all 后、sha256_file 前调用此闭包)。原实现仅在 sha256 存在时 emit
+    // (空串跳过校验的 dev 兜底不发 verify),这里保持一致。frontend 据此从下载进度
+    // (0–95%)切到「校验中」(96%),不再出现 96%→0% 倒退。
+    let on_pre_verify: Option<Box<dyn FnOnce() + Send>> =
+        expected.as_ref().filter(|s| !s.trim().is_empty()).map(|_| {
+            let app_for_verify = app.clone();
+            Box::new(move || {
+                let _ = app_for_verify.emit(
+                    "kb_model:progress",
+                    serde_json::json!({ "stage": "verify" }),
+                );
+            }) as Box<dyn FnOnce() + Send>
+        });
     let req = crate::platform::download::DownloadRequest {
         url: &url,
         dest: &archive,
@@ -291,6 +301,7 @@ pub async fn kb_model_download(
         max_bytes: MODEL_TARGZ_SIZE,
         is_cancelled,
         on_progress,
+        on_pre_verify,
     };
     crate::platform::download::download_to_part_with_verify(req)
         .await

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -278,7 +278,8 @@ pub async fn kb_model_download(
             );
         }
     });
-    let is_cancelled: Box<dyn Fn() -> bool + Send> = Box::new(|| CANCEL.load(Ordering::Relaxed));
+    let is_cancelled: Box<dyn Fn() -> bool + Send + Sync> =
+        Box::new(|| CANCEL.load(Ordering::Relaxed));
     // `verify` 事件恢复到重构前时点:下载成功后、sha256 校验开始前 emit(helper 在
     // sync_all 后、sha256_file 前调用此闭包)。原实现仅在 sha256 存在时 emit
     // (空串跳过校验的 dev 兜底不发 verify),这里保持一致。frontend 据此从下载进度
@@ -300,6 +301,7 @@ pub async fn kb_model_download(
         expected_sha256,
         max_bytes: MODEL_TARGZ_SIZE,
         is_cancelled,
+        user_agent: Some("pinvou3-kb/1.0"),
         on_progress,
         on_pre_verify,
     };

--- a/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/model_download.rs
@@ -299,7 +299,12 @@ pub async fn kb_model_download(
         dest: &archive,
         part: &part,
         expected_sha256,
-        max_bytes: MODEL_TARGZ_SIZE,
+        // 进度 total 的回退估算(缺 Content-Length 时按它算 100%),与重构前一致。
+        total_hint: MODEL_TARGZ_SIZE,
+        // 原实现无硬上限,靠 sha256 精确校验兜底;这里给 2 倍的宽松挡板,既挡离谱
+        // 大文件,也放行合法的自定义镜像/重发包(略大于 MODEL_TARGZ_SIZE 仍可用,
+        // 只需 SHA 匹配)。此前复用 MODEL_TARGZ_SIZE 当 max_bytes 会误拒这些镜像。
+        max_bytes: MODEL_TARGZ_SIZE.saturating_mul(2),
         is_cancelled,
         user_agent: Some("pinvou3-kb/1.0"),
         on_progress,

--- a/pinvou3-app/src-tauri/src/features/scheduled/tasks.rs
+++ b/pinvou3-app/src-tauri/src/features/scheduled/tasks.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -108,56 +108,88 @@ impl Default for ScheduledTaskUiMetadataRegistry {
     }
 }
 
-#[derive(Clone)]
-struct ScheduledTaskUiMetadataStore {
-    path: Arc<PathBuf>,
-    registry: Arc<RwLock<ScheduledTaskUiMetadataRegistry>>,
+/// How [`VersionedJsonStore`] reacts to an unreadable / unsupported payload.
+enum QuarantineStrategy {
+    /// Emit a `warn!` and leave the offending file in place (UI metadata store).
+    LogInPlace,
+    /// Rename the file to `<name>.invalid-<ts>` and log (model-binding / read-state).
+    Rename,
 }
 
-impl ScheduledTaskUiMetadataStore {
+/// Per-store behaviour carried by the registry type itself.
+///
+/// The three scheduled registries share an identical open/persist skeleton but
+/// differ in (a) schema version, (b) how an old version is migrated, (c) whether
+/// invalid payloads are quarantined or merely logged, and (d) the human-readable
+/// label/suffix used in diagnostics. This trait carries exactly those
+/// differences so [`VersionedJsonStore<T>`] can stay generic without assuming
+/// the three stores are textually identical.
+trait VersionedRegistry:
+    Default + serde::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync + 'static
+{
+    /// Schema version persisted in (and supported by) this registry.
+    const SUPPORTED_VERSION: u32;
+    /// Read back the schema version of a deserialised instance.
+    fn schema_version(&self) -> u32;
+    /// Migrate an older-version instance up to [`SUPPORTED_VERSION`].
+    ///
+    /// Infallible: every concrete store always produces a replacement (the
+    /// read-state store deliberately resets to default, dropping viewed runs).
+    fn migrate(self) -> Self;
+    /// Quarantine policy for newer-than-supported / invalid-JSON payloads.
+    const QUARANTINE: QuarantineStrategy;
+    /// Human-readable label used in log/error messages for this store.
+    const LABEL: &'static str;
+    /// Fallback file-name stem when the on-disk path has no file component.
+    const QUARANTINE_FALLBACK_NAME: &'static str;
+    /// Store-specific suffix appended to quarantine / read-failure warnings.
+    const WARN_SUFFIX: &'static str;
+}
+
+/// Versioned-JSON registry store with schema migration, quarantine, and atomic
+/// writes. Collapses the three previously hand-rolled stores into one generic
+/// core; per-store differences live on [`VersionedRegistry`].
+#[derive(Clone)]
+struct VersionedJsonStore<T: VersionedRegistry> {
+    path: Arc<PathBuf>,
+    registry: Arc<RwLock<T>>,
+}
+
+impl<T: VersionedRegistry> VersionedJsonStore<T> {
     fn open(path: PathBuf) -> Result<Self> {
         let mut migrated = false;
         let registry = match std::fs::read_to_string(&path) {
-            Ok(raw) => match serde_json::from_str::<ScheduledTaskUiMetadataRegistry>(&raw) {
-                Ok(registry)
-                    if registry.schema_version == SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION =>
-                {
-                    registry
-                }
-                Ok(registry)
-                    if registry.schema_version < SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION =>
-                {
+            Ok(raw) => match serde_json::from_str::<T>(&raw) {
+                Ok(registry) if registry.schema_version() == T::SUPPORTED_VERSION => registry,
+                Ok(registry) if registry.schema_version() < T::SUPPORTED_VERSION => {
                     migrated = true;
-                    ScheduledTaskUiMetadataRegistry {
-                        schema_version: SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION,
-                        tasks: registry.tasks,
-                    }
+                    registry.migrate()
                 }
                 Ok(registry) => {
-                    log::warn!(
-                        "Ignoring newer scheduled task UI metadata schema v{} at {}",
-                        registry.schema_version,
-                        path.display()
+                    Self::handle_invalid(
+                        &path,
+                        &format!(
+                            "schema v{} is newer than supported v{}",
+                            registry.schema_version(),
+                            T::SUPPORTED_VERSION
+                        ),
                     );
-                    ScheduledTaskUiMetadataRegistry::default()
+                    T::default()
                 }
                 Err(error) => {
-                    log::warn!(
-                        "Ignoring invalid scheduled task UI metadata {}: {error}",
-                        path.display()
-                    );
-                    ScheduledTaskUiMetadataRegistry::default()
+                    Self::handle_invalid(&path, &format!("invalid JSON: {error}"));
+                    T::default()
                 }
             },
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                ScheduledTaskUiMetadataRegistry::default()
-            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => T::default(),
             Err(error) => {
                 log::warn!(
-                    "Unable to read scheduled task UI metadata {}: {error}",
-                    path.display()
+                    "Unable to read {} {}: {error}{}",
+                    T::LABEL,
+                    path.display(),
+                    T::WARN_SUFFIX
                 );
-                ScheduledTaskUiMetadataRegistry::default()
+                T::default()
             }
         };
         let store = Self {
@@ -167,7 +199,8 @@ impl ScheduledTaskUiMetadataStore {
         if migrated {
             if let Err(error) = store.persist(&store.registry.read()) {
                 log::warn!(
-                    "Unable to persist migrated scheduled task UI metadata {}: {error:#}",
+                    "Unable to persist migrated {} {}: {error:#}",
+                    T::LABEL,
                     store.path.display()
                 );
             }
@@ -175,6 +208,117 @@ impl ScheduledTaskUiMetadataStore {
         Ok(store)
     }
 
+    fn persist(&self, registry: &T) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {} dir {}", T::LABEL, parent.display()))?;
+        }
+        let payload = serde_json::to_vec_pretty(registry)
+            .with_context(|| format!("serialize {}", T::LABEL))?;
+        deepseek_tui::utils::write_atomic(self.path.as_ref(), &payload)
+            .with_context(|| format!("write {} {}", T::LABEL, self.path.display()))
+    }
+
+    /// Apply this store's quarantine policy to an invalid payload at `path`.
+    fn handle_invalid(path: &Path, reason: &str) {
+        match T::QUARANTINE {
+            QuarantineStrategy::LogInPlace => {
+                log::warn!(
+                    "Ignoring invalid {} {} ({reason})",
+                    T::LABEL,
+                    path.display()
+                );
+            }
+            QuarantineStrategy::Rename => {
+                let timestamp = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos();
+                let file_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(T::QUARANTINE_FALLBACK_NAME);
+                let quarantine_path =
+                    path.with_file_name(format!("{file_name}.invalid-{timestamp}"));
+                match std::fs::rename(path, &quarantine_path) {
+                    Ok(()) => log::warn!(
+                        "Quarantined {} {} to {} ({reason}){}",
+                        T::LABEL,
+                        path.display(),
+                        quarantine_path.display(),
+                        T::WARN_SUFFIX
+                    ),
+                    Err(error) => log::warn!(
+                        "Invalid {} {} ({reason}) could not be quarantined: {error}{}",
+                        T::LABEL,
+                        path.display(),
+                        T::WARN_SUFFIX
+                    ),
+                }
+            }
+        }
+    }
+}
+
+impl VersionedRegistry for ScheduledTaskUiMetadataRegistry {
+    const SUPPORTED_VERSION: u32 = SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION;
+    const QUARANTINE: QuarantineStrategy = QuarantineStrategy::LogInPlace;
+    const LABEL: &'static str = "scheduled task UI metadata";
+    const QUARANTINE_FALLBACK_NAME: &'static str = "scheduled-task-ui-metadata.json";
+    const WARN_SUFFIX: &'static str = "";
+
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    fn migrate(self) -> Self {
+        Self {
+            schema_version: SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION,
+            tasks: self.tasks,
+        }
+    }
+}
+
+impl VersionedRegistry for ScheduledTaskModelBindingRegistry {
+    const SUPPORTED_VERSION: u32 = SCHEDULED_MODEL_BINDING_SCHEMA_VERSION;
+    const QUARANTINE: QuarantineStrategy = QuarantineStrategy::Rename;
+    const LABEL: &'static str = "scheduled model binding state";
+    const QUARANTINE_FALLBACK_NAME: &'static str = "model-bindings.json";
+    const WARN_SUFFIX: &'static str = "; scheduled tasks will fall back to wire model names";
+
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    fn migrate(self) -> Self {
+        Self {
+            schema_version: SCHEDULED_MODEL_BINDING_SCHEMA_VERSION,
+            tasks: self.tasks,
+        }
+    }
+}
+
+impl VersionedRegistry for ScheduledRunReadRegistry {
+    const SUPPORTED_VERSION: u32 = SCHEDULED_RUN_READ_STATE_SCHEMA_VERSION;
+    const QUARANTINE: QuarantineStrategy = QuarantineStrategy::Rename;
+    const LABEL: &'static str = "scheduled run read state";
+    const QUARANTINE_FALLBACK_NAME: &'static str = "scheduled-run-read-state.json";
+    const WARN_SUFFIX: &'static str = "; treating all runs as unread";
+
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Older read-state schemas are dropped: viewed-run tracking resets on
+    /// upgrade, matching the legacy hand-rolled store.
+    fn migrate(self) -> Self {
+        Self::default()
+    }
+}
+
+type ScheduledTaskUiMetadataStore = VersionedJsonStore<ScheduledTaskUiMetadataRegistry>;
+
+impl VersionedJsonStore<ScheduledTaskUiMetadataRegistry> {
     fn metadata_for(&self, automation_id: &str) -> (bool, Option<String>) {
         self.registry
             .read()
@@ -243,89 +387,11 @@ impl ScheduledTaskUiMetadataStore {
         }
         Ok(())
     }
-
-    fn persist(&self, registry: &ScheduledTaskUiMetadataRegistry) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("create scheduled task UI metadata dir {}", parent.display())
-            })?;
-        }
-        let payload =
-            serde_json::to_vec_pretty(registry).context("serialize scheduled task UI metadata")?;
-        deepseek_tui::utils::write_atomic(self.path.as_ref(), &payload)
-            .with_context(|| format!("write scheduled task UI metadata {}", self.path.display()))
-    }
 }
 
-#[derive(Clone)]
-struct ScheduledTaskModelBindingStore {
-    path: Arc<PathBuf>,
-    registry: Arc<RwLock<ScheduledTaskModelBindingRegistry>>,
-}
+type ScheduledTaskModelBindingStore = VersionedJsonStore<ScheduledTaskModelBindingRegistry>;
 
-impl ScheduledTaskModelBindingStore {
-    fn open(path: PathBuf) -> Result<Self> {
-        let mut migrated = false;
-        let registry = match std::fs::read_to_string(&path) {
-            Ok(raw) => match serde_json::from_str::<ScheduledTaskModelBindingRegistry>(&raw) {
-                Ok(registry)
-                    if registry.schema_version == SCHEDULED_MODEL_BINDING_SCHEMA_VERSION =>
-                {
-                    registry
-                }
-                Ok(registry)
-                    if registry.schema_version < SCHEDULED_MODEL_BINDING_SCHEMA_VERSION =>
-                {
-                    migrated = true;
-                    ScheduledTaskModelBindingRegistry {
-                        schema_version: SCHEDULED_MODEL_BINDING_SCHEMA_VERSION,
-                        tasks: registry.tasks,
-                    }
-                }
-                Ok(registry) => {
-                    quarantine_invalid_model_binding_state(
-                        &path,
-                        &format!(
-                            "schema v{} is newer than supported v{}",
-                            registry.schema_version, SCHEDULED_MODEL_BINDING_SCHEMA_VERSION
-                        ),
-                    );
-                    ScheduledTaskModelBindingRegistry::default()
-                }
-                Err(error) => {
-                    quarantine_invalid_model_binding_state(
-                        &path,
-                        &format!("invalid JSON: {error}"),
-                    );
-                    ScheduledTaskModelBindingRegistry::default()
-                }
-            },
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                ScheduledTaskModelBindingRegistry::default()
-            }
-            Err(error) => {
-                log::warn!(
-                    "Unable to read scheduled model binding state {}: {error}; scheduled tasks will fall back to wire model names",
-                    path.display()
-                );
-                ScheduledTaskModelBindingRegistry::default()
-            }
-        };
-        let store = Self {
-            path: Arc::new(path),
-            registry: Arc::new(RwLock::new(registry)),
-        };
-        if migrated {
-            if let Err(error) = store.persist(&store.registry.read()) {
-                log::warn!(
-                    "Unable to persist migrated scheduled model binding state {}: {error:#}",
-                    store.path.display()
-                );
-            }
-        }
-        Ok(store)
-    }
-
+impl VersionedJsonStore<ScheduledTaskModelBindingRegistry> {
     fn model_id_for(&self, automation_id: &str, model: &str) -> Option<String> {
         self.registry
             .read()
@@ -406,106 +472,11 @@ impl ScheduledTaskModelBindingStore {
         }
         Ok(())
     }
-
-    fn persist(&self, registry: &ScheduledTaskModelBindingRegistry) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("create scheduled model binding dir {}", parent.display())
-            })?;
-        }
-        let payload =
-            serde_json::to_vec_pretty(registry).context("serialize scheduled model bindings")?;
-        deepseek_tui::utils::write_atomic(self.path.as_ref(), &payload)
-            .with_context(|| format!("write scheduled model bindings {}", self.path.display()))
-    }
 }
 
-fn quarantine_invalid_model_binding_state(path: &std::path::Path, reason: &str) {
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("model-bindings.json");
-    let quarantine_path = path.with_file_name(format!("{file_name}.invalid-{timestamp}"));
-    match std::fs::rename(path, &quarantine_path) {
-        Ok(()) => log::warn!(
-            "Quarantined scheduled model binding state {} to {} ({reason}); scheduled tasks will fall back to wire model names",
-            path.display(),
-            quarantine_path.display()
-        ),
-        Err(error) => log::warn!(
-            "Invalid scheduled model binding state {} ({reason}) could not be quarantined: {error}; scheduled tasks will fall back to wire model names",
-            path.display()
-        ),
-    }
-}
+type ScheduledRunReadStore = VersionedJsonStore<ScheduledRunReadRegistry>;
 
-#[derive(Clone)]
-struct ScheduledRunReadStore {
-    path: Arc<PathBuf>,
-    registry: Arc<RwLock<ScheduledRunReadRegistry>>,
-}
-
-impl ScheduledRunReadStore {
-    fn open(path: PathBuf) -> Result<Self> {
-        let mut migrated = false;
-        let registry = match std::fs::read_to_string(&path) {
-            Ok(raw) => match serde_json::from_str::<ScheduledRunReadRegistry>(&raw) {
-                Ok(registry)
-                    if registry.schema_version == SCHEDULED_RUN_READ_STATE_SCHEMA_VERSION =>
-                {
-                    registry
-                }
-                Ok(registry)
-                    if registry.schema_version < SCHEDULED_RUN_READ_STATE_SCHEMA_VERSION =>
-                {
-                    migrated = true;
-                    ScheduledRunReadRegistry::default()
-                }
-                Ok(registry) => {
-                    quarantine_invalid_read_state(
-                        &path,
-                        &format!(
-                            "schema v{} is newer than supported v{}",
-                            registry.schema_version, SCHEDULED_RUN_READ_STATE_SCHEMA_VERSION
-                        ),
-                    );
-                    ScheduledRunReadRegistry::default()
-                }
-                Err(error) => {
-                    quarantine_invalid_read_state(&path, &format!("invalid JSON: {error}"));
-                    ScheduledRunReadRegistry::default()
-                }
-            },
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                ScheduledRunReadRegistry::default()
-            }
-            Err(error) => {
-                log::warn!(
-                    "Unable to read scheduled run state {}: {error}; treating all runs as unread",
-                    path.display()
-                );
-                ScheduledRunReadRegistry::default()
-            }
-        };
-        let store = Self {
-            path: Arc::new(path),
-            registry: Arc::new(RwLock::new(registry)),
-        };
-        if migrated {
-            if let Err(error) = store.persist(&store.registry.read()) {
-                log::warn!(
-                    "Unable to persist migrated scheduled run state {}: {error:#}",
-                    store.path.display()
-                );
-            }
-        }
-        Ok(store)
-    }
-
+impl VersionedJsonStore<ScheduledRunReadRegistry> {
     fn is_viewed(&self, automation_id: &str, run_id: &str) -> bool {
         self.registry
             .read()
@@ -580,41 +551,6 @@ impl ScheduledRunReadStore {
             return Err(error);
         }
         Ok(())
-    }
-
-    fn persist(&self, registry: &ScheduledRunReadRegistry) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("create scheduled run read-state dir {}", parent.display())
-            })?;
-        }
-        let payload =
-            serde_json::to_vec_pretty(registry).context("serialize scheduled run read state")?;
-        deepseek_tui::utils::write_atomic(self.path.as_ref(), &payload)
-            .with_context(|| format!("write scheduled run read state {}", self.path.display()))
-    }
-}
-
-fn quarantine_invalid_read_state(path: &std::path::Path, reason: &str) {
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("scheduled-run-read-state.json");
-    let quarantine_path = path.with_file_name(format!("{file_name}.invalid-{timestamp}"));
-    match std::fs::rename(path, &quarantine_path) {
-        Ok(()) => log::warn!(
-            "Quarantined scheduled run state {} to {} ({reason}); treating all runs as unread",
-            path.display(),
-            quarantine_path.display()
-        ),
-        Err(error) => log::warn!(
-            "Invalid scheduled run state {} ({reason}) could not be quarantined: {error}; treating all runs as unread",
-            path.display()
-        ),
     }
 }
 
@@ -2239,6 +2175,161 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).expect("create temp home");
         dir
+    }
+
+    // ── VersionedJsonStore<T> 通用核心(合并三 store) ──────────────────
+    // 这组测试覆盖合并前的行为契约:open 空 / 当前版本直读 / 旧版本迁移 /
+    // 损坏 JSON quarantine / 原子 persist;并区分 Rename 与 LogInPlace 两种策略。
+    #[test]
+    fn versioned_json_store_open_empty_uses_default_registry() {
+        let dir = temp_home();
+        let path = dir.join("empty-read-state.json");
+        let store = VersionedJsonStore::<ScheduledRunReadRegistry>::open(path.clone())
+            .expect("open missing file");
+        assert!(store.registry.read().viewed_runs.is_empty());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn versioned_json_store_open_current_version_passes_through() {
+        let dir = temp_home();
+        let path = dir.join("current.json");
+        let mut registry = ScheduledRunReadRegistry::default();
+        registry.viewed_runs.insert(
+            "automation-1".to_string(),
+            HashSet::from(["run-1".to_string()]),
+        );
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&registry).expect("serialize"),
+        )
+        .expect("write registry");
+
+        let store = VersionedJsonStore::<ScheduledRunReadRegistry>::open(path)
+            .expect("open current-version payload");
+        let guard = store.registry.read();
+        assert_eq!(
+            guard.viewed_runs.get("automation-1"),
+            Some(&HashSet::from(["run-1".to_string()]))
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn versioned_json_store_open_old_version_migrates_and_repersists() {
+        let dir = temp_home();
+        let path = dir.join("old-ui-metadata.json");
+        // 旧版本(0 < 当前 1)且保留 tasks,触发 migrate。
+        let legacy = serde_json::json!({
+            "schema_version": 0,
+            "tasks": {
+                "automation-1": {
+                    "pinned": true,
+                    "pinned_at": "2024-01-01T00:00:00Z",
+                    "updated_at": "2024-01-01T00:00:00Z"
+                }
+            }
+        });
+        std::fs::write(&path, legacy.to_string()).expect("write legacy payload");
+
+        let store = VersionedJsonStore::<ScheduledTaskUiMetadataRegistry>::open(path.clone())
+            .expect("open old-version payload");
+        let guard = store.registry.read();
+        assert_eq!(
+            guard.schema_version,
+            SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION
+        );
+        assert!(guard.tasks.contains_key("automation-1"));
+        drop(guard);
+
+        // 迁移后已重新落盘为当前版本。
+        let repersisted: ScheduledTaskUiMetadataRegistry =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read repersisted"))
+                .expect("parse repersisted");
+        assert_eq!(
+            repersisted.schema_version,
+            SCHEDULED_TASK_UI_METADATA_SCHEMA_VERSION
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn versioned_json_store_open_corrupt_json_quarantines_rename_store() {
+        let dir = temp_home();
+        let path = dir.join("corrupt-read-state.json");
+        std::fs::write(&path, "{ definitely-not-json").expect("write corrupt payload");
+
+        let store = VersionedJsonStore::<ScheduledRunReadRegistry>::open(path.clone())
+            .expect("corrupt payload must not block startup");
+        assert!(store.registry.read().viewed_runs.is_empty());
+        assert!(
+            !path.exists(),
+            "corrupt rename-store payload must be quarantined"
+        );
+        assert!(
+            std::fs::read_dir(&dir)
+                .expect("read quarantine dir")
+                .filter_map(Result::ok)
+                .any(|entry| entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("corrupt-read-state.json.invalid-")),
+            "a quarantine sidecar must exist"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn versioned_json_store_open_corrupt_json_keeps_log_in_place_store() {
+        let dir = temp_home();
+        let path = dir.join("corrupt-ui-metadata.json");
+        std::fs::write(&path, "{ definitely-not-json").expect("write corrupt payload");
+
+        let store = VersionedJsonStore::<ScheduledTaskUiMetadataRegistry>::open(path.clone())
+            .expect("corrupt payload must not block startup");
+        assert!(store.registry.read().tasks.is_empty());
+        // LogInPlace 策略:不搬走原文件。
+        assert!(
+            path.exists(),
+            "log-in-place store must leave the offending file untouched"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn versioned_json_store_persist_writes_atomically_and_roundtrips() {
+        let dir = temp_home();
+        let path = dir.join("persist-model-bindings.json");
+        let store = VersionedJsonStore::<ScheduledTaskModelBindingRegistry>::open(path.clone())
+            .expect("open fresh store");
+
+        let mut registry = store.registry.read().clone();
+        registry.tasks.insert(
+            "automation-1".to_string(),
+            ScheduledTaskModelBinding {
+                model_id: "model-id-1".to_string(),
+                model: "model-1".to_string(),
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+            },
+        );
+        store.persist(&registry).expect("persist registry");
+
+        let reloaded: ScheduledTaskModelBindingRegistry =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read persisted"))
+                .expect("parse persisted");
+        assert_eq!(
+            reloaded
+                .tasks
+                .get("automation-1")
+                .map(|binding| binding.model_id.clone()),
+            Some("model-id-1".to_string())
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -463,6 +463,65 @@ impl SessionStore {
         }
     }
 
+    /// Persist `session` atomically, then run retention reconciliation.
+    ///
+    /// This collapses the shared tail (`save_session_atomic` succeeded by an
+    /// `enforce_session_retention_locked` whose failure is logged and swallowed)
+    /// that 13 public methods previously inlined. Retention reconciliation never
+    /// invalidates a committed save: it runs after the atomic write has landed,
+    /// mirroring the historical "save first, best-effort cleanup" contract.
+    ///
+    /// `event` describes the mutating operation (e.g. "committed save",
+    /// "title update") so the diagnostic uniquely identifies which call failed.
+    /// The helper deliberately does NOT re-check `is_scheduled_session`: callers
+    /// that branch on it (notably [`Self::save`]) decide scheduling before
+    /// delegating here.
+    fn persist_then_reconcile(
+        &self,
+        session: &SavedSession,
+        event: &'static str,
+    ) -> Result<PathBuf> {
+        let path = self.save_session_atomic(session)?;
+        if let Err(error) = self.enforce_session_retention_locked() {
+            eprintln!("[sessions] retention reconciliation failed after {event}: {error:#}");
+        }
+        Ok(path)
+    }
+
+    /// Atomically persist `session` (enriching any failure with `save_context`),
+    /// then run best-effort retention reconciliation.
+    ///
+    /// Variant of [`persist_then_reconcile`] for callers that attach a
+    /// session-specific error context to the atomic save (engine-state, token,
+    /// artifact persistence). Reconciliation keeps the same "log and swallow"
+    /// contract as the other variant.
+    fn persist_then_reconcile_with(
+        &self,
+        session: &SavedSession,
+        save_context: impl FnOnce() -> String,
+        event: &'static str,
+    ) -> Result<PathBuf> {
+        let path = self
+            .save_session_atomic(session)
+            .with_context(save_context)?;
+        if let Err(error) = self.enforce_session_retention_locked() {
+            eprintln!("[sessions] retention reconciliation failed after {event}: {error:#}");
+        }
+        Ok(path)
+    }
+
+    /// Run best-effort retention reconciliation after a committed mutation.
+    ///
+    /// Used by methods (notably [`Self::create_scheduled_run`]) where the atomic
+    /// save is followed by side effects (profile insertion + rollback) before
+    /// the retention tail, so [`persist_then_reconcile`] cannot couple them.
+    /// Same "log and swallow" contract as the persist variants.
+    fn reconcile_retention(&self, event: &'static str) {
+        if let Err(error) = self.enforce_session_retention_locked() {
+            eprintln!("[sessions] retention reconciliation failed after {event}: {error:#}");
+        }
+    }
+
     /// Open `~/.pinvou3/sessions/` without inferring that a live tool call
     /// crashed. This constructor is safe for secondary stores opened while the
     /// application process is already running.
@@ -613,24 +672,11 @@ impl SessionStore {
 
     /// 落盘整个 session（atomic write 由上游处理）。
     pub fn save(&self, session: &SavedSession) -> Result<PathBuf> {
-        if self.is_scheduled_session(&session.metadata.id)? {
-            let _mutation = self.scheduled_mutation.lock();
-            let path = self.save_session_atomic(session)?;
-            if let Err(error) = self.enforce_session_retention_locked() {
-                eprintln!(
-                    "[sessions] scheduled retention reconciliation failed after committed save: {error:#}"
-                );
-            }
-            return Ok(path);
-        }
         let _mutation = self.scheduled_mutation.lock();
-        let path = self.save_session_atomic(session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] session retention reconciliation failed after session save: {error:#}"
-            );
+        if self.is_scheduled_session(&session.metadata.id)? {
+            return self.persist_then_reconcile(session, "committed save");
         }
-        Ok(path)
+        self.persist_then_reconcile(session, "session save")
     }
 
     /// 删除 session（含 artifacts 子目录）。
@@ -860,13 +906,11 @@ impl SessionStore {
         session.messages = state.messages;
         session.system_prompt = persisted_system_prompt(state.system_prompt.as_ref());
 
-        self.save_session_atomic(&session)
-            .with_context(|| format!("persist scheduled engine state for {id}"))?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] scheduled retention reconciliation failed after committed engine state save: {error:#}"
-            );
-        }
+        self.persist_then_reconcile_with(
+            &session,
+            || format!("persist scheduled engine state for {id}"),
+            "committed engine state save",
+        )?;
         Ok(session)
     }
 
@@ -899,13 +943,11 @@ impl SessionStore {
         session.messages = state.messages;
         session.system_prompt = persisted_system_prompt(state.system_prompt.as_ref());
 
-        self.save_session_atomic(&session)
-            .with_context(|| format!("persist chat engine state for {id}"))?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] chat retention reconciliation failed after committed engine state save: {error:#}"
-            );
-        }
+        self.persist_then_reconcile_with(
+            &session,
+            || format!("persist chat engine state for {id}"),
+            "committed engine state save",
+        )?;
         Ok(session)
     }
 
@@ -943,13 +985,11 @@ impl SessionStore {
         session.messages.push(display_message);
         session.metadata.message_count = session.messages.len();
         session.metadata.updated_at = Utc::now();
-        self.save_session_atomic(&session)
-            .with_context(|| format!("persist admitted chat display for {id}"))?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] chat retention reconciliation failed after admitted display save: {error:#}"
-            );
-        }
+        self.persist_then_reconcile_with(
+            &session,
+            || format!("persist admitted chat display for {id}"),
+            "admitted display save",
+        )?;
         Ok(session)
     }
 
@@ -977,13 +1017,11 @@ impl SessionStore {
         session.metadata.updated_at = Utc::now();
         session.metadata.total_tokens = base_total_tokens.saturating_add(engine_total_tokens);
 
-        self.save_session_atomic(&session)
-            .with_context(|| format!("persist scheduled token total for {id}"))?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] scheduled retention reconciliation failed after committed token save: {error:#}"
-            );
-        }
+        self.persist_then_reconcile_with(
+            &session,
+            || format!("persist scheduled token total for {id}"),
+            "committed token save",
+        )?;
         Ok(session)
     }
 
@@ -1032,11 +1070,7 @@ impl SessionStore {
             }
             return Err(err).context("save scheduled session profile");
         }
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] scheduled retention reconciliation failed after committed create: {error:#}"
-            );
-        }
+        self.reconcile_retention("committed create");
         Ok(session)
     }
 
@@ -1317,10 +1351,7 @@ impl SessionStore {
             .load_session_snapshot(id)
             .with_context(|| format!("load_session({id}) for title update"))?;
         session.metadata.title = title;
-        self.save_session_atomic(&session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!("[sessions] retention reconciliation failed after title update: {error:#}");
-        }
+        self.persist_then_reconcile(&session, "title update")?;
         Ok(())
     }
 
@@ -1337,12 +1368,7 @@ impl SessionStore {
             .load_session_snapshot(id)
             .with_context(|| format!("load_session({id}) for activity update"))?;
         session.metadata.updated_at = Utc::now();
-        self.save_session_atomic(&session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] retention reconciliation failed after activity update: {error:#}"
-            );
-        }
+        self.persist_then_reconcile(&session, "activity update")?;
         Ok(())
     }
 
@@ -1402,12 +1428,7 @@ impl SessionStore {
         session.metadata.message_count = messages.len();
         session.metadata.updated_at = Utc::now();
         session.messages = messages;
-        self.save_session_atomic(&session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] retention reconciliation failed after transcript update: {error:#}"
-            );
-        }
+        self.persist_then_reconcile(&session, "transcript update")?;
         Ok(())
     }
 
@@ -1447,10 +1468,7 @@ impl SessionStore {
         session.metadata.message_count = messages.len();
         session.metadata.updated_at = Utc::now();
         session.messages = messages;
-        self.save_session_atomic(&session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!("[sessions] retention reconciliation failed after transcript CAS: {error:#}");
-        }
+        self.persist_then_reconcile(&session, "transcript CAS")?;
         Ok(next_revision)
     }
 
@@ -1488,12 +1506,7 @@ impl SessionStore {
             })
             .collect();
         session.metadata.updated_at = now;
-        self.save_session_atomic(&session)?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] retention reconciliation failed after artifact update: {error:#}"
-            );
-        }
+        self.persist_then_reconcile(&session, "artifact update")?;
         Ok(())
     }
 
@@ -1534,13 +1547,11 @@ impl SessionStore {
             storage_path: path,
         });
         session.metadata.updated_at = now;
-        self.save_session_atomic(&session)
-            .with_context(|| format!("persist scheduled artifact for {id}"))?;
-        if let Err(error) = self.enforce_session_retention_locked() {
-            eprintln!(
-                "[sessions] scheduled retention reconciliation failed after committed artifact append: {error:#}"
-            );
-        }
+        self.persist_then_reconcile_with(
+            &session,
+            || format!("persist scheduled artifact for {id}"),
+            "committed artifact append",
+        )?;
         Ok(())
     }
 

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -3,20 +3,19 @@
 //! Platform runtime policy is owned by the sibling `platform` module. This module keeps
 //! platform-neutral status, transcription, model download, and Tauri command glue.
 //!
-//! 其中 model_available、download_current_model、transcribe、sha256_file、
+//! 其中 model_available、download_current_model、transcribe、
 //! model_file_verified 等函数仅被 `platform/{windows,linux}.rs` 调用;macOS 用系统
 //! Speech 框架(见 `platform/voice_asr_speech.rs`),不引用这些函数。因此它们在 macOS
 //! 编译目标下被 clippy 误报为 dead code,但删除会破坏 Windows/Linux 构建。
 #![allow(dead_code)]
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use tauri::Emitter;
 
 use crate::platform::paths;
@@ -369,7 +368,7 @@ pub fn model_file_verified(path: &Path, spec: &AsrModelSpec) -> bool {
         remember_model_verification_with_metadata(path, spec, &metadata, true);
         return true;
     }
-    let verified = sha256_file(path)
+    let verified = crate::platform::hashing::sha256_file(path)
         .map(|got| got.eq_ignore_ascii_case(spec.sha256))
         .unwrap_or(false);
     remember_model_verification_with_metadata(path, spec, &metadata, verified);
@@ -402,23 +401,6 @@ fn remember_model_verification_with_metadata(
             verified,
         });
     }
-}
-
-fn sha256_file(path: &Path) -> Result<String, String> {
-    let mut file = std::fs::File::open(path).map_err(|e| format!("打开校验文件失败: {e}"))?;
-    let mut hasher = Sha256::new();
-    let mut buf = vec![0u8; 1024 * 1024];
-    loop {
-        let n = file
-            .read(&mut buf)
-            .map_err(|e| format!("读取校验文件失败: {e}"))?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-    let digest = hasher.finalize();
-    Ok(crate::platform::encoding::hex_lower(&digest))
 }
 
 /// 转码到 16k 单声道 → 调 sense-voice-main → 清洗输出。供 transcribe_voice_audio 调用。
@@ -607,7 +589,7 @@ mod tests {
         std::fs::write(&file, b"abc").unwrap();
 
         assert_eq!(
-            sha256_file(&file).unwrap(),
+            crate::platform::hashing::sha256_file(&file).unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         );
 

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -9,7 +9,6 @@
 //! 编译目标下被 clippy 误报为 dead code,但删除会破坏 Windows/Linux 构建。
 #![allow(dead_code)]
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -22,7 +21,6 @@ use crate::platform::paths;
 
 static ASR_INSTALLING: AtomicBool = AtomicBool::new(false);
 static ASR_CANCEL: AtomicBool = AtomicBool::new(false);
-const ASR_CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 static MODEL_VERIFICATION_CACHE: OnceLock<Mutex<Option<ModelVerificationCache>>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
@@ -192,27 +190,55 @@ pub async fn download_asr_model(
             emit_download_cancelled(app);
             return Err("已取消".to_string());
         }
-        match download_model_from_url(app, &url, &tmp, &spec).await {
-            Ok(()) => {
-                if ASR_CANCEL.load(Ordering::Acquire) {
-                    let _ = std::fs::remove_file(&tmp);
-                    emit_download_cancelled(app);
-                    return Err("已取消".to_string());
-                }
-                let _ = app.emit(
+        // 校验阶段事件:helper 内部完成下载→sha256 校验→原子 rename。
+        let _ = app.emit(
+            "voice_asr:progress",
+            serde_json::json!({ "stage": "verify" }),
+        );
+        // 进度节流:每 1 MiB 或到达 total 才 emit(与原 download_model_from_url 一致)。
+        // helper 把真实 Content-Length(或缺失时回退到 max_bytes=expected_size)作为
+        // 进度 total 传入闭包,这里直接透传,不改写。helper 的 on_progress 是
+        // `Fn`(非 FnMut),节流用的 last_emit 状态用 Arc<Mutex> 承载以保持 `Fn`。
+        let app_clone = app.clone();
+        let model_id = spec.id;
+        let filename = spec.filename;
+        let last_emit_clone = std::sync::Arc::new(std::sync::Mutex::new(0u64));
+        let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |downloaded: u64, t: u64| {
+            let mut guard = match last_emit_clone.lock() {
+                Ok(g) => g,
+                Err(_) => return,
+            };
+            if downloaded - *guard >= 1_048_576 || downloaded >= t {
+                *guard = downloaded;
+                drop(guard);
+                let _ = app_clone.emit(
                     "voice_asr:progress",
-                    serde_json::json!({ "stage": "verify" }),
+                    serde_json::json!({ "stage": "model", "modelId": model_id, "filename": filename, "downloaded": downloaded, "total": t }),
                 );
-                let result = verify_and_promote_model(&tmp, &dest, &spec);
-                match result {
-                    Ok(()) => return Ok(dest),
-                    Err(_) if ASR_CANCEL.load(Ordering::Acquire) => {
-                        let _ = std::fs::remove_file(&tmp);
-                        emit_download_cancelled(app);
-                        return Err("已取消".to_string());
-                    }
-                    Err(err) => return Err(err),
-                }
+            }
+        });
+        let is_cancelled = Box::new(|| ASR_CANCEL.load(Ordering::Acquire));
+        // 原实现无硬性 Content-Length 上限,靠下载后 expected_size+sha256 精确校验兜底。
+        // 这里给一个 generous 上限(预期大小的 2 倍,且不少于 16 MiB),仅挡离谱大文件,
+        // 不影响真实模型(expected_size 即其精确大小)。
+        let max_bytes = spec.expected_size.max(16 * 1024 * 1024) * 2;
+        let req = crate::platform::download::DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &tmp,
+            expected_sha256: spec.sha256,
+            max_bytes,
+            is_cancelled,
+            on_progress,
+        };
+        match crate::platform::download::download_to_part_with_verify(req).await {
+            Ok(()) => {
+                remember_model_verification(&dest, &spec, true);
+                return Ok(dest);
+            }
+            Err(err) if err == "已取消" => {
+                emit_download_cancelled(app);
+                return Err(err);
             }
             Err(err) => {
                 let _ = std::fs::remove_file(&tmp);
@@ -240,70 +266,6 @@ fn model_download_urls(spec: &AsrModelSpec) -> Vec<String> {
     urls
 }
 
-async fn download_model_from_url(
-    app: &tauri::AppHandle,
-    url: &str,
-    tmp: &Path,
-    spec: &AsrModelSpec,
-) -> Result<(), String> {
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .user_agent("pinvou3-asr/1.0")
-        .build()
-        .map_err(|e| format!("构建 ASR 模型下载客户端失败: {e}"))?;
-    let response = tokio::select! {
-        result = client.get(url).send() => {
-            result.map_err(|e| format!("连接 ASR 模型源失败: {e}"))?
-        }
-        _ = wait_for_asr_cancel() => {
-            let _ = std::fs::remove_file(tmp);
-            return Err("已取消".to_string());
-        }
-    };
-    let mut resp = response
-        .error_for_status()
-        .map_err(|e| format!("ASR 模型源响应异常: {e}"))?;
-    let total = resp
-        .content_length()
-        .filter(|n| *n > 0)
-        .unwrap_or(spec.expected_size);
-    let mut file = std::fs::File::create(tmp).map_err(|e| format!("创建 ASR 模型文件失败: {e}"))?;
-    let mut downloaded: u64 = 0;
-    let mut last_emit: u64 = 0;
-    loop {
-        let chunk = tokio::select! {
-            result = resp.chunk() => {
-                result.map_err(|e| format!("ASR 模型下载中断: {e}"))?
-            }
-            _ = wait_for_asr_cancel() => {
-                drop(file);
-                let _ = std::fs::remove_file(tmp);
-                return Err("已取消".to_string());
-            }
-        };
-        let Some(chunk) = chunk else {
-            break;
-        };
-        file.write_all(&chunk)
-            .map_err(|e| format!("写入 ASR 模型失败: {e}"))?;
-        downloaded += chunk.len() as u64;
-        if downloaded - last_emit >= 1_048_576 || downloaded >= total {
-            last_emit = downloaded;
-            let _ = app.emit(
-                "voice_asr:progress",
-                serde_json::json!({ "stage": "model", "modelId": spec.id, "filename": spec.filename, "downloaded": downloaded, "total": total }),
-            );
-        }
-    }
-    Ok(())
-}
-
-async fn wait_for_asr_cancel() {
-    while !ASR_CANCEL.load(Ordering::Acquire) {
-        tokio::time::sleep(ASR_CANCEL_POLL_INTERVAL).await;
-    }
-}
-
 fn emit_download_cancelled(app: &tauri::AppHandle) {
     let _ = app.emit(
         "voice_asr:progress",
@@ -317,30 +279,6 @@ fn temp_model_path(dest: &Path) -> PathBuf {
         .and_then(|name| name.to_str())
         .unwrap_or("asr-model.gguf");
     dest.with_file_name(format!("{filename}.part"))
-}
-
-fn verify_and_promote_model(tmp: &Path, dest: &Path, spec: &AsrModelSpec) -> Result<(), String> {
-    if ASR_CANCEL.load(Ordering::Acquire) {
-        let _ = std::fs::remove_file(tmp);
-        return Err("已取消".to_string());
-    }
-    if !model_file_verified(tmp, spec) {
-        let _ = std::fs::remove_file(tmp);
-        return Err("ASR 模型校验失败，请重试下载。".to_string());
-    }
-    if ASR_CANCEL.load(Ordering::Acquire) {
-        let _ = std::fs::remove_file(tmp);
-        return Err("已取消".to_string());
-    }
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("创建 ASR 目录失败: {e}"))?;
-    }
-    if dest.exists() {
-        let _ = std::fs::remove_file(dest);
-    }
-    std::fs::rename(tmp, dest).map_err(|e| format!("保存 ASR 模型失败: {e}"))?;
-    remember_model_verification(dest, spec, true);
-    Ok(())
 }
 
 pub fn model_file_verified(path: &Path, spec: &AsrModelSpec) -> bool {
@@ -645,23 +583,6 @@ mod tests {
 
         std::fs::write(&file, b"abcd").unwrap();
         assert!(!model_file_verified(&file, &spec));
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn failed_verification_removes_part_file() {
-        let root = std::env::temp_dir().join(format!("pinvou3-asr-promote-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&root);
-        let part = root.join("model.gguf.part");
-        let dest = root.join("model.gguf");
-        std::fs::write(&part, b"abc").unwrap();
-
-        let result = verify_and_promote_model(&part, &dest, &test_spec(3, "bad"));
-
-        assert!(result.is_err());
-        assert!(!part.exists());
-        assert!(!dest.exists());
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -234,6 +234,7 @@ pub async fn download_asr_model(
             expected_sha256: spec.sha256,
             max_bytes,
             is_cancelled,
+            user_agent: Some("pinvou3-asr/1.0"),
             on_progress,
             on_pre_verify,
         };

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -213,9 +213,10 @@ pub async fn download_asr_model(
             }
         });
         let is_cancelled = Box::new(|| ASR_CANCEL.load(Ordering::Acquire));
-        // 原实现无硬性 Content-Length 上限,靠下载后 expected_size+sha256 精确校验兜底。
-        // 这里给一个 generous 上限(预期大小的 2 倍,且不少于 16 MiB),仅挡离谱大文件,
-        // 不影响真实模型(expected_size 即其精确大小)。
+        // 进度 total 的回退估算:与重构前一致用 `expected_size`(缺 Content-Length 时
+        // 进度按它算 100%)。max_bytes 只做离谱大文件挡板,刻意与 total 分开——此前
+        // 复用单字段会让进度停在约 50%(2*expected_size 当 total)。
+        let total_hint = spec.expected_size;
         let max_bytes = spec.expected_size.max(16 * 1024 * 1024) * 2;
         // `verify` 事件恢复到重构前时点:下载成功后、sha256 校验开始前 emit(helper 在
         // sync_all 后、sha256_file 前调用此闭包)。frontend 据此从下载进度(0–95%)
@@ -233,6 +234,7 @@ pub async fn download_asr_model(
             part: &tmp,
             expected_sha256: spec.sha256,
             max_bytes,
+            total_hint,
             is_cancelled,
             user_agent: Some("pinvou3-asr/1.0"),
             on_progress,

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -190,11 +190,6 @@ pub async fn download_asr_model(
             emit_download_cancelled(app);
             return Err("已取消".to_string());
         }
-        // 校验阶段事件:helper 内部完成下载→sha256 校验→原子 rename。
-        let _ = app.emit(
-            "voice_asr:progress",
-            serde_json::json!({ "stage": "verify" }),
-        );
         // 进度节流:每 1 MiB 或到达 total 才 emit(与原 download_model_from_url 一致)。
         // helper 把真实 Content-Length(或缺失时回退到 max_bytes=expected_size)作为
         // 进度 total 传入闭包,这里直接透传,不改写。helper 的 on_progress 是
@@ -222,6 +217,16 @@ pub async fn download_asr_model(
         // 这里给一个 generous 上限(预期大小的 2 倍,且不少于 16 MiB),仅挡离谱大文件,
         // 不影响真实模型(expected_size 即其精确大小)。
         let max_bytes = spec.expected_size.max(16 * 1024 * 1024) * 2;
+        // `verify` 事件恢复到重构前时点:下载成功后、sha256 校验开始前 emit(helper 在
+        // sync_all 后、sha256_file 前调用此闭包)。frontend 据此从下载进度(0–95%)
+        // 切到「校验中」(96%),不再出现 96%→0% 倒退。
+        let app_for_verify = app.clone();
+        let on_pre_verify: Option<Box<dyn FnOnce() + Send>> = Some(Box::new(move || {
+            let _ = app_for_verify.emit(
+                "voice_asr:progress",
+                serde_json::json!({ "stage": "verify" }),
+            );
+        }));
         let req = crate::platform::download::DownloadRequest {
             url: &url,
             dest: &dest,
@@ -230,6 +235,7 @@ pub async fn download_asr_model(
             max_bytes,
             is_cancelled,
             on_progress,
+            on_pre_verify,
         };
         match crate::platform::download::download_to_part_with_verify(req).await {
             Ok(()) => {

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -212,7 +212,7 @@ pub async fn download_asr_model(
                 );
             }
         });
-        let is_cancelled = Box::new(|| ASR_CANCEL.load(Ordering::Acquire));
+        let is_cancelled = std::sync::Arc::new(|| ASR_CANCEL.load(Ordering::Acquire));
         // 进度 total 的回退估算:与重构前一致用 `expected_size`(缺 Content-Length 时
         // 进度按它算 100%)。max_bytes 只做离谱大文件挡板,刻意与 total 分开——此前
         // 复用单字段会让进度停在约 50%(2*expected_size 当 total)。

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -31,9 +31,15 @@ pub struct DownloadRequest<'a> {
     pub part: &'a Path,
     /// 期望的 sha256(小写十六进制);空串表示跳过校验(dev 本地包常用)。
     pub expected_sha256: &'a str,
-    /// 内容长度上限(字节数)。`Content-Length` 超过此值即拒绝;流式累计超过即中止。
-    /// 设为 `u64::MAX` 等价于不设硬上限。
+    /// 内容长度**硬上限**(字节数)。`Content-Length` 超过此值即拒绝;流式累计超过即中止。
+    /// 设为 `u64::MAX` 等价于不设硬上限。仅用于挡离谱大文件,与进度估算无关。
     pub max_bytes: u64,
+    /// 进度 total 的**回退估算值**:仅当响应缺 `Content-Length`(或为 0)时,
+    /// 才用此值作为 `on_progress` 的 `total` 参数。二者刻意拆开——voice 把
+    /// `expected_size` 当估算、把 `2*expected_size` 当上限;knowledge 把
+    /// `MODEL_TARGZ_SIZE` 当估算、把 `2*MODEL_TARGZ_SIZE` 当上限——避免复用单字段
+    /// 导致进度停在约 50% 或合法镜像被拒。
+    pub total_hint: u64,
     /// 取消谓词:返回 `true` 时中止下载并清理 `.part`。
     /// 需 `Sync` 以便在 `tokio::select!` 中与网络 future 并发轮询(恢复重构前
     /// voice 的 `tokio::select!{ send(), wait_for_cancel() }` 响应性)。
@@ -41,13 +47,17 @@ pub struct DownloadRequest<'a> {
     /// 可选 `User-Agent`。重构前 voice/knowledge 各自设置 `pinvou3-asr/1.0`、
     /// `pinvou3-kb/1.0`;helper 通过该字段透传,`None` 时不设置。
     pub user_agent: Option<&'a str>,
-    /// 进度回调 `(downloaded, total)`。`total` 为 `Content-Length`(缺省/为 0 时由调用方
-    /// 在构造请求时填入估算值)。
+    /// 进度回调 `(downloaded, total)`。`total` 为 `Content-Length`(缺省/为 0 时回退到
+    /// [`DownloadRequest::total_hint`])。
     pub on_progress: Box<dyn Fn(u64, u64) + Send + 'a>,
     /// 下载流完成(`sync_all` 后)、sha256 校验**开始前**触发的一次性回调。
     /// 用于在原始时点(下载完成 → verify 事件 → 校验)emit `verify` 进度事件,恢复
     /// 「下载 0–95% → verify → done」的 frontend 事件顺序。`None` = 不触发。
-    pub on_pre_verify: Option<Box<dyn FnOnce() + Send + 'a>>,
+    ///
+    /// 必须为 `'static`:helper 把刷盘/校验/提升整体挪进 `spawn_blocking`,此回调
+    /// 在阻塞任务内触发;调用方需捕获 owned 数据(如克隆的 `AppHandle`),不借用 `req`
+    /// 的生命周期参数。voice/knowledge 两处实现均已是 `'static`。
+    pub on_pre_verify: Option<Box<dyn FnOnce() + Send + 'static>>,
 }
 
 /// `.part` 清理守卫:覆盖所有非成功退出路径(取消 / 网络错误 / 超长 / sha256 不匹配 /
@@ -95,7 +105,9 @@ impl<'a> Drop for PartGuard<'a> {
 /// helper 以闭包承载各调用方的取消源,这里在 select 分支内轮询该闭包恢复响应性。
 const CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
-pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Result<(), String> {
+pub(crate) async fn download_to_part_with_verify(
+    mut req: DownloadRequest<'_>,
+) -> Result<(), String> {
     // 下载开始前先查一次取消(与 voice 原循环语义一致)。
     if (req.is_cancelled)() {
         let _ = std::fs::remove_file(req.part);
@@ -139,12 +151,15 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
             .map_err(|e| format!("下载源响应异常: {e}"))?
     };
 
-    // 上限以 max_bytes 为准:Content-Length 申报超限直接拒(此时 `.part` 尚未创建,
-    // 仍清理一次以兜底历史残留)。
+    // 进度 total 与硬上限解耦:
+    // - `total`(进度估算)= 真实 `Content-Length`,缺省/为 0 时回退 `total_hint`;
+    // - `max_bytes`(硬上限)只用于挡离谱大文件。二者复用同一字段会把 voice 进度停在
+    //   约 50%(expected_size*2 当 total)、或让 knowledge 的合法镜像(略大于
+    //   MODEL_TARGZ_SIZE)被拒。
     let total = response
         .content_length()
         .filter(|n| *n > 0)
-        .unwrap_or(req.max_bytes);
+        .unwrap_or(req.total_hint);
     if total > req.max_bytes {
         let _ = std::fs::remove_file(req.part);
         return Err(format!("下载内容超过 {} 字节上限", req.max_bytes));
@@ -194,41 +209,62 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
             return Err("已取消".to_string());
         }
     }
-    // 刷盘后再做校验(rename 前确保数据落盘)。
-    file.sync_all()
-        .map_err(|e| format!("同步下载文件失败: {e}"))?;
+    // 刷盘、sha256 校验、原子 rename 都是**同步**文件 I/O:原 knowledge 流程把它们
+    // 一起放在 `spawn_blocking` 里(对约 389MB 的模型包做 sha256 会长时间占满 worker)。
+    // 这里把文件句柄的 sync + 校验 + 提升整体挪进 `spawn_blocking`,避免在 async
+    // runtime 上做阻塞 I/O(影响其他命令与事件处理)。`on_pre_verify` 是 `Send` 的
+    // `FnOnce`,可安全带进阻塞任务,在 sync 后、SHA 前触发,恢复重构前事件时序。
     drop(file);
+    let part = req.part.to_path_buf();
+    let dest = req.dest.to_path_buf();
+    let expected_sha256 = req.expected_sha256.to_string();
+    let on_pre_verify = req.on_pre_verify.take();
+    let result = tokio::task::spawn_blocking(move || -> Result<(), String> {
+        // 重新打开句柄做 sync_all(create 后未 sync 的句柄已 Drop)。
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&part)
+            .map_err(|e| format!("同步下载文件失败: {e}"))?;
+        file.sync_all()
+            .map_err(|e| format!("同步下载文件失败: {e}"))?;
+        drop(file);
 
-    // 下载流已完成、校验即将开始:触发调用方的 `verify` 进度事件,恢复重构前的
-    // frontend 事件顺序(下载 0–95% → verify → 校验 → done)。
-    if let Some(on_pre_verify) = req.on_pre_verify {
-        on_pre_verify();
-    }
-
-    // sha256 校验:空串跳过(与 knowledge/voice 的 dev 兜底一致)。
-    if !req.expected_sha256.trim().is_empty() {
-        let got = crate::platform::hashing::sha256_file(req.part)
-            .map_err(|e| format!("读取下载文件失败: {e}"))?;
-        if !got.eq_ignore_ascii_case(req.expected_sha256) {
-            return Err(format!(
-                "下载校验失败(expected {}, got {})",
-                req.expected_sha256, got
-            ));
+        // 下载流已完成、校验即将开始:触发调用方的 `verify` 进度事件,恢复重构前的
+        // frontend 事件顺序(下载 0–95% → verify → 校验 → done)。
+        if let Some(on_pre_verify) = on_pre_verify {
+            on_pre_verify();
         }
-    }
+
+        // sha256 校验:空串跳过(与 knowledge/voice 的 dev 兜底一致)。
+        if !expected_sha256.trim().is_empty() {
+            let got = crate::platform::hashing::sha256_file(&part)
+                .map_err(|e| format!("读取下载文件失败: {e}"))?;
+            if !got.eq_ignore_ascii_case(&expected_sha256) {
+                return Err(format!(
+                    "下载校验失败(expected {}, got {})",
+                    expected_sha256, got
+                ));
+            }
+        }
+
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("创建目标目录失败: {e}"))?;
+        }
+        if dest.exists() {
+            let _ = std::fs::remove_file(&dest);
+        }
+        std::fs::rename(&part, &dest).map_err(|e| format!("保存下载文件失败: {e}"))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("下载校验任务异常: {e}"))?;
 
     // 校验后再查一次取消(rename 是不可逆的最后一步)。
     if (req.is_cancelled)() {
         return Err("已取消".to_string());
     }
 
-    if let Some(parent) = req.dest.parent() {
-        std::fs::create_dir_all(parent).map_err(|e| format!("创建目标目录失败: {e}"))?;
-    }
-    if req.dest.exists() {
-        let _ = std::fs::remove_file(req.dest);
-    }
-    std::fs::rename(req.part, req.dest).map_err(|e| format!("保存下载文件失败: {e}"))?;
+    result?;
     // rename 成功:`.part` 已被消费为 `dest`,解除守卫,避免 Drop 时误删。
     guard.disarm();
     Ok(())
@@ -307,6 +343,27 @@ mod tests {
         (url, handle)
     }
 
+    /// 起 HTTP/1.1 fixture 但**不声明 `Content-Length`**,改用 `Connection: close`
+    /// 让 body 长度由连接结束隐含。用于验证缺 `Content-Length` 时进度 total 回退到
+    /// `total_hint`(而非 `max_bytes`,否则进度会停在约 50%)。
+    fn serve_without_content_length(body: Vec<u8>) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let url = format!("http://{addr}/payload");
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = std::io::Read::read(&mut stream, &mut buf);
+                let header =
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nConnection: close\r\n\r\n";
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+            }
+        });
+        (url, handle)
+    }
+
     fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + Sync + 'a> {
         Box::new(|| false)
     }
@@ -330,6 +387,7 @@ mod tests {
             part: &part,
             expected_sha256: HELLO_SHA,
             max_bytes: 1024,
+            total_hint: 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress: noop_progress(),
@@ -360,6 +418,7 @@ mod tests {
             part: &part,
             expected_sha256: HELLO_SHA, // 故意不匹配 "abc"
             max_bytes: 1024,
+            total_hint: 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress: noop_progress(),
@@ -390,6 +449,7 @@ mod tests {
             part: &part,
             expected_sha256: "", // 跳过校验(dev 兜底)
             max_bytes: 1024,
+            total_hint: 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress: noop_progress(),
@@ -431,6 +491,7 @@ mod tests {
             part: &part,
             expected_sha256: "",
             max_bytes: 10 * 1024 * 1024,
+            total_hint: 10 * 1024 * 1024,
             is_cancelled,
             user_agent: None,
             on_progress,
@@ -462,6 +523,7 @@ mod tests {
             part: &part,
             expected_sha256: ABC_SHA,
             max_bytes: 1024, // body 2048 > 上限 → Content-Length 即拒
+            total_hint: 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress: noop_progress(),
@@ -496,6 +558,7 @@ mod tests {
             part: &part,
             expected_sha256: "",
             max_bytes: 1024 * 1024,
+            total_hint: 1024 * 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress: noop_progress(),
@@ -545,6 +608,7 @@ mod tests {
             part: &part,
             expected_sha256: "",
             max_bytes: 1024 * 1024,
+            total_hint: 1024 * 1024,
             is_cancelled: never_cancel(),
             user_agent: None,
             on_progress,
@@ -564,6 +628,51 @@ mod tests {
             verify_idx.is_some_and(|v| v > last_progress.unwrap()),
             "verify must fire AFTER last download progress, got events = {:?}",
             *events
+        );
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 缺 `Content-Length` 时,进度 total 必须回退到 `total_hint`(而非 `max_bytes`)。
+    /// 此前复用单字段会让进度停在约 50%(voice 的 max_bytes=2*expected_size)。
+    #[tokio::test]
+    async fn missing_content_length_falls_back_to_total_hint() {
+        let dir = scratch_dir("hint");
+        let body = vec![0u8; 32 * 1024];
+        let (url, handle) = serve_without_content_length(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        // 故意让 max_bytes 远大于 total_hint:若 helper 错把 max_bytes 当 total,
+        // 进度回调收到的 t 会是 1 GiB;正确实现应回退到 total_hint=32 KiB。
+        let seen_total = Arc::new(std::sync::Mutex::new(0u64));
+        let seen_total_clone = Arc::clone(&seen_total);
+        let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |_d, t| {
+            let mut g = seen_total_clone.lock().unwrap();
+            *g = (*g).max(t);
+        });
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: "",
+            max_bytes: 1024 * 1024 * 1024,
+            total_hint: 32 * 1024,
+            is_cancelled: never_cancel(),
+            on_progress,
+            on_pre_verify: None,
+            user_agent: None,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_ok(), "err = {:?}", result.err());
+        assert_eq!(
+            *seen_total.lock().unwrap(),
+            32 * 1024,
+            "missing Content-Length should fall back to total_hint, not max_bytes"
         );
         handle.join().unwrap();
         let _ = std::fs::remove_dir_all(&dir);

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -43,7 +43,14 @@ pub struct DownloadRequest<'a> {
     /// 取消谓词:返回 `true` 时中止下载并清理 `.part`。
     /// 需 `Sync` 以便在 `tokio::select!` 中与网络 future 并发轮询(恢复重构前
     /// voice 的 `tokio::select!{ send(), wait_for_cancel() }` 响应性)。
-    pub is_cancelled: Box<dyn Fn() -> bool + Send + Sync + 'a>,
+    ///
+    /// 刻意用 `Arc<dyn Fn() -> bool + Send + Sync + 'static>`(而非 `Box<... + 'a>`):
+    /// 刷盘/sha256/原子 rename 整体挪进 `spawn_blocking`,该闭包必须可被克隆进
+    /// 阻塞任务,在 sha256 完成后、触碰旧 `dest`/rename **之前**再次检查取消
+    /// (大型模型包 sha256 耗时较长,若此时用户取消,必须在提升文件前中止,否则
+    /// 会「报告取消却留下已安装文件」)。`'static` 不借用 `req` 的生命周期参数;
+    /// voice/knowledge 两调用方的取消源分别是 `static AtomicBool`,天然 `'static`。
+    pub is_cancelled: std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static>,
     /// 可选 `User-Agent`。重构前 voice/knowledge 各自设置 `pinvou3-asr/1.0`、
     /// `pinvou3-kb/1.0`;helper 通过该字段透传,`None` 时不设置。
     pub user_agent: Option<&'a str>,
@@ -219,6 +226,9 @@ pub(crate) async fn download_to_part_with_verify(
     let dest = req.dest.to_path_buf();
     let expected_sha256 = req.expected_sha256.to_string();
     let on_pre_verify = req.on_pre_verify.take();
+    // 取消谓词克隆进阻塞任务:sha256 完成后、rename 前再查一次。`is_cancelled` 是
+    // `Arc<dyn Fn() -> bool + Send + Sync + 'static>`,可安全 move 进 `spawn_blocking`。
+    let is_cancelled = std::sync::Arc::clone(&req.is_cancelled);
     let result = tokio::task::spawn_blocking(move || -> Result<(), String> {
         // 重新打开句柄做 sync_all(create 后未 sync 的句柄已 Drop)。
         let file = std::fs::OpenOptions::new()
@@ -245,6 +255,18 @@ pub(crate) async fn download_to_part_with_verify(
                     expected_sha256, got
                 ));
             }
+        }
+
+        // 校验完成后、触碰旧 `dest`/rename 之前再查一次取消。大型模型包的 sha256
+        // 可能扫描数十秒,若期间用户取消,必须在提升文件前中止——否则 rename 已经
+        // 把 `.part` 提升为正式 `dest`,调用方却按「已取消」路径结束(voice 不登记
+        // 校验缓存、knowledge 跳过部署),形成「报告取消却留下已安装文件」的回归。
+        // 此时 `.part` 仍存在,由调用方(或 helper 的 PartGuard)按取消路径清理。
+        // 重构前 voice 的 `verify_and_promote_model` 在 SHA 后、删除旧目标/rename 前
+        // 也会再查一次 `ASR_CANCEL`,这里恢复该语义。注意不要删除此检查:仅靠闭包
+        // 返回后的检查会把「校验阶段取消」静默变成「下载成功」。
+        if is_cancelled() {
+            return Err("已取消".to_string());
         }
 
         if let Some(parent) = dest.parent() {
@@ -364,8 +386,8 @@ mod tests {
         (url, handle)
     }
 
-    fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + Sync + 'a> {
-        Box::new(|| false)
+    fn never_cancel() -> std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static> {
+        std::sync::Arc::new(|| false)
     }
     fn noop_progress<'a>() -> Box<dyn Fn(u64, u64) + Send + 'a> {
         Box::new(|_, _| {})
@@ -480,9 +502,9 @@ mod tests {
         let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |_d, _t| {
             cancel.store(true, Ordering::SeqCst);
         });
-        let is_cancelled: Box<dyn Fn() -> bool + Send + Sync> = {
+        let is_cancelled: std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static> = {
             let f = Arc::clone(&flag);
-            Box::new(move || f.load(Ordering::SeqCst))
+            Arc::new(move || f.load(Ordering::SeqCst))
         };
 
         let req = DownloadRequest {
@@ -503,6 +525,61 @@ mod tests {
         assert_eq!(result.unwrap_err(), "已取消");
         assert!(!part.exists(), "part should be cleaned on cancel");
         assert!(!dest.exists(), "dest should not exist on cancel");
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_verify_keeps_part_and_returns_cancelled() {
+        // 复审发现:大型模型 sha256 扫描期间取消,必须在「提升文件(rename)」之前
+        // 中止,不能报告取消却留下已安装 `dest`。这里用一个 `on_pre_verify` 钩子在
+        // 「下载完成、sha256 开始前」的瞬间翻转取消标志(等价于 sha256 期间取消),
+        // 断言:helper 返回「已取消」,且 `dest` 不存在、`.part` 保留(由调用方/守卫清理)。
+        let dir = scratch_dir("cancelverify");
+        let body = b"hello world".to_vec();
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let cancel_flag = Arc::clone(&flag);
+        // 下载完成、sha256 开始前触发:等价于「verify 阶段取消」。
+        let on_pre_verify: Option<Box<dyn FnOnce() + Send>> = Some(Box::new(move || {
+            cancel_flag.store(true, Ordering::SeqCst);
+        }));
+        let is_cancelled: std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static> = {
+            let f = Arc::clone(&flag);
+            Arc::new(move || f.load(Ordering::SeqCst))
+        };
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: HELLO_SHA,
+            max_bytes: 1024,
+            total_hint: 1024,
+            is_cancelled,
+            user_agent: None,
+            on_progress: noop_progress(),
+            on_pre_verify,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        // 必须是「已取消」,而不是 Ok(sha256 校验通过后继续 rename)。
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "已取消",
+            "cancel during verify must abort before promoting the file"
+        );
+        // 关键契约:取消发生在 rename 之前,`dest` 绝不能存在。
+        assert!(
+            !dest.exists(),
+            "dest must NOT be promoted after verify-stage cancel"
+        );
         handle.join().unwrap();
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -1,0 +1,347 @@
+//! 流式下载校验 helper:下载到 `.part` → 逐块取消/进度 → sha256 校验 → 原子 rename。
+//!
+//! 收敛 voice/knowledge 等异步下载路径共享的「下载 → 校验 → 提升」骨架。三调用方
+//! 取消机制不同(voice 的 AtomicBool、native_installer 无取消、knowledge 的
+//! AtomicBool + 进度事件),因此取消谓词与进度回调一律由调用方以闭包注入,
+//! helper 不假定统一取消源。
+//!
+//! **设计取舍**:本函数为 `async fn`(reqwest 异步流式)。`features/connectors/
+//! native_installer.rs::download_verified` 是 `reqwest::blocking` 的同步函数,且始终在
+//! `tokio::task::spawn_blocking` 内被调用(飞书/钉钉/企微 ensure_cli),该线程上没有
+//! 可 `.await` 的异步运行时;强行 `block_on` 嵌套运行时会与外层 tauri runtime 冲突,
+//! 属于 force-fit。故 native_installer 保持独立同步实现(见 task 报告差异表),仅迁移
+//! 同构的 voice/knowledge 两路。
+//!
+//! 复用 [`crate::platform::hashing::sha256_file`] 做校验,不重复实现 sha256。
+
+use std::path::Path;
+
+/// 单次下载请求(下载到 `part` → 校验 → rename 到 `dest`)。
+///
+/// `is_cancelled` 在下载**开始前**与**每收到一个 chunk 后**被调用,返回 `true` 立即中止、
+/// 删除 `.part`。`on_progress(downloaded, total)` 在每次 chunk 后被调用(调用方自行节流,
+/// 与原有「每 1~2 MiB 或到达 total 才 emit」行为一致)。二者均为 `Send` 闭包,由调用方
+/// 填入具体 AtomicBool 读取 / Tauri emit 逻辑。
+pub struct DownloadRequest<'a> {
+    /// 下载源 URL。
+    pub url: &'a str,
+    /// 最终目标路径(校验通过后 `rename` 的目的地)。
+    pub dest: &'a Path,
+    /// 临时 `.part` 路径(流式落盘位置,失败时删除)。
+    pub part: &'a Path,
+    /// 期望的 sha256(小写十六进制);空串表示跳过校验(dev 本地包常用)。
+    pub expected_sha256: &'a str,
+    /// 内容长度上限(字节数)。`Content-Length` 超过此值即拒绝;流式累计超过即中止。
+    /// 设为 `u64::MAX` 等价于不设硬上限。
+    pub max_bytes: u64,
+    /// 取消谓词:返回 `true` 时中止下载并清理 `.part`。
+    pub is_cancelled: Box<dyn Fn() -> bool + Send + 'a>,
+    /// 进度回调 `(downloaded, total)`。`total` 为 `Content-Length`(缺省/为 0 时由调用方
+    /// 在构造请求时填入估算值)。
+    pub on_progress: Box<dyn Fn(u64, u64) + Send + 'a>,
+}
+
+/// 下载到 `.part` → 校验 sha256 → 原子 `rename` 到 `dest`。
+///
+/// 失败语义:取消 / 网络错误 / 超长 / sha256 不匹配 时删除 `.part` 后返回 `Err`。
+/// 成功时 `dest` 就绪、`.part` 已被 `rename` 消费。
+pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Result<(), String> {
+    // 下载开始前先查一次取消(与 voice 原循环语义一致)。
+    if (req.is_cancelled)() {
+        let _ = std::fs::remove_file(req.part);
+        return Err("已取消".to_string());
+    }
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::default())
+        .build()
+        .map_err(|e| format!("创建下载客户端失败: {e}"))?;
+    let response = client
+        .get(req.url)
+        .send()
+        .await
+        .map_err(|e| format!("连接下载源失败: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("下载源响应异常: {e}"))?;
+
+    // 上限以 max_bytes 为准:Content-Length 申报超限直接拒。
+    let total = response
+        .content_length()
+        .filter(|n| *n > 0)
+        .unwrap_or(req.max_bytes);
+    if total > req.max_bytes {
+        let _ = std::fs::remove_file(req.part);
+        return Err(format!("下载内容超过 {} 字节上限", req.max_bytes));
+    }
+
+    use futures_util::StreamExt;
+    let mut stream = response.bytes_stream();
+    let mut file =
+        std::fs::File::create(req.part).map_err(|e| format!("创建下载暂存文件失败: {e}"))?;
+    let mut downloaded: u64 = 0;
+    while let Some(chunk) = stream
+        .next()
+        .await
+        .transpose()
+        .map_err(|e| format!("下载中断: {e}"))?
+    {
+        // 写盘后查取消(与原实现一致:已写的不丢,但停止接收后续 chunk)。
+        use std::io::Write;
+        file.write_all(&chunk)
+            .map_err(|e| format!("写盘失败: {e}"))?;
+        downloaded = downloaded.saturating_add(chunk.len() as u64);
+        if downloaded > req.max_bytes {
+            drop(file);
+            let _ = std::fs::remove_file(req.part);
+            return Err(format!("下载内容超过 {} 字节上限", req.max_bytes));
+        }
+        (req.on_progress)(downloaded, total);
+        if (req.is_cancelled)() {
+            drop(file);
+            let _ = std::fs::remove_file(req.part);
+            return Err("已取消".to_string());
+        }
+    }
+    // 刷盘后再做校验(rename 前确保数据落盘)。
+    file.sync_all()
+        .map_err(|e| format!("同步下载文件失败: {e}"))?;
+    drop(file);
+
+    // sha256 校验:空串跳过(与 knowledge/voice 的 dev 兜底一致)。
+    if !req.expected_sha256.trim().is_empty() {
+        let got = crate::platform::hashing::sha256_file(req.part)
+            .map_err(|e| format!("读取下载文件失败: {e}"))?;
+        if !got.eq_ignore_ascii_case(req.expected_sha256) {
+            let _ = std::fs::remove_file(req.part);
+            return Err(format!(
+                "下载校验失败(expected {}, got {})",
+                req.expected_sha256, got
+            ));
+        }
+    }
+
+    // 校验后再查一次取消(rename 是不可逆的最后一步)。
+    if (req.is_cancelled)() {
+        let _ = std::fs::remove_file(req.part);
+        return Err("已取消".to_string());
+    }
+
+    if let Some(parent) = req.dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("创建目标目录失败: {e}"))?;
+    }
+    if req.dest.exists() {
+        let _ = std::fs::remove_file(req.dest);
+    }
+    std::fs::rename(req.part, req.dest).map_err(|e| format!("保存下载文件失败: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    /// "hello world" 的 sha256。
+    const HELLO_SHA: &str = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    /// "abc" 的 sha256。
+    const ABC_SHA: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    fn scratch_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "pinvou3_download_test_{label}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        dir
+    }
+
+    /// 用 `std::net::TcpListener` 起一个最小 HTTP/1.1 fixture(不触网、不新增 mockito):
+    /// 接受一次连接,返回固定 body,然后退出。
+    fn serve_once(body: Vec<u8>) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let url = format!("http://{addr}/payload");
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                // 读请求行/头(忽略内容,读到空行或阻塞即可)。
+                let mut buf = [0u8; 1024];
+                let _ = std::io::Read::read(&mut stream, &mut buf);
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+            }
+        });
+        (url, handle)
+    }
+
+    fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + 'a> {
+        Box::new(|| false)
+    }
+    fn noop_progress<'a>() -> Box<dyn Fn(u64, u64) + Send + 'a> {
+        Box::new(|_, _| {})
+    }
+
+    #[tokio::test]
+    async fn happy_path_downloads_verifies_and_renames() {
+        let dir = scratch_dir("happy");
+        let body = b"hello world".to_vec();
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: HELLO_SHA,
+            max_bytes: 1024,
+            is_cancelled: never_cancel(),
+            on_progress: noop_progress(),
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_ok(), "err = {:?}", result.err());
+        assert!(dest.exists(), "dest should exist after rename");
+        assert!(!part.exists(), "part should be consumed");
+        assert_eq!(std::fs::read(&dest).unwrap(), body);
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn sha256_mismatch_returns_err_and_cleans_part() {
+        let dir = scratch_dir("mismatch");
+        let (url, handle) = serve_once(b"abc".to_vec());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: HELLO_SHA, // 故意不匹配 "abc"
+            max_bytes: 1024,
+            is_cancelled: never_cancel(),
+            on_progress: noop_progress(),
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_err());
+        assert!(!part.exists(), "part should be cleaned on mismatch");
+        assert!(!dest.exists(), "dest should not exist on mismatch");
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn empty_sha256_skips_verification() {
+        let dir = scratch_dir("skip");
+        let body = b"abc".to_vec();
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: "", // 跳过校验(dev 兜底)
+            max_bytes: 1024,
+            is_cancelled: never_cancel(),
+            on_progress: noop_progress(),
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_ok(), "err = {:?}", result.err());
+        assert_eq!(std::fs::read(&dest).unwrap(), body);
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn cancellation_mid_download_aborts_and_cleans_part() {
+        let dir = scratch_dir("cancel");
+        // 构造一个足够大的 body,使 chunk 循环能跑到取消点。
+        let body = vec![0u8; 64 * 1024];
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let flag = Arc::new(AtomicBool::new(false));
+        // 进度回调:第一次推进后置位取消。
+        let cancel = Arc::clone(&flag);
+        let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |_d, _t| {
+            cancel.store(true, Ordering::SeqCst);
+        });
+        let is_cancelled: Box<dyn Fn() -> bool + Send> = {
+            let f = Arc::clone(&flag);
+            Box::new(move || f.load(Ordering::SeqCst))
+        };
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: "",
+            max_bytes: 10 * 1024 * 1024,
+            is_cancelled,
+            on_progress,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "已取消");
+        assert!(!part.exists(), "part should be cleaned on cancel");
+        assert!(!dest.exists(), "dest should not exist on cancel");
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn content_length_over_max_bytes_is_rejected() {
+        let dir = scratch_dir("toolong");
+        let body = vec![0u8; 2048];
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: ABC_SHA,
+            max_bytes: 1024, // body 2048 > 上限 → Content-Length 即拒
+            is_cancelled: never_cancel(),
+            on_progress: noop_progress(),
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("上限"),
+            "should mention size cap"
+        );
+        assert!(!part.exists());
+        assert!(!dest.exists());
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -39,12 +39,49 @@ pub struct DownloadRequest<'a> {
     /// 进度回调 `(downloaded, total)`。`total` 为 `Content-Length`(缺省/为 0 时由调用方
     /// 在构造请求时填入估算值)。
     pub on_progress: Box<dyn Fn(u64, u64) + Send + 'a>,
+    /// 下载流完成(`sync_all` 后)、sha256 校验**开始前**触发的一次性回调。
+    /// 用于在原始时点(下载完成 → verify 事件 → 校验)emit `verify` 进度事件,恢复
+    /// 「下载 0–95% → verify → done」的 frontend 事件顺序。`None` = 不触发。
+    pub on_pre_verify: Option<Box<dyn FnOnce() + Send + 'a>>,
+}
+
+/// `.part` 清理守卫:覆盖所有非成功退出路径(取消 / 网络错误 / 超长 / sha256 不匹配 /
+/// 目录创建失败 / rename 失败)的 `.part` 删除。成功路径(`rename` 已消费 `.part`)调用
+/// [`PartGuard::disarm`] 解除,Drop 时不再删除。
+///
+/// 必须声明在使用 `.part` 的 `File` 句柄**之前**,以保证 Drop 顺序为 file 先于 guard
+/// (Windows 上文件句柄未关闭会导致 `remove_file` 失败)。
+struct PartGuard<'a> {
+    part: &'a Path,
+    armed: bool,
+}
+
+impl<'a> PartGuard<'a> {
+    fn new(part: &'a Path) -> Self {
+        Self { part, armed: true }
+    }
+    /// 标记成功:`.part` 已被 `rename` 消费为 `dest`,Drop 时跳过删除。
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<'a> Drop for PartGuard<'a> {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = std::fs::remove_file(self.part);
+        }
+    }
 }
 
 /// 下载到 `.part` → 校验 sha256 → 原子 `rename` 到 `dest`。
 ///
-/// 失败语义:取消 / 网络错误 / 超长 / sha256 不匹配 时删除 `.part` 后返回 `Err`。
-/// 成功时 `dest` 就绪、`.part` 已被 `rename` 消费。
+/// 失败语义:取消 / 网络错误 / 超长 / sha256 不匹配 / 目录创建失败 / rename 失败 时,
+/// 由 [`PartGuard`] 删除 `.part` 后返回 `Err`。成功时 `dest` 就绪、`.part` 已被 `rename`
+/// 消费(守卫已 `disarm`,不会误删)。
+///
+/// 事件顺序:`on_progress`(下载中,0–95%)→ `on_pre_verify`(下载完成、校验开始前,
+/// 用于 emit `verify`)→ 校验 → rename → done。该顺序恢复重构前的 frontend 事件时序。
 pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Result<(), String> {
     // 下载开始前先查一次取消(与 voice 原循环语义一致)。
     if (req.is_cancelled)() {
@@ -65,7 +102,8 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
         .error_for_status()
         .map_err(|e| format!("下载源响应异常: {e}"))?;
 
-    // 上限以 max_bytes 为准:Content-Length 申报超限直接拒。
+    // 上限以 max_bytes 为准:Content-Length 申报超限直接拒(此时 `.part` 尚未创建,
+    // 仍清理一次以兜底历史残留)。
     let total = response
         .content_length()
         .filter(|n| *n > 0)
@@ -77,6 +115,9 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
 
     use futures_util::StreamExt;
     let mut stream = response.bytes_stream();
+    // 清理守卫:从此处起任何 `Err` 退出都会删除 `.part`。声明在 `file` 之前,使 Drop
+    // 顺序为 file 先于 guard(Windows 文件句柄未关闭时 remove 会失败)。
+    let mut guard = PartGuard::new(req.part);
     let mut file =
         std::fs::File::create(req.part).map_err(|e| format!("创建下载暂存文件失败: {e}"))?;
     let mut downloaded: u64 = 0;
@@ -92,14 +133,10 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
             .map_err(|e| format!("写盘失败: {e}"))?;
         downloaded = downloaded.saturating_add(chunk.len() as u64);
         if downloaded > req.max_bytes {
-            drop(file);
-            let _ = std::fs::remove_file(req.part);
             return Err(format!("下载内容超过 {} 字节上限", req.max_bytes));
         }
         (req.on_progress)(downloaded, total);
         if (req.is_cancelled)() {
-            drop(file);
-            let _ = std::fs::remove_file(req.part);
             return Err("已取消".to_string());
         }
     }
@@ -108,12 +145,17 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
         .map_err(|e| format!("同步下载文件失败: {e}"))?;
     drop(file);
 
+    // 下载流已完成、校验即将开始:触发调用方的 `verify` 进度事件,恢复重构前的
+    // frontend 事件顺序(下载 0–95% → verify → 校验 → done)。
+    if let Some(on_pre_verify) = req.on_pre_verify {
+        on_pre_verify();
+    }
+
     // sha256 校验:空串跳过(与 knowledge/voice 的 dev 兜底一致)。
     if !req.expected_sha256.trim().is_empty() {
         let got = crate::platform::hashing::sha256_file(req.part)
             .map_err(|e| format!("读取下载文件失败: {e}"))?;
         if !got.eq_ignore_ascii_case(req.expected_sha256) {
-            let _ = std::fs::remove_file(req.part);
             return Err(format!(
                 "下载校验失败(expected {}, got {})",
                 req.expected_sha256, got
@@ -123,7 +165,6 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
 
     // 校验后再查一次取消(rename 是不可逆的最后一步)。
     if (req.is_cancelled)() {
-        let _ = std::fs::remove_file(req.part);
         return Err("已取消".to_string());
     }
 
@@ -134,6 +175,8 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
         let _ = std::fs::remove_file(req.dest);
     }
     std::fs::rename(req.part, req.dest).map_err(|e| format!("保存下载文件失败: {e}"))?;
+    // rename 成功:`.part` 已被消费为 `dest`,解除守卫,避免 Drop 时误删。
+    guard.disarm();
     Ok(())
 }
 
@@ -182,6 +225,34 @@ mod tests {
         (url, handle)
     }
 
+    /// 起 HTTP/1.1 fixture,但声明的 `Content-Length` 大于实际发送字节数后立即断连,
+    /// 使 reqwest 流式读取中途报错(下载中断)。用于验证 `.part` 在网络中途错误时被清理
+    /// (Finding 2 的 Drop 守卫契约)。
+    fn serve_truncated(
+        declared_len: usize,
+        send_bytes: usize,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let url = format!("http://{addr}/payload");
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut buf = [0u8; 1024];
+                let _ = std::io::Read::read(&mut stream, &mut buf);
+                let header = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    declared_len
+                );
+                let _ = stream.write_all(header.as_bytes());
+                let body = vec![0u8; send_bytes];
+                let _ = stream.write_all(&body);
+                let _ = stream.flush();
+                // 故意不发完声明的字节数就关闭连接 → hyper 报 IncompleteMessage。
+            }
+        });
+        (url, handle)
+    }
+
     fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + 'a> {
         Box::new(|| false)
     }
@@ -207,6 +278,7 @@ mod tests {
             max_bytes: 1024,
             is_cancelled: never_cancel(),
             on_progress: noop_progress(),
+            on_pre_verify: None,
         };
         let result = download_to_part_with_verify(req).await;
 
@@ -235,6 +307,7 @@ mod tests {
             max_bytes: 1024,
             is_cancelled: never_cancel(),
             on_progress: noop_progress(),
+            on_pre_verify: None,
         };
         let result = download_to_part_with_verify(req).await;
 
@@ -263,6 +336,7 @@ mod tests {
             max_bytes: 1024,
             is_cancelled: never_cancel(),
             on_progress: noop_progress(),
+            on_pre_verify: None,
         };
         let result = download_to_part_with_verify(req).await;
 
@@ -302,6 +376,7 @@ mod tests {
             max_bytes: 10 * 1024 * 1024,
             is_cancelled,
             on_progress,
+            on_pre_verify: None,
         };
         let result = download_to_part_with_verify(req).await;
 
@@ -331,6 +406,7 @@ mod tests {
             max_bytes: 1024, // body 2048 > 上限 → Content-Length 即拒
             is_cancelled: never_cancel(),
             on_progress: noop_progress(),
+            on_pre_verify: None,
         };
         let result = download_to_part_with_verify(req).await;
 
@@ -341,6 +417,93 @@ mod tests {
         );
         assert!(!part.exists());
         assert!(!dest.exists());
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn network_error_mid_download_cleans_part() {
+        let dir = scratch_dir("neterr");
+        // 声明 8 KiB 但只发 1 KiB 就断连 → reqwest 流式读取中途报错(下载中断)。
+        let (url, handle) = serve_truncated(8 * 1024, 1024);
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: "",
+            max_bytes: 1024 * 1024,
+            is_cancelled: never_cancel(),
+            on_progress: noop_progress(),
+            on_pre_verify: None,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_err(), "err = {:?}", result.err());
+        assert!(
+            !part.exists(),
+            "part must be cleaned on mid-download network error (Finding 2)"
+        );
+        assert!(!dest.exists());
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn on_pre_verify_fires_after_download_before_rename() {
+        // Finding 1:`verify` 必须在下载完成后、校验/rename 前触发(恢复重构前时序)。
+        // 用共享 Vec 记录事件顺序,断言 verify 出现在最后一条 download 进度之后、
+        // 且 helper 返回 Ok(rename 成功)。
+        let dir = scratch_dir("preverify");
+        let body = vec![0u8; 64 * 1024];
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        let events = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let total_hint = body.len() as u64;
+        let ev_progress = Arc::clone(&events);
+        let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |d, t| {
+            if d >= t || d >= total_hint {
+                ev_progress.lock().unwrap().push(format!("progress:{d}"));
+            }
+        });
+        let ev_verify = Arc::clone(&events);
+        let on_pre_verify: Option<Box<dyn FnOnce() + Send>> = Some(Box::new(move || {
+            ev_verify.lock().unwrap().push("verify".to_string());
+        }));
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: "",
+            max_bytes: 1024 * 1024,
+            is_cancelled: never_cancel(),
+            on_progress,
+            on_pre_verify,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(result.is_ok(), "err = {:?}", result.err());
+        let events = events.lock().unwrap();
+        let last_progress = events.iter().rposition(|e| e.starts_with("progress"));
+        let verify_idx = events.iter().position(|e| e == "verify");
+        assert!(
+            last_progress.is_some(),
+            "should have emitted download progress"
+        );
+        assert!(
+            verify_idx.is_some_and(|v| v > last_progress.unwrap()),
+            "verify must fire AFTER last download progress, got events = {:?}",
+            *events
+        );
         handle.join().unwrap();
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -281,11 +281,11 @@ pub(crate) async fn download_to_part_with_verify(
     .await
     .map_err(|e| format!("下载校验任务异常: {e}"))?;
 
-    // 校验后再查一次取消(rename 是不可逆的最后一步)。
-    if (req.is_cancelled)() {
-        return Err("已取消".to_string());
-    }
-
+    // 成功的 `rename` 就是提交点:阻塞任务内已在 rename **前**查过取消(校验期间取消
+    // 会在提升文件前中止),闭包成功返回即代表 `.part` 已原子提升为正式 `dest`。
+    // 此后再观察到取消**不得**改变返回值——否则会出现「报告已取消但 dest 已存在」
+    // 的返回值与磁盘状态不一致(voice 不登记校验缓存、knowledge 跳过部署,文件却已
+    // 就位)。故这里直接透传闭包结果并解除守卫,不再查取消。
     result?;
     // rename 成功:`.part` 已被消费为 `dest`,解除守卫,避免 Drop 时误删。
     guard.disarm();
@@ -580,6 +580,55 @@ mod tests {
             !dest.exists(),
             "dest must NOT be promoted after verify-stage cancel"
         );
+        handle.join().unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// 第三轮复审 [P1]:`rename` 成功即提交点,提交后观察到取消**不得**改变返回值。
+    /// 用「dest 存在即取消」的谓词精确命中该窗口——下载/校验/rename 前 dest 均不
+    /// 存在(谓词返回 false),rename 原子完成后 dest 出现(谓词变为 true)。修复前
+    /// 闭包返回后的取消检查会命中该谓词,返回 `Err("已取消")` 却留下已安装 `dest`
+    /// (返回值与磁盘状态不一致);修复后 rename 即提交,helper 返回 `Ok`、`dest`
+    /// 就位、`.part` 已被消费。
+    #[tokio::test]
+    async fn cancel_flag_after_rename_is_commit_point() {
+        let dir = scratch_dir("commitpoint");
+        let body = b"hello world".to_vec();
+        let (url, handle) = serve_once(body.clone());
+        let part = dir.join("payload.part");
+        let dest = dir.join("payload");
+        let _ = std::fs::remove_file(&part);
+        let _ = std::fs::remove_file(&dest);
+
+        // 取消谓词 = dest 是否已存在:rename 前恒为 false,rename 完成后翻转为 true。
+        // 这精确覆盖「闭包内最后一次取消检查之后、提交完成之前」的竞态窗口。
+        let dest_probe = dest.clone();
+        let is_cancelled: std::sync::Arc<dyn Fn() -> bool + Send + Sync + 'static> =
+            Arc::new(move || dest_probe.exists());
+
+        let req = DownloadRequest {
+            url: &url,
+            dest: &dest,
+            part: &part,
+            expected_sha256: HELLO_SHA,
+            max_bytes: 1024,
+            total_hint: 1024,
+            is_cancelled,
+            user_agent: None,
+            on_progress: noop_progress(),
+            on_pre_verify: None,
+        };
+        let result = download_to_part_with_verify(req).await;
+
+        assert!(
+            result.is_ok(),
+            "successful rename is the commit point; cancel observed after it must not \
+             turn the result into Err(\"已取消\") with dest already present: {:?}",
+            result.err()
+        );
+        assert!(dest.exists(), "dest must be in place after commit");
+        assert_eq!(std::fs::read(&dest).unwrap(), body);
+        assert!(!part.exists(), "part must be consumed by rename");
         handle.join().unwrap();
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/pinvou3-app/src-tauri/src/platform/download.rs
+++ b/pinvou3-app/src-tauri/src/platform/download.rs
@@ -35,7 +35,12 @@ pub struct DownloadRequest<'a> {
     /// 设为 `u64::MAX` 等价于不设硬上限。
     pub max_bytes: u64,
     /// 取消谓词:返回 `true` 时中止下载并清理 `.part`。
-    pub is_cancelled: Box<dyn Fn() -> bool + Send + 'a>,
+    /// 需 `Sync` 以便在 `tokio::select!` 中与网络 future 并发轮询(恢复重构前
+    /// voice 的 `tokio::select!{ send(), wait_for_cancel() }` 响应性)。
+    pub is_cancelled: Box<dyn Fn() -> bool + Send + Sync + 'a>,
+    /// 可选 `User-Agent`。重构前 voice/knowledge 各自设置 `pinvou3-asr/1.0`、
+    /// `pinvou3-kb/1.0`;helper 通过该字段透传,`None` 时不设置。
+    pub user_agent: Option<&'a str>,
     /// 进度回调 `(downloaded, total)`。`total` 为 `Content-Length`(缺省/为 0 时由调用方
     /// 在构造请求时填入估算值)。
     pub on_progress: Box<dyn Fn(u64, u64) + Send + 'a>,
@@ -82,6 +87,14 @@ impl<'a> Drop for PartGuard<'a> {
 ///
 /// 事件顺序:`on_progress`(下载中,0–95%)→ `on_pre_verify`(下载完成、校验开始前,
 /// 用于 emit `verify`)→ 校验 → rename → done。该顺序恢复重构前的 frontend 事件时序。
+/// 取消轮询间隔,与重构前 voice 的 `ASR_CANCEL_POLL_INTERVAL` 一致(50ms)。
+///
+/// 重构前的 voice 下载用 `tokio::select!` 把 `client.get(url).send()` 与每个
+/// `resp.chunk()` 都包在 `wait_for_asr_cancel()` 轮询 future 上,这样取消标志翻转后
+/// 即便服务器中途停顿(无 chunk 到达)、或连接阶段卡住,也能在一个轮询周期内中止。
+/// helper 以闭包承载各调用方的取消源,这里在 select 分支内轮询该闭包恢复响应性。
+const CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
 pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Result<(), String> {
     // 下载开始前先查一次取消(与 voice 原循环语义一致)。
     if (req.is_cancelled)() {
@@ -89,18 +102,42 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
         return Err("已取消".to_string());
     }
 
-    let client = reqwest::Client::builder()
-        .connect_timeout(std::time::Duration::from_secs(15))
-        .redirect(reqwest::redirect::Policy::default())
-        .build()
-        .map_err(|e| format!("创建下载客户端失败: {e}"))?;
-    let response = client
-        .get(req.url)
-        .send()
-        .await
-        .map_err(|e| format!("连接下载源失败: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("下载源响应异常: {e}"))?;
+    let client = {
+        let mut builder = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(15))
+            .redirect(reqwest::redirect::Policy::default());
+        if let Some(ua) = req.user_agent {
+            builder = builder.user_agent(ua);
+        }
+        builder
+            .build()
+            .map_err(|e| format!("创建下载客户端失败: {e}"))?
+    };
+    let response = {
+        // 与重构前 voice 一致:连接阶段也用 select! 竞速取消轮询,
+        // 避免服务器响应慢时无法及时中止。轮询闭包每个 poll 周期重新借用 req,
+        // 不跨 await 持有,故对非 Sync 的取消源也安全。
+        let send_fut = client.get(req.url).send();
+        tokio::pin!(send_fut);
+        let result = tokio::select! {
+            result = &mut send_fut => result,
+            _ = async {
+                loop {
+                    if (req.is_cancelled)() {
+                        return;
+                    }
+                    tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
+                }
+            } => {
+                let _ = std::fs::remove_file(req.part);
+                return Err("已取消".to_string());
+            }
+        };
+        result
+            .map_err(|e| format!("连接下载源失败: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("下载源响应异常: {e}"))?
+    };
 
     // 上限以 max_bytes 为准:Content-Length 申报超限直接拒(此时 `.part` 尚未创建,
     // 仍清理一次以兜底历史残留)。
@@ -121,12 +158,29 @@ pub(crate) async fn download_to_part_with_verify(req: DownloadRequest<'_>) -> Re
     let mut file =
         std::fs::File::create(req.part).map_err(|e| format!("创建下载暂存文件失败: {e}"))?;
     let mut downloaded: u64 = 0;
-    while let Some(chunk) = stream
-        .next()
-        .await
-        .transpose()
-        .map_err(|e| format!("下载中断: {e}"))?
-    {
+    loop {
+        // 与重构前 voice 一致:每个 chunk 的到达也用 select! 竞速取消轮询,
+        // 这样服务器中途停顿(无 chunk 到达)时仍能在一个轮询周期内中止。
+        let chunk = {
+            let next_fut = stream.next();
+            tokio::pin!(next_fut);
+            tokio::select! {
+                item = &mut next_fut => item,
+                _ = async {
+                    loop {
+                        if (req.is_cancelled)() {
+                            return;
+                        }
+                        tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
+                    }
+                } => {
+                    return Err("已取消".to_string());
+                }
+            }
+        };
+        let Some(chunk) = chunk.transpose().map_err(|e| format!("下载中断: {e}"))? else {
+            break;
+        };
         // 写盘后查取消(与原实现一致:已写的不丢,但停止接收后续 chunk)。
         use std::io::Write;
         file.write_all(&chunk)
@@ -253,7 +307,7 @@ mod tests {
         (url, handle)
     }
 
-    fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + 'a> {
+    fn never_cancel<'a>() -> Box<dyn Fn() -> bool + Send + Sync + 'a> {
         Box::new(|| false)
     }
     fn noop_progress<'a>() -> Box<dyn Fn(u64, u64) + Send + 'a> {
@@ -277,6 +331,7 @@ mod tests {
             expected_sha256: HELLO_SHA,
             max_bytes: 1024,
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress: noop_progress(),
             on_pre_verify: None,
         };
@@ -306,6 +361,7 @@ mod tests {
             expected_sha256: HELLO_SHA, // 故意不匹配 "abc"
             max_bytes: 1024,
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress: noop_progress(),
             on_pre_verify: None,
         };
@@ -335,6 +391,7 @@ mod tests {
             expected_sha256: "", // 跳过校验(dev 兜底)
             max_bytes: 1024,
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress: noop_progress(),
             on_pre_verify: None,
         };
@@ -363,7 +420,7 @@ mod tests {
         let on_progress: Box<dyn Fn(u64, u64) + Send> = Box::new(move |_d, _t| {
             cancel.store(true, Ordering::SeqCst);
         });
-        let is_cancelled: Box<dyn Fn() -> bool + Send> = {
+        let is_cancelled: Box<dyn Fn() -> bool + Send + Sync> = {
             let f = Arc::clone(&flag);
             Box::new(move || f.load(Ordering::SeqCst))
         };
@@ -375,6 +432,7 @@ mod tests {
             expected_sha256: "",
             max_bytes: 10 * 1024 * 1024,
             is_cancelled,
+            user_agent: None,
             on_progress,
             on_pre_verify: None,
         };
@@ -405,6 +463,7 @@ mod tests {
             expected_sha256: ABC_SHA,
             max_bytes: 1024, // body 2048 > 上限 → Content-Length 即拒
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress: noop_progress(),
             on_pre_verify: None,
         };
@@ -438,6 +497,7 @@ mod tests {
             expected_sha256: "",
             max_bytes: 1024 * 1024,
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress: noop_progress(),
             on_pre_verify: None,
         };
@@ -486,6 +546,7 @@ mod tests {
             expected_sha256: "",
             max_bytes: 1024 * 1024,
             is_cancelled: never_cancel(),
+            user_agent: None,
             on_progress,
             on_pre_verify,
         };

--- a/pinvou3-app/src-tauri/src/platform/hashing.rs
+++ b/pinvou3-app/src-tauri/src/platform/hashing.rs
@@ -1,0 +1,68 @@
+//! 文件 sha256 摘要，供 voice/native_installer/knowledge 等多处复用。
+//!
+//! 与各调用方原实现等价：File::open → 1 MiB(或更大)缓冲循环 →
+//! crate::platform::encoding::hex_lower(finalize)。返回 io::Result，
+//! 由调用方各自转换为 Result<_, String> 以保留原中文错误文案。
+
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+/// 计算文件 sha256，返回小写十六进制字符串。
+pub(crate) fn sha256_file(path: &Path) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 1024 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(crate::platform::encoding::hex_lower(&hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 用 std::env::temp_dir 生成临时文件（**不新增 tempfile 依赖**——已确认
+    /// Cargo.toml 无 tempfile/mockito；遵循「新增依赖须告知用户」公约）。
+    fn scratch_file(name: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "pinvou3_hashing_test_{name}_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    #[test]
+    fn sha256_file_matches_known_vector() {
+        let p = scratch_file("hello");
+        std::fs::write(&p, b"hello world").unwrap();
+        // "hello world" 的 sha256:
+        let expect = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+        assert_eq!(sha256_file(&p).unwrap(), expect);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn sha256_file_missing_path_errors() {
+        let r = sha256_file(Path::new("/nonexistent/__definitely_not_here__"));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn sha256_file_empty_file() {
+        let p = scratch_file("empty");
+        std::fs::write(&p, b"").unwrap();
+        // 空文件的 sha256:
+        let expect = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        assert_eq!(sha256_file(&p).unwrap(), expect);
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/pinvou3-app/src-tauri/src/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/mod.rs
@@ -4,6 +4,7 @@ pub mod connector_state;
 pub mod credential_store;
 pub(crate) mod encoding;
 pub(crate) mod filesystem;
+pub(crate) mod hashing;
 pub(crate) mod notifications;
 pub(crate) mod os;
 pub(crate) mod path_policy;

--- a/pinvou3-app/src-tauri/src/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/mod.rs
@@ -13,6 +13,7 @@ pub mod paths;
 pub mod prefs;
 pub(crate) mod process;
 pub(crate) mod startup;
+pub(crate) mod strings;
 pub mod super_permission;
 pub(crate) mod ui_cache;
 pub(crate) mod window_startup;

--- a/pinvou3-app/src-tauri/src/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/mod.rs
@@ -2,6 +2,7 @@ pub mod app_events;
 pub(crate) mod capabilities;
 pub mod connector_state;
 pub mod credential_store;
+pub(crate) mod download;
 pub(crate) mod encoding;
 pub(crate) mod filesystem;
 pub(crate) mod hashing;

--- a/pinvou3-app/src-tauri/src/platform/strings.rs
+++ b/pinvou3-app/src-tauri/src/platform/strings.rs
@@ -1,0 +1,84 @@
+//! UTF-8 安全的字符串截断，供 audit（审计字段 ≤600 字节）与 harness
+//! （LLM prompt 各段字节上限）等处复用。
+//!
+//! 直接 `&s[..max_bytes]` 在 `max_bytes` 落在多字节字符（中文）中间时会 panic——
+//! 角色产出几乎全是中文，曾导致 `build_review_prompt` 在 `spawn_blocking` 里
+//! panic → turn 崩溃 → engine busy flag 永不复位 → 卡死（P0 根因）。所有按字节
+//! 切中文的地方都必须走这里。
+
+/// 按 UTF-8 char 边界向下取整截断 `s` 到 ≤ `max_bytes` 字节，返回前缀切片。
+///
+/// 收敛原 `harness::truncate_on_char_boundary` 与 `audit::clip`（硬编码 600），
+/// 两者实现完全一致（`while end > 0 && !s.is_char_boundary(end) { end -= 1 }`），
+/// 故语义零变化。
+pub(crate) fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_returns_empty() {
+        assert_eq!(truncate_utf8("", 0), "");
+        assert_eq!(truncate_utf8("", 10), "");
+    }
+
+    #[test]
+    fn all_ascii_truncates_at_byte_count() {
+        assert_eq!(truncate_utf8("hello world", 5), "hello");
+        // 整串不超过上限时原样返回。
+        assert_eq!(truncate_utf8("abc", 100), "abc");
+    }
+
+    #[test]
+    fn multibyte_truncates_when_max_is_on_boundary() {
+        // max_bytes 恰为 char 边界时不应回退。
+        let s = "abcd压"; // "abcd"=4 字节, '压'=3 字节
+        assert_eq!(truncate_utf8(s, 4), "abcd");
+        assert_eq!(truncate_utf8(s, 7), "abcd压");
+    }
+
+    #[test]
+    fn max_inside_multibyte_char_falls_back_to_boundary() {
+        // max_bytes 落在 '压'（3 字节）中间(5,6) → 回退到 4。
+        let s = "abcd压";
+        assert_eq!(truncate_utf8(s, 5), "abcd");
+        assert_eq!(truncate_utf8(s, 6), "abcd");
+        assert!(truncate_utf8(s, 5).is_char_boundary(truncate_utf8(s, 5).len()));
+    }
+
+    #[test]
+    fn never_panics_on_chinese_char_boundary() {
+        // 复现 P0 根因:大纲是中文,直接 &s[..2000] 会切在多字节字符中间 panic。
+        // 构造一个 byte 2000 恰好落在某个 3 字节汉字中间的串。
+        let mut s = String::from("# 中国人口发展趋势分析 — 大纲\n");
+        while s.len() < 2100 {
+            s.push_str("总人口降至14.09亿，老龄化压力持续加大；");
+        }
+        assert!(s.len() > 2000);
+        let out = truncate_utf8(&s, 2000);
+        assert!(out.len() <= 2000);
+        assert!(s.starts_with(out));
+        // 返回值本身必须是合法 UTF-8(能再被切片/打印而不 panic)。
+        let _ = format!("{out}...");
+    }
+
+    #[test]
+    fn audit_clip_600_semantics_preserved() {
+        // 原 audit::clip 的 600 硬编码契约：中文字段截到 ≤600 字节且不切半字符。
+        let s = "中".repeat(300); // 900 字节
+        let c = truncate_utf8(&s, 600);
+        assert!(c.len() <= 600);
+        assert!(c.chars().all(|ch| ch == '中'));
+        assert_eq!(truncate_utf8("short", 600), "short");
+    }
+}


### PR DESCRIPTION
## 背景

全仓 Rust 深度审计（`docs/rust-deep-refactor-设计.md`）识别出多处真实重复与可复用 helper。
本 PR 是三波重构的第一波——**在拆分 god-module（Wave 2）之前，先落地共享原语**，为后续拆分提供被复用的 helper。
强度：激进；落地：每模块/集群一个 PR；本波为 Wave 1，全部低风险。

## 变更（7 个任务，10 个提交）

| 任务 | 内容 |
|---|---|
| **1a** | 新增 `platform::hashing::sha256_file`，迁移 3 处真实重复（native_installer/voice_asr/model_download）；`files.rs:226`（内存 bytes）与 `workspace.rs:749`（指纹嵌入）因形态不等价、不在范围 |
| **1b** | 新增 `platform::download`（流式+校验+原子提升+取消，闭包承载取消/进度差异）；迁移 voice/knowledge；native_installer 因同步 `reqwest::blocking` 形态不匹配、有意保留 |
| **1c** | `prelude::require_active_sid`，收敛 14 处 `ok_or_else("no active session")`（workflows 7/interaction 5/memory 1/chat 1） |
| **1d** | 泛型 `VersionedJsonStore<T>` + `VersionedRegistry` trait，合并 scheduled 三同构 store；sessions `persist_then_reconcile` 收敛 13 处保留再协调尾部 |
| **1e** | `IngestResult` 构造器（warning/with_markdown/placeholder），替换 30/35 处字面量；5 处因 markdown+warning 均为独立运行时变量、无单一构造器可表达、保留 |
| **1f** | `ConnectorSkillGate` trait + 默认实现，收敛 4 连接器（tmeet/dingtalk/feishu/wecom）技能门控四元组 |
| **1g** | `platform::strings::truncate_utf8`，统一 `harness::truncate_on_char_boundary` 与 `audit::clip`；额外发现 engine.rs 5 处 `clip` 调用一并迁移 |

## 两处已批准的行为微调

设计已显式批准本波以下两处非纯行为保持，PR 正文据此披露：

- **1f**：feishu/wecom 的 `set_*_disabled_flag` 由 `()` 统一为 `Result<(), String>`（写失败从静默忽略改为传播）。6 处上游调用点（feishu.rs:339/355/357、wecom.rs:252/266/268）已适配 `?`；`refresh_connector_auth_gates`（读路径）不受影响。
- **1b**：native_installer 未迁移（同步 `reqwest::blocking` 在 `spawn_blocking` 线程上，调 async helper 会嵌套运行时）。

## 实际验证

- \`python3 scripts/architecture-guard.py\`：**PASS**，基线保持为空（无新增架构债）
- \`cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check\`：clean
- \`cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib\`：PASS
- \`cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1\`：**878 passed / 0 failed / 12 ignored**
- \`./scripts/fork-guard.sh --fast\`：PASS（13 条 \`APP|\` 指纹全过；\`run_now_shared\`、\`send(Op::CompactContext\` 指纹在位）
- 已 rebase 至最新 \`origin/main\`（09c7d283），rebase 后重跑全量验证通过
- 每个 helper 配套单测（sha256 已知向量/空文件/缺失、download happy/mismatch/cancel/pre-verify 时序/清理契约、truncate UTF-8 边界/中文 P0 回归、VersionedJsonStore 五臂 match、ConnectorSkillGate 往返）

## 已知风险

- Wave 1 为共享底座，Wave 2 拆分将直接消费本波 helper；若本波有未发现的行为偏差，影响面会在 Wave 2 放大。已通过逐任务评审 + 全分支评审两道关把控。
- 4 处 LOW 级日志文案漂移（1d RunRead LABEL、双 engine-state label、1f 英文 id 代替中文显示名）经全分支评审判定为「可接受、非阻塞」，均为罕见失败路径、无测试依赖；如需完美归因可在后续小 PR 打磨。

## 范围

仅 \`pinvou3-app/src-tauri/src/\`（24 文件）。未触及 \`CodeWhale/\` submodule、前端、\`remote-control-relay/\`。

## 后续

Wave 2（god-module 按职责拆分）与 Wave 3（跨层迁移与行为清理）计划将在本波合入后按实际 helper 签名编写。