### PR TITLE
fix: 修正模型选择器显示实际模型

### DIFF
--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -41,7 +41,8 @@ import { assistantResponseAvailable, assistantResponseText } from '../conversati
 import {
   ComposerToolMenu,
 } from '../settings/SettingsView.jsx';
-import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
+import { visibleUserModels } from '../../shared/model-options.js';
+import { selectorMainLabel } from '../settings/model-catalog.js';
 import { isNearConversationBottom } from '../conversation/conversation-model.js';
 import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
 import { PlanLayer, cardBoxCls, cardBtnCls } from '../tools/tool-renderers.jsx';
@@ -1242,7 +1243,7 @@ export function CodexAcpView({
     ? nativeControls.mode
     : (activeId ? 'yolo' : (nativeDraftControls.mode || 'yolo'));
   const nativeModelChoices = visibleUserModels((bs && bs.savedModels) || [])
-    .map(model => ({ value: model.id, name: modelDisplayName(model) || model.id }));
+    .map(model => ({ value: model.id, name: selectorMainLabel(model, t) || model.id }));
   const nativeSessionModelId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.modelId : null)
     : (nativeDraftControls.modelId || null);

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -41,7 +41,7 @@ import { assistantResponseAvailable, assistantResponseText } from '../conversati
 import {
   ComposerToolMenu,
 } from '../settings/SettingsView.jsx';
-import { visibleUserModels } from '../../shared/model-options.js';
+import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
 import { isNearConversationBottom } from '../conversation/conversation-model.js';
 import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
 import { PlanLayer, cardBoxCls, cardBtnCls } from '../tools/tool-renderers.jsx';
@@ -1242,7 +1242,7 @@ export function CodexAcpView({
     ? nativeControls.mode
     : (activeId ? 'yolo' : (nativeDraftControls.mode || 'yolo'));
   const nativeModelChoices = visibleUserModels((bs && bs.savedModels) || [])
-    .map(model => ({ value: model.id, name: model.name || model.id }));
+    .map(model => ({ value: model.id, name: modelDisplayName(model) || model.id }));
   const nativeSessionModelId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.modelId : null)
     : (nativeDraftControls.modelId || null);

--- a/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
+++ b/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 import { Check, ChevronDown, ChevronRight, ClipboardCheck, Clock, FileChartLine, MessageCircle, Newspaper, Play, Plus, Trash2, X } from '../../components/icons.jsx';
 import { bridge, useBridgeState } from '../../hooks/useBridge.js';
-import { visibleUserModels } from '../../shared/model-options.js';
+import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
 import { can } from '../../shared/platform.js';
 import dailyBriefImage from '../../assets/scheduled/daily-brief.jpg';
 import followUpMonitorImage from '../../assets/scheduled/follow-up-monitor.jpg';
@@ -955,7 +955,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
 
       const modelOptions = savedModels.map(model => ({
         value: model.id,
-        label: model.name && model.name !== model.model ? `${model.name} · ${model.model}` : model.model,
+        label: modelDisplayName(model),
         model: model.model,
       }));
       if (detailForm && detailForm.modelId && !modelOptions.some(option => option.value === detailForm.modelId)) {

--- a/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
+++ b/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal, flushSync } from 'react-dom';
 import { Check, ChevronDown, ChevronRight, ClipboardCheck, Clock, FileChartLine, MessageCircle, Newspaper, Play, Plus, Trash2, X } from '../../components/icons.jsx';
 import { bridge, useBridgeState } from '../../hooks/useBridge.js';
-import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
+import { visibleUserModels } from '../../shared/model-options.js';
+import { selectorMainLabel } from '../settings/model-catalog.js';
 import { can } from '../../shared/platform.js';
 import dailyBriefImage from '../../assets/scheduled/daily-brief.jpg';
 import followUpMonitorImage from '../../assets/scheduled/follow-up-monitor.jpg';
@@ -955,7 +956,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
 
       const modelOptions = savedModels.map(model => ({
         value: model.id,
-        label: modelDisplayName(model),
+        label: selectorMainLabel(model, t),
         model: model.model,
       }));
       if (detailForm && detailForm.modelId && !modelOptions.some(option => option.value === detailForm.modelId)) {

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -5,7 +5,7 @@ import { VllmSetupProgress } from '../../components/VllmSetupProgress.jsx';
 import PetSettingsSection from '../pet/PetSettingsSection.jsx';
 import { DEFAULT_PET_ID } from '../pet/pet-registry.js';
 import { bridge, isLocalModel } from '../../hooks/useBridge.js';
-import { visibleUserModels } from '../../shared/model-options.js';
+import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
 import { can, isWeb } from '../../shared/platform.js';
 import { buildComposerToolMenuState } from './composer-tool-menu-logic.js';
 import { notifyComposerToolsChanged } from '../tools/tool-events.js';
@@ -498,7 +498,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
             title={busy ? t.modelSwitchBusy : t.switchModelTitle}
             className={`inline-flex items-center gap-1.5 pl-3 pr-2 py-1 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50 ${isDark ? 'bg-[#2A2B2D] text-[#E3E3E3] hover:bg-[#333537]' : 'bg-[#EAEDF1] text-[#1F1F1F] hover:bg-[#E0E3E7]'}`}>
             <span className="w-1.5 h-1.5 rounded-full bg-[#34A853]"></span>
-            <span className="max-w-[220px] truncate">{current ? current.name : t.modelNonePick}</span>
+            <span className="max-w-[220px] truncate">{current ? modelDisplayName(current) : t.modelNonePick}</span>
             <ChevronDown size={13} />
           </button>
           {open && canSwitchModels && (
@@ -510,8 +510,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
                     className={`w-full flex items-center gap-2 px-3 py-2 text-left transition-colors ${isDark ? 'hover:bg-[#2A2B2D]' : 'hover:bg-[#F0F4F9]'}`}>
                     <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${m.id === effectiveId ? 'bg-[#34A853]' : 'bg-transparent'}`}></span>
                     <span className="flex-1 min-w-0">
-                      <span className={`block text-[13px] truncate ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{m.name}</span>
-                      <span className={`block text-[11px] truncate ${isDark ? 'text-[#9AA0A6]' : 'text-[#5F6368]'}`}>{m.model}</span>
+                      <span className={`block text-[13px] truncate ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{modelDisplayName(m)}</span>
                     </span>
                     {m.id === activeModelId && <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${isDark ? 'bg-[#37393B] text-[#9AA0A6]' : 'bg-[#E8EAED] text-[#5F6368]'}`}>{t.modelActiveTag}</span>}
                   </button>
@@ -1335,7 +1334,9 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
       const modalTitle = initial.__new
         ? (isCodingPlan ? settingsCopy.addProvider(selectedProvider) : t.modelFormAddTitle)
         : (isCodingPlan ? settingsCopy.editProvider(selectedProvider) : t.modelFormEditTitle);
-      const saveName = name.trim() || (isLocalPreset ? settingsCopy.localModelName(model.trim()) : (model.trim() ? model.trim() : selectedProvider));
+      const saveName = showDisplayNameField
+        ? (name.trim() || settingsCopy.localModelName(model.trim()))
+        : (isLocalPreset ? (name.trim() || settingsCopy.localModelName(model.trim())) : (model.trim() || selectedProvider));
       const credentialState = initial.credential_state || (initial.has_secret ? 'configured' : 'missing');
       const hasSavedKey = !!initial.has_secret || credentialState === 'configured' || credentialState === 'env_override';
       const keyStatusText = credentialState === 'env_override' ? t.credEnvOverride

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -5,7 +5,7 @@ import { VllmSetupProgress } from '../../components/VllmSetupProgress.jsx';
 import PetSettingsSection from '../pet/PetSettingsSection.jsx';
 import { DEFAULT_PET_ID } from '../pet/pet-registry.js';
 import { bridge, isLocalModel } from '../../hooks/useBridge.js';
-import { modelDisplayName, visibleUserModels } from '../../shared/model-options.js';
+import { visibleUserModels } from '../../shared/model-options.js';
 import { can, isWeb } from '../../shared/platform.js';
 import { buildComposerToolMenuState } from './composer-tool-menu-logic.js';
 import { notifyComposerToolsChanged } from '../tools/tool-events.js';
@@ -498,7 +498,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
             title={busy ? t.modelSwitchBusy : t.switchModelTitle}
             className={`inline-flex items-center gap-1.5 pl-3 pr-2 py-1 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50 ${isDark ? 'bg-[#2A2B2D] text-[#E3E3E3] hover:bg-[#333537]' : 'bg-[#EAEDF1] text-[#1F1F1F] hover:bg-[#E0E3E7]'}`}>
             <span className="w-1.5 h-1.5 rounded-full bg-[#34A853]"></span>
-            <span className="max-w-[220px] truncate">{current ? modelDisplayName(current) : t.modelNonePick}</span>
+            <span className="max-w-[220px] truncate">{current ? selectorMainLabel(current, t) : t.modelNonePick}</span>
             <ChevronDown size={13} />
           </button>
           {open && canSwitchModels && (
@@ -510,7 +510,8 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
                     className={`w-full flex items-center gap-2 px-3 py-2 text-left transition-colors ${isDark ? 'hover:bg-[#2A2B2D]' : 'hover:bg-[#F0F4F9]'}`}>
                     <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${m.id === effectiveId ? 'bg-[#34A853]' : 'bg-transparent'}`}></span>
                     <span className="flex-1 min-w-0">
-                      <span className={`block text-[13px] truncate ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{modelDisplayName(m)}</span>
+                      <span className={`block text-[13px] truncate ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{selectorMainLabel(m, t)}</span>
+                      <span className={`block text-[11px] truncate ${isDark ? 'text-[#9AA0A6]' : 'text-[#5F6368]'}`}>{selectorSubLabel(m, t)}</span>
                     </span>
                     {m.id === activeModelId && <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${isDark ? 'bg-[#37393B] text-[#9AA0A6]' : 'bg-[#E8EAED] text-[#5F6368]'}`}>{t.modelActiveTag}</span>}
                   </button>

--- a/pinvou3-app/src/shared/model-options.js
+++ b/pinvou3-app/src/shared/model-options.js
@@ -2,4 +2,8 @@ function visibleUserModels(models) {
   return (models || []).filter(model => model && model.id);
 }
 
-export { visibleUserModels };
+function modelDisplayName(model) {
+  return (model && (model.model || model.name)) || '';
+}
+
+export { modelDisplayName, visibleUserModels };

--- a/pinvou3-app/src/shared/model-options.js
+++ b/pinvou3-app/src/shared/model-options.js
@@ -2,8 +2,4 @@ function visibleUserModels(models) {
   return (models || []).filter(model => model && model.id);
 }
 
-function modelDisplayName(model) {
-  return (model && (model.model || model.name)) || '';
-}
-
-export { modelDisplayName, visibleUserModels };
+export { visibleUserModels };

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -395,6 +395,11 @@ assert.ok(
   'scheduled model selection should use saved model ids and submit modelId with the wire model'
 );
 assert.ok(
+  /label:\s*modelDisplayName\(model\)/.test(indexHtml) &&
+    !/label:\s*model\.name && model\.name !== model\.model \?/.test(indexHtml),
+  'scheduled model selection should display the wire model instead of stale display names'
+);
+assert.ok(
   !/data-testid="scheduled-task-pin"/.test(indexHtml) &&
     !/data-testid="scheduled-task-actions"/.test(indexHtml) &&
     !/data-testid="scheduled-task-action-menu"/.test(indexHtml) &&

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -395,7 +395,7 @@ assert.ok(
   'scheduled model selection should use saved model ids and submit modelId with the wire model'
 );
 assert.ok(
-  /label:\s*modelDisplayName\(model\)/.test(indexHtml) &&
+  /label:\s*selectorMainLabel\(model, t\)/.test(indexHtml) &&
     !/label:\s*model\.name && model\.name !== model\.model \?/.test(indexHtml),
   'scheduled model selection should display the wire model instead of stale display names'
 );

--- a/pinvou3-app/tests/settings_ui_smoke.js
+++ b/pinvou3-app/tests/settings_ui_smoke.js
@@ -607,6 +607,7 @@ async function modalWidth(page, headingText) {
       && savedCodingPlan.provider_kind === 'coding_plan'
       && savedCodingPlan.vendor === 'glm'
       && savedCodingPlan.model === 'glm-5-turbo'
+      && savedCodingPlan.name === 'glm-5-turbo'
       && savedCodingPlan.base_url === 'https://open.bigmodel.cn/api/coding/paas/v4'
       && savedCodingPlan.api_key === 'sk-coding-plan'
       && savedCodingPlan.credential_action === 'replace',
@@ -745,7 +746,12 @@ async function modalWidth(page, headingText) {
     const call = [...window.__SETTINGS_TEST__.calls].reverse().find(item => item.cmd === 'save_model');
     return call && call.args && call.args.model;
   });
-  rec('⑦ 输入 API Key 后可保存新增模型', savedModel && savedModel.model === 'deepseek-v4-pro' && savedModel.api_key === 'sk-model-test', JSON.stringify(savedModel));
+  rec('⑦ 输入 API Key 后可保存新增模型',
+    savedModel
+      && savedModel.model === 'deepseek-v4-pro'
+      && savedModel.name === 'deepseek-v4-pro'
+      && savedModel.api_key === 'sk-model-test',
+    JSON.stringify(savedModel));
 
   await clickSettingsSection(page, '搜索');
   const searchList = await page.evaluate(() => {


### PR DESCRIPTION
## 概述

修正模型选择器优先展示 `name` 导致的误导问题，让聊天输入框和定时任务里的模型选择统一展示实际发往后端的 `model`。

## 改了什么

- 新增共享的 `modelDisplayName(model)`，统一以 `model.model` 作为模型显示名，缺失时再回退到 `name`。
- 聊天输入底部模型选择器、设置页旧版模型选择器、定时任务模型选择器改用同一显示逻辑。
- 保存隐藏显示名的云端模型时，将 `name` 写成当前实际 `model`，避免旧配置里 `name=deepseek-v4-pro`、`model=deepseek-v4-flash` 这类错位继续污染 UI。
- 增加设置页 smoke 和定时任务单测断言，覆盖模型保存与显示回归。

## 改动原因

用户保存或编辑模型后，真实请求使用 `model` 字段，但聊天输入底部选择器展示 `name` 字段。历史配置或编辑路径中如果 `name` 没同步到最新模型 ID，就会出现 UI 显示 `deepseek-v4-pro`、实际请求 `deepseek-v4-flash` 的错觉。

## 影响面

- 影响范围：`pinvou3-app` 前端模型选择展示、设置页模型保存、定时任务模型下拉展示。
- 兼容性：已有配置不迁移数据，只在 UI 展示时优先读实际 `model`；新增/编辑云端模型保存时同步 `name`。
- CodeWhale：未改动 gitlink 或 fork 行为，不涉及 fork inventory / fingerprint 更新。

## 验证

- `git ls-remote origin refs/heads/main`：确认 GitHub main 为 `09c7d2838f3af860321e888e18030e03be5087b6`。
- `git fetch origin main:refs/remotes/origin/main` + `git rev-parse origin/main`：本地 tracking ref 与 GitHub main SHA 一致。
- `npm --prefix pinvou3-app run lint:ui`：通过。
- `npm --prefix pinvou3-app run check:architecture`：通过，`architecture guard passed: no architecture debt increased`。
- `npm --prefix pinvou3-app run test:scheduled`：通过。
- `npm --prefix pinvou3-app run test:settings-ui`：通过，36 项 PASS。
- `npm --prefix pinvou3-app run build:ui`：通过；仅有既有 Vite 非 module script 打包提示和 chunk size warning。
- `git diff --check`：通过；仅有 Windows LF/CRLF 工作区提示。

## 风险矩阵

| 触发路径 | 可能后果 | 覆盖方式 | 状态 |
| --- | --- | --- | --- |
| 聊天输入底部模型选择器展示旧 `name` | 用户误以为实际请求的是另一个模型 | 共享 `modelDisplayName` + 设置页 smoke 覆盖新增模型保存 | 已覆盖 |
| 定时任务模型下拉展示 `name · model` | 定时任务配置页继续暴露陈旧名称 | `test:scheduled` 新增源码断言 | 已覆盖 |
| 云端模型保存时隐藏显示名但保留旧 `name` | 后续 UI 仍可能显示旧模型 ID | `test:settings-ui` 断言 `savedModel.name === savedModel.model` | 已覆盖 |

## 已知风险 / 未测范围

- 未运行完整 `npm --prefix pinvou3-app test` 全量套件；本次只覆盖模型设置、定时任务、UI lint、架构守卫和 UI build。
- 未运行 Rust / Cargo 测试；本次未修改 Rust、Tauri 后端或 CodeWhale。
- 本地启动 Tauri app 已成功进入 `window_shown` / `bridge:init_done`，具体模型切换流程仍建议在桌面端手动确认一次。

## Submission checklist

- [x] I based this PR on the latest `main`.
- [x] Every commit includes a matching `Signed-off-by` trailer (`git commit -s`).
- [x] I removed credentials, private data, internal URLs, and sensitive logs.
- [x] I updated tests and documentation where behavior changed.
- [x] If the `CodeWhale` gitlink or fork behavior changed, this PR also updates the fork inventory, fingerprints, and result-oriented tests.
