### PR TITLE
feat(settings): refresh Tencent Coding/Token Plan per 2026-08 official docs

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -5491,6 +5491,12 @@ mod tests {
                 "openai",
                 ApiProvider::Openai,
             ),
+            (
+                "glm-5.2",
+                "https://api.lkeap.cloud.tencent.com/plan/v3/chat/completions",
+                "openai",
+                ApiProvider::Openai,
+            ),
         ];
 
         for (model, base_url, expected_provider, expected_api_provider) in cases {

--- a/pinvou3-app/src-tauri/src/platform/prefs/model.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs/model.rs
@@ -71,6 +71,19 @@ pub(super) fn migrated_minimax_base_url(value: &str) -> Option<String> {
     })
 }
 
+/// Identifies known Coding Plan/Token Plan endpoints as (vendor, canonical
+/// base_url). The two Tencent Cloud subscription tiers (checked against the
+/// official docs, 2026-08):
+/// - Coding Plan /coding/v3: overview 1823/130092 (2026-08-21),
+///   OpenAI-compatible; the same page also offers an Anthropic-compatible
+///   /coding/anthropic endpoint (not used by this repo);
+/// - Token Plan /plan/v3: access guide 1823/130075 and plan doc 1823/130119,
+///   OpenAI-compatible; a different subscription from Coding Plan with a
+///   different model lineup.
+/// Both tiers go through the generic OpenAI route: identify only backfills
+/// vendor/coding_plan metadata and does not take part in wire routing;
+/// dropping either arm makes stored configs lose separate reasoning-field
+/// parsing.
 pub(super) fn identify_coding_plan_endpoint(
     base_url: &str,
 ) -> Option<(&'static str, &'static str)> {
@@ -265,5 +278,71 @@ mod tests {
                 "{preset:?}/{model:?} 上下文窗口兜底错误"
             );
         }
+    }
+
+    /// Coding-plan endpoint identification regression: every catalog endpoint
+    /// (including both Tencent tiers) must resolve to (vendor, canonical
+    /// base_url); off-catalog compatible endpoints must return None. Losing an
+    /// identification makes stored configs lose coding_plan metadata and
+    /// separate reasoning-field parsing in normalize_provider_metadata
+    /// (see the PR #155 review).
+    #[test]
+    fn identify_coding_plan_endpoint_matches_catalog() {
+        let cases: &[(&str, &str, &str)] = &[
+            (
+                "https://open.bigmodel.cn/api/coding/paas/v4",
+                "glm",
+                "https://open.bigmodel.cn/api/coding/paas/v4",
+            ),
+            (
+                "https://api.z.ai/api/coding/paas/v4",
+                "glm",
+                "https://api.z.ai/api/coding/paas/v4",
+            ),
+            (
+                "https://api.kimi.com/coding/v1",
+                "kimi",
+                "https://api.kimi.com/coding/v1",
+            ),
+            (
+                "https://api.lkeap.cloud.tencent.com/coding/v3",
+                "tencent",
+                "https://api.lkeap.cloud.tencent.com/coding/v3",
+            ),
+            (
+                "https://api.lkeap.cloud.tencent.com/plan/v3",
+                "tencent",
+                "https://api.lkeap.cloud.tencent.com/plan/v3",
+            ),
+        ];
+        for (input, expected_vendor, expected_base) in cases {
+            let (vendor, base) = identify_coding_plan_endpoint(input)
+                .unwrap_or_else(|| panic!("{input} must be identified as a coding-plan endpoint"));
+            assert_eq!(vendor, *expected_vendor, "{input}");
+            assert_eq!(base, *expected_base, "{input}");
+        }
+        assert_eq!(
+            identify_coding_plan_endpoint("https://api.deepseek.com"),
+            None
+        );
+        assert_eq!(
+            identify_coding_plan_endpoint("https://api.lkeap.cloud.tencent.com/other/v3"),
+            None,
+            "unlisted lkeap path must not be identified"
+        );
+    }
+
+    /// When a user pastes a full chat/completions URL or variants with a
+    /// trailing slash/uppercase/outer whitespace, normalization must run
+    /// before identification; the canonical base_url is what gets persisted
+    /// and read back.
+    #[test]
+    fn identify_coding_plan_endpoint_normalizes_user_input() {
+        let (vendor, base) = identify_coding_plan_endpoint(
+            " HTTPS://API.LKEAP.CLOUD.TENCENT.COM/coding/v3/chat/completions/ ",
+        )
+        .expect("normalized tencent coding-plan endpoint must be identified");
+        assert_eq!(vendor, "tencent");
+        assert_eq!(base, "https://api.lkeap.cloud.tencent.com/coding/v3");
     }
 }

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -1137,7 +1137,7 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
                       <span className="min-w-0 flex-1">
                         <span className={`block text-[14px] leading-5 truncate ${active ? ('text-[#007AFF] dark:text-[#64B5F6]') : ('text-[#1C1C1E] dark:text-[#F2F2F7]')}`}>{item.custom ? ((activeProvider && settingsCopy.customModelTitles[activeProvider.key]) || settingsCopy.customModelTitle(selectedProvider)) : (item.title || item.model || `${settingsCopy.customModel} ID`)}</span>
                         {item.desc && <span className={`block mt-0.5 text-[12px] leading-[16px] truncate text-[#8A8A8E] dark:text-[#8E8E93]`}>{item.custom
-                          ? (activeProvider && activeProvider.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (activeProvider.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (activeProvider.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc)))
+                          ? (activeProvider && activeProvider.key === 'tencent_token_plan' ? settingsCopy.customTokenPlanDesc : (activeProvider && activeProvider.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (activeProvider.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (activeProvider.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc))))
                           : (settingsCopy.modelDescriptions[item.desc] || item.desc)}</span>}
                       </span>
                       {active && <Check size={17} strokeWidth={2.4} className={'text-[#007AFF] dark:text-[#64B5F6]'} />}
@@ -1217,7 +1217,7 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
                   const active = preset === group.preset && !item.custom && catalogItemMatchesModel(item, model);
                   const itemTitle = item.custom ? (settingsCopy.customModelTitles[group.key] || settingsCopy.customModelTitle(presetProviderLabel(group.preset, t))) : item.title;
                   const itemDescription = item.custom
-                    ? (group.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (group.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (group.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc)))
+                    ? (group.key === 'tencent_token_plan' ? settingsCopy.customTokenPlanDesc : (group.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (group.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (group.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc))))
                     : (settingsCopy.modelDescriptions[item.desc] || item.desc);
                   return (
                     <button

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -158,6 +158,25 @@ const MODEL_CATALOG = {
         { model: '', title: '自定义 GLM Coding Plan 模型', desc: '手动填写 Coding Plan 模型 ID', custom: true },
       ],
     },
+    // The two Tencent Cloud subscription tiers are modeled separately per the
+    // official docs (TokenHub product 1823):
+    // - Coding Plan: https://cloud.tencent.com/document/product/1823/130092
+    //   (checked 2026-08-21) OpenAI-compatible base URL /coding/v3; the catalog
+    //   lists all three of its model rows. The same page also offers an
+    //   Anthropic-compatible /coding/anthropic endpoint for Claude Code-style
+    //   tools; this repo's OpenAI route does not use it.
+    // - Token Plan: https://cloud.tencent.com/document/product/1823/130119
+    //   (checked 2026-08-27) OpenAI-compatible base URL /plan/v3 (access guide
+    //   in 130075); its general and Hy tiers have different lineups, and it is
+    //   a different subscription from Coding Plan.
+    // Both endpoints are identified as vendor=tencent coding_plan by
+    // identify_coding_plan_endpoint on the Rust side, so both groups must keep
+    // providerKind=CODING_PLAN to stay consistent with the metadata read back
+    // after saving. Model names pass through the generic OpenAI-compatible
+    // route verbatim and must use the official lowercase wire ids; the other
+    // parallel official spellings on the same page (e.g. kimi-k-2-5 and the
+    // deepseek/deepseek-v4-* forms) are registered in legacyAliases so stored
+    // configs match with any of them.
     {
       key: 'tencent_coding_plan',
       section: 'coding_plan',
@@ -171,7 +190,36 @@ const MODEL_CATALOG = {
       endpointAliases: ['https://api.lkeap.cloud.tencent.com/coding/v3/chat/completions'],
       items: [
         { model: 'tc-code-latest', title: 'tc-code-latest', desc: 'Coding Plan 自动模型' },
+        { model: 'glm-5', legacyAliases: ['glm-5-0'], title: 'glm-5', desc: '旗舰编码模型' },
+        { model: 'kimi-k2.5', legacyAliases: ['kimi-k-2-5'], title: 'kimi-k2.5', desc: '官方将于 2026-08-31 下线' },
         { model: '', title: '自定义腾讯云 Coding Plan 模型', desc: '手动填写 Coding Plan 模型 ID', custom: true },
+      ],
+    },
+    {
+      key: 'tencent_token_plan',
+      section: 'coding_plan',
+      title: '腾讯云 Token Plan / Tencent Cloud Token Plan',
+      configTitle: '腾讯云 Token Plan',
+      desc: '腾讯云 TokenHub Token 订阅接口',
+      preset: 'openai_compatible',
+      providerKind: PROVIDER_KIND_CODING_PLAN,
+      vendor: 'tencent',
+      baseUrl: 'https://api.lkeap.cloud.tencent.com/plan/v3',
+      endpointAliases: ['https://api.lkeap.cloud.tencent.com/plan/v3/chat/completions'],
+      // kimi-k2.5 is still listed in the general tier (2026-08-27 revision,
+      // retiring 2026-08-31, now agreeing with the Coding Plan page); drop the
+      // row once the retirement takes effect.
+      items: [
+        { model: 'tc-code-latest', title: 'tc-code-latest', desc: '自动模型，智能路由' },
+        { model: 'glm-5.2', legacyAliases: ['glm-5-2'], title: 'glm-5.2', desc: '旗舰推理与编码' },
+        { model: 'glm-5.1', legacyAliases: ['glm-5-1'], title: 'glm-5.1', desc: '均衡智能与成本' },
+        { model: 'glm-5', legacyAliases: ['glm-5-0'], title: 'glm-5', desc: '通用推理，默认推荐' },
+        { model: 'deepseek-v4-pro-202606', legacyAliases: ['deepseek/deepseek-v4-pro-0813', 'deepseek/deepseek-v4-pro'], title: 'deepseek-v4-pro-202606', desc: '高能力模型' },
+        { model: 'deepseek-v4-flash-202605', legacyAliases: ['deepseek/deepseek-v4-flash-0731', 'deepseek/deepseek-v4-flash'], title: 'deepseek-v4-flash-202605', desc: '快速响应' },
+        { model: 'minimax-m2.7', legacyAliases: ['minimax-m-2-7'], title: 'minimax-m2.7', desc: '最新推荐' },
+        { model: 'kimi-k2.5', legacyAliases: ['kimi-k-2-5'], title: 'kimi-k2.5', desc: '官方将于 2026-08-31 下线' },
+        { model: 'hy3', legacyAliases: ['hy3-preview'], title: 'hy3', desc: 'Hy 套餐专属模型' },
+        { model: '', title: '自定义腾讯云 Token Plan 模型', desc: '手动填写 Token Plan 模型 ID', custom: true },
       ],
     },
     {

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -880,6 +880,7 @@ Object.assign(dictEn.uiSettingsDetail, {
   providerCatalog:{
     local:{title:'Local Model',desc:'Default model for the local service'}, glm_coding_plan:{title:'Zhipu Coding Plan / GLM Coding Plan',configTitle:'Zhipu Coding Plan',desc:'Dedicated endpoint for coding and agent tasks'},
     tencent_coding_plan:{title:'Tencent Cloud Coding Plan',configTitle:'Tencent Cloud Coding Plan',desc:'Tencent Cloud coding-plan endpoint'},
+    tencent_token_plan:{title:'Tencent Cloud Token Plan',configTitle:'Tencent Cloud Token Plan',desc:'Dedicated gateway for Tencent Cloud TokenHub Token Plan subscriptions'},
     kimi_coding_plan:{title:'Kimi Coding Plan',configTitle:'Kimi Coding Plan',desc:'Dedicated endpoint for Kimi coding tasks'},
     deepseek:{title:'DeepSeek',configTitle:'DeepSeek',desc:'Official DeepSeek API'}, kimi:{title:'Kimi China',configTitle:'Kimi',desc:'Official Moonshot API'},
     glm:{title:'Zhipu Open Platform / GLM API',configTitle:'GLM API',desc:'Standard Zhipu Open Platform API'},
@@ -922,6 +923,10 @@ Object.assign(dictEn.uiSettingsDetail.modelDescriptions, {
   '本地服务默认模型':'Default model for the local service',
   '旗舰编码模型':'Flagship coding model', '高性能编码模型':'High-performance coding model',
   '日常编码模型':'Everyday coding model', 'Coding Plan 自动模型':'Coding Plan automatic model',
+  '自动模型，智能路由':'Automatic model with smart routing',
+  '官方将于 2026-08-31 下线':'Will be retired on 2026-08-31',
+  'Hy 套餐专属模型':'Exclusive to the Hy plan',
+  '手动填写 Token Plan 模型 ID':'Enter a Token Plan model ID manually',
   '标准编码模型':'Standard coding model', 'K3 256K 上下文模型':'K3 with 256K context',
   'K3 长上下文模型':'K3 long-context model', '高速编码模型':'High-speed coding model',
   '旗舰推理':'Flagship reasoning model',
@@ -944,11 +949,12 @@ Object.assign(dictEn.uiSettingsDetail.modelDescriptions, {
 });
 
 dictEn.uiSettingsDetail.customCodingPlanDesc = 'Enter a Coding Plan model ID manually';
+dictEn.uiSettingsDetail.customTokenPlanDesc = 'Enter a Token Plan model ID manually';
 dictEn.uiSettingsDetail.modelAlias = 'Alias';
 dictEn.uiSettingsDetail.modelAliasPlaceholder = 'Optional, e.g. Daily assistant';
 
 dictEn.uiSettingsDetail.customModelTitles = {
   glm:'Custom GLM model', qwen:'Custom Qwen model',
   openai_compatible:'Custom compatible model', glm_coding_plan:'Custom GLM Coding Plan model',
-  tencent_coding_plan:'Custom Tencent Cloud Coding Plan model', kimi_coding_plan:'Custom Kimi Coding Plan model',
+  tencent_coding_plan:'Custom Tencent Cloud Coding Plan model', tencent_token_plan:'Custom Tencent Cloud Token Plan model', kimi_coding_plan:'Custom Kimi Coding Plan model',
 };

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -882,6 +882,7 @@ Object.assign(dictJa.uiSettingsDetail, {
   providerCatalog:{
     local:{title:'ローカルモデル',desc:'ローカルサービスのデフォルトモデル'}, glm_coding_plan:{title:'Zhipu Coding Plan / GLM Coding Plan',configTitle:'Zhipu Coding Plan',desc:'コーディングと Agent 向けの専用エンドポイント'},
     tencent_coding_plan:{title:'Tencent Cloud Coding Plan',configTitle:'Tencent Cloud Coding Plan',desc:'Tencent Cloud のコーディングプラン用エンドポイント'},
+    tencent_token_plan:{title:'Tencent Cloud Token Plan',configTitle:'Tencent Cloud Token Plan',desc:'Tencent Cloud TokenHub Token Plan サブスクリプション専用ゲートウェイ'},
     kimi_coding_plan:{title:'Kimi Coding Plan',configTitle:'Kimi Coding Plan',desc:'Kimi のコーディング向け専用エンドポイント'},
     deepseek:{title:'DeepSeek',configTitle:'DeepSeek',desc:'DeepSeek 公式 API'}, kimi:{title:'Kimi China',configTitle:'Kimi',desc:'Moonshot 公式 API'},
     glm:{title:'Zhipu Open Platform / GLM API',configTitle:'GLM API',desc:'Zhipu Open Platform の標準 API'},
@@ -924,6 +925,10 @@ Object.assign(dictJa.uiSettingsDetail.modelDescriptions, {
   '本地服务默认模型':'ローカルサービスのデフォルトモデル',
   '旗舰编码模型':'フラッグシップコーディングモデル', '高性能编码模型':'高性能コーディングモデル',
   '日常编码模型':'日常向けコーディングモデル', 'Coding Plan 自动模型':'Coding Plan 自動モデル',
+  '自动模型，智能路由':'自動モデル（スマートルーティング）',
+  '官方将于 2026-08-31 下线':'2026-08-31 に提供終了予定',
+  'Hy 套餐专属模型':'Hy プラン専用モデル',
+  '手动填写 Token Plan 模型 ID':'Token Plan モデル ID を手動入力',
   '标准编码模型':'標準コーディングモデル', 'K3 256K 上下文模型':'K3 256K コンテキストモデル',
   'K3 长上下文模型':'K3 長コンテキストモデル', '高速编码模型':'高速コーディングモデル',
   '旗舰推理':'フラッグシップ推論モデル',
@@ -946,11 +951,12 @@ Object.assign(dictJa.uiSettingsDetail.modelDescriptions, {
 });
 
 dictJa.uiSettingsDetail.customCodingPlanDesc = 'Coding Plan モデル ID を手動入力';
+dictJa.uiSettingsDetail.customTokenPlanDesc = 'Token Plan モデル ID を手動入力';
 dictJa.uiSettingsDetail.modelAlias = '別名';
 dictJa.uiSettingsDetail.modelAliasPlaceholder = '任意（例：日常アシスタント）';
 
 dictJa.uiSettingsDetail.customModelTitles = {
   glm:'カスタム GLM モデル', qwen:'カスタム Qwen モデル',
   openai_compatible:'カスタム互換モデル', glm_coding_plan:'カスタム GLM Coding Plan モデル',
-  tencent_coding_plan:'カスタム Tencent Cloud Coding Plan モデル', kimi_coding_plan:'カスタム Kimi Coding Plan モデル',
+  tencent_coding_plan:'カスタム Tencent Cloud Coding Plan モデル', tencent_token_plan:'カスタム Tencent Cloud Token Plan モデル', kimi_coding_plan:'カスタム Kimi Coding Plan モデル',
 };

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -936,9 +936,10 @@ Object.assign(dictZh.uiAttachments, {
 
 // 自定义项标题/描述的逐供应商口径（与 i18n 化前硬编码目录一致）；未列出的供应商回退 customModelTitle。
 dictZh.uiSettingsDetail.customCodingPlanDesc = '手动填写 Coding Plan 模型 ID';
+dictZh.uiSettingsDetail.customTokenPlanDesc = '手动填写 Token Plan 模型 ID';
 
 dictZh.uiSettingsDetail.customModelTitles = {
   glm:'自定义 GLM 模型', qwen:'自定义通义模型',
   openai_compatible:'自定义兼容模型', glm_coding_plan:'自定义 GLM Coding Plan 模型',
-  tencent_coding_plan:'自定义腾讯云 Coding Plan 模型', kimi_coding_plan:'自定义 Kimi Coding Plan 模型',
+  tencent_coding_plan:'自定义腾讯云 Coding Plan 模型', tencent_token_plan:'自定义腾讯云 Token Plan 模型', kimi_coding_plan:'自定义 Kimi Coding Plan 模型',
 };

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -78,6 +78,37 @@ test('z.ai 直连存量小写配置仍命中大写目录行 -> 预设', () => {
   // 另一迁移项 GLM-5-Turbo（旧拼写 glm-5-turbo）同样兼容。
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'glm-5-turbo' })), true);
 });
+test('Tencent Coding Plan catalog hits with legacy alias compatibility (official 2026-08-21 model table)', () => {
+  // Each of the three model rows hits; glm-5-0 / kimi-k-2-5 are the official
+  // parallel second spellings on the same page, registered in legacyAliases,
+  // so stored configs count as preset with either spelling.
+  const base = 'https://api.lkeap.cloud.tencent.com/coding/v3';
+  for (const model of ['tc-code-latest', 'glm-5', 'glm-5-0', 'kimi-k2.5', 'kimi-k-2-5']) {
+    assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'tencent', base_url: base, model })), true, model);
+  }
+  assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'tencent', base_url: base, model: 'glm-5.2' })), false, 'glm-5.2 is not in the official Coding Plan model table');
+});
+test('Tencent Token Plan is a separate catalog: distinguished from Coding Plan by base_url, no cross-group match', () => {
+  // /plan/v3 general+Hy tiers hit their own group (official 2026-08-27 model
+  // table, every row and every registered parallel spelling); on Coding Plan's
+  // /coding/v3 the URL does not match, and with identical vendor+provider_kind
+  // the exact comparison keeps the model custom.
+  const planBase = 'https://api.lkeap.cloud.tencent.com/plan/v3';
+  const planModels = [
+    'tc-code-latest',
+    'glm-5.2', 'glm-5-2', 'glm-5.1', 'glm-5-1', 'glm-5', 'glm-5-0',
+    'deepseek-v4-pro-202606', 'deepseek/deepseek-v4-pro-0813', 'deepseek/deepseek-v4-pro',
+    'deepseek-v4-flash-202605', 'deepseek/deepseek-v4-flash-0731', 'deepseek/deepseek-v4-flash',
+    'minimax-m2.7', 'minimax-m-2-7',
+    'kimi-k2.5', 'kimi-k-2-5',
+    'hy3', 'hy3-preview',
+  ];
+  for (const model of planModels) {
+    assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'tencent', base_url: planBase, model })), true, model);
+  }
+  assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'tencent', base_url: 'https://api.lkeap.cloud.tencent.com/coding/v3', model: 'glm-5.2' })), false, 'Token Plan-exclusive models must not match the Coding Plan catalog');
+  assert.strictEqual(providerLabelForModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'tencent', base_url: planBase, model: 'glm-5.2' }), t), '腾讯云 Token Plan / Tencent Cloud Token Plan');
+});
 test('catalogItemMatchesModel 精确比较+legacyAliases 兼容迁移拼写', () => {
   // SettingsView 编辑弹窗的 initialCatalogMatch/known/active 均复用此比较:
   // 存量小写 glm-5.2 必须命中 z.ai 直连目录行 GLM-5.2(经 legacyAliases),


### PR DESCRIPTION
## Background

The original version of this PR removed the Tencent Cloud Coding Plan template and both lkeap endpoint identifications on the premise that the service was unusable. Review (thanks @zhuowp) correctly flagged that premise as outdated, and the branch has been rebuilt to instead keep and update the Tencent entries per the current official docs.

Verification of the review's factual basis:
- The official Coding Plan overview (https://cloud.tencent.com/document/product/1823/130092, updated 2026-08-21) documents the OpenAI-compatible base URL `https://api.lkeap.cloud.tencent.com/coding/v3`, model `tc-code-latest`, and a supported-tool list that now includes Codex.
- The Token Plan access guide (1823/130075) and subscription doc (1823/130119) document `https://api.lkeap.cloud.tencent.com/plan/v3` as an OpenAI-compatible base.
- Plan terms restrict usage to interactive coding tools and forbid non-interactive API automation/batch use — an interactive coding agent falls in the permitted category; no reproducible server-side rejection of this client exists.
- Unauthenticated probes of both endpoints return OpenAI-shaped `401 not_authorized` (standard auth error, not a client-tool rejection).

## Changes

- **Catalog** (`model-catalog.js`): `tencent_coding_plan` now lists the full official three-model table — `tc-code-latest`, `glm-5` (alias `glm-5-0`), `kimi-k2.5` (alias `kimi-k-2-5`, official retirement 2026-08-31). New `tencent_token_plan` template models the separate Token Plan subscription on `/plan/v3` (general-tier models incl. `glm-5.2`/`glm-5.1`, DeepSeek V4 dated ids, `minimax-m2.7`, retiring `kimi-k2.5`, plus Hy-tier `hy3`), refreshed to that page's 2026-08-27 revision. Alternative official spellings (e.g. `glm-5-0`, `kimi-k-2-5`, and the `deepseek/deepseek-v4-flash[-0731]` / `deepseek/deepseek-v4-pro[-0813]` forms) are registered as `legacyAliases` so every accepted wire id matches.
- **Endpoint identification** (`prefs/model.rs`): both lkeap endpoints are kept and now documented with their official-doc basis; added regression tests covering every catalog endpoint (incl. negative cases and user-input normalization) so stored configs cannot silently lose coding-plan metadata again.
- **Bridge** (`bridge.rs`): vendor routing and separate reasoning-field parsing for `tencent` are kept; the route test gains a `/plan/v3` case.
- **i18n** (`src/shared/i18n/{zh,en,ja}.js`, `SettingsView.jsx`): trilingual entries for the new template, model descriptions, and a `customTokenPlanDesc` branch so Token Plan custom rows show correct copy in all three languages. The monolithic `settings-i18n.js` was removed on main by the per-language i18n split (#341), so the keys live in the per-language modules.
- **Tests** (`model_catalog_grouping.test.js`): coverage for both Tencent templates — catalog hits, alias compatibility, and no cross-matching between the two base URLs.
- **Comments**: new developer-facing comments, Rust doc comments, JS test names, and test diagnostics are written in English per `CONTRIBUTING.md`; localized zh UI-copy keys (catalog `title`/`desc` and the i18n dictionaries) stay localized.

## Verification

- `cargo test --lib`: 1678 passed / 1 failed — the failure is a pre-existing cross-test isolation flake (`dingtalk_skill_gate_extracts_and_removes_official_mono_skill`; passes in isolation and no `runtime_bundle` file is touched by this PR). Includes the 6 `coding_plan` tests; local SIGBUS during compile worked around with `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_OPT_LEVEL=0`, a known local-machine issue
- `node tests/model_catalog_grouping.test.js`: 45 passed
- `npm run test:ui-language`, `npm run lint` (0 errors), `cargo fmt --check`, `python3 scripts/architecture-guard.py`, `./scripts/fork-guard.sh --fast`: all pass
- Branch rebased onto latest `main` (f7e3d8ea); `git merge-tree --write-tree origin/main HEAD` is clean

## Known notes

- Both official pages now agree that `kimi-k2.5` retires 2026-08-31 (the Token Plan page's 2026-08-27 revision lists it in the general tier). The row is listed in both Tencent templates with the retirement disclosed, and the grouping tests cover both spellings; drop it once the date passes.
- The official docs also offer an Anthropic-compatible endpoint `/coding/anthropic` for Claude Code-style tools; this repo's OpenAI-compatible route does not use it (noted in code comments).
- No CodeWhale submodule change; no fork fingerprint changes.

