### PR TITLE
chore(ci): macOS 发布构建超时放宽至 150 分钟

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -358,8 +358,9 @@ jobs:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.build_required == 'true'
     runs-on: macos-15
-    # 首次双 target + fat LTO 实跑约 48 分钟，50 分钟几乎无 runner 抖动余量。
-    timeout-minutes: 90
+    # 冷缓存双 target + fat LTO 实测可能超过 90 分钟（0.7.4 发布构建曾逼近上限），
+    # 放宽至 150 分钟以覆盖冷缓存与 runner 抖动，避免发布构建被超时取消。
+    timeout-minutes: 150
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
       VERSION: ${{ needs.check-version-bump.outputs.version }}


### PR DESCRIPTION
## 背景

0.7.4 发布时，release-packages 的 macOS universal 构建在冷缓存下实测耗时逼近 90 分钟上限（实际约 89 分钟），首次构建被超时取消，导致发布流程中断，需要人工重跑补齐产物。

## 变更

- `.github/workflows/release-packages.yml`：`构建 macOS universal dmg` job 的 `timeout-minutes` 由 90 分钟放宽至 150 分钟，并更新注释说明原因，为冷缓存与 runner 抖动留出余量。
- 仅调整 macOS 发布构建超时；Linux/Windows 构建实测均在 90 分钟内完成，保持原超时不变。

## 实际验证

- YAML 解析通过。
- `scripts/tests/test_ci_gate_policy.py`、`scripts/tests/test_release_manifest_probe.py` 全部通过（10 passed）。
- 0.7.4 重跑后的 macOS 构建在放宽后仍可正常完成（实际约 89 分钟）。

## 已知风险

- 仅延长 job 上限，不改变构建行为；发布构建最长等待时间由 90 分钟增至 150 分钟，成本在可接受范围。