### PR TITLE
fix(artifact): 修复产物 HTML 预览在 WebKit 下的无限放大反馈

### DIFF
--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -751,6 +751,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
     const ScaledHtmlPreview = ({ html, onFrameLoad, onOpenExternal, zoomMode = 'auto-width', customScale = 1, onScaleChange, onCustomScaleChange }) => {
       const wrapRef = useRef(null);
       const frameRef = useRef(null);
+      const naturalRef = useRef(null); // 当前 html 的内容自然尺寸缓存(在面板参考宽度下测得)
       const [box, setBox] = useState(null); // { w, h, scale }
       const [ready, setReady] = useState(false);
       const managedZoom = zoomMode !== 'auto-width';
@@ -761,11 +762,23 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
           if (!fr || !wrap || !fr.contentWindow) return;
           const doc = fr.contentWindow.document;
           const de = doc.documentElement, bd = doc.body;
-          const naturalW = Math.max(de ? de.scrollWidth : 0, bd ? bd.scrollWidth : 0);
-          const h = Math.max(de ? de.scrollHeight : 0, bd ? bd.scrollHeight : 0);
           const panelW = wrap.clientWidth;
           const panelH = wrap.clientHeight;
-          const w = managedZoom ? Math.max(canvasW, naturalW || 0) : naturalW;
+          // 内容自然尺寸只在面板参考宽度下测量一次并缓存；后续仅依据面板尺寸重算缩放。
+          // 若把「已按自然宽度撑开的 iframe 视口」每次再喂回测量，弹层里的 vw/vh 与
+          // 溢出内容（如 right:-120px 的绝对定位元素）会让 scrollWidth/scrollHeight 随 iframe
+          // 被撑大而继续放大，触发 ResizeObserver 无限反馈 → 预览无限放大。
+          let nat = naturalRef.current;
+          if (!nat) {
+            const cw = Math.max(de ? de.scrollWidth : 0, bd ? bd.scrollWidth : 0);
+            const ch = Math.max(de ? de.scrollHeight : 0, bd ? bd.scrollHeight : 0);
+            nat = { w: cw, h: ch };
+            // iframe 内容可能尚未真正加载(scrollWidth=0)：这种空测量不写入缓存，
+            // 等 onLoad 后测到真实尺寸再缓存，避免把首轮空值固化导致正常页面缩放出错。
+            if (cw > 0) naturalRef.current = nat;
+          }
+          const w = managedZoom ? Math.max(canvasW, nat.w || 0) : nat.w;
+          const h = nat.h;
           let scale = 1;
           if (zoomMode === 'fit') {
             const widthScale = w > 0 && panelW > 0 ? panelW / w : 1;
@@ -791,7 +804,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
           if (onScaleChange) onScaleChange(scale);
         } catch (e) { /* 未就绪/跨域，忽略 */ }
       };
-      useEffect(() => { setReady(false); setBox(null); }, [html]);
+      useEffect(() => { setReady(false); setBox(null); naturalRef.current = null; }, [html]);
       useEffect(() => { measure(); }, [zoomMode, customScale]);
       useEffect(() => {
         if (!wrapRef.current || typeof ResizeObserver === 'undefined') return;

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -773,9 +773,9 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
             const cw = Math.max(de ? de.scrollWidth : 0, bd ? bd.scrollWidth : 0);
             const ch = Math.max(de ? de.scrollHeight : 0, bd ? bd.scrollHeight : 0);
             nat = { w: cw, h: ch };
-            // iframe 内容可能尚未真正加载(scrollWidth=0)：这种空测量不写入缓存，
+            // iframe 内容可能尚未真正加载(scrollWidth=0 或 scrollHeight=0)：这种空测量不写入缓存，
             // 等 onLoad 后测到真实尺寸再缓存，避免把首轮空值固化导致正常页面缩放出错。
-            if (cw > 0) naturalRef.current = nat;
+            if (cw > 0 && ch > 0) naturalRef.current = nat;
           }
           const w = managedZoom ? Math.max(canvasW, nat.w || 0) : nat.w;
           const h = nat.h;


### PR DESCRIPTION
## 背景

产物 HTML 预览组件 `ScaledHtmlPreview` 在 WebKit 系内核(Linux WebKitGTK / macOS WKWebView)下预览依赖视口尺寸(`100vh`/`12vw`)或含越界绝对定位元素(如 `right:-120px`)的页面时,会**无限放大**。

根因:`measure()` 把 iframe 撑到内容自身 `scrollWidth/scrollHeight` 后**再从被撑大的 iframe 重新测量**——视口被撑大后 scroll 尺寸继续放大,形成 ResizeObserver 自反馈死循环(实测 `naturalW` 从约 1435 无界涨到 6900+)。Windows WebView2/Blink 因 `overflow:hidden` 会收敛 `scrollWidth`,本就不触发。

## 改动

- `pinvou3-app/src/features/settings/SettingsView.jsx`:`ScaledHtmlPreview.measure()` 改为把**内容自然尺寸只在面板参考宽度下测量一次并缓存**(`naturalRef`),后续仅依据面板尺寸重算缩放,不再把被撑大的 iframe 视口喂回测量;`html` 切换时清缓存;空测量(`scrollWidth=0`)不写入缓存,避免 iframe 加载前把首轮空值固化。

## 验证

- Linux WebKitGTK 2.52.3 复现并复测:修复前 `naturalW` 无界增长,修复后恒定、几次测量内收敛。
- Chromium(Blink,即 Windows WebView2 内核)实测收敛,确认该内核实测本就不发散。
- `eslint src/features/settings/SettingsView.jsx` 通过。
- `npm run build:ui`(vite)通过。

## 影响面 / 风险

- 只影响 HTML 产物预览的缩放测量;其它产物类型(md/text/image/pdf)与 `vis.mode==='html'` 的普通 iframe 路径不经过该组件,不受影响。
- `remote-control-relay` 未引用该组件,无影响。
- 行为细节:每个 html 的自然尺寸被冻结一次,之后面板宽度变化只重算缩放比例(transform),对正常(非该 bug)页面显示与改动前等价。
