### PR TITLE
refactor(tools): 收尾 isDark prop 链——protected helpers 与重复按钮常量归一 (P3)

### DIFF
--- a/pinvou3-app/src/features/artifacts/ArtifactsPanel.jsx
+++ b/pinvou3-app/src/features/artifacts/ArtifactsPanel.jsx
@@ -61,7 +61,7 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
       + 'img{max-width:100%;height:auto;}'
       + '</style>';
 
-    const ArtifactsPanel = ({ bs, theme, t, onClose, isWide, onGotoSettings, isFullscreen = false, onToggleFullscreen, preferredArtifactPath, onPreviewArtifact, designMode = false, designCommand, selectedDesignElement, designChanges = [], onDesignRuntimeStatus, onDesignElementSelected, onDesignChangeApplied, onDesignMutation, onDesignApplyChange, onDesignClearChanges, onDesignAiSubmit, designAiState, onDesignAiStateChange }) => {
+    const ArtifactsPanel = ({ bs, t, onClose, isWide, onGotoSettings, isFullscreen = false, onToggleFullscreen, preferredArtifactPath, onPreviewArtifact, designMode = false, designCommand, selectedDesignElement, designChanges = [], onDesignRuntimeStatus, onDesignElementSelected, onDesignChangeApplied, onDesignMutation, onDesignApplyChange, onDesignClearChanges, onDesignAiSubmit, designAiState, onDesignAiStateChange }) => {
       const uiA = t.uiArtifacts;
       const showDesignWorkbench = isFullscreen && designMode;
       const canOpenContainingFolder = can('externalSystemOpen');
@@ -589,7 +589,6 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
                 artifact={sel}
                 initialText={pv.text || ''}
                 initialInfo={pv.info}
-                isDark={theme === 'dark'}
                 t={t}
                 onSaved={updateMarkdownPreview}
                 onReloaded={updateMarkdownPreview}
@@ -866,7 +865,6 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
                         className={`w-[300px] shrink-0 overflow-hidden border-l border-black/10 bg-white dark:border-white/10 dark:bg-[#1E1F20]`}
                         data-testid="artifact-design-inspector-host">
                         <DesignInspectorPanel
-                          isDark={theme === 'dark'}
                           t={t}
                           selectedElement={selectedDesignElement}
                           changes={designChanges}

--- a/pinvou3-app/src/features/artifacts/ArtifactsPanel.jsx
+++ b/pinvou3-app/src/features/artifacts/ArtifactsPanel.jsx
@@ -62,7 +62,6 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
       + '</style>';
 
     const ArtifactsPanel = ({ bs, theme, t, onClose, isWide, onGotoSettings, isFullscreen = false, onToggleFullscreen, preferredArtifactPath, onPreviewArtifact, designMode = false, designCommand, selectedDesignElement, designChanges = [], onDesignRuntimeStatus, onDesignElementSelected, onDesignChangeApplied, onDesignMutation, onDesignApplyChange, onDesignClearChanges, onDesignAiSubmit, designAiState, onDesignAiStateChange }) => {
-      const isDark = theme === 'dark';
       const uiA = t.uiArtifacts;
       const showDesignWorkbench = isFullscreen && designMode;
       const canOpenContainingFolder = can('externalSystemOpen');
@@ -590,7 +589,7 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
                 artifact={sel}
                 initialText={pv.text || ''}
                 initialInfo={pv.info}
-                isDark={isDark}
+                isDark={theme === 'dark'}
                 t={t}
                 onSaved={updateMarkdownPreview}
                 onReloaded={updateMarkdownPreview}
@@ -649,7 +648,7 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
             <p className="text-[13px] max-w-[360px]">{(vis && vis.warning) || t.apUnsupported}</p>
             {vis && dependencyCheckButton(vis.warning)}
             {(!isWeb || canDownloadArtifacts) && (
-              <button onClick={() => sel && bridge.artifacts.openArtifactExternal(sel.path)} className={cardBtnCls(isDark, 'primary')}>
+              <button onClick={() => sel && bridge.artifacts.openArtifactExternal(sel.path)} className={cardBtnCls('primary')}>
                 {t.apBtnOpen}
               </button>
             )}
@@ -867,7 +866,7 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
                         className={`w-[300px] shrink-0 overflow-hidden border-l border-black/10 bg-white dark:border-white/10 dark:bg-[#1E1F20]`}
                         data-testid="artifact-design-inspector-host">
                         <DesignInspectorPanel
-                          isDark={isDark}
+                          isDark={theme === 'dark'}
                           t={t}
                           selectedElement={selectedDesignElement}
                           changes={designChanges}
@@ -898,13 +897,13 @@ const ArtifactTileIcon = ({ name, tileCls = 'w-9 h-9 rounded-[10px]', glyphCls =
                     <div className="mt-3 flex items-center gap-2">
                       {(!isWeb || canDownloadArtifacts) && (
                         <button onClick={() => bridge.artifacts.openArtifactExternal(sel.path)}
-                          className={`flex-1 flex items-center justify-center gap-1.5 ${cardBtnCls(isDark, 'primary')}`}>
+                          className={`flex-1 flex items-center justify-center gap-1.5 ${cardBtnCls('primary')}`}>
                           <ExternalLink size={15} /> {t.apBtnOpen}
                         </button>
                       )}
                       {canOpenContainingFolder && (
                         <button onClick={() => bridge.artifacts.openContainingFolder(sel.path)}
-                          className={`flex-1 flex items-center justify-center gap-1.5 ${cardBtnCls(isDark)}`}>
+                          className={`flex-1 flex items-center justify-center gap-1.5 ${cardBtnCls()}`}>
                           <FolderOpen size={15} /> {t.apBtnLocate}
                         </button>
                       )}

--- a/pinvou3-app/src/features/artifacts/DesignInspectorPanel.jsx
+++ b/pinvou3-app/src/features/artifacts/DesignInspectorPanel.jsx
@@ -103,7 +103,7 @@ const describeSelectedElement = (element, L) => {
   };
 };
 
-const DesignInspectorPanel = ({ isDark, t, selectedElement, changes = [], onApplyChange, onClearChanges, docked = false }) => {
+const DesignInspectorPanel = ({ t, selectedElement, changes = [], onApplyChange, onClearChanges, docked = false }) => {
   const L = t.uiArtifacts;
   const style = (selectedElement && selectedElement.computedStyle) || {};
   const [textDraft, setTextDraft] = useState('');

--- a/pinvou3-app/src/features/artifacts/EditableMarkdownPreview.jsx
+++ b/pinvou3-app/src/features/artifacts/EditableMarkdownPreview.jsx
@@ -44,7 +44,6 @@ const EditableMarkdownPreview = forwardRef(function EditableMarkdownPreview({
   artifact,
   initialText,
   initialInfo,
-  isDark,
   t,
   onSaved,
   onReloaded,

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -2290,7 +2290,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                       messageIndex={item.messageIndex}
                       attachmentIndex={index}
                       sessionId={sessionId}
-                      copyText={copyClipboardText}
+                       copyText={copyClipboardText}
                       labels={{
                         open: t.attachmentOpen,
                         download: t.attachmentDownload,

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -10,7 +10,7 @@ import { ComposerModelSelector, ComposerToolMenu } from '../settings/SettingsVie
 import { ComposerPopover } from '../../components/ComposerPopover.jsx';
 import { PinvouLogo } from '../../components/PinvouLogo.jsx';
 import { ArtifactCard, localizeTool, tsToolsData } from '../tools/tool-common.jsx';
-import { CarefulBlockedCard, PlanCard, PlanStuckCard, ToolCard, UserInputCard } from '../tools/tool-renderers.jsx';
+import { CarefulBlockedCard, PlanCard, PlanStuckCard, ToolCard, UserInputCard, cardBtnCls } from '../tools/tool-renderers.jsx';
 import {
   ConversationActivityIndicator,
   ConversationTimeline,
@@ -2247,8 +2247,8 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                     : 'bg-[#D3E3FD] text-[#1F1F1F] dark:bg-[#004A77] dark:text-[#E3E3E3]'
                 }`} />
               <div className="flex gap-2 justify-end mt-1">
-                <button className={CARD_BTN} onClick={() => { setEditing(false); setVal(item.text); }}>{t.cpCancel}</button>
-                <button className={CARD_BTN_PRIMARY} onClick={commit}>{t.resend}</button>
+                <button className={cardBtnCls()} onClick={() => { setEditing(false); setVal(item.text); }}>{t.cpCancel}</button>
+                <button className={cardBtnCls('primary')} onClick={commit}>{t.resend}</button>
               </div>
             </div>
           </div>

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -79,12 +79,6 @@ import {
 
 const UNIFIED_CONVERSATION_UI_KEY = 'pinvou_conversation_ui_v2';
 const MULTI_AGENT_ENABLED = can('multiAgent');
-// Inlined from cardBtnCls(isDark, variant) in tool-renderers.jsx so ChatView can drop its
-// local isDark. P1-7/P3 may collapse these back to cardBtnCls(variant) once that helper
-// no longer takes a theme arg. Non-primary dark originally had no border → dark:border-transparent
-// suppresses the light-side border in dark.
-const CARD_BTN = 'px-3 py-1.5 rounded-full text-[13px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-white text-[#1F1F1F] hover:bg-[#E1E5EA] border border-black/10 dark:bg-[#333537] dark:text-[#E3E3E3] dark:hover:bg-[#444746] dark:border-transparent';
-const CARD_BTN_PRIMARY = 'px-3 py-1.5 rounded-full text-[13px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-[#0B57D0] text-white hover:bg-[#0A4BB8] dark:bg-[#A8C7FA] dark:text-[#062E6F] dark:hover:bg-[#C2DBFF]';
 
 function unifiedConversationUiEnabled() {
   try {
@@ -1486,7 +1480,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                     renderToolItem={(item) => item.legacyItem
                       && !isSearchTool(item.tool)
                       && !isFetchTool(item.tool)
-                      ? <ToolCard item={item.legacyItem} sessionId={activeSessionId} theme={theme} t={t} variant="timeline" />
+                      ? <ToolCard item={item.legacyItem} sessionId={activeSessionId} t={t} variant="timeline" />
                       : undefined}
                     onOpenExternal={openChatExternalUrl}
                   />
@@ -2564,7 +2558,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
               ) : null}
               {pd.draft ? (
                 <div className="mt-2 rounded-[14px] p-3 flex items-center gap-3 max-w-[460px]" style={{ background: theme === 'dark' ? '#1C1C1E' : '#F2F2F7' }}>
-                  <AppIcon card={pd.draft} isDark={theme === 'dark'} cls="w-11 h-11 rounded-[12px]" fb={22} />
+                  <AppIcon card={pd.draft} cls="w-11 h-11 rounded-[12px]" fb={22} />
                   <div className="min-w-0 flex-1">
                     <div className="text-[15px] font-semibold leading-snug truncate" style={{ color: theme === 'dark' ? '#fff' : '#000' }}>{pd.draft.name}</div>
                     <div className="text-[13px] truncate" style={{ color: theme === 'dark' ? 'rgba(235,235,245,.6)' : 'rgba(60,60,67,.6)' }}>{pd.draft.description || deptLabelFor(t, pd.draft.dept)}</div>
@@ -2587,7 +2581,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       }
 
       if (item.type === 'tool') {
-        return <ToolCard item={item} sessionId={sessionId} theme={theme} t={t} />;
+        return <ToolCard item={item} sessionId={sessionId} t={t} />;
       }
 
       if (item.type === 'persona_equip') {
@@ -2600,7 +2594,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
             <div className="text-[12px] font-medium" style={{ color: '#8E8E93' }}>{t.cpEquipBubbleSys}</div>
             <div className="rounded-[14px] p-4 max-w-[560px]" style={{ background: theme === 'dark' ? '#1C1C1E' : '#F2F2F7' }}>
               <div className="flex items-center gap-3 mb-3">
-                <AppIcon card={c} isDark={theme === 'dark'} cls="w-11 h-11 rounded-[12px]" fb={22} />
+                <AppIcon card={c} cls="w-11 h-11 rounded-[12px]" fb={22} />
                 <div className="text-[15px] font-semibold leading-snug" style={{ color: theme === 'dark' ? '#fff' : '#000' }}>{t.cpEquipBubbleTitle(cd.name)}</div>
               </div>
               <div className="text-[13px] space-y-1" style={{ color: theme === 'dark' ? '#C7C7CC' : '#3C3C43' }}>

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -2290,7 +2290,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                       messageIndex={item.messageIndex}
                       attachmentIndex={index}
                       sessionId={sessionId}
-                       copyText={copyClipboardText}
+                      copyText={copyClipboardText}
                       labels={{
                         open: t.attachmentOpen,
                         download: t.attachmentDownload,

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1878,7 +1878,6 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
               data-testid="artifact-fullscreen-panel">
               <ArtifactsPanel
                 bs={bs}
-                theme={theme}
                 t={t}
                 onClose={closeArtifactsPanel}
                 isWide={true}
@@ -1915,7 +1914,6 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                 style={{ width: artifactW + 'px' }}>
                 <ArtifactsPanel
                   bs={bs}
-                  theme={theme}
                   t={t}
                   onClose={closeArtifactsPanel}
                   isWide={true}
@@ -1944,7 +1942,6 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
           {artifactsVisible && !isWide && !artifactsFullscreen && (
             <ArtifactsPanel
               bs={bs}
-              theme={theme}
               t={t}
               onClose={closeArtifactsPanel}
               isWide={false}
@@ -2502,10 +2499,10 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const assistantSelectionTargetRef = useRef(null);
 
       if (item.type === 'artifact_card') return <ArtifactCard item={item} theme={theme} t={t} isLatest={isLatestArtifact} />;
-      if (item.type === 'plan_card') return <PlanCard item={item} theme={theme} t={t} onPrefill={onPrefill} />;
-      if (item.type === 'plan_stuck') return <PlanStuckCard item={item} theme={theme} t={t} />;
-      if (item.type === 'careful_blocked') return <CarefulBlockedCard item={item} theme={theme} t={t} />;
-      if (item.type === 'user_input') return <UserInputCard item={item} theme={theme} t={t} />;
+      if (item.type === 'plan_card') return <PlanCard item={item} t={t} onPrefill={onPrefill} />;
+      if (item.type === 'plan_stuck') return <PlanStuckCard item={item} t={t} />;
+      if (item.type === 'careful_blocked') return <CarefulBlockedCard item={item} t={t} />;
+      if (item.type === 'user_input') return <UserInputCard item={item} t={t} />;
       if (item.type === 'user') {
         return <UserBubble item={item} sessionId={sessionId} theme={theme} editable={editable} t={t} conversationVariant={conversationVariant} />;
       }

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -695,13 +695,13 @@ function NativePlanCard({ item, theme, t, copy, modePlan, busy, onAccept, onDisc
   const active = item.cardState === 'active' && !item.resolved && !!item.planId;
   const statusText = copy[NATIVE_PLAN_STATUS_COPY[item.statusKey]] || '';
   return (
-    <div className={cardBoxCls(isDark, isDark ? 'border-[#A8C7FA]/30' : 'border-[#0B57D0]/20')}>
+    <div className={cardBoxCls('border-[#0B57D0]/20 dark:border-[#A8C7FA]/30')}>
       <div className={`text-[14px] font-semibold mb-3 ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{t.planReady}</div>
       {(!item.plan && !item.todos)
         ? <div className={`text-[13px] ${isDark ? 'text-[#C4C7C5]' : 'text-[#444746]'}`}>{t.planEmpty}</div>
         : <>
-            <PlanLayer label={t.planLabel} explanation={item.plan && item.plan.explanation} items={item.plan && item.plan.items} field="step" isDark={isDark} />
-            <PlanLayer label={t.planTodos} items={item.todos && item.todos.items} field="content" isDark={isDark} />
+            <PlanLayer label={t.planLabel} explanation={item.plan && item.plan.explanation} items={item.plan && item.plan.items} field="step" />
+            <PlanLayer label={t.planTodos} items={item.todos && item.todos.items} field="content" />
           </>}
       <div className={`h-px my-3 ${isDark ? 'bg-white/10' : 'bg-black/10'}`}></div>
       {active ? (
@@ -710,14 +710,14 @@ function NativePlanCard({ item, theme, t, copy, modePlan, busy, onAccept, onDisc
           <button
             type="button"
             data-testid="native-plan-accept"
-            className={cardBtnCls(isDark, 'primary')}
+            className={cardBtnCls('primary')}
             disabled={busy || !modePlan}
             onClick={() => onAccept(item)}
           >{t.planGo}</button>
           <button
             type="button"
             data-testid="native-plan-discard"
-            className={cardBtnCls(isDark)}
+            className={cardBtnCls()}
             onClick={() => onDiscard(item)}
           >{t.planDrop}</button>
         </div>
@@ -776,14 +776,14 @@ function NativeYoloConfirmCard({ theme, t, busy, onConfirm, onCancel }) {
           <button
             type="button"
             data-testid="native-yolo-confirm-cancel"
-            className={cardBtnCls(isDark)}
+            className={cardBtnCls()}
             disabled={busy}
             onClick={onCancel}
           >{t.modeYoloConfirmCancel}</button>
           <button
             type="button"
             data-testid="native-yolo-confirm-ok"
-            className={cardBtnCls(isDark, 'primary')}
+            className={cardBtnCls('primary')}
             disabled={busy}
             onClick={onConfirm}
           >{t.modeYoloConfirmOk}</button>

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -1244,7 +1244,7 @@ let kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], al
                   <div className="mt-5">
                     {modelFailed ? (
                       <div className="flex items-center justify-center gap-3">
-                        <button onClick={() => startModelDownload(false)} className={`px-5 py-2.5 rounded-xl text-[14px] font-bold ${isDark ? 'bg-white/10 text-white' : 'bg-[#eceef7] text-[#3f4250]'}`}>{t.kbModelRetryBtn}</button>
+                        <button onClick={() => startModelDownload(false)} className={`px-5 py-2.5 rounded-xl text-[14px] font-bold bg-[#eceef7] text-[#3f4250] dark:bg-white/10 dark:text-white`}>{t.kbModelRetryBtn}</button>
                         <button onClick={() => startModelDownload(true)} className="px-5 py-2.5 rounded-xl text-[14px] font-bold text-white"
                           style={{ background: 'linear-gradient(135deg,#6f5cf0,#5b6cf2)', boxShadow: '0 6px 16px rgba(108,92,231,.32)' }}>{t.kbModelRepairBtn} →</button>
                       </div>
@@ -1307,7 +1307,7 @@ let kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], al
                   </div>
                 )}
                 {idx && (idx.running || idx.resumable || idx.failed > 0) && (
-                  <div className={`mb-5 rounded-2xl border p-4 ${isDark ? 'border-white/10 bg-white/[0.04]' : 'border-[#dfe3ee] bg-[#f8f9fd]'}`}>
+                  <div className={`mb-5 rounded-2xl border p-4 border-[#dfe3ee] bg-[#f8f9fd] dark:border-white/10 dark:bg-white/[0.04]`}>
                     <div className="flex flex-wrap items-start justify-between gap-3">
                       <div className="min-w-0">
                         <div className={`text-[14px] font-bold ${ink}`}>
@@ -1555,9 +1555,9 @@ let kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], al
           {/* 「+ 添加 ▾」下拉菜单：文件 / 文件夹(后端 WalkDir 递归展开目录) */}
           {addMenu && typeof document !== 'undefined' && createPortal(
             <div onPointerDown={(e) => e.stopPropagation()} style={{ left: addMenu.left, top: addMenu.top, width: addMenu.width }}
-              className={`fixed z-[1000] overflow-hidden rounded-xl py-1 shadow-xl ring-1 ${isDark ? 'bg-[#202124] ring-white/10' : 'bg-white ring-black/10'}`}>
-              <button data-testid="kb-add-files" onClick={() => chooseAdd('files')} className={`w-full h-9 px-3 flex items-center gap-2 text-left text-[14px] ${isDark ? 'text-[#E3E3E3] hover:bg-[#303134]' : 'text-[#1F1F1F] hover:bg-[#F1F3F4]'}`}><FileText size={15} /><span>{t.kbAddFiles}</span></button>
-              <button data-testid="kb-add-folder" onClick={() => chooseAdd('folders')} disabled={!folderPickerAvailable} className={`w-full h-9 px-3 flex items-center gap-2 text-left text-[14px] ${folderPickerAvailable ? (isDark ? 'text-[#E3E3E3] hover:bg-[#303134]' : 'text-[#1F1F1F] hover:bg-[#F1F3F4]') : 'opacity-40 cursor-default'}`}><FolderOpen size={15} /><span>{t.kbAddFolder}</span></button>
+              className={`fixed z-[1000] overflow-hidden rounded-xl py-1 shadow-xl ring-1 bg-white ring-black/10 dark:bg-[#202124] dark:ring-white/10`}>
+              <button data-testid="kb-add-files" onClick={() => chooseAdd('files')} className={`w-full h-9 px-3 flex items-center gap-2 text-left text-[14px] text-[#1F1F1F] hover:bg-[#F1F3F4] dark:text-[#E3E3E3] dark:hover:bg-[#303134]`}><FileText size={15} /><span>{t.kbAddFiles}</span></button>
+              <button data-testid="kb-add-folder" onClick={() => chooseAdd('folders')} disabled={!folderPickerAvailable} className={`w-full h-9 px-3 flex items-center gap-2 text-left text-[14px] ${folderPickerAvailable ? 'text-[#1F1F1F] hover:bg-[#F1F3F4] dark:text-[#E3E3E3] dark:hover:bg-[#303134]' : 'opacity-40 cursor-default'}`}><FolderOpen size={15} /><span>{t.kbAddFolder}</span></button>
             </div>, document.body)}
         </div>
       );

--- a/pinvou3-app/src/features/personas/Personas.jsx
+++ b/pinvou3-app/src/features/personas/Personas.jsx
@@ -34,7 +34,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
     // 头像加载失败时按部门降级到本地图标
     const DEPT_ICON = { engineering: Terminal, design: Palette, product: AppWindow, marketing: TrendingUp, finance: Briefcase, sales: TrendingUp, testing: Cpu, 'project-management': Briefcase, 'paid-media': Radio, support: User, academic: Award, 'game-development': Cpu, 'spatial-computing': Globe, 'supply-chain': Briefcase, hr: User, legal: Award, specialized: Feather, tool: Cpu };
     // App Store 风头像块:本地头像图,失败降级图标(绝不显示文字)
-    const AppIcon = ({ card, isDark, cls = 'w-14 h-14 rounded-[14px]', fb = 26 }) => {
+    const AppIcon = ({ card, cls = 'w-14 h-14 rounded-[14px]', fb = 26 }) => {
       const [err, setErr] = useState(false);
       const Fallback = DEPT_ICON[(card && card.dept)] || User;
       return (
@@ -70,7 +70,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
                 className="absolute -top-2 -right-2 w-5 h-5 rounded-full flex items-center justify-center text-[11px] leading-none bg-[#fff] dark:bg-[#2C2C2E] border border-[rgba(0,0,0,.1)] dark:border-[#48484a]"
                 style={{ color:'#8E8E93', boxShadow:'0 2px 6px rgba(0,0,0,.15)' }}>✕</button>
               <div className="flex flex-col items-center text-center gap-2">
-                <AppIcon card={persona} isDark={isDark} cls="w-12 h-12 rounded-[14px]" fb={22} />
+                <AppIcon card={persona} cls="w-12 h-12 rounded-[14px]" fb={22} />
                 <div className="w-full min-w-0">
                   <div className="text-[13px] font-semibold leading-tight truncate text-[#000] dark:text-[#fff]">{cd.name}</div>
                   <div className="text-[11px] mt-0.5 truncate text-[rgba(60,60,67,.6)] dark:text-[rgba(235,235,245,.6)]">{deptLabelFor(t, persona.dept)}</div>
@@ -83,7 +83,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
     };
 
     // 双击卡片打开的详情 modal —— FLIP 转场 + 拉取并展示完整人设正文(body)。
-    const PersonaDetailModal = ({ card, originRect, equipped, onClose, onEquip, isDark, t }) => {
+    const PersonaDetailModal = ({ card, originRect, equipped, onClose, onEquip, t }) => {
       const panelRef = useRef(null);
       const [body, setBody] = useState(null); // null=loading
       useEffect(() => {
@@ -112,7 +112,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
             className="w-full h-[88vh] md:h-auto md:max-h-[84vh] md:max-w-[560px] flex flex-col rounded-t-[14px] md:rounded-[14px] overflow-hidden bg-[#F2F2F7] dark:bg-[#1C1C1E] text-[#000] dark:text-[#fff]">
             {/* 顶部:头像 + 名称/部门 + 关闭 */}
             <div className="flex items-center gap-4 px-5 pt-5 pb-4 shrink-0 bg-[#fff] dark:bg-[#000]">
-              <AppIcon card={card} isDark={isDark} />
+              <AppIcon card={card} />
               <div className="min-w-0 flex-1">
                 <h2 className="text-[20px] font-semibold truncate text-[#000] dark:text-[#fff]">{cd.name}</h2>
                 <p className="text-[13px] mt-0.5" style={{ color:'#8E8E93' }}>{deptLabelFor(t, card.dept)}{card.source==='user'?' · ' + t.cpBadgeUser:''}</p>
@@ -139,7 +139,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
     };
 
     // 自创卡编辑器:新建 / 编辑 / ③ 草稿预填都复用它。initial.source==='user' 且有 id → 编辑(update),否则新建(create)。
-    const PersonaEditorModal = ({ initial, onClose, onSaved, onDeleted, isDark, t }) => {
+    const PersonaEditorModal = ({ initial, onClose, onSaved, onDeleted, t }) => {
       const init = initial || {};
       const isEdit = !!(init.id && init.source === 'user');
       const [confirmDel, setConfirmDel] = useState(false);
@@ -423,7 +423,7 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
                           <div key={c.id} onClick={(e) => openDetail(c, e)} onContextMenu={(e) => openCtx(c, e)}
                             className="group py-4 flex flex-col gap-2.5 border-b cursor-pointer border-b-[rgba(198,198,200,.5)] dark:border-b-[#38383A]">
                             <div className="flex items-center gap-4">
-                              <AppIcon card={c} isDark={isDark} />
+                              <AppIcon card={c} />
                               <div className="flex-1 min-w-0">
                                 <h2 className="text-[17px] font-semibold tracking-tight truncate mb-0.5 text-[#000] dark:text-[#fff]">{cd.name}</h2>
                                 <p className="text-[13px] truncate text-[rgba(60,60,67,.6)] dark:text-[rgba(235,235,245,.6)]">{deptLabelFor(t, c.dept)}{isUser ? ' · ' + t.cpBadgeUser : ''}</p>
@@ -473,13 +473,13 @@ const DEPT_LABELS = { academic:'学术', design:'设计', engineering:'工程', 
 
           {detail ? createPortal((
             <PersonaDetailModal card={detail.card} originRect={detail.rect} equipped={active && active.id===detail.card.id}
-              isDark={isDark} t={t} onClose={()=>setDetail(null)}
+              t={t} onClose={()=>setDetail(null)}
               onEquip={(card)=>{ equip(card); }} />
           ), document.body) : null}
 
           {/* 自创卡编辑器(新建/编辑) —— portal 到 body,蒙层盖住侧边栏 */}
           {editor ? createPortal((
-            <PersonaEditorModal initial={editor.initial} isDark={isDark} t={t}
+            <PersonaEditorModal initial={editor.initial} t={t}
               onClose={()=>setEditor(null)}
               onSaved={(sum)=>setToast((editor.initial && editor.initial.id ? t.cpToastSaved : t.cpToastCreated)(sum.name))}
               onDeleted={(card)=>setToast(t.cpToastDeleted(card.name))} />

--- a/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
+++ b/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
@@ -224,11 +224,11 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
           })}
           {footerAction && (
             <>
-              <div className={`my-1 mx-2 h-px ${isDark ? 'bg-[#3A3B3E]' : 'bg-[#DFE1E5]'}`} />
+              <div className={`my-1 mx-2 h-px bg-[#DFE1E5] dark:bg-[#3A3B3E]`} />
               <button type="button"
                 onClick={() => { closeMenu(); footerAction.onClick(); }}
-                className={`flex w-full min-h-9 items-center gap-3 rounded-[8px] px-3 py-2 text-left text-[14px] transition-colors ${isDark ? 'text-[#E3E3E3] hover:bg-[#303134]' : 'text-[#202124] hover:bg-[#F1F3F4]'}`}>
-                <Plus size={15} className={`shrink-0 ${isDark ? 'text-[#9AA0A6]' : 'text-[#5F6368]'}`} />
+                className={`flex w-full min-h-9 items-center gap-3 rounded-[8px] px-3 py-2 text-left text-[14px] transition-colors text-[#202124] hover:bg-[#F1F3F4] dark:text-[#E3E3E3] dark:hover:bg-[#303134]`}>
+                <Plus size={15} className={`shrink-0 text-[#5F6368] dark:text-[#9AA0A6]`} />
                 <span className="min-w-0 flex-1 truncate">{footerAction.label}</span>
               </button>
             </>

--- a/pinvou3-app/src/features/tools/tool-common.jsx
+++ b/pinvou3-app/src/features/tools/tool-common.jsx
@@ -168,7 +168,7 @@ const AcFmtIcon = FileTypeIcon;
       });
       return fields;
     };
-    const ReceiptBlock = ({ text, isDark, t }) => {
+    const ReceiptBlock = ({ text, t }) => {
       const f = parseReceipt(text);
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       const body = 'text-[#444746] dark:text-[#C4C7C5]';
@@ -177,10 +177,10 @@ const AcFmtIcon = FileTypeIcon;
       const pv = (f.preview && f.preview !== '(none)') ? f.preview.replace(/\\n/g, '\n') : '';
       const pvIsDiff = pv && (/(^|\n)@@/.test(pv) || (pv.indexOf('@@') >= 0 && /(^|\n)[+-]/.test(pv)));
       const note = <div className={`mt-0.5 text-[11px] ${muted}`}>{t.receiptNote}</div>;
-      if (pvIsDiff) return (<div><DiffView text={pv} isDark={isDark} t={t} />{note}</div>);
+      if (pvIsDiff) return (<div><DiffView text={pv} t={t} />{note}</div>);
       return (
         <div>
-          <div className={outBox(isDark)} style={{ whiteSpace: 'pre-wrap' }}>{pv || t.receiptEmpty}</div>
+          <div className={outBox()} style={{ whiteSpace: 'pre-wrap' }}>{pv || t.receiptEmpty}</div>
           {pv ? note : null}
         </div>
       );
@@ -197,36 +197,35 @@ const AcFmtIcon = FileTypeIcon;
     };
     const looksDiff = (text) => typeof text === 'string'
       && /(^|\n)--- /.test(text) && /(^|\n)\+\+\+ /.test(text);
-    // P3: isDark 参数现已 vestigial(内部三元式已迁 dark:);保留函数签名以免改 tool-renderers 调用点 outBox(isDark)。
-    const outBox = (isDark) => 'tool-card-output custom-scrollbar rounded-lg p-2 text-[12px] bg-white text-[#444746] dark:bg-[#131314] dark:text-[#C4C7C5]';
+    const outBox = () => 'tool-card-output custom-scrollbar rounded-lg p-2 text-[12px] bg-white text-[#444746] dark:bg-[#131314] dark:text-[#C4C7C5]';
     const TODO_SYM = { completed: '☑', in_progress: '◐', pending: '☐' };
     const TODO_TOOLS = ['checklist_write', 'checklist_update', 'checklist_add', 'checklist_list', 'todo_write', 'todo_update', 'todo_add', 'todo_list', 'update_plan'];
 
-    const OutputPre = ({ text, isDark }) => (
-      <pre className={outBox(isDark)} style={{ whiteSpace: 'pre-wrap' }}>
+    const OutputPre = ({ text }) => (
+      <pre className={outBox()} style={{ whiteSpace: 'pre-wrap' }}>
         {typeof text === 'string' ? text : JSON.stringify(text, null, 2)}
       </pre>
     );
-    const OutputError = ({ text, isDark }) => (
+    const OutputError = ({ text }) => (
       <pre className={`tool-card-output custom-scrollbar rounded-lg p-2 text-[12px] bg-white text-[#C5221F] dark:bg-[#131314] dark:text-[#F28B82]`} style={{ whiteSpace: 'pre-wrap' }}>
         {typeof text === 'string' ? text : JSON.stringify(text, null, 2)}
       </pre>
     );
-    const ListDirView = ({ items, isDark, t }) => {
+    const ListDirView = ({ items, t }) => {
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       const sorted = items.slice().sort((a, b) => ((b.is_dir ? 1 : 0) - (a.is_dir ? 1 : 0)) || String(a.name).localeCompare(String(b.name)));
       return (
-        <div className={outBox(isDark)} style={{ fontFamily: 'monospace' }}>
+        <div className={outBox()} style={{ fontFamily: 'monospace' }}>
           <div className={`mb-1 ${muted}`} style={{ fontFamily: 'inherit' }}>{t.listDirCount(items.length)}</div>
           {sorted.map((it, i) => <div key={i}>{it.is_dir ? '📁' : '📄'} {it.name}{it.is_dir ? '/' : ''}</div>)}
         </div>
       );
     };
-    const GrepView = ({ data, isDark, t }) => {
+    const GrepView = ({ data, t }) => {
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       const matches = Array.isArray(data.matches) ? data.matches : [];
       return (
-        <div className={outBox(isDark)}>
+        <div className={outBox()}>
           <div className={`mb-1 ${muted}`}>
             {t.grepHits(data.total_matches != null ? data.total_matches : matches.length)}
             {data.files_searched != null ? t.grepFiles(data.files_searched) : ''}
@@ -244,7 +243,7 @@ const AcFmtIcon = FileTypeIcon;
     // IDE 风格 diff viewer:解析 unified diff → 行号 + 着色背景 + 文件头 + 摘要脚注。
     // 替换原纯文本按行着色版本(2026-07 升级,对齐 Cursor/Claude Code/Cline 行业标准)。
     // 解析失败或 receipt preview 截断时降级为单列文本,绝不崩。
-    const DiffView = ({ text, isDark, t }) => {
+    const DiffView = ({ text, t }) => {
       const parsed = useMemo(() => parseUnifiedDiff(text), [text]);
       // M4:diffStats 在 parsed 不变时不必重算,用 useMemo 避免每次渲染 O(n) 扫描。
       // 多文件场景每个 file 段各自算 stats;顶层 stats(向后兼容/全局胶囊)只走聚合。
@@ -266,7 +265,7 @@ const AcFmtIcon = FileTypeIcon;
           // "[diff omitted] ..." 原因(summary 在前)。summary 走正常字色,
           // omitReason 整段保持灰字提示。
           return (
-            <div className={outBox(isDark)} style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+            <div className={outBox()} style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
               {parsed.summary ? <div className={body + ' mb-1'}>{parsed.summary}</div> : null}
               <div className={muted}>{parsed.omitReason}</div>
             </div>
@@ -279,7 +278,7 @@ const AcFmtIcon = FileTypeIcon;
         const muted = 'text-[#757575] dark:text-[#8E8E8E]';
         const color = (l) => /^(\+\+\+|---)/.test(l) ? muted : l.startsWith('+') ? add : l.startsWith('-') ? del : l.startsWith('@@') ? hunk : '';
         return (
-          <pre className={outBox(isDark)} style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
+          <pre className={outBox()} style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace' }}>
             {lines.map((l, i) => <div key={i} className={color(l)}>{l || ' '}</div>)}
           </pre>
         );
@@ -309,7 +308,7 @@ const AcFmtIcon = FileTypeIcon;
         // 内联样式优先级最高:显式 y 滚动 + x 裁剪(保圆角),expanded 时放开 max-height。
         <div
           data-testid="diff-view"
-          className={`${outBox(isDark)} p-0`}
+          className={`${outBox()} p-0`}
           style={{ overflowY: 'auto', overflowX: 'hidden', ...(expanded ? { maxHeight: 'none' } : {}) }}
         >
           {files.map((file, fi) => {
@@ -389,11 +388,11 @@ const AcFmtIcon = FileTypeIcon;
         </div>
       );
     };
-    const ShellView = ({ data, isDark, t }) => {
+    const ShellView = ({ data, t }) => {
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       const del = 'text-[#C5221F] dark:text-[#F28B82]';
       return (
-        <div className={outBox(isDark)}>
+        <div className={outBox()}>
           <div className={`mb-1 ${muted}`}>
             {data.status || ''}{data.exit_code != null ? ` · exit ${data.exit_code}` : ''}
             {data.duration_ms != null ? ` · ${data.duration_ms}ms` : ''}
@@ -405,20 +404,20 @@ const AcFmtIcon = FileTypeIcon;
       );
     };
     // exec_shell 的 content 其实是纯 stdout 文本（结构化字段在 metadata，前端没拿）→ 给终端样式
-    const ShellTextView = ({ cmd, text, isDark }) => {
+    const ShellTextView = ({ cmd, text }) => {
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       return (
-        <div className={outBox(isDark)} style={{ fontFamily: 'monospace' }}>
+        <div className={outBox()} style={{ fontFamily: 'monospace' }}>
           {cmd && <div className={muted} style={{ whiteSpace: 'pre-wrap' }}>$ {cmd}</div>}
           <pre style={{ whiteSpace: 'pre-wrap', margin: 0, fontFamily: 'inherit' }}>{typeof text === 'string' ? text : JSON.stringify(text)}</pre>
         </div>
       );
     };
-    const TodoView = ({ snap, isDark, t }) => {
+    const TodoView = ({ snap, t }) => {
       const muted = 'text-[#757575] dark:text-[#8E8E8E]';
       const items = Array.isArray(snap.items) ? snap.items : [];
       return (
-        <div className={outBox(isDark)}>
+        <div className={outBox()}>
           {snap.completion_pct != null && <div className={`mb-1 ${muted}`}>{t.todoProgress(snap.completion_pct)}</div>}
           {snap.explanation && <div className="mb-1">{snap.explanation}</div>}
           {items.map((it, i) => (
@@ -543,7 +542,7 @@ const AcFmtIcon = FileTypeIcon;
     };
     const isWeatherTool = (name) => name === 'mcp_weather_get_weather';
     const isStockQuoteTool = (name) => name === 'mcp_iwencai_hithink_market_query';
-    const StockQuoteCard = ({ data, isDark, t }) => {
+    const StockQuoteCard = ({ data, t }) => {
       const T = tc(t);
       const price = typeof data.price === 'string' ? parseFloat(data.price) : data.price;
       const changePercent = typeof data.changePercent === 'string' ? parseFloat(data.changePercent) : data.changePercent;

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -208,7 +208,7 @@ function expertStatusPresentation({ summary, failedSpawn = false, itemState, cop
  * `pinvou:open-subagent`，由 ChatView 打开只读执行记录面板。
  * status/wait/cancel 等协调操作渲染成安静的单行，不冒充新委派。
  */
-const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
+const ExpertAgentCard = ({ item, t, sessionId: sessionIdProp }) => {
   const copy = t.uiMultiAgent;
   const args = item.args || {};
   const agentId = extractSubagentId(item.output);
@@ -539,12 +539,12 @@ const ToolOutput = ({ item, t }) => {
       return <OutputPre text={out} />;
     };
 
-    const ToolCard = ({ item, theme, t, variant = 'legacy', sessionId }) => {
+    const ToolCard = ({ item, t, variant = 'legacy', sessionId }) => {
       // 委派实例不走通用工具卡：专家卡是多智能体的第一公民展示（ADR-0006）。
       // 提前返回发生在本组件任何 Hook 之前，且 item.name 对一个实例终生不变，
       // 因此每个实例的 Hook 数量恒定，不触犯 Hook 规则。
       if (EXPERT_CARD_ENABLED && (item.name === 'agent' || isAgentWaitCall(item.name, item.args))) {
-        return <ExpertAgentCard item={item} theme={theme} t={t} sessionId={sessionId} />;
+        return <ExpertAgentCard item={item} t={t} sessionId={sessionId} />;
       }
       const isTimeline = variant === 'timeline';
       const isRunning = item.state === 'running';

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -209,7 +209,6 @@ function expertStatusPresentation({ summary, failedSpawn = false, itemState, cop
  * status/wait/cancel 等协调操作渲染成安静的单行，不冒充新委派。
  */
 const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
-  const isDark = theme === 'dark';
   const copy = t.uiMultiAgent;
   const args = item.args || {};
   const agentId = extractSubagentId(item.output);
@@ -328,9 +327,7 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
       <div
         data-testid="expert-agent-card"
         className={`flex w-full items-center rounded-[12px] border px-2 py-1.5 transition-colors ${
-          isDark
-            ? 'border-[#38383A] bg-[#1C1C1E] hover:bg-[#2C2C2E]'
-            : 'border-[#E5E5EA] bg-white hover:bg-[#F2F2F7]'
+          'border-[#E5E5EA] bg-white hover:bg-[#F2F2F7] dark:border-[#38383A] dark:bg-[#1C1C1E] dark:hover:bg-[#2C2C2E]'
         }`}
       >
         <button
@@ -340,7 +337,6 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
         >
           <AppIcon
             card={{ id: identity.avatarKey, name: subtitle || name, dept: identity.personaDept }}
-            isDark={isDark}
             cls="h-8 w-8 shrink-0 overflow-hidden rounded-[10px]"
             fb={14}
           />
@@ -348,7 +344,7 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
             className="min-w-0 max-w-[148px] shrink-0"
             title={subtitle ? `${name} · ${subtitle}` : name}
           >
-            <span className={`block truncate text-[12.5px] font-semibold leading-[15px] ${isDark ? 'text-[#E5E5EA]' : 'text-[#1C1C1E]'}`}>
+            <span className={`block truncate text-[12.5px] font-semibold leading-[15px] text-[#1C1C1E] dark:text-[#E5E5EA]`}>
               {name}
             </span>
             {subtitle && (
@@ -423,7 +419,7 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
                   data-testid="expert-agent-child-card"
                   onClick={() => openSubagentTranscript(entry.agent_id, sessionId)}
                   className={`flex min-w-0 flex-1 items-center gap-2 rounded-[10px] px-2 py-1.5 text-left ${
-                    isDark ? 'hover:bg-white/[0.06]' : 'hover:bg-black/[0.035]'
+                    'hover:bg-black/[0.035] dark:hover:bg-white/[0.06]'
                   }`}
                 >
                   <AppIcon
@@ -432,7 +428,6 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
                       name: childPresentation.subtitle || childPresentation.name,
                       dept: childPresentation.identity.personaDept,
                     }}
-                    isDark={isDark}
                     cls="h-7 w-7 shrink-0 overflow-hidden rounded-[9px]"
                     fb={13}
                   />
@@ -442,7 +437,7 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
                       ? `${childPresentation.name} · ${childPresentation.subtitle}`
                       : childPresentation.name}
                   >
-                    <span className={`block truncate text-[11.5px] font-semibold leading-[14px] ${isDark ? 'text-[#E5E5EA]' : 'text-[#1C1C1E]'}`}>
+                    <span className={`block truncate text-[11.5px] font-semibold leading-[14px] text-[#1C1C1E] dark:text-[#E5E5EA]`}>
                       {childPresentation.name}
                     </span>
                     {childPresentation.subtitle && (

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -473,9 +473,9 @@ const ExpertAgentCard = ({ item, theme, t, sessionId: sessionIdProp }) => {
   );
 };
 
-const ToolOutput = ({ item, isDark, t }) => {
+const ToolOutput = ({ item, t }) => {
       const out = item.output;
-      if (item.success === false) return <OutputError text={out} isDark={isDark} />;
+      if (item.success === false) return <OutputError text={out} />;
       if (isWeatherTool(item.name)) {
         let raw = out;
         const envelope = tryParseJson(out);
@@ -512,36 +512,36 @@ const ToolOutput = ({ item, isDark, t }) => {
             high: findVal(d, '最高价'),
             low: findVal(d, '最低价'),
           };
-          return <StockQuoteCard data={mapped} isDark={isDark} t={t} />;
+          return <StockQuoteCard data={mapped} t={t} />;
         }
-        if (w && w.type === 'stock_quote' && !w.error) return <StockQuoteCard data={w} isDark={isDark} t={t} />;
+        if (w && w.type === 'stock_quote' && !w.error) return <StockQuoteCard data={w} t={t} />;
       }
-      if (isReceipt(out)) return <ReceiptBlock text={out} isDark={isDark} t={t} />;
-      if (item.name === 'list_dir') { const v = tryParseJson(out); if (Array.isArray(v)) return <ListDirView items={v} isDark={isDark} t={t} />; }
-      else if (item.name === 'grep_files') { const v = tryParseJson(out); if (v && Array.isArray(v.matches)) return <GrepView data={v} isDark={isDark} t={t} />; }
+      if (isReceipt(out)) return <ReceiptBlock text={out} t={t} />;
+      if (item.name === 'list_dir') { const v = tryParseJson(out); if (Array.isArray(v)) return <ListDirView items={v} t={t} />; }
+      else if (item.name === 'grep_files') { const v = tryParseJson(out); if (v && Array.isArray(v.matches)) return <GrepView data={v} t={t} />; }
       else if (isShellExecutionTool(item.name)) {
         const v = tryParseJson(out);
-        if (v && (v.stdout != null || v.exit_code != null || v.status)) return <ShellView data={v} isDark={isDark} t={t} />;
-        return <ShellTextView cmd={item.args && item.args.command} text={out} isDark={isDark} />;
+        if (v && (v.stdout != null || v.exit_code != null || v.status)) return <ShellView data={v} t={t} />;
+        return <ShellTextView cmd={item.args && item.args.command} text={out} />;
       }
       // edit_file / write_file 走 Rust similar crate 输出 unified diff,走 DiffView。
       // 注意:apply_patch 后端返回 JSON(apply_patch.rs::execute 返回 ToolResult::json),
       // looksDiff 永远 false,所以这里不把 apply_patch 加进路由 —— 加了也只是 dead code
       // (PR #195 M2)。若未来后端给 apply_patch 输出 unified diff,再把它加回来。
-      else if (item.name === 'edit_file' || item.name === 'write_file') { if (looksDiff(out)) return <DiffView text={out} isDark={isDark} t={t} />; }
+      else if (item.name === 'edit_file' || item.name === 'write_file') { if (looksDiff(out)) return <DiffView text={out} t={t} />; }
       else if (item.name === 'append_file') {
         // append_file 与 write_file 一样由后端输出 unified diff,走 DiffView;
         // 旧 session 落盘的是 "appended N bytes" 纯文本,保留字节摘要兜底。
-        if (looksDiff(out)) return <DiffView text={out} isDark={isDark} />;
+        if (looksDiff(out)) return <DiffView text={out} />;
         // 旧文件超大时后端输出 "summary\n[diff omitted] ...":不能只显示字节摘要,
         // 否则 omit 说明被吞掉 —— 与 write_file 一样落到 OutputPre 展示完整原文。
         if (!/\[diff omitted\]/i.test(out)) {
           const m = String(out).match(/appended (\d+) bytes[\s\S]*?\((\d+) -> (\d+) bytes\)/i);
-          if (m) return <div className={outBox(isDark)}>{t.appendBytes(/^Created/i.test(out), m[1], m[2], m[3])}</div>;
+          if (m) return <div className={outBox()}>{t.appendBytes(/^Created/i.test(out), m[1], m[2], m[3])}</div>;
         }
       }
-      else if (TODO_TOOLS.indexOf(item.name) >= 0) { const v = tryTailJson(out); if (v && Array.isArray(v.items)) return <TodoView snap={v} isDark={isDark} t={t} />; }
-      return <OutputPre text={out} isDark={isDark} />;
+      else if (TODO_TOOLS.indexOf(item.name) >= 0) { const v = tryTailJson(out); if (v && Array.isArray(v.items)) return <TodoView snap={v} t={t} />; }
+      return <OutputPre text={out} />;
     };
 
     const ToolCard = ({ item, theme, t, variant = 'legacy', sessionId }) => {
@@ -571,9 +571,6 @@ const ToolOutput = ({ item, isDark, t }) => {
       const isFailed = item.state === 'failed';
       const quiet = QUIET_TOOLS.has(item.name);
       const summary = toolSummary(item.name, item.args, t);
-
-      // P3: isDark 仍为 ToolOutput 子组件 prop 透传保留(detail 行 <ToolOutput isDark={isDark} />)。
-      const isDark = theme === 'dark';
 
       // 状态色:按 isRunning/isDone/isFailed 三态,各自给出 light base + dark: token。
       const statusColor = isRunning
@@ -622,7 +619,7 @@ const ToolOutput = ({ item, isDark, t }) => {
       const detail = displayExpanded ? (
         <div className={`${isTimeline ? 'px-3 pb-3' : 'px-4 pb-3'} border-t border-black/5 dark:border-white/5`}>
           {item.output != null
-            ? <div className="mt-2"><ToolOutput item={item} isDark={isDark} t={t} /></div>
+            ? <div className="mt-2"><ToolOutput item={item} t={t} /></div>
             : null}
         </div>
       ) : null;
@@ -748,21 +745,21 @@ const ToolOutput = ({ item, isDark, t }) => {
       );
     };
 
-    const cardBoxCls = (isDark, accent) =>
-      `rounded-[16px] border p-4 my-1 ${isDark ? 'bg-[#1E1F20] border-white/10' : 'bg-[#F0F4F9] border-black/5'} ${accent || ''}`;
-    const cardBtnCls = (isDark, variant) => {
+    const cardBoxCls = (accent) =>
+      `rounded-[16px] border p-4 my-1 bg-[#F0F4F9] border-black/5 dark:bg-[#1E1F20] dark:border-white/10 ${accent || ''}`;
+    const cardBtnCls = (variant) => {
       const base = 'px-3 py-1.5 rounded-full text-[13px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed';
-      if (variant === 'primary') return `${base} ${isDark ? 'bg-[#A8C7FA] text-[#062E6F] hover:bg-[#C2DBFF]' : 'bg-[#0B57D0] text-white hover:bg-[#0A4BB8]'}`;
-      return `${base} ${isDark ? 'bg-[#333537] text-[#E3E3E3] hover:bg-[#444746]' : 'bg-white text-[#1F1F1F] hover:bg-[#E1E5EA] border border-black/10'}`;
+      if (variant === 'primary') return `${base} bg-[#0B57D0] text-white hover:bg-[#0A4BB8] dark:bg-[#A8C7FA] dark:text-[#062E6F] dark:hover:bg-[#C2DBFF]`;
+      return `${base} bg-white text-[#1F1F1F] hover:bg-[#E1E5EA] border border-black/10 dark:border-transparent dark:bg-[#333537] dark:text-[#E3E3E3] dark:hover:bg-[#444746]`;
     };
 
     // 品悟角色配色（与产物卡一致）：品=盾·橙 #FF9500/#FF9F0A，悟=闪光·紫 #5E5CE6。
-    // 返回 { name, accentHex, text(类), softBg(类), Icon }。
+    // 返回 { name, accentHex(inline-style 原色,品需 isDark), text(类), softBg(类), Icon }。
     const pvRole = (isWu, isDark) => isWu
       ? { name: '悟', accentHex: '#5E5CE6', text: 'text-[#5E5CE6]',
-          softBg: isDark ? 'bg-[#5E5CE6]/15' : 'bg-[#5E5CE6]/[0.10]', Icon: AcSparkles }
-      : { name: '品', accentHex: isDark ? '#FF9F0A' : '#FF9500', text: isDark ? 'text-[#FF9F0A]' : 'text-[#FF9500]',
-          softBg: isDark ? 'bg-[#FF9F0A]/15' : 'bg-[#FF9500]/[0.10]', Icon: AcShieldCheck };
+          softBg: 'bg-[#5E5CE6]/[0.10] dark:bg-[#5E5CE6]/15', Icon: AcSparkles }
+      : { name: '品', accentHex: isDark ? '#FF9F0A' : '#FF9500', text: 'text-[#FF9500] dark:text-[#FF9F0A]',
+          softBg: 'bg-[#FF9500]/[0.10] dark:bg-[#FF9F0A]/15', Icon: AcShieldCheck };
 
     // ==========================================
     // PinvouSummonCard — 🧭 召唤式检阅（Boss 主动呼叫 Pinvou）
@@ -891,7 +888,7 @@ const ToolOutput = ({ item, isDark, t }) => {
         return () => clearInterval(b);
       }, []);
       const role = pvRole(isWu, isDark);
-      // P3: isDark 保留——stroke 行内 style 与 pvRole(protected) 仍需它。
+      // isDark 保留——SVG circle stroke 与 pvRole 品·accentHex(inline-style 原色)仍需它。
       const muted = 'text-[#3C3C43]/60 dark:text-[#EBEBF5]/60';
       return (
         <div className="py-8 flex flex-col items-center text-center">
@@ -920,7 +917,7 @@ const ToolOutput = ({ item, isDark, t }) => {
       const role = pvRole(isWu, isDark);
       const muted = 'text-[#3C3C43]/60 dark:text-[#EBEBF5]/60';
       const body = 'text-[#000] dark:text-[#fff]';
-      // P3: isDark 保留——pvRole(protected) 与 PinvouLoading isDark prop 仍需它。
+      // isDark 保留——pvRole 品·accentHex 与 PinvouLoading SVG stroke 仍需它。
       if (item.loading) return <PinvouLoading isWu={isWu} isDark={isDark} t={t} isLocal={isLocal} />;
       if (item.error) return (
         <div className="py-2">
@@ -963,13 +960,11 @@ const ToolOutput = ({ item, isDark, t }) => {
     // ==========================================
     // PlanCard — ✨ 方案准备好
     // ==========================================
-    const PlanCard = ({ item, theme, t, onPrefill }) => {
-      const isDark = theme === 'dark';
+    const PlanCard = ({ item, t, onPrefill }) => {
       const webReadOnly = multiAgentWebReadOnly();
       const active = item.cardState === 'active' && !item.resolved && !!item.planId;
-      // P3: isDark 保留——cardBoxCls/cardBtnCls(protected) 仍需它。
       return (
-        <div className={cardBoxCls(isDark, isDark ? 'border-[#A8C7FA]/30' : 'border-[#0B57D0]/20')}>
+        <div className={cardBoxCls('border-[#0B57D0]/20 dark:border-[#A8C7FA]/30')}>
           <div className={`text-[14px] font-semibold mb-3 text-[#1F1F1F] dark:text-[#E3E3E3]`}>{t.planReady}</div>
           {(!item.plan && !item.todos)
             ? <div className={`text-[13px] text-[#444746] dark:text-[#C4C7C5]`}>{t.planEmpty}</div>
@@ -981,9 +976,9 @@ const ToolOutput = ({ item, isDark, t }) => {
           {active ? (
             <div className="flex items-center gap-2 flex-wrap">
               <span className={`text-[13px] mr-1 text-[#444746] dark:text-[#C4C7C5]`}>{t.planNext}</span>
-              <button className={cardBtnCls(isDark, 'primary') + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.acceptPlan(item.id, item.planMarkdown, undefined, item.planId)}>{t.planGo}</button>
-              <button className={cardBtnCls(isDark) + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => onPrefill && onPrefill(t.planRevisePrefill)}>{t.planEdit}</button>
-              <button className={cardBtnCls(isDark) + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.discardPlan(item.id, item.planId)}>{t.planDrop}</button>
+              <button className={cardBtnCls('primary') + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.acceptPlan(item.id, item.planMarkdown, undefined, item.planId)}>{t.planGo}</button>
+              <button className={cardBtnCls() + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => onPrefill && onPrefill(t.planRevisePrefill)}>{t.planEdit}</button>
+              <button className={cardBtnCls() + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.discardPlan(item.id, item.planId)}>{t.planDrop}</button>
             </div>
           ) : (
             <div className={`text-[13px] font-medium text-[#137333] dark:text-[#93D5A6]`}>{item.statusLabel}</div>
@@ -995,13 +990,11 @@ const ToolOutput = ({ item, isDark, t }) => {
     // ==========================================
     // PlanStuckCard — Plan 模式 AI 撞只读保护(白名单/sandbox)的兜底卡
     // ==========================================
-    const PlanStuckCard = ({ item, theme, t }) => {
-      const isDark = theme === 'dark';
+    const PlanStuckCard = ({ item, t }) => {
       const webReadOnly = multiAgentWebReadOnly();
       const done = item.resolved;
-      // P3: isDark 保留——cardBoxCls/cardBtnCls(protected) 仍需它。
       return (
-        <div className={cardBoxCls(isDark, isDark ? 'border-[#FDD663]/30' : 'border-[#E37400]/20')}>
+        <div className={cardBoxCls('border-[#E37400]/20 dark:border-[#FDD663]/30')}>
           <div className={`text-[13px] leading-relaxed mb-3 text-[#1F1F1F] dark:text-[#E3E3E3]`}>
             {t.stuckPlanPre} <code className="px-1 rounded bg-black/20">{item.toolName || t.uiToolRender.toolUnknown}</code> {t.stuckPlanPost}
           </div>
@@ -1009,8 +1002,8 @@ const ToolOutput = ({ item, isDark, t }) => {
             <div className={`text-[13px] text-[#444746] dark:text-[#C4C7C5]`}>{item.statusLabel || t.handled}</div>
           ) : (
             <div className="flex items-center gap-2 flex-wrap">
-              <button className={cardBtnCls(isDark) + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.planStuckReplan(item.id)}>{t.stuckReplan}</button>
-              <button className={cardBtnCls(isDark, 'primary') + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.planStuckGo(item.id)}>⚡ {t.stuckGo}</button>
+              <button className={cardBtnCls() + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.planStuckReplan(item.id)}>{t.stuckReplan}</button>
+              <button className={cardBtnCls('primary') + ' disabled:opacity-40 disabled:cursor-not-allowed'} disabled={webReadOnly} onClick={() => bridge.interaction.planStuckGo(item.id)}>⚡ {t.stuckGo}</button>
             </div>
           )}
         </div>
@@ -1034,8 +1027,7 @@ const ToolOutput = ({ item, isDark, t }) => {
       for (let i = 0; i < REASON_MAP.length; i++) if (REASON_MAP[i][0].test(s)) return t[REASON_MAP[i][1]];
       return t.rsDefault;
     };
-    const CarefulBlockedCard = ({ item, theme, t }) => {
-      const isDark = theme === 'dark';
+    const CarefulBlockedCard = ({ item, t }) => {
       const [showTech, setShowTech] = useState(false);
       const md = item.metadata || {};
       const cmd = (item.args && (item.args.command || item.args.cmd)) || t.cbCmdUnknown;
@@ -1044,9 +1036,8 @@ const ToolOutput = ({ item, isDark, t }) => {
       const humanReasons = [...new Set(rawReasons.map(r => humanizeReason(r, t)))];
       if (humanReasons.length === 0) humanReasons.push(t.rsDefault);
       const hasTech = rawReasons.length > 0 || rawSuggestions.length > 0;
-      // P3: isDark 保留——cardBoxCls(protected) 仍需它。
       return (
-        <div className={cardBoxCls(isDark, isDark ? 'border-[#F28B82]/40' : 'border-[#C5221F]/30')}>
+        <div className={cardBoxCls('border-[#C5221F]/30 dark:border-[#F28B82]/40')}>
           <div className={`text-[14px] font-semibold mb-2 text-[#C5221F] dark:text-[#F28B82]`}>{t.cbTitle}</div>
           <div className={`text-[12px] mb-1 text-[#757575] dark:text-[#8E8E8E]`}>{t.cbWant}</div>
           <pre className={`text-[12px] font-mono rounded-lg p-2 mb-2 overflow-x-auto bg-white text-[#C5221F] dark:bg-[#131314] dark:text-[#F28B82]`}>{cmd}</pre>

--- a/pinvou3-app/src/features/workflow/WorkflowView.jsx
+++ b/pinvou3-app/src/features/workflow/WorkflowView.jsx
@@ -8,14 +8,7 @@ import { can, isWeb } from '../../shared/platform.js';
 import { dict } from '../../shared/i18n.js';
 import { OFFICE_HTML_STYLE } from '../artifacts/ArtifactsPanel.jsx';
 import { ScaledHtmlPreview } from '../settings/SettingsView.jsx';
-// Inlined equivalents of cardBtnCls(theme-derived) / cardBtnCls(theme-derived,'primary')
-// from tool-renderers.jsx, expanded to static dark: variant strings. tool-renderers.jsx is
-// migrated in its own P1-7 PR; this file inlines the two variants here (instead of calling
-// the helper) so it has zero theme-derived references. P1-7/P3 may later restore the helper
-// call as cardBtnCls(variant). Base matches tool-renderers.jsx cardBtnCls base; non-primary
-// dark originally had no border so dark:border-transparent suppresses the light-side border.
-const WF_BTN = 'px-3 py-1.5 rounded-full text-[13px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-white text-[#1F1F1F] hover:bg-[#E1E5EA] border border-black/10 dark:border-transparent dark:bg-[#333537] dark:text-[#E3E3E3] dark:hover:bg-[#444746]';
-const WF_BTN_PRIMARY = 'px-3 py-1.5 rounded-full text-[13px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-[#0B57D0] text-white hover:bg-[#0A4BB8] dark:bg-[#A8C7FA] dark:text-[#062E6F] dark:hover:bg-[#C2DBFF]';
+import { cardBtnCls } from '../tools/tool-renderers.jsx';
 
 const WidgetCard = ({ title, children, theme }) => {
       return (
@@ -954,7 +947,7 @@ const WidgetCard = ({ title, children, theme }) => {
             ))}
           </div>
           <div className="flex justify-end mt-3">
-            <button disabled={!canSubmit} onClick={submit} className={`${WF_BTN_PRIMARY} ${canSubmit ? '' : 'opacity-50 cursor-not-allowed'}`}>{t.uiWorkflow.submit}</button>
+            <button disabled={!canSubmit} onClick={submit} className={`${cardBtnCls('primary')} ${canSubmit ? '' : 'opacity-50 cursor-not-allowed'}`}>{t.uiWorkflow.submit}</button>
           </div>
         </div>
       );
@@ -997,16 +990,16 @@ const WidgetCard = ({ title, children, theme }) => {
               className="w-full rounded-[10px] p-2 text-[13px] outline-none border mb-2 bg-white dark:bg-[#131314] border-black/10 dark:border-white/10 text-[#1F1F1F] dark:text-[#E3E3E3]" />
           )}
           <div className="flex items-center gap-2 flex-wrap justify-end">
-            <button className={WF_BTN} onClick={() => card.roleId && bridge.workflow.selectWorkflowRole(card.roleId)}>{t.uiWorkflow.viewOutputs}</button>
+            <button className={cardBtnCls()} onClick={() => card.roleId && bridge.workflow.selectWorkflowRole(card.roleId)}>{t.uiWorkflow.viewOutputs}</button>
             {rejecting ? (
               <React.Fragment>
-                <button className={WF_BTN} onClick={() => { setRejecting(false); setReason(''); }}>{t.uiWorkflow.cancel}</button>
-                <button className={WF_BTN_PRIMARY} onClick={() => bridge.workflow.rejectWorkflowGate(card.cardId, card.roleId, reason.trim())}>{t.uiWorkflow.confirmReject}</button>
+                <button className={cardBtnCls()} onClick={() => { setRejecting(false); setReason(''); }}>{t.uiWorkflow.cancel}</button>
+                <button className={cardBtnCls('primary')} onClick={() => bridge.workflow.rejectWorkflowGate(card.cardId, card.roleId, reason.trim())}>{t.uiWorkflow.confirmReject}</button>
               </React.Fragment>
             ) : (
               <React.Fragment>
-                <button className={WF_BTN} onClick={() => setRejecting(true)}>{t.uiWorkflow.reject}</button>
-                <button className={WF_BTN_PRIMARY} onClick={() => bridge.workflow.approveWorkflowGate(card.cardId, card.roleId)}>{t.uiWorkflow.gateApprove}</button>
+                <button className={cardBtnCls()} onClick={() => setRejecting(true)}>{t.uiWorkflow.reject}</button>
+                <button className={cardBtnCls('primary')} onClick={() => bridge.workflow.approveWorkflowGate(card.cardId, card.roleId)}>{t.uiWorkflow.gateApprove}</button>
               </React.Fragment>
             )}
           </div>
@@ -1034,8 +1027,8 @@ const WidgetCard = ({ title, children, theme }) => {
                     <div className="text-[14px] font-semibold mb-2 text-[#1F1F1F] dark:text-[#E3E3E3]">{card.text || t.uiWorkflow.completed}</div>
                     <div className="text-[12px] mb-3 break-all text-[#757575] dark:text-[#8E8E8E]">{card.path}</div>
                     <div className="flex items-center gap-2 flex-wrap justify-end">
-                      <button className={WF_BTN} onClick={() => bridge.artifacts.openContainingFolder(card.path)}>{t.uiWorkflow.openFolder}</button>
-                      <button className={WF_BTN_PRIMARY} onClick={() => bridge.artifacts.openArtifactExternal(card.path)}>{t.uiWorkflow.openProduct}</button>
+                      <button className={cardBtnCls()} onClick={() => bridge.artifacts.openContainingFolder(card.path)}>{t.uiWorkflow.openFolder}</button>
+                      <button className={cardBtnCls('primary')} onClick={() => bridge.artifacts.openArtifactExternal(card.path)}>{t.uiWorkflow.openProduct}</button>
                     </div>
                   </div>
                 ) : null}
@@ -1122,7 +1115,7 @@ const WidgetCard = ({ title, children, theme }) => {
               {wfUi.attachments && (!isWeb || can('hostFilePicker')) && (
                 <div>
                   <label className="block text-[12px] font-semibold mb-1.5 text-[#0B57D0] dark:text-[#A8C7FA]">{t.uiWorkflow.attachments}</label>
-                  <button onClick={pickAttachments} disabled={picking || starting} className={`${WF_BTN} disabled:opacity-40`}>
+                  <button onClick={pickAttachments} disabled={picking || starting} className={`${cardBtnCls()} disabled:opacity-40`}>
                     {picking ? t.uiWorkflow.picking : <span className="inline-flex items-center gap-1.5"><Paperclip size={14} />{isWeb ? t.uiWorkflow.pickDesktopFiles : t.uiWorkflow.uploadAttachments}</span>}
                   </button>
                   {files.length > 0 && (
@@ -1144,8 +1137,8 @@ const WidgetCard = ({ title, children, theme }) => {
               {error && <div className="text-[13px] text-[#C5221F] dark:text-[#F28B82]">⚠️ {error}</div>}
             </div>
             <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-black/10 dark:border-white/10">
-              <button onClick={onClose} disabled={starting} className={`${WF_BTN} disabled:opacity-40 disabled:cursor-not-allowed`}>{t.uiWorkflow.cancel}</button>
-              <button onClick={start} disabled={starting} className={`${WF_BTN_PRIMARY} ${starting ? 'opacity-60 cursor-not-allowed' : ''}`}>{starting ? t.uiWorkflow.starting : t.uiWorkflow.start}</button>
+              <button onClick={onClose} disabled={starting} className={`${cardBtnCls()} disabled:opacity-40 disabled:cursor-not-allowed`}>{t.uiWorkflow.cancel}</button>
+              <button onClick={start} disabled={starting} className={`${cardBtnCls('primary')} ${starting ? 'opacity-60 cursor-not-allowed' : ''}`}>{starting ? t.uiWorkflow.starting : t.uiWorkflow.start}</button>
             </div>
           </div>
         </div>
@@ -1333,18 +1326,18 @@ const WidgetCard = ({ title, children, theme }) => {
             <div className="flex items-center gap-2">
               {/* 回奏已完成的 run 常驻奏折入口(自动弹窗只在完成瞬间触发一次,事后/刷新后从这里看) */}
               {memorialRoleId && memorialDone && (
-                <button onClick={() => setMemorialOpen(true)} className={WF_BTN}>{t.uiWorkflow.memorialBtn}</button>
+                <button onClick={() => setMemorialOpen(true)} className={cardBtnCls()}>{t.uiWorkflow.memorialBtn}</button>
               )}
               {run.status === 'stopped' ? (
-                <button onClick={() => openRestart(restartBrief)} className={WF_BTN_PRIMARY}>{t.uiWorkflow.editAndRestart}</button>
+                <button onClick={() => openRestart(restartBrief)} className={cardBtnCls('primary')}>{t.uiWorkflow.editAndRestart}</button>
               ) : run.status !== 'complete' ? (
                 <button data-testid="workflow-stop-restart" onClick={stopAndRestart} disabled={stopping}
-                  className={`${WF_BTN} ${stopping ? 'opacity-50 cursor-not-allowed' : ''}`}>{stopping ? t.uiWorkflow.stopping : t.uiWorkflow.stopAndEdit}</button>
+                  className={`${cardBtnCls()} ${stopping ? 'opacity-50 cursor-not-allowed' : ''}`}>{stopping ? t.uiWorkflow.stopping : t.uiWorkflow.stopAndEdit}</button>
               ) : null}
-              <button onClick={() => { setOpened(false); setExited(true); }} className={WF_BTN}>{t.uiWorkflow.backToTemplates}</button>
+              <button onClick={() => { setOpened(false); setExited(true); }} className={cardBtnCls()}>{t.uiWorkflow.backToTemplates}</button>
               {/* 看板内新建 = 跟当前看板同工作流(开机自动恢复直接进看板时没经过模板卡,
                   必须在这里按 run 反查工作流对象,否则表单回落错) */}
-              <button onClick={() => { setRestartBrief(''); setNewTaskWorkflow(runWorkflow || workflows[0] || null); setShowNewTask(true); }} className={WF_BTN_PRIMARY}>{t.uiWorkflow.newTask}</button>
+              <button onClick={() => { setRestartBrief(''); setNewTaskWorkflow(runWorkflow || workflows[0] || null); setShowNewTask(true); }} className={cardBtnCls('primary')}>{t.uiWorkflow.newTask}</button>
             </div>
           </div>
           <div className="flex-1 overflow-auto custom-scrollbar px-6 md:px-10 pb-4">

--- a/pinvou3-app/tests/workflow_other_answer_contract.test.mjs
+++ b/pinvou3-app/tests/workflow_other_answer_contract.test.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 // 这是一个源码契约守卫（无需 DOM/bundler）：仅断言关键代码形态成立。
 const root = fileURLToPath(new URL('../', import.meta.url));
 const wf = fs.readFileSync(path.join(root, 'src/features/workflow/WorkflowView.jsx'), 'utf8');
+const codex = fs.readFileSync(path.join(root, 'src/features/codex/CodexAcpView.jsx'), 'utf8');
 const i18n = fs.readFileSync(path.join(root, 'src/shared/i18n.js'), 'utf8');
 
 // 1. 「其他」答案对象必须带稳定字段 kind:'other'，label 走 i18n。
@@ -58,4 +59,28 @@ assert.match(
   "WorkflowView 次要操作必须用 cardBtnCls() 保持默认样式",
 );
 
-console.log('OK: Workflow 「其他」答案契约 + cardBtnCls 签名契约 (kind:other 高亮 + i18n label 三语 + P3 签名)');
+// 5. cardBtnCls/cardBoxCls 的 P3 单参签名必须覆盖全部消费 View。
+//    CodexAcpView 的 NativePlanCard/NativeYoloConfirmCard 曾漏改（旧签名把布尔当
+//    variant/accent，主按钮静默退化为默认样式、卡片边框类丢失——评审 #168 指出）。
+assert.doesNotMatch(
+  codex,
+  /cardBtnCls\(\s*isDark/,
+  "CodexAcpView 不得再用旧签名 cardBtnCls(isDark, ...)；应改为 cardBtnCls() / cardBtnCls('primary')",
+);
+assert.doesNotMatch(
+  codex,
+  /cardBoxCls\(\s*isDark/,
+  "CodexAcpView 不得再用旧签名 cardBoxCls(isDark, ...)；accent 应预拼 dark: 串",
+);
+assert.match(
+  codex,
+  /cardBtnCls\('primary'\)/,
+  "CodexAcpView 主操作（接受方案/确认 yolo）必须用 cardBtnCls('primary') 保持 primary 样式",
+);
+assert.match(
+  codex,
+  /cardBtnCls\(\)/,
+  "CodexAcpView 次要操作必须用 cardBtnCls() 保持默认样式",
+);
+
+console.log('OK: Workflow 「其他」答案契约 + cardBtnCls 签名契约 (kind:other 高亮 + i18n label 三语 + P3 签名全覆盖)');

--- a/pinvou3-app/tests/workflow_other_answer_contract.test.mjs
+++ b/pinvou3-app/tests/workflow_other_answer_contract.test.mjs
@@ -39,4 +39,23 @@ for (const [lang, expected] of [['zh', '其他'], ['en', 'Other'], ['ja', 'そ�
   assert.match(block[0], new RegExp(`other:\\s*'${expected}'`), `dict.${lang}.uiToolRender.other must be '${expected}'`);
 }
 
-console.log('OK: Workflow 「其他」答案契约 (kind:other 高亮 + i18n label 三语)');
+// 4. cardBtnCls 必须使用 P3 新签名（单参数 variant），不得残留旧签名
+//    cardBtnCls(isDark, variant) —— 旧调用会把布尔值当 variant，静默丢失 primary 样式
+//    （评审 #168 曾指出 WorkflowView 16 处旧签名调用）。
+assert.doesNotMatch(
+  wf,
+  /cardBtnCls\(\s*isDark/,
+  "cardBtnCls 不得再用旧签名 cardBtnCls(isDark, ...)；应改为 cardBtnCls() / cardBtnCls('primary')",
+);
+assert.match(
+  wf,
+  /cardBtnCls\('primary'\)/,
+  "WorkflowView 主操作（提交/审批/启动/重新开始等）必须用 cardBtnCls('primary') 保持 primary 样式",
+);
+assert.match(
+  wf,
+  /cardBtnCls\(\)/,
+  "WorkflowView 次要操作必须用 cardBtnCls() 保持默认样式",
+);
+
+console.log('OK: Workflow 「其他」答案契约 + cardBtnCls 签名契约 (kind:other 高亮 + i18n label 三语 + P3 签名)');


### PR DESCRIPTION
## 背景

isDark/theme → Tailwind dark: 变体迁移的最后一环(P3),承接 #166(P1+P2)。

#166 完成了 className 与 inline-style 三元式的主体迁移,但留下两类「protected」阻塞点未处理:
1. `tool-renderers.jsx` 的共享 helper `cardBoxCls`/`cardBtnCls`/`pvRole` 仍吃 `isDark` 形参,被 4 个 View 消费 → 草率迁会放大爆炸半径。
2. ChatView/WorkflowView 为「不带 isDark」而把 `cardBtnCls(theme-derived, variant)` 展开成了重复的内联常量 `CARD_BTN`/`WF_BTN`,显式标注「P3 可回收到 cardBtnCls(variant)」。

本 PR 处理这两类,收尾整条 isDark prop 链。

## 变更(2 commits,7 文件,净 -30 行)

**tool-renderers.jsx(共享 helper)**
- `cardBoxCls(isDark, accent)` → `cardBoxCls(accent)`;`cardBtnCls(isDark, variant)` → `cardBtnCls(variant)`:内部三元式迁静态 `dark:` 串。
- `pvRole`:`text`/`softBg` 字段迁 `dark:` 串;`accentHex` 仍为 inline-style 原色(品=橙 #FF9500/#FF9F0A),保留 `isDark` 形参。
- `ToolOutput`/`ToolCard` 删除 `theme`/`isDark`;`PlanCard`/`PlanStuckCard`/`CarefulBlockedCard`/`UserInputCard` 删除 `theme`/`isDark`,accent 参数改预拼 `dark:` 串,`cardBtnCls` 调用去 `isDark`。

**tool-common.jsx**
- `outBox(isDark)` → `outBox()`(内部早已迁 `dark:`,签名 vestigial)。
- `ReceiptBlock`/`OutputPre`/`OutputError`/`ListDirView`/`GrepView`/`DiffView`/`ShellView`/`ShellTextView`/`TodoView`/`StockQuoteCard`:删除 vestigial `isDark` 形参与透传。

**消费方**
- `ArtifactsPanel`:删除本地 `const isDark`,3 处 `cardBtnCls` 调用去 `isDark`;删除 `EditableMarkdownPreview`/`DesignInspectorPanel` 的 `isDark` 传参点。
- `ChatView`:`CARD_BTN`/`CARD_BTN_PRIMARY` 重复常量收拢回 `cardBtnCls()`/`cardBtnCls('primary')`;2 处 `<ToolCard>` 去掉 `theme` prop;4 处卡片(`PlanCard`/`PlanStuckCard`/`CarefulBlockedCard`/`UserInputCard`)调用点去掉悬空 `theme` prop。
- `WorkflowView`:`WF_BTN`/`WF_BTN_PRIMARY` 重复常量收拢回 `cardBtnCls()`/`cardBtnCls('primary')`(16 处调用点)。

### 评审修复(zhuowp 复审)
- **cardBtnCls 静默退化**:此前版本 WorkflowView 16 处仍按旧签名 `cardBtnCls(isDark, 'primary')`/`cardBtnCls(isDark)` 调用,JS 把布尔当 `variant`,主按钮(提交/审批/拒绝/启动/打开产物等)静默退化为默认样式。本次重建全部改为 `cardBtnCls('primary')`/`cardBtnCls()`,核实零残留。
- **dead isDark 形参**:`EditableMarkdownPreview`/`DesignInspectorPanel` 接收 `isDark` 但体内零引用 → 删形参;`ArtifactsPanel` 2 处 `isDark={theme === 'dark'}` 传参点删除。
- **ArtifactsPanel 死 theme prop**:`ArtifactsPanel.jsx` 解构 `theme` 但体内零引用、零转发(独立组件 `ArtifactCard` 才是真消费方)→ 删 `theme` 形参 + ChatView 3 处 `<ArtifactsPanel>` 调用点同步删除。`ArtifactCard` 仍消费 `theme`,保留。
- **重建误回退**:历史 commit `0cb29b47`(提交信息只声明改 markdown 测试 + ChatView 悬空 prop)实际回退了 #166 在 `ToolStoreView`(40 行 isDark)/`WorkflowView`(142 行 isDark)的迁移,与「收尾 isDark prop 链」目标相反。本次重建丢弃该回退,从 #166 头部干净 replay。

## 保留点(如实说明)

以下 `isDark`/`theme` 保留是有意为之,非遗漏:
- `pvRole` 的 `accentHex`、`PinvouLoading` 的 SVG circle `stroke`:inline-style 原色/rgba,不能纯 className 化。
- `theme` prop 根链(`DetachedShell.jsx`/`main.jsx`):因 KnowledgeView/Personas/NavigationComponents 等仍有真实动态值 inline-style(boxShadow/linear-gradient/运行时拼色)消费 `isDark`,根链暂不删除。

## 实际验证

- [x] `npm run lint:ui` — 0 问题(含 tool-renderers/tool-common/WorkflowView/ArtifactsPanel/ChatView)
- [x] `npm run test:diff-parser` — 24 passed(DiffView 解析,tool-common)
- [x] `npm run test:file-icon-theme` — 6 passed(tool-common 相邻)
- [x] `npm run test:scheduled` — PASS(静态扫描)
- [x] `npm run test:i18n-no-zh-literals` — OK(ToolStoreView/WorkflowView 无活跃中文字面量)
- [x] `npm run test:markdown` — PASS(契约由 #166 fcabe6d2 同步)
- [x] `python3 scripts/architecture-guard.py` — passed(AGENTS.md §3 要求)
- [x] grep 确认 5 文件无残留 `outBox(isDark)`/`cardBtnCls(isDark`/`<ToolCard theme=`(零命中)
- [ ] **合并前**:完整 `npm test` + 明/暗双主题冒烟工具卡/工作流按钮/产物面板(沙箱无 Chrome,需在完整环境跑)

## 已知风险

- `cardBtnCls`/`cardBoxCls` 是被 4 个 View 消费的共享 helper,签名变更虽已更新全部调用点,但建议合并后重点冒烟:工具卡(Plan/Stuck/CarefulBlocked)、工作流按钮、产物面板按钮的明/暗双态。
- `pvRole` 保留 `isDark` 形参是为 inline-style `accentHex`,非对称(悟=紫不需要,品=橙需要)——已在注释说明。

依赖 #166,建议 #166 合并后再合本 PR。

---
- [x] 自检:签名变更全调用点覆盖(0 残留)、dead 形参/prop 清理、无 #166 迁移回退
- [x] 评审修复:cardBtnCls 16 处、dead isDark/theme、误回退重建
- [x] DCO:全部 commit 带 `Signed-off-by`(邮箱匹配作者)
