### PR TITLE
ci(pr-check): 移除 pull_request base 限制以覆盖堆叠 PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,7 +35,12 @@ name: PR Check
 
 on:
   pull_request:
-    branches: [main]
+    # 不限制 base 分支:堆叠 PR(base 为功能分支而非 main)同样必须跑完整
+    # lint + test gate。此前 `branches: [main]` 使栈中段 PR(base=功能分支)
+    # 只触发无 base 过滤的 DCO/Gitleaks/dependency-review,整条 pr-check
+    # (含 lint:ui / npm test / 浏览器 smoke / required-gate)被静默跳过,
+    # 导致 no-undef 与签名回归在栈中段漏检(见 #166/#168 评审)。changes
+    # job 已按路径短路无关 job(rust-test 默认跳过等),不会无差别烧 CI 分钟。
     # 标签事件用于按需开启/关闭 ci:full-rust。
     # closed 事件会进入同一个 concurrency group，及时取消已合并/关闭 PR 的旧任务。
     types: [opened, synchronize, reopened, labeled, unlabeled, closed]


### PR DESCRIPTION
## 背景

评审 i18n/isDark 重构栈(#151→#166→#168)时发现:多条回归(`no-undef` 可秒抓的 `SettingsView` 未定义 `isDark`、`WorkflowView` `cardBtnCls` 旧签名残留)在 CI 阶段全部漏检。根因不是工具缺失,而是 **CI gate 在堆叠 PR 上从未运行**。

## 根因

`pr-check.yml` 的 `pull_request` 触发器限定 `branches: [main]`:

```yaml
on:
  pull_request:
    branches: [main]   # ← 只在 base=main 时触发
```

堆叠 PR 的 base 是功能分支而非 main:

| PR | base | pr-check 是否运行 |
|---|---|---|
| #151 | `main` | ✅ 跑了(lint:ui / npm test / 浏览器 smoke 全绿) |
| #166 | `refactor/i18n-cleanup-dead-code` | ❌ 完全没跑 |
| #168 | `refactor/isdark-dark-variant-settings` | ❌ 完全没跑 |

而 `dco.yml` / `secret-scan.yml` / `dependency-review.yml` **无** base 过滤,照常运行,给人"CI 在工作"的假象——但唯一能跑 `lint:ui` + `npm test` + 浏览器 smoke 的 `pr-check.yml` 对栈中段 PR 静默跳过。

## 变更

移除 `pull_request` 的 `branches: [main]` 限制(1 行删除 + 注释说明)。

## 成本与正确性

- **CI 分钟**:`changes` job 的 paths-filter 已按路径短路无关 job(`rust-test` 默认跳过、`relay-test`/`release-contract-test` 仅相关路径触发),不会因 base 放开而无差别烧 CI。
- **architecture-guard / ci-fork-link-check**:用 `github.base_ref` 取 PR 自身 base 作 diff 基线。堆叠 PR 的 base 为功能分支时,diff 仍是"本 PR 相对其 base 的增量",测量正确,行为不变。
- **merge_queue / push(main)**:不受影响。

## 实际验证

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-check.yml'))"` → YAML 合法。
- `BASE_REF` 用法审计:架构守卫与 fork-link 取 `github.base_ref`,堆叠场景 diff 基线正确,无回归。

## 已知风险

- 本 PR 自身 base=main,修复前后都会跑 pr-check,无法直接验证"堆叠 PR 现在会跑"。验证方式:合入后,对任一栈中段 PR(#166/#168)push 一个空 commit,观察 `frontend-test`/`required-gate` 是否出现并运行。

## 范围

仅 CI 触发条件修复,不改任何代码或测试逻辑。

---
- [x] 自检:根因定位(base 过滤)、成本(路径短路)、正确性(BASE_REF 审计)均已核实
- [x] DCO:`Signed-off-by` 邮箱匹配作者

🤖 Generated with [ZCode](https://zcode.dev)