### PR TITLE
fix(test): 修复中断轮次清理测试与后台 worker 的竞态断言

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/turn_shell_tasks.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/turn_shell_tasks.rs
@@ -1256,7 +1256,11 @@ mod tests {
         // reclaim race against the inline cleanup, so the report can record
         // the kill in either path. Only the terminal job status is
         // authoritative here.
-        if !report.killed.iter().any(|entry| entry.task_id.as_deref() == Some(current.as_str())) {
+        if !report
+            .killed
+            .iter()
+            .any(|entry| entry.task_id.as_deref() == Some(current.as_str()))
+        {
             tokio::time::timeout(Duration::from_secs(2), async {
                 while status(&manager, &current) == ShellStatus::Running {
                     tokio::time::sleep(Duration::from_millis(25)).await;

--- a/pinvou3-app/src-tauri/src/features/assistant/turn_shell_tasks.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/turn_shell_tasks.rs
@@ -1252,8 +1252,19 @@ mod tests {
             .await
             .expect("finish interrupted turn");
 
-        assert_eq!(report.killed.len(), 1);
-        assert_eq!(report.killed[0].task_id.as_deref(), Some(current.as_str()));
+        // The background supervisor started by `prepare_turn` may win the
+        // reclaim race against the inline cleanup, so the report can record
+        // the kill in either path. Only the terminal job status is
+        // authoritative here.
+        if !report.killed.iter().any(|entry| entry.task_id.as_deref() == Some(current.as_str())) {
+            tokio::time::timeout(Duration::from_secs(2), async {
+                while status(&manager, &current) == ShellStatus::Running {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                }
+            })
+            .await
+            .expect("interrupted turn should reclaim its current job");
+        }
         assert_eq!(status(&manager, &current), ShellStatus::Killed);
         assert_eq!(status(&manager, &previous), ShellStatus::Running);
         assert_eq!(status(&manager, &older_late), ShellStatus::Running);


### PR DESCRIPTION
## 背景

合并 #165 后 main 上 CI 失败（[run 30981514976](https://github.com/Pinvou/pinvou-agent/actions/runs/30981514976)），失败的是 `rust-test` 中的 `forkguard_interrupted_turn_preserves_preexisting_and_old_agent_jobs`，与本次合并的 artifact HTML 预览提交无关，是一个既有 flaky 问题。

## 根因

测试断言 `finalize_turn(..., interrupted=true)` 内联返回的 `report.killed.len() == 1`。

但 `finalize_scope` 在 `interrupted=true` 时调用 `request_cancel_scope`，其中 `cleanup_notify.notify_one()` 会唤醒后台 supervisor worker。worker 与内联清理存在竞态：当 worker 抢先 kill 掉 `current` 任务后，worker 的成功 report 被丢弃，内联清理再执行时该任务已非 Running，`list_jobs()` 不再返回它，`candidates` 为空 → `report.killed` 变空 → 断言失败。

这是**良性**竞态：
- `engine.rs` 调用方仅用 `report.killed` 做 `log::info!` 计数（engine.rs:2426），影响产品决策的是 `failure_summary()`；
- engine.rs:2415-2419 注释和同模块兄弟测试 `cancellation_before_turn_binding_still_kills_the_scope_job` 均已说明该 race 设计如此，并以终极任务状态为唯一权威。

## 变更

对齐兄弟测试范式：先看 report 是否已记录该 kill，否则用 `tokio::time::timeout` 轮询 `current` 的终极状态（2s 内应转 Killed），最终仍以任务状态为权威断言。

## 实际验证

- 本地连跑该测试 **30 次**，全部通过（修复前为 flaky）；
- 全量 lib 测试（`--skip` 预存的 hang 测试 `sample_all_keeps_other_fields`）：**890 passed; 0 failed; 12 ignored**，无回归。

## 已知风险

仅改动测试，不改产品行为；轮询超时上限 2s 与兄弟测试一致，不会拖慢 CI。