### PR TITLE
feat(remote-control): 支持动态选择 Windows 磁盘

### DIFF
--- a/pinvou3-app/src-tauri/src/features/remote_control/file_access.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/file_access.rs
@@ -97,10 +97,21 @@ pub fn list_host_files(requested: Option<String>) -> Result<HostFileListing, Str
 
 fn host_roots() -> Vec<HostFileRoot> {
     let home = paths::user_home_dir();
-    vec![HostFileRoot {
+    let mut roots = vec![HostFileRoot {
         name: "Home".to_string(),
         path: platform::display_path(&home),
-    }]
+    }];
+    for (name, path) in platform::host_file_roots() {
+        let display_path = platform::display_path(&path);
+        if roots.iter().any(|root| root.path == display_path) {
+            continue;
+        }
+        roots.push(HostFileRoot {
+            name,
+            path: display_path,
+        });
+    }
+    roots
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/pinvou3-app/src-tauri/src/features/remote_control/platform/fallback.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/platform/fallback.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) fn configure_private_open_options(_options: &mut OpenOptions) {}
 
@@ -17,6 +17,10 @@ pub(super) fn sync_parent_directory(_parent: &Path) -> std::io::Result<()> {
 
 pub(super) fn display_path(path: &Path) -> String {
     path.to_string_lossy().into_owned()
+}
+
+pub(super) fn host_file_roots() -> Vec<(String, PathBuf)> {
+    Vec::new()
 }
 
 #[cfg(test)]

--- a/pinvou3-app/src-tauri/src/features/remote_control/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/platform/mod.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 mod unix;
@@ -34,6 +34,10 @@ pub(super) fn sync_parent_directory(parent: &Path) -> std::io::Result<()> {
 
 pub(super) fn display_path(path: &Path) -> String {
     imp::display_path(path)
+}
+
+pub(super) fn host_file_roots() -> Vec<(String, PathBuf)> {
+    imp::host_file_roots()
 }
 
 #[cfg(test)]

--- a/pinvou3-app/src-tauri/src/features/remote_control/platform/unix.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/platform/unix.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) fn configure_private_open_options(options: &mut OpenOptions) {
     options.mode(0o600);
@@ -20,6 +20,10 @@ pub(super) fn sync_parent_directory(parent: &Path) -> std::io::Result<()> {
 
 pub(super) fn display_path(path: &Path) -> String {
     path.to_string_lossy().into_owned()
+}
+
+pub(super) fn host_file_roots() -> Vec<(String, PathBuf)> {
+    Vec::new()
 }
 
 #[cfg(test)]

--- a/pinvou3-app/src-tauri/src/features/remote_control/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/platform/windows.rs
@@ -1,8 +1,8 @@
 use std::fs::{File, OpenOptions};
 use std::os::windows::ffi::OsStrExt as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use windows_sys::Win32::Storage::FileSystem::{
-    MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    GetLogicalDrives, MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
 };
 
 pub(super) fn configure_private_open_options(_options: &mut OpenOptions) {}
@@ -52,7 +52,42 @@ pub(super) fn display_path(path: &Path) -> String {
     }
 }
 
+pub(super) fn host_file_roots() -> Vec<(String, PathBuf)> {
+    // SAFETY: GetLogicalDrives has no pointer arguments and only reads the process-visible
+    // logical-drive bitmask maintained by Windows.
+    logical_drive_roots(unsafe { GetLogicalDrives() })
+}
+
+fn logical_drive_roots(mask: u32) -> Vec<(String, PathBuf)> {
+    (0_u8..26)
+        .filter(|index| mask & (1_u32 << index) != 0)
+        .map(|index| {
+            let letter = char::from(b'A' + index);
+            (format!("{letter}:"), PathBuf::from(format!(r"{letter}:\")))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 pub(super) fn private_file_is_restricted(path: &Path) -> std::io::Result<bool> {
     Ok(path.is_file())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logical_drive_mask_maps_to_ordered_roots() {
+        let roots = logical_drive_roots((1 << 2) | (1 << 3) | (1 << 25));
+
+        assert_eq!(
+            roots,
+            vec![
+                ("C:".to_string(), PathBuf::from(r"C:\")),
+                ("D:".to_string(), PathBuf::from(r"D:\")),
+                ("Z:".to_string(), PathBuf::from(r"Z:\")),
+            ]
+        );
+    }
 }

--- a/pinvou3-app/src/platform/web/host-file-picker.js
+++ b/pinvou3-app/src/platform/web/host-file-picker.js
@@ -16,7 +16,7 @@
     cancel: "取消", chooseThisFolder: "选择此文件夹", choose: "选择",
     currentFolder: function (path) { return "当前文件夹：" + path; },
     selectedCount: function (n) { return "已选择 " + n + " 项"; },
-    thisComputer: "此电脑", emptyFolder: "此目录中没有可选内容",
+    thisComputer: "此电脑", home: "用户目录", emptyFolder: "此目录中没有可选内容",
     loadFailed: function (err) { return "读取失败：" + err; },
     alreadyOpen: "已有文件选择器正在打开",
   };
@@ -75,6 +75,8 @@
       var selected = new Map();
       var currentPath = null;
       var parentPath = null;
+      var rootEntries = [];
+      var showingRoots = false;
       var disposed = false;
       var loadGeneration = 0;
 
@@ -89,10 +91,15 @@
       header.appendChild(close);
 
       var toolbar = element("div", "pinvou-host-picker-toolbar");
+      var rootsButton = element("button", "pinvou-host-picker-root-button", labels.thisComputer);
+      rootsButton.type = "button";
+      rootsButton.title = labels.thisComputer;
+      rootsButton.disabled = true;
       var up = element("button", "pinvou-host-picker-icon", "←");
       up.type = "button";
       up.title = labels.goUp;
       var pathLabel = element("div", "pinvou-host-picker-path", labels.loadingPath);
+      toolbar.appendChild(rootsButton);
       toolbar.appendChild(up);
       toolbar.appendChild(pathLabel);
 
@@ -159,26 +166,16 @@
         updateSelection();
       }
 
-      function renderListing(listing) {
-        currentPath = listing && (listing.path || listing.current_path || listing.currentPath) || null;
-        parentPath = listing && (listing.parent || listing.parent_path || listing.parentPath) || null;
-        pathLabel.textContent = currentPath || labels.thisComputer;
-        up.disabled = !parentPath;
+      function renderEntries(entries, preserveOrder) {
         body.replaceChildren();
-
-        var entries = [];
-        if (listing && Array.isArray(listing.roots) && !parentPath) {
-          entries = entries.concat(listing.roots.map(function (root) {
-            return Object.assign({ is_dir: true, kind: "root" }, root);
-          }));
-        }
-        if (listing && Array.isArray(listing.entries)) entries = entries.concat(listing.entries);
         entries = entries.filter(function (entry) { return allowedByFilters(entry, options.filters); });
-        entries.sort(function (a, b) {
-          var ad = entryIsDirectory(a) ? 0 : 1;
-          var bd = entryIsDirectory(b) ? 0 : 1;
-          return ad - bd || String(a.name || "").localeCompare(String(b.name || ""), "zh-CN");
-        });
+        if (!preserveOrder) {
+          entries.sort(function (a, b) {
+            var ad = entryIsDirectory(a) ? 0 : 1;
+            var bd = entryIsDirectory(b) ? 0 : 1;
+            return ad - bd || String(a.name || "").localeCompare(String(b.name || ""), "zh-CN");
+          });
+        }
 
         if (!entries.length) {
           body.appendChild(element("div", "pinvou-host-picker-empty", labels.emptyFolder));
@@ -187,7 +184,10 @@
           var row = element("button", "pinvou-host-picker-row");
           row.type = "button";
           var icon = element("span", "pinvou-host-picker-file-icon", entryIsDirectory(entry) ? "📁" : "📄");
-          var name = element("span", "pinvou-host-picker-name", entry.name || entry.path || "");
+          var displayName = entry.kind === "root" && entry.name === "Home"
+            ? labels.home
+            : (entry.name || entry.path || "");
+          var name = element("span", "pinvou-host-picker-name", displayName);
           var size = element("span", "pinvou-host-picker-size", entryIsDirectory(entry) ? "" : formatSize(entry.size));
           row.appendChild(icon);
           row.appendChild(name);
@@ -204,8 +204,42 @@
         updateSelection();
       }
 
+      function rememberRoots(listing) {
+        if (!listing || !Array.isArray(listing.roots)) return;
+        rootEntries = listing.roots.filter(function (root) {
+          return root && root.path;
+        }).map(function (root) {
+          return Object.assign({}, root, { is_dir: true, kind: "root" });
+        });
+      }
+
+      function showRoots() {
+        if (!rootEntries.length) return;
+        loadGeneration += 1;
+        showingRoots = true;
+        currentPath = null;
+        parentPath = null;
+        pathLabel.textContent = labels.thisComputer;
+        rootsButton.disabled = false;
+        up.disabled = true;
+        renderEntries(rootEntries.slice(), true);
+      }
+
+      function renderListing(listing) {
+        rememberRoots(listing);
+        showingRoots = false;
+        currentPath = listing && (listing.path || listing.current_path || listing.currentPath) || null;
+        parentPath = listing && (listing.parent || listing.parent_path || listing.parentPath) || null;
+        pathLabel.textContent = currentPath || labels.thisComputer;
+        rootsButton.disabled = rootEntries.length === 0;
+        up.disabled = !parentPath && rootEntries.length === 0;
+        renderEntries(listing && Array.isArray(listing.entries) ? listing.entries.slice() : [], false);
+      }
+
       function load(path) {
         var generation = ++loadGeneration;
+        showingRoots = false;
+        rootsButton.disabled = rootEntries.length === 0;
         up.disabled = true;
         confirm.disabled = true;
         body.replaceChildren(element("div", "pinvou-host-picker-status", labels.loadingPath));
@@ -214,6 +248,7 @@
           renderListing(listing);
         }).catch(function (error) {
           if (disposed || generation !== loadGeneration) return;
+          rootsButton.disabled = rootEntries.length === 0;
           body.replaceChildren(element("div", "pinvou-host-picker-error", labels.loadFailed(String(error && error.message ? error.message : error))));
         });
       }
@@ -224,7 +259,11 @@
 
       close.addEventListener("click", function () { finish(null); });
       cancel.addEventListener("click", function () { finish(null); });
-      up.addEventListener("click", function () { if (parentPath) load(parentPath); });
+      rootsButton.addEventListener("click", showRoots);
+      up.addEventListener("click", function () {
+        if (parentPath) load(parentPath);
+        else if (!showingRoots) showRoots();
+      });
       confirm.addEventListener("click", function () {
         if (directoryMode) finish(currentPath);
         else finish(multiple ? Array.from(selected.keys()) : Array.from(selected.keys())[0] || null);
@@ -241,11 +280,11 @@
     ".pinvou-host-picker-header,.pinvou-host-picker-toolbar,.pinvou-host-picker-footer{display:flex;align-items:center;padding:12px 16px;border-bottom:1px solid #3c4043}",
     ".pinvou-host-picker-header{justify-content:space-between}.pinvou-host-picker-heading{font-size:17px;font-weight:650}",
     ".pinvou-host-picker-icon{display:grid;place-items:center;width:36px;height:36px;border:0;border-radius:50%;background:transparent;color:inherit;font-size:22px;cursor:pointer}.pinvou-host-picker-icon:hover{background:#303134}.pinvou-host-picker-icon:disabled{opacity:.35;cursor:default}",
-    ".pinvou-host-picker-toolbar{gap:10px;padding-block:8px}.pinvou-host-picker-path{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#bdc1c6;font-size:13px}",
+    ".pinvou-host-picker-toolbar{gap:10px;padding-block:8px}.pinvou-host-picker-root-button{flex:none;height:32px;padding:0 12px;border:0;border-radius:16px;background:transparent;color:inherit;font-size:13px;cursor:pointer}.pinvou-host-picker-root-button:hover{background:#303134}.pinvou-host-picker-root-button:disabled{opacity:.45;cursor:default}.pinvou-host-picker-path{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#bdc1c6;font-size:13px}",
     ".pinvou-host-picker-body{flex:1;overflow:auto;padding:8px}.pinvou-host-picker-row{display:grid;grid-template-columns:28px minmax(0,1fr) auto;align-items:center;gap:8px;width:100%;min-height:44px;padding:7px 10px;border:0;border-radius:10px;background:transparent;color:inherit;text-align:left;cursor:pointer}.pinvou-host-picker-row:hover{background:#303134}.pinvou-host-picker-row.is-selected{background:#394457;color:#d2e3fc}",
     ".pinvou-host-picker-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px}.pinvou-host-picker-size{color:#9aa0a6;font-size:12px}.pinvou-host-picker-status,.pinvou-host-picker-empty,.pinvou-host-picker-error{padding:28px;text-align:center;color:#9aa0a6;font-size:13px}.pinvou-host-picker-error{color:#f28b82}",
     ".pinvou-host-picker-footer{justify-content:space-between;gap:12px;border-top:1px solid #3c4043;border-bottom:0}.pinvou-host-picker-selection{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#9aa0a6;font-size:12px}.pinvou-host-picker-actions{display:flex;gap:8px}.pinvou-host-picker-button{height:38px;padding:0 18px;border:1px solid #5f6368;border-radius:19px;background:transparent;color:#e8eaed;font-weight:600;cursor:pointer}.pinvou-host-picker-button:hover{background:#303134}.pinvou-host-picker-primary{border-color:#8ab4f8;background:#8ab4f8;color:#202124}.pinvou-host-picker-button:disabled{opacity:.4;cursor:default}",
-    "html:not(.dark) .pinvou-host-picker-panel{border-color:#dadce0;background:#fff;color:#202124}html:not(.dark) .pinvou-host-picker-header,html:not(.dark) .pinvou-host-picker-toolbar,html:not(.dark) .pinvou-host-picker-footer{border-color:#dadce0}html:not(.dark) .pinvou-host-picker-row:hover{background:#f1f3f4}html:not(.dark) .pinvou-host-picker-row.is-selected{background:#d2e3fc;color:#174ea6}",
+    "html:not(.dark) .pinvou-host-picker-panel{border-color:#dadce0;background:#fff;color:#202124}html:not(.dark) .pinvou-host-picker-header,html:not(.dark) .pinvou-host-picker-toolbar,html:not(.dark) .pinvou-host-picker-footer{border-color:#dadce0}html:not(.dark) .pinvou-host-picker-root-button:hover,html:not(.dark) .pinvou-host-picker-row:hover{background:#f1f3f4}html:not(.dark) .pinvou-host-picker-row.is-selected{background:#d2e3fc;color:#174ea6}",
     "@media(max-width:600px){.pinvou-host-picker-overlay{align-items:stretch;padding:0}.pinvou-host-picker-panel{width:100%;height:100%;max-height:none;border:0;border-radius:0}.pinvou-host-picker-footer{padding-bottom:max(12px,env(safe-area-inset-bottom))}.pinvou-host-picker-selection{display:none}}",
   ].join("");
   document.head.appendChild(style);

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -1803,7 +1803,7 @@ dict.zh.uiPlatformMisc = {
     close: '关闭', goUp: '上一级', loadingPath: '正在读取桌面端目录…', loading: '正在读取…',
     cancel: '取消', chooseThisFolder: '选择此文件夹', choose: '选择',
     currentFolder: path => `当前文件夹：${path}`, selectedCount: n => `已选择 ${n} 项`,
-    thisComputer: '此电脑', emptyFolder: '此目录中没有可选内容',
+    thisComputer: '此电脑', home: '用户目录', emptyFolder: '此目录中没有可选内容',
     loadFailed: err => `读取失败：${err}`, alreadyOpen: '已有文件选择器正在打开',
   },
   // platform/web/bootstrap.js 的 invoke 拒绝错误文案,由 React 入口挂到
@@ -1829,7 +1829,7 @@ dict.en.uiPlatformMisc = {
     close: 'Close', goUp: 'Up one level', loadingPath: 'Reading desktop folder…', loading: 'Loading…',
     cancel: 'Cancel', chooseThisFolder: 'Choose this folder', choose: 'Choose',
     currentFolder: path => `Current folder: ${path}`, selectedCount: n => `${n} selected`,
-    thisComputer: 'This PC', emptyFolder: 'Nothing to select in this folder',
+    thisComputer: 'This PC', home: 'Home', emptyFolder: 'Nothing to select in this folder',
     loadFailed: err => `Failed to read: ${err}`, alreadyOpen: 'A file picker is already open',
   },
   webClientErrors: {
@@ -1853,7 +1853,7 @@ dict.ja.uiPlatformMisc = {
     close: '閉じる', goUp: '上の階層へ', loadingPath: 'デスクトップのフォルダーを読み込み中…', loading: '読み込み中…',
     cancel: 'キャンセル', chooseThisFolder: 'このフォルダーを選択', choose: '選択',
     currentFolder: path => `現在のフォルダー：${path}`, selectedCount: n => `${n} 件選択中`,
-    thisComputer: 'この PC', emptyFolder: 'このフォルダーに選択できる項目はありません',
+    thisComputer: 'この PC', home: 'ホーム', emptyFolder: 'このフォルダーに選択できる項目はありません',
     loadFailed: err => `読み込みに失敗しました：${err}`, alreadyOpen: 'ファイル選択ダイアログはすでに開いています',
   },
   webClientErrors: {

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -35,6 +35,10 @@ const bridge = [
   ...desktopBridgeSources,
 ].join('\n');
 const bootstrap = fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'bootstrap.js'), 'utf8');
+const hostFilePicker = fs.readFileSync(
+  path.join(root, 'src', 'platform', 'web', 'host-file-picker.js'),
+  'utf8',
+);
 const commandsRoot = path.join(root, 'src-tauri', 'src', 'app', 'commands');
 const commands = fs.readdirSync(commandsRoot)
   .filter(name => name.endsWith('.rs'))
@@ -128,6 +132,16 @@ assert.match(bootstrap, /SEMANTIC_COMMAND_REQUIREMENTS/);
 assert.match(bootstrap, /supportsCapability\(capability\)/);
 assert.match(bootstrap, /if \(!this\.desktopCapabilitiesReady\) return false/);
 assert.match(bridge, /if \(IS_WEB && typeof PLATFORM\.can === "function"\) return PLATFORM\.can\(name\) === true/);
+assert.match(hostFilePicker, /function rememberRoots\(listing\)/,
+  'the Web host picker must retain the desktop-provided root inventory');
+assert.match(hostFilePicker, /function showRoots\(\)/,
+  'the Web host picker must expose an explicit root view');
+assert.match(hostFilePicker, /rootsButton\.addEventListener\("click", showRoots\)/,
+  'the root view must remain directly reachable from nested folders');
+assert.match(hostFilePicker, /if \(parentPath\) load\(parentPath\);[\s\S]{0,100}else if \(!showingRoots\) showRoots\(\);/,
+  'up from a filesystem root must return to the root inventory');
+assert.doesNotMatch(hostFilePicker, /Array\.isArray\(listing\.roots\) && !parentPath/,
+  'filesystem roots must not be mixed into a drive directory listing');
 // HTML5 拖放复用 deviceFileUpload 分块通道:同一能力门控、同一上传/取消/丢弃语义。
 assert.match(webBridge, /canAccept: function \(\) \{ return hasCapability\("deviceFileUpload"\); \}/,
   'browser drop must gate on the negotiated device upload capability');

--- a/remote-control-relay/test/web-ui.smoke.cjs
+++ b/remote-control-relay/test/web-ui.smoke.cjs
@@ -143,6 +143,20 @@ function minimalRpcResult(command, args = {}) {
       return { ready: false, missing: ['desktop_component'] };
     case 'kb_model_status':
       return { installed: false, downloading: false };
+    case 'web_access_list_host_files': {
+      const roots = [
+        { name: 'Home', path: 'C:\\Users\\smoke' },
+        { name: 'C:', path: 'C:\\' },
+        { name: 'D:', path: 'D:\\' },
+      ];
+      if (args.path === 'D:\\') {
+        return {
+          path: 'D:\\', parent: null, roots,
+          entries: [{ name: 'report.txt', path: 'D:\\report.txt', is_dir: false, size: 12 }],
+        };
+      }
+      return { path: 'C:\\Users\\smoke', parent: 'C:\\Users', roots, entries: [] };
+    }
     case 'get_effective_model_config':
     case 'find_resumable_run':
     case 'get_active_persona':
@@ -490,6 +504,40 @@ async function main() {
 
   const desktopLayout = await waitForSharedUi(desktopPage, 1440, 900);
   record('共享 WebUI 在 1440x900 电脑浏览器完整渲染', desktopLayout.textLength > 10);
+
+  const hostPickerNavigation = await desktopPage.evaluate(async () => {
+    const waitFor = async predicate => {
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        if (predicate()) return;
+        await new Promise(resolve => setTimeout(resolve, 20));
+      }
+      throw new Error('host picker state timeout');
+    };
+    const rowNames = () => Array.from(document.querySelectorAll('.pinvou-host-picker-name'))
+      .map(node => node.textContent);
+    const pickerPromise = window.PinvouHostFilePicker.open({ multiple: true });
+    await waitFor(() => document.querySelector('.pinvou-host-picker-root-button:not(:disabled)'));
+    document.querySelector('.pinvou-host-picker-root-button').click();
+    await waitFor(() => rowNames().includes('D:'));
+    const rootNames = rowNames();
+    const dDrive = Array.from(document.querySelectorAll('.pinvou-host-picker-row'))
+      .find(row => row.querySelector('.pinvou-host-picker-name')?.textContent === 'D:');
+    dDrive.click();
+    await waitFor(() => document.querySelector('.pinvou-host-picker-path')?.textContent === 'D:\\');
+    const driveNames = rowNames();
+    document.querySelector('.pinvou-host-picker-toolbar .pinvou-host-picker-icon').click();
+    await waitFor(() => rowNames().includes('D:'));
+    const rootsAfterUp = rowNames();
+    document.querySelector('.pinvou-host-picker-actions .pinvou-host-picker-button').click();
+    await pickerPromise;
+    return { rootNames, driveNames, rootsAfterUp };
+  });
+  record('远程文件选择器动态列出盘符，盘根目录上一级返回此电脑',
+    ['用户目录', 'C:', 'D:'].every(name => hostPickerNavigation.rootNames.includes(name))
+      && hostPickerNavigation.driveNames.includes('report.txt')
+      && !hostPickerNavigation.driveNames.includes('C:')
+      && ['用户目录', 'C:', 'D:'].every(name => hostPickerNavigation.rootsAfterUp.includes(name)),
+    JSON.stringify(hostPickerNavigation));
 
   const joinFrames = browserWebSocketFrames.filter(message => message.type === 'web_client_join');
   const v2ClientFrames = browserWebSocketFrames.filter(message => (

--- a/remote-control-relay/test/web-ui.smoke.cjs
+++ b/remote-control-relay/test/web-ui.smoke.cjs
@@ -515,6 +515,11 @@ async function main() {
     };
     const rowNames = () => Array.from(document.querySelectorAll('.pinvou-host-picker-name'))
       .map(node => node.textContent);
+    // Home 根入口的文案来自 main.jsx 注入的 PinvouHostFilePickerStrings(shared/i18n.js
+    // uiPlatformMisc.hostFilePicker)。断言必须从该对象取值,不得硬编码某语言文案,
+    // 否则会与页面默认语言策略或 picker 内 fallback 文本隐性耦合。
+    const homeLabel = (window.PinvouHostFilePickerStrings || {}).home;
+    if (!homeLabel) throw new Error('host picker strings missing localized home label');
     const pickerPromise = window.PinvouHostFilePicker.open({ multiple: true });
     await waitFor(() => document.querySelector('.pinvou-host-picker-root-button:not(:disabled)'));
     document.querySelector('.pinvou-host-picker-root-button').click();
@@ -530,13 +535,16 @@ async function main() {
     const rootsAfterUp = rowNames();
     document.querySelector('.pinvou-host-picker-actions .pinvou-host-picker-button').click();
     await pickerPromise;
-    return { rootNames, driveNames, rootsAfterUp };
+    return { homeLabel, rootNames, driveNames, rootsAfterUp };
   });
   record('远程文件选择器动态列出盘符，盘根目录上一级返回此电脑',
-    ['用户目录', 'C:', 'D:'].every(name => hostPickerNavigation.rootNames.includes(name))
+    !!hostPickerNavigation.homeLabel
+      && hostPickerNavigation.rootNames.includes(hostPickerNavigation.homeLabel)
+      && ['C:', 'D:'].every(name => hostPickerNavigation.rootNames.includes(name))
       && hostPickerNavigation.driveNames.includes('report.txt')
       && !hostPickerNavigation.driveNames.includes('C:')
-      && ['用户目录', 'C:', 'D:'].every(name => hostPickerNavigation.rootsAfterUp.includes(name)),
+      && hostPickerNavigation.rootsAfterUp.includes(hostPickerNavigation.homeLabel)
+      && ['C:', 'D:'].every(name => hostPickerNavigation.rootsAfterUp.includes(name)),
     JSON.stringify(hostPickerNavigation));
 
   const joinFrames = browserWebSocketFrames.filter(message => message.type === 'web_client_join');


### PR DESCRIPTION
## 背景

远程 WebUI 选择目标电脑文件时，Windows 客户端虽然能够访问其他磁盘，但文件选择器只提供用户目录入口，位于 D 盘等位置的文件缺少可发现的导航入口。

## 变更

- Windows 通过系统 API 动态枚举当前进程可见的逻辑磁盘，并与用户目录共同作为文件浏览根入口。
- WebUI 增加明确的“此电脑”根视图；从盘符根目录点击上一级可返回根列表，盘符不会混入当前目录内容。
- 补齐简体中文、英文、日文文案，并增加 Web 权限契约与完整 WebUI 冒烟回归。

## 影响与兼容性

- Windows 新增动态盘符入口；macOS/Linux 保持现有用户目录范围。
- 未新增 Relay 命令或协议，既有路径校验、文件权限和附件上传流程不变。
- 旧桌面客户端不会返回盘符清单，会自然退化为仅显示用户目录。

## 实际验证

- `npm run lint:ui`
- `npm run test:ui-language`
- `npm run test:web-access-contract`
- `npm run test:webui`（32 项完整 WebUI 用户旅程通过）
- `uv run --no-project python scripts/architecture-guard.py`
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml`
- 已部署至 `https://pinvou.com/pinvou3/remote-test/` 并完成实际体验验证。

## ⚠️ 正式发布前部署事项

当前只更新了 `remote-test` 测试环境。正式打包或发布桌面客户端前，必须使用正式 base path 重新构建 WebUI，并将静态资源部署至正式 Remote Relay 环境；否则正式 WebUI 仍会显示旧文件选择器，无法展示新增盘符入口。

本 PR 不修改 `server.js` 或 Relay 协议，正式环境只需要同步部署 WebUI 静态资源，无需更换 Relay 服务端逻辑。