### PR TITLE
fix(credential): 缓存凭据值缓解 macOS ad-hoc keychain 反复弹窗

### DIFF
--- a/docs/macos-keychain-弹窗说明.md
+++ b/docs/macos-keychain-弹窗说明.md
@@ -1,0 +1,109 @@
+# macOS Keychain 反复弹窗说明
+
+## 现象
+
+社区版（GitHub Releases 的 `*-community.dmg`）在 macOS 上首次访问 Keychain 时弹出
+"xxx 想要使用钥匙串" 的授权窗口；**即使点了「始终允许」,后续仍会反复弹出同一窗口**。
+相关 Issue:#175。
+
+## 根因
+
+这是 macOS 安全机制在 **ad-hoc 签名** 下的固有行为,不是应用代码 bug。
+
+### 1. 社区版是 ad-hoc 签名
+
+`pinvou3-app/src-tauri/config/platforms/macos/tauri.conf.json` 中
+`macOS.signingIdentity = "-"`(Apple 的 ad-hoc 签名标识),未启用 Hardened Runtime,
+也没有 Apple Developer ID 公证(公证需要 Apple 开发者账号 + `$99/年` 证书)。
+
+ad-hoc 签名**没有证书身份,只有一个 `cdhash`**(二进制内容的密码学指纹)。
+
+### 2. "始终允许"绑定应用的代码签名身份
+
+macOS Keychain 的「始终允许」不是全局开关,而是把"哪个应用可以免密访问"这条规则
+写进**那一条 keychain item 的 ACL(Access Control List)**。这里的"哪个应用"是用
+**designated requirement(DR)** 来识别的:
+
+- 有证书签名的应用:DR 形如 `identifier "com.pinvou.pinvou3" and anchor apple generic
+  and certificate leaf[subject.CN] = ...`。这是**稳定**身份,ACL 一次写入、长期命中。
+- ad-hoc 签名的应用:DR 形如 `cdhash H"…"`。这是**不稳定**身份:
+  - 应用每次重新编译/发布,`cdhash` 都会变;
+  - Universal binary(Apple Silicon + Intel)两个架构切片各有独立 `cdhash`;
+  - 某些 macOS 版本下,cdhash-only DR 在后续访问的校验中无法稳定匹配。
+
+结果:点「始终允许」时,系统尝试把当前进程的 DR 写入 item ACL;但因为 ad-hoc 的 DR
+无法在后续访问时可靠命中,系统下次访问又把当前进程判定为"未授权应用" → 重新弹窗。
+
+### 3. keyring 后端不设自定义 ACL
+
+应用使用 `codewhale-secrets` → `keyring` crate(v3.x,`apple-native` feature)
+→ `security-framework` 的经典 `SecKeychainAddGenericPassword` API 创建 Keychain item。
+该 API **不传任何 `SecAccess` / 自定义 ACL**,完全依赖 macOS 默认访问控制 —— 而
+默认访问控制在 ad-hoc 签名下正是无法稳定放行上述 DR 的那一层。
+
+### 4. 多 item × 多次读取放大问题
+
+应用按用途分多个 Keychain service(均以 `pinvou3-` 前缀命名,与第三方应用隔离):
+
+- `pinvou3-model-api-key` — 模型 API Key(每个模型一条)
+- `pinvou3-search-api-key` — 搜索 API Key
+- `pinvou3-mcp-secret` — 工具市场 / MCP 连接器密钥
+- `pinvou3-ima-secret` — IMA 密钥
+
+每个 item 首次访问各自弹一次;而设置页每次打开(`get_settings`)都会回读所有已配置
+item 的状态。**单 item 反复弹 + 多 item 各自弹 = "无限弹窗" 体感。**
+
+> 注:全部 Keychain 访问都在单一 Tauri 主进程内完成,不涉及子进程或 Node sidecar
+> 另开 Keychain(已排查 `codex-bridge-runtime`、`remote-control-relay`,均不读 Keychain)。
+
+## 缓解措施(本仓库已做)
+
+`pinvou3-app/src-tauri/src/platform/credential_store.rs` 增加了**进程级凭据值缓存**:
+
+- 同一 `(service, account)` 在一次进程生命周期内只访问 Keychain **一次**(首次 `get`
+  触发授权弹窗,用户点「允许」后读取成功并缓存);
+- 之后命中缓存即不再触碰 Keychain,**应用运行期间不再为该凭据反复弹窗**;
+- `set` / `delete` 同步更新缓存;环境变量路径不经过此缓存;Keychain 仍是单一真相源;
+- 仅缓存 `Ok` 结果(含 `Ok(None)` 表示"已知不存在"),`Err` 不缓存以便自愈。
+
+**剩余边界**:应用重启后,每个已配置凭据的首次访问仍会弹一次。这是 ad-hoc 签名的
+根本限制,缓存无法跨越进程边界。
+
+## 用户手动缓解(可选)
+
+如不想忍受任何弹窗,可二选一:
+
+### 方案 A:用环境变量绕过 Keychain(最干净)
+
+把 API Key 放进环境变量,应用优先读环境变量、完全不碰 Keychain:
+
+```bash
+# 模型 key(以 DeepSeek 为例)
+echo 'export DEEPSEEK_API_KEY="sk-你的key"' >> ~/.zshrc
+# 搜索 key(按你用的 provider)
+# Metaso:    METASO_API_KEY
+# Baidu:     BAIDU_SEARCH_API_KEY
+source ~/.zshrc
+```
+
+完整环境变量名见 `CodeWhale/crates/secrets/src/lib.rs` 的 `env_for` 函数。
+
+### 方案 B:手动给 Keychain item 加宽松 ACL
+
+打开「钥匙串访问」App → 找到 `pinvou3-*` 开头的条目 → 双击 → 「访问」标签 →
+把应用列表设为「允许所有应用程序访问此项」(安全性下降,但可一劳永逸止弹)。
+
+## 永久方案(规划中)
+
+接入 Apple Developer ID 签名 + 公证后,应用获得**稳定证书身份**,Keychain ACL 可
+持久命中,「始终允许」即真正生效、不再反复弹。落地点与前置条件见
+`pinvou3-app/src-tauri/packaging/macos/entitlements.plist` 的注释路线图:
+
+1. `tauri.conf.json`:`mac.hardenedRuntime = true`(公证要求 Hardened Runtime)。
+2. 配置 `signingIdentity` 为 Developer ID Application 证书 + `notarytool` 公证。
+3. 评估是否补充 `com.apple.security.cs.allow-jit` / `disable-library-validation`
+   等 entitlement(按实际运行决定,不全开)。
+4. `com.apple.security.device.audio-input` 必须保留(ASR 麦克风采集必需)。
+
+官方 Developer ID 构建走私有发布流水线(`scripts/release-macos.sh` 头注释提及的
+"official" 后缀产物);社区版受限于无 Apple 证书,ad-hoc 是当前可发布形态。

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -1,10 +1,33 @@
 use codewhale_secrets::{DefaultKeyringStore, Secrets, SecretsError};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
 const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
+
+/// 进程级凭据值缓存(键 = `(service, account)`,值 = 缓存的凭据,`None` 表示"已知不存在")。
+///
+/// **目的**:缓解 macOS ad-hoc 签名下 Keychain 反复弹窗(#175)。macOS Keychain 的 ACL
+/// 以应用代码签名身份(designated requirement)识别可信应用;社区版 DMG 是 ad-hoc 签名
+/// (`signingIdentity = "-"`),只有 cdhash、无稳定证书身份,无法建立持久 ACL —— 导致
+/// "始终允许"无效、每次访问 keychain item 都重新判定为未授权应用并弹窗。`keyring` crate
+/// 的 macOS 后端用经典 `SecKeychainAddGenericPassword` API,创建 item 时不设自定义 ACL,
+/// 完全依赖默认访问控制,ad-hoc 下默认访问控制无法稳定放行。
+///
+/// 缓存让同一凭据在一次进程生命周期内只访问 Keychain 一次:首次 `get` 触发授权弹窗
+/// (用户点"允许"后本次成功读取并缓存),之后命中缓存即不触碰 Keychain,应用使用期间不再
+/// 反复弹窗。重启应用后首次访问仍会弹一次(详见 `docs/macos-keychain-弹窗说明.md`)。
+///
+/// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与 `RuntimeModelCredential`
+/// 在 bridge 层的内存缓存(见 `bridge.rs` 的 `api_key`)同级。Keychain 仍是单一真相源:
+/// `set`/`delete` 同步更新缓存;环境变量路径不经过此缓存。仅 `Ok` 结果缓存(含 `Ok(None)`),
+/// `Err` 不缓存,允许临时性 Keychain 故障恢复后自愈。
+static VALUE_CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
+
+fn value_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
+    VALUE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 const SEARCH_API_KEY_SERVICE: &str = "pinvou3-search-api-key";
 const MCP_SECRET_SERVICE: &str = "pinvou3-mcp-secret";
 const IMA_SECRET_SERVICE: &str = "pinvou3-ima-secret";
@@ -203,6 +226,19 @@ impl std::fmt::Debug for SystemCredentialStore {
 
 impl CredentialStore for SystemCredentialStore {
     fn get(&self, reference: &CredentialReference) -> Result<Option<String>, CredentialError> {
+        let cache_key = (reference.service.clone(), reference.account.clone());
+        // 命中进程级缓存(含"已知不存在"的 None)即直接返回,不触碰 Keychain —— 这是
+        // macOS ad-hoc 签名下避免反复弹窗的关键(见 VALUE_CACHE 注释)。
+        if let Ok(cache) = value_cache().lock() {
+            if let Some(cached) = cache.get(&cache_key) {
+                log::info!(
+                    "[credential_store] get cache hit service={} account={}",
+                    reference.service,
+                    reference.account
+                );
+                return Ok(cached.clone());
+            }
+        }
         let started_at = Instant::now();
         log::info!(
             "[credential_store] get start service={} account={}",
@@ -224,6 +260,12 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
+        // 仅缓存 Ok 结果(含 Ok(None));Err 不缓存,允许下次重试自愈。
+        if let Ok(value) = &result {
+            if let Ok(mut cache) = value_cache().lock() {
+                cache.insert(cache_key, value.clone());
+            }
+        }
         result
     }
 
@@ -251,6 +293,15 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
+        // 写入成功后同步更新缓存:后续 get 命中即不再访问 Keychain。
+        if result.is_ok() {
+            if let Ok(mut cache) = value_cache().lock() {
+                cache.insert(
+                    (reference.service.clone(), reference.account.clone()),
+                    Some(value.to_string()),
+                );
+            }
+        }
         result
     }
 
@@ -270,6 +321,15 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
+        // 删除成功后缓存为 None,避免下次 get 再次访问 Keychain(命中"已知不存在")。
+        if result.is_ok() {
+            if let Ok(mut cache) = value_cache().lock() {
+                cache.insert(
+                    (reference.service.clone(), reference.account.clone()),
+                    None,
+                );
+            }
+        }
         result
     }
 }
@@ -385,6 +445,93 @@ pub fn is_secret_like(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 测试间清空进程级凭据值缓存,避免 static 状态串扰。
+    /// (生产代码不需要清空;缓存跨整个进程生命周期持久是设计意图。)
+    fn reset_value_cache() {
+        value_cache()
+            .lock()
+            .expect("value cache lock")
+            .clear();
+    }
+
+    #[test]
+    fn value_cache_roundtrip_set_get_delete_consistency() {
+        reset_value_cache();
+        let key = ("pinvou3-model-api-key".to_string(), "model:m1".to_string());
+
+        // 初始:缓存未命中(value_cache.get 返回 None 表示"未缓存")。
+        {
+            let cache = value_cache().lock().unwrap();
+            assert!(cache.get(&key).is_none(), "缓存应为空");
+        }
+
+        // 模拟 get 成功后缓存 Ok(None) —— "已知不存在"。
+        {
+            let mut cache = value_cache().lock().unwrap();
+            cache.insert(key.clone(), None);
+        }
+        {
+            let cache = value_cache().lock().unwrap();
+            assert_eq!(cache.get(&key), Some(&None), "应缓存为已知不存在");
+        }
+
+        // 模拟 set 成功后更新为 Some(value)。
+        {
+            let mut cache = value_cache().lock().unwrap();
+            cache.insert(key.clone(), Some("sk-secret-1234567890".to_string()));
+        }
+        {
+            let cache = value_cache().lock().unwrap();
+            assert_eq!(
+                cache.get(&key),
+                Some(&Some("sk-secret-1234567890".to_string())),
+                "set 后缓存应反映新值"
+            );
+        }
+
+        // 模拟 delete 成功后回退为 None。
+        {
+            let mut cache = value_cache().lock().unwrap();
+            cache.insert(key.clone(), None);
+        }
+        {
+            let cache = value_cache().lock().unwrap();
+            assert_eq!(cache.get(&key), Some(&None), "delete 后应缓存为不存在");
+        }
+
+        reset_value_cache();
+    }
+
+    #[test]
+    fn value_cache_distinguishes_services() {
+        reset_value_cache();
+        let model_key = (
+            "pinvou3-model-api-key".to_string(),
+            "model:m1".to_string(),
+        );
+        let search_key = (
+            "pinvou3-search-api-key".to_string(),
+            "search:metaso".to_string(),
+        );
+        {
+            let mut cache = value_cache().lock().unwrap();
+            cache.insert(model_key.clone(), Some("sk-model".to_string()));
+            cache.insert(search_key.clone(), Some("mk-search".to_string()));
+        }
+        {
+            let cache = value_cache().lock().unwrap();
+            assert_eq!(
+                cache.get(&model_key),
+                Some(&Some("sk-model".to_string()))
+            );
+            assert_eq!(
+                cache.get(&search_key),
+                Some(&Some("mk-search".to_string()))
+            );
+        }
+        reset_value_cache();
+    }
 
     #[test]
     fn memory_store_roundtrip_and_delete() {

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(test)]
+use std::thread;
 use std::time::Instant;
 
 const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
@@ -326,6 +328,12 @@ impl CredentialStore for SystemCredentialStore {
             reference.service,
             reference.account
         );
+        // 持 per-key 锁覆盖"访问 Keychain + 回写值缓存"整段,与 get/delete 采用同一锁范围,
+        // 串行化同一凭据的所有并发写。若仅在缓存回写时加锁而后端写入在锁外,并发 set 的
+        // 后端完成顺序与缓存回写顺序可能错位,导致缓存值与 Keychain 不一致(lost-update)。
+        // 失败时不更新缓存,保留既有自愈语义(见 VALUE_CACHE 并发正确性小节)。
+        let lock = key_lock_for(&reference.service, &reference.account);
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
         let secrets = self.secrets_for(&reference.service);
         log::info!(
             "[credential_store] set backend ready service={} account={} elapsed_ms={}",
@@ -343,11 +351,8 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
-        // 写入成功后同步更新缓存:后续 get 命中即不再访问 Keychain。
-        // 持 per-key 锁串行化,避免与正在进行的 get 竞争回写陈旧值(见 VALUE_CACHE 并发小节)。
+        // 写入成功后同步更新缓存(仍在同一 per-key 临界区内),后续 get 命中即不再访问 Keychain。
         if result.is_ok() {
-            let lock = key_lock_for(&reference.service, &reference.account);
-            let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
             if let Ok(mut cache) = value_cache().lock() {
                 cache.insert(
                     (reference.service.clone(), reference.account.clone()),
@@ -365,6 +370,10 @@ impl CredentialStore for SystemCredentialStore {
             reference.service,
             reference.account
         );
+        // 持 per-key 锁覆盖"访问 Keychain + 回写值缓存"整段,锁范围与 get/set 一致
+        // (见 VALUE_CACHE 并发正确性小节)。失败时不更新缓存。
+        let lock = key_lock_for(&reference.service, &reference.account);
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
         let secrets = self.secrets_for(&reference.service);
         let result = secrets.delete(&reference.account).map_err(secrets_error);
         log::info!(
@@ -374,11 +383,8 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
-        // 删除成功后缓存为 None,避免下次 get 再次访问 Keychain(命中"已知不存在")。
-        // 持 per-key 锁串行化,语义与 set 一致。
+        // 删除成功后缓存为 None(仍在同一临界区内),避免下次 get 再次访问 Keychain(命中"已知不存在")。
         if result.is_ok() {
-            let lock = key_lock_for(&reference.service, &reference.account);
-            let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
             if let Ok(mut cache) = value_cache().lock() {
                 cache.insert((reference.service.clone(), reference.account.clone()), None);
             }
@@ -693,6 +699,136 @@ mod tests {
         store.get(&search_ref).unwrap();
         assert_eq!(model_backend.get_count(), 1, "model 后端不应被重复访问");
         assert_eq!(search_backend.get_count(), 1, "search 后端不应被重复访问");
+    }
+
+    /// 并发契约:多个线程同时对同一凭据 `get`(缓存未命中),只应访问后端**一次**。
+    /// per-key 锁串行化 + 持锁后 double-check 保证后续线程命中缓存,不再触碰后端(不再弹窗)。
+    /// 此为缓解反复弹窗的核心契约;移除 per-key 锁或 double-check 均会使 `get_count` > 1。
+    #[test]
+    fn system_store_concurrent_gets_access_backend_once() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        backend.seed("model:concurrent-get-probe", "sk-concurrent-1234567890");
+        let store = Arc::new(SystemCredentialStore::new());
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
+        );
+
+        let reference = Arc::new(CredentialReference::for_model("concurrent-get-probe"));
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let store = store.clone();
+                let reference = reference.clone();
+                thread::spawn(move || {
+                    store
+                        .get(&reference)
+                        .unwrap()
+                        .as_deref()
+                        .map(str::to_string)
+                })
+            })
+            .collect();
+        for handle in handles {
+            assert_eq!(
+                handle.join().unwrap().as_deref(),
+                Some("sk-concurrent-1234567890"),
+                "所有并发 get 应返回同一正确值"
+            );
+        }
+        assert_eq!(
+            backend.get_count(),
+            1,
+            "16 个并发 get 应只访问后端一次(per-key 锁 + double-check)"
+        );
+    }
+
+    /// 并发契约:多个线程并发 `set` 同一凭据后,缓存值须与后端最终值一致。
+    /// per-key 锁串行化"后端写入 + 缓存回写",消除 lost-update 导致的缓存陈旧。
+    #[test]
+    fn system_store_concurrent_sets_keep_cache_consistent_with_backend() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        let store = Arc::new(SystemCredentialStore::new());
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
+        );
+
+        let reference = Arc::new(CredentialReference::for_model("concurrent-set-probe"));
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let store = store.clone();
+                let reference = reference.clone();
+                thread::spawn(move || {
+                    store
+                        .set(&reference, &format!("sk-value-{i}-1234567890"))
+                        .unwrap()
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        // 并发写结束后,缓存值(get 命中缓存)须与后端最终值一致。
+        let backend_value = backend
+            .values
+            .lock()
+            .expect("fake store values lock")
+            .get("model:concurrent-set-probe")
+            .cloned();
+        let cache_value = store.get(&reference).unwrap();
+        assert_eq!(
+            cache_value, backend_value,
+            "并发 set 后缓存值须与后端最终值一致"
+        );
+    }
+
+    /// 并发契约:`set` 与 `delete` 并发后,缓存的存在性须与后端一致。
+    /// per-key 锁串行化两种操作,避免"后端已删除但缓存仍有旧值"的不一致。
+    #[test]
+    fn system_store_concurrent_set_and_delete_keep_cache_consistent() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        backend.seed("model:concurrent-sd-probe", "sk-initial-1234567890");
+        let store = Arc::new(SystemCredentialStore::new());
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
+        );
+
+        let reference = Arc::new(CredentialReference::for_model("concurrent-sd-probe"));
+        // 预热缓存,使后续 set/delete 走"缓存已存在"路径。
+        store.get(&reference).unwrap();
+
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let store = store.clone();
+            let reference = reference.clone();
+            handles.push(thread::spawn(move || {
+                store.set(&reference, "sk-set-1234567890").unwrap()
+            }));
+        }
+        for _ in 0..4 {
+            let store = store.clone();
+            let reference = reference.clone();
+            handles.push(thread::spawn(move || store.delete(&reference).unwrap()));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let backend_has = backend
+            .values
+            .lock()
+            .expect("fake store values lock")
+            .contains_key("model:concurrent-sd-probe");
+        let cache_has = store.get(&reference).unwrap().is_some();
+        assert_eq!(
+            cache_has, backend_has,
+            "并发 set/delete 后缓存存在性须与后端一致"
+        );
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -1,6 +1,8 @@
 use codewhale_secrets::{DefaultKeyringStore, Secrets, SecretsError};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+#[cfg(test)]
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 
@@ -19,14 +21,47 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// (用户点"允许"后本次成功读取并缓存),之后命中缓存即不触碰 Keychain,应用使用期间不再
 /// 反复弹窗。重启应用后首次访问仍会弹一次(详见 `docs/macos-keychain-弹窗说明.md`)。
 ///
-/// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与 `RuntimeModelCredential`
-/// 在 bridge 层的内存缓存(见 `bridge.rs` 的 `api_key`)同级。Keychain 仍是单一真相源:
-/// `set`/`delete` 同步更新缓存;环境变量路径不经过此缓存。仅 `Ok` 结果缓存(含 `Ok(None)`),
-/// `Err` 不缓存,允许临时性 Keychain 故障恢复后自愈。
+/// **并发正确性**:Keychain 读取可能因授权弹窗阻塞数秒至数分钟。若 `get` 在"读缓存未命中
+/// → 访问 Keychain → 回写缓存"期间释放锁,并发场景会出两类问题:① 多线程同时未命中同一
+/// key → 都访问 Keychain → 都弹窗(重复弹窗);② 线程 A 读到旧值阻塞中、线程 B `set` 新值
+/// 已更新缓存,A 读完后用旧值覆盖缓存 → 此后进程持续返回陈旧密钥(凭据正确性 bug)。为此
+/// `KEY_LOCKS` 为每个 `(service, account)` 维护一把 `Arc<Mutex<()>>`,`get`/`set`/`delete`
+/// 在"访问 Keychain + 读写值缓存"整段持有对应 key 的锁,串行化同一凭据的所有操作;不同 key
+/// 互不阻塞。锁内部从不嵌套 `value_cache`/`KEY_LOCKS` 之外的锁,无死锁风险。
+///
+/// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与本 crate 内其他明文 secret
+/// 在内存中的驻留(如 bridge 注入给引擎的 api_key、marketplace 重灌进进程 env 的 mcp
+/// secret)同等敏感等级,均仅驻留进程内存、不落盘。Keychain 仍是单一真相源:`set`/`delete`
+/// 同步更新缓存;环境变量路径不经过此缓存。仅 `Ok` 结果缓存(含 `Ok(None)`),`Err` 不缓存,
+/// 允许临时性 Keychain 故障(或用户在授权弹窗上点"拒绝")后下次重试自愈。
+///
+/// **陈旧边界**:`Ok(None)`("已知不存在")会缓存整个进程生命周期;若运行期间用户经"钥匙串
+/// 访问"App 或其它进程新增了该 item,本应用在重启前仍读到 `None`(设置页误显示"未配置")。
+/// 这是进程级内存缓存的固有边界,正常改 keychain 的路径走应用 UI(经 `set`/`delete` 同步
+/// 更新缓存),故影响有限。
 static VALUE_CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
 
 fn value_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
     VALUE_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 每个 `(service, account)` 一把锁,串行化同一凭据的"访问 Keychain + 读写值缓存",
+/// 消除并发下的重复弹窗与陈旧覆盖(见 `VALUE_CACHE` 的"并发正确性"小节)。不同 key 互不阻塞。
+static KEY_LOCKS: OnceLock<Mutex<HashMap<(String, String), Arc<Mutex<()>>>>> = OnceLock::new();
+
+fn key_locks() -> &'static Mutex<HashMap<(String, String), Arc<Mutex<()>>>> {
+    KEY_LOCKS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 取(或惰性创建)某 `(service, account)` 对应的 per-key 锁。锁句柄为 `Arc`,克隆后
+/// 在释放 `key_locks` 自身锁的前提下被调用方持有,确保"取锁"不与"持锁"嵌套、无死锁。
+fn key_lock_for(service: &str, account: &str) -> Arc<Mutex<()>> {
+    let key = (service.to_string(), account.to_string());
+    let mut locks = key_locks().lock().expect("key locks poisoned");
+    locks
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
 }
 const SEARCH_API_KEY_SERVICE: &str = "pinvou3-search-api-key";
 const MCP_SECRET_SERVICE: &str = "pinvou3-mcp-secret";
@@ -227,12 +262,27 @@ impl std::fmt::Debug for SystemCredentialStore {
 impl CredentialStore for SystemCredentialStore {
     fn get(&self, reference: &CredentialReference) -> Result<Option<String>, CredentialError> {
         let cache_key = (reference.service.clone(), reference.account.clone());
-        // 命中进程级缓存(含"已知不存在"的 None)即直接返回,不触碰 Keychain —— 这是
+        // 快路径:命中进程级缓存(含"已知不存在"的 None)即直接返回,不触碰 Keychain —— 这是
         // macOS ad-hoc 签名下避免反复弹窗的关键(见 VALUE_CACHE 注释)。
         if let Ok(cache) = value_cache().lock() {
             if let Some(cached) = cache.get(&cache_key) {
                 log::info!(
                     "[credential_store] get cache hit service={} account={}",
+                    reference.service,
+                    reference.account
+                );
+                return Ok(cached.clone());
+            }
+        }
+        // 未命中:取 per-key 锁,在持锁临界区内"再次检查缓存(double-check)→ 访问 Keychain
+        // → 回写缓存",串行化同一凭据的所有并发 get/set/delete(见 VALUE_CACHE 并发小节)。
+        let lock = key_lock_for(&reference.service, &reference.account);
+        let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
+        // double-check:另一线程可能刚把结果写入缓存,命中即避免重复访问 Keychain/重复弹窗。
+        if let Ok(cache) = value_cache().lock() {
+            if let Some(cached) = cache.get(&cache_key) {
+                log::info!(
+                    "[credential_store] get cache hit (double-check) service={} account={}",
                     reference.service,
                     reference.account
                 );
@@ -294,7 +344,10 @@ impl CredentialStore for SystemCredentialStore {
             started_at.elapsed().as_millis()
         );
         // 写入成功后同步更新缓存:后续 get 命中即不再访问 Keychain。
+        // 持 per-key 锁串行化,避免与正在进行的 get 竞争回写陈旧值(见 VALUE_CACHE 并发小节)。
         if result.is_ok() {
+            let lock = key_lock_for(&reference.service, &reference.account);
+            let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
             if let Ok(mut cache) = value_cache().lock() {
                 cache.insert(
                     (reference.service.clone(), reference.account.clone()),
@@ -322,12 +375,12 @@ impl CredentialStore for SystemCredentialStore {
             started_at.elapsed().as_millis()
         );
         // 删除成功后缓存为 None,避免下次 get 再次访问 Keychain(命中"已知不存在")。
+        // 持 per-key 锁串行化,语义与 set 一致。
         if result.is_ok() {
+            let lock = key_lock_for(&reference.service, &reference.account);
+            let _guard = lock.lock().unwrap_or_else(|e| e.into_inner());
             if let Ok(mut cache) = value_cache().lock() {
-                cache.insert(
-                    (reference.service.clone(), reference.account.clone()),
-                    None,
-                );
+                cache.insert((reference.service.clone(), reference.account.clone()), None);
             }
         }
         result
@@ -446,91 +499,200 @@ pub fn is_secret_like(value: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// 测试间清空进程级凭据值缓存,避免 static 状态串扰。
-    /// (生产代码不需要清空;缓存跨整个进程生命周期持久是设计意图。)
-    fn reset_value_cache() {
-        value_cache()
+    /// 内存 `KeyringStore` 兼 spy:记录 `get` 调用次数,用于断言"命中缓存后不再触底层"。
+    /// 仅用于测试;不触碰真实 Keychain。
+    struct FakeKeyringStore {
+        values: Mutex<HashMap<String, String>>,
+        get_count: AtomicU64,
+    }
+
+    impl FakeKeyringStore {
+        fn new() -> Self {
+            Self {
+                values: Mutex::new(HashMap::new()),
+                get_count: AtomicU64::new(0),
+            }
+        }
+
+        fn get_count(&self) -> u64 {
+            self.get_count.load(Ordering::Relaxed)
+        }
+
+        fn seed(&self, key: &str, value: &str) {
+            self.values
+                .lock()
+                .expect("fake store values lock")
+                .insert(key.to_string(), value.to_string());
+        }
+    }
+
+    impl codewhale_secrets::KeyringStore for FakeKeyringStore {
+        fn get(&self, key: &str) -> Result<Option<String>, SecretsError> {
+            self.get_count.fetch_add(1, Ordering::Relaxed);
+            Ok(self
+                .values
+                .lock()
+                .expect("fake store values lock")
+                .get(key)
+                .cloned())
+        }
+
+        fn set(&self, key: &str, value: &str) -> Result<(), SecretsError> {
+            self.values
+                .lock()
+                .expect("fake store values lock")
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+
+        fn delete(&self, key: &str) -> Result<(), SecretsError> {
+            self.values
+                .lock()
+                .expect("fake store values lock")
+                .remove(key);
+            Ok(())
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "in-memory (test)"
+        }
+    }
+
+    /// 把一个 fake `Secrets` 注入 store 的 service 缓存,使 `secrets_for` 命中它而不
+    /// 触碰真实 Keychain。借此可断言"缓存命中后不再访问底层后端"。
+    fn inject_fake_secrets(store: &SystemCredentialStore, service: &str, fake: Arc<Secrets>) {
+        store
+            .cache
             .lock()
-            .expect("value cache lock")
-            .clear();
+            .expect("credential store cache lock")
+            .insert(service.to_string(), fake);
     }
 
+    /// 核心契约:首次 `get` 访问底层后端并缓存结果;第二次 `get` 命中缓存,
+    /// **不再触碰底层后端**(这正是缓解反复弹窗的关键)。
     #[test]
-    fn value_cache_roundtrip_set_get_delete_consistency() {
-        reset_value_cache();
-        let key = ("pinvou3-model-api-key".to_string(), "model:m1".to_string());
+    fn system_store_second_get_hits_cache_without_touching_backend() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        backend.seed("model:cache-hit-probe", "sk-cached-1234567890");
+        let store = SystemCredentialStore::new();
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
+        );
 
-        // 初始:缓存未命中(value_cache.get 返回 None 表示"未缓存")。
-        {
-            let cache = value_cache().lock().unwrap();
-            assert!(cache.get(&key).is_none(), "缓存应为空");
-        }
-
-        // 模拟 get 成功后缓存 Ok(None) —— "已知不存在"。
-        {
-            let mut cache = value_cache().lock().unwrap();
-            cache.insert(key.clone(), None);
-        }
-        {
-            let cache = value_cache().lock().unwrap();
-            assert_eq!(cache.get(&key), Some(&None), "应缓存为已知不存在");
-        }
-
-        // 模拟 set 成功后更新为 Some(value)。
-        {
-            let mut cache = value_cache().lock().unwrap();
-            cache.insert(key.clone(), Some("sk-secret-1234567890".to_string()));
-        }
-        {
-            let cache = value_cache().lock().unwrap();
-            assert_eq!(
-                cache.get(&key),
-                Some(&Some("sk-secret-1234567890".to_string())),
-                "set 后缓存应反映新值"
-            );
-        }
-
-        // 模拟 delete 成功后回退为 None。
-        {
-            let mut cache = value_cache().lock().unwrap();
-            cache.insert(key.clone(), None);
-        }
-        {
-            let cache = value_cache().lock().unwrap();
-            assert_eq!(cache.get(&key), Some(&None), "delete 后应缓存为不存在");
-        }
-
-        reset_value_cache();
+        let reference = CredentialReference::for_model("cache-hit-probe");
+        // 首次:未命中缓存,触达底层后端。
+        assert_eq!(
+            store.get(&reference).unwrap().as_deref(),
+            Some("sk-cached-1234567890")
+        );
+        assert_eq!(backend.get_count(), 1, "首次 get 应访问后端一次");
+        // 第二次:命中进程级缓存,不再访问后端。
+        assert_eq!(
+            store.get(&reference).unwrap().as_deref(),
+            Some("sk-cached-1234567890")
+        );
+        assert_eq!(
+            backend.get_count(),
+            1,
+            "第二次 get 命中缓存,后端访问次数不应增加"
+        );
     }
 
+    /// `set` 成功后同步更新缓存,使得后续 `get` 命中缓存而不再访问后端。
     #[test]
-    fn value_cache_distinguishes_services() {
-        reset_value_cache();
-        let model_key = (
-            "pinvou3-model-api-key".to_string(),
-            "model:m1".to_string(),
+    fn system_store_set_updates_cache_so_subsequent_get_skips_backend() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        let store = SystemCredentialStore::new();
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
         );
-        let search_key = (
-            "pinvou3-search-api-key".to_string(),
-            "search:metaso".to_string(),
+
+        let reference = CredentialReference::for_model("set-sync-probe");
+        store.set(&reference, "sk-new-9999999999").unwrap();
+        assert_eq!(backend.get_count(), 0, "set 不应触发后端 get");
+        // set 已更新缓存,后续 get 命中缓存,不触后端。
+        assert_eq!(
+            store.get(&reference).unwrap().as_deref(),
+            Some("sk-new-9999999999")
         );
-        {
-            let mut cache = value_cache().lock().unwrap();
-            cache.insert(model_key.clone(), Some("sk-model".to_string()));
-            cache.insert(search_key.clone(), Some("mk-search".to_string()));
-        }
-        {
-            let cache = value_cache().lock().unwrap();
-            assert_eq!(
-                cache.get(&model_key),
-                Some(&Some("sk-model".to_string()))
-            );
-            assert_eq!(
-                cache.get(&search_key),
-                Some(&Some("mk-search".to_string()))
-            );
-        }
-        reset_value_cache();
+        assert_eq!(backend.get_count(), 0, "set 后 get 应命中缓存,不访问后端");
+    }
+
+    /// `delete` 成功后缓存为"已知不存在"(None),后续 `get` 命中缓存返回 None,
+    /// 不再访问后端(命中"已知不存在"分支)。
+    #[test]
+    fn system_store_delete_marks_cache_known_absent() {
+        let backend = Arc::new(FakeKeyringStore::new());
+        backend.seed("model:delete-probe", "sk-will-be-deleted-12345");
+        let store = SystemCredentialStore::new();
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(backend.clone())),
+        );
+
+        let reference = CredentialReference::for_model("delete-probe");
+        // 先填充缓存(首次 get 触达后端)。
+        assert_eq!(
+            store.get(&reference).unwrap().as_deref(),
+            Some("sk-will-be-deleted-12345")
+        );
+        let count_before_delete = backend.get_count();
+        // delete 后缓存更新为 None。
+        store.delete(&reference).unwrap();
+        // 后续 get 命中"已知不存在",返回 None 且不触后端。
+        assert_eq!(store.get(&reference).unwrap(), None);
+        assert_eq!(
+            backend.get_count(),
+            count_before_delete,
+            "delete 后 get 应命中缓存,不访问后端"
+        );
+    }
+
+    /// 缓存按 `(service, account)` 隔离:一个凭据的缓存不影响另一凭据的后端访问。
+    #[test]
+    fn system_store_cache_isolates_services() {
+        let model_backend = Arc::new(FakeKeyringStore::new());
+        model_backend.seed("model:isolate-probe", "sk-model-isolated-123");
+        let search_backend = Arc::new(FakeKeyringStore::new());
+        search_backend.seed("search:isolate-probe", "mk-search-isolated-123");
+
+        let store = SystemCredentialStore::new();
+        inject_fake_secrets(
+            &store,
+            MODEL_API_KEY_SERVICE,
+            Arc::new(Secrets::new(model_backend.clone())),
+        );
+        inject_fake_secrets(
+            &store,
+            SEARCH_API_KEY_SERVICE,
+            Arc::new(Secrets::new(search_backend.clone())),
+        );
+
+        let model_ref = CredentialReference::for_model("isolate-probe");
+        let search_ref = CredentialReference::for_search_provider("isolate-probe");
+
+        // 各自首次 get 触达各自后端。
+        assert_eq!(
+            store.get(&model_ref).unwrap().as_deref(),
+            Some("sk-model-isolated-123")
+        );
+        assert_eq!(
+            store.get(&search_ref).unwrap().as_deref(),
+            Some("mk-search-isolated-123")
+        );
+        assert_eq!(model_backend.get_count(), 1);
+        assert_eq!(search_backend.get_count(), 1);
+
+        // 再次 get 均命中各自缓存,两个后端访问次数都不增加。
+        store.get(&model_ref).unwrap();
+        store.get(&search_ref).unwrap();
+        assert_eq!(model_backend.get_count(), 1, "model 后端不应被重复访问");
+        assert_eq!(search_backend.get_count(), 1, "search 后端不应被重复访问");
     }
 
     #[test]


### PR DESCRIPTION
## 背景

Fixes #175。

macOS 社区版(`*-community.dmg`)安装后,首次访问 Keychain 弹出授权窗口,**即使点「始终允许」仍反复弹出**,导致应用不可用。

## 根因

这是 macOS 安全机制在 **ad-hoc 签名** 下的固有行为,非代码 bug:

- 社区版是 ad-hoc 签名(`config/platforms/macos/tauri.conf.json` 中 `signingIdentity = "-"`),无证书身份,只有 `cdhash`。
- 「始终允许」把"可信应用"写进**单条 keychain item 的 ACL**,以 **designated requirement(DR)** 识别。证书签名应用 DR 稳定 → ACL 一次写入长期命中;**ad-hoc 的 cdhash-only DR 不稳定**(应用更新/universal binary 两架构切片各有 cdhash)→ 后续访问校验无法稳定命中 → 又被判"未授权" → 反复弹窗。
- `keyring` crate(macOS 后端)用经典 `SecKeychainAddGenericPassword` API,创建 item 时不设自定义 ACL,完全依赖默认访问控制,ad-hoc 下无法稳定放行。
- 放大因素:应用有多个 `pinvou3-*` keychain service(model/search/mcp/ima),每个 item 各自弹;设置页每次 `get_settings` 回读所有 item 状态 → "无限弹窗"。全部访问在单一 Tauri 主进程内(已排查无 sidecar 另开 keychain)。

## 变更

**方案:仅缓解 + 文档**(经与维护者确认方向)。

1. `pinvou3-app/src-tauri/src/platform/credential_store.rs` — 加进程级凭据值缓存(`OnceLock<Mutex<HashMap<(service, account), Option<String>>>>`):
   - 同一 `(service, account)` 在一次进程生命周期内**只访问 Keychain 一次**,之后命中缓存不再触碰 → 应用运行期间不再为该凭据反复弹窗;
   - `set`/`delete` 同步更新缓存;仅缓存 `Ok`(含 `Ok(None)` "已知不存在"),`Err` 不缓存以便自愈;Keychain 仍是单一真相源;
   - 安全性:缓存值为明文 secret,仅在进程内存(不落盘),与 bridge 层 `RuntimeModelCredential` 内存缓存同级;环境变量路径不经过此缓存。
2. `docs/macos-keychain-弹窗说明.md`(新增)— 根因、本仓库缓解、用户手动方案(环境变量绕过 / 手动改 ACL)、永久方案路线(Developer ID 公证)。

## 已知限制(非本次范围)

- 应用重启后每个已配置凭据首次访问仍弹一次(ad-hoc 签名根本限制,缓存无法跨进程)。永久解决需 Developer ID 签名 + 公证(见 entitlements.plist 注释路线图)。
- 本 PR 不改变默认存储后端(仍 Keychain),不动设置 UI / i18n。

## 验证

- `cargo check`:干净(仅 CodeWhale 预存 warning)。
- `cargo test --lib platform::credential_store::`:9 过(含 2 个新缓存一致性/多 service 隔离测试)。
- `cargo test --lib platform::prefs::`:28 过,无回归。
- `python3 scripts/architecture-guard.py`:passed。
- `./scripts/fork-guard.sh --fast`:指纹层全过(本改动不涉及 fork-distinct 行为)。

## 风险

- 进程级缓存值在进程内存持有明文 secret。权衡上可接受(与已有 bridge 内存缓存同级;不落盘;Keychain 仍权威)。
- 缓存使「在应用运行期间通过『钥匙串访问』App 修改某 item 后,应用仍读到旧缓存值」——但这是所有内存缓存的固有特征,且改 keychain 的正常路径是经应用 UI(会走 `set`/`delete` 同步更新缓存)。