### PR TITLE
fix(workflow): 修复新建任务弹窗遮罩范围

### DIFF
--- a/pinvou3-app/src/features/workflow/WorkflowView.jsx
+++ b/pinvou3-app/src/features/workflow/WorkflowView.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { Paperclip } from '../../components/icons.jsx';
 import { bridge } from '../../hooks/useBridge.js';
@@ -1087,8 +1088,8 @@ const WidgetCard = ({ title, children, theme }) => {
       }
       const briefEmpty = briefText.trim().length === 0;
       const titleText = wfUi.newTaskTitle || t.uiWorkflow.newTaskTitle((workflow && workflow.name) || t.uiWorkflow.workflow);
-      return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      const modal = (
+        <div data-testid="workflow-new-task-modal" className="fixed inset-0 z-50 flex items-center justify-center p-6">
           <div className="absolute inset-0 bg-black/60" onClick={() => { if (!starting) onClose(); }}></div>
           <div className={`relative w-[560px] max-w-[92vw] flex flex-col rounded-[16px] overflow-hidden shadow-2xl ${isDark ? 'bg-[#1E1F20]' : 'bg-white'}`}>
             <div className={`flex items-center justify-between px-4 py-3 border-b ${isDark ? 'border-white/10' : 'border-black/10'}`}>
@@ -1148,6 +1149,7 @@ const WidgetCard = ({ title, children, theme }) => {
           </div>
         </div>
       );
+      return typeof document === 'undefined' ? modal : createPortal(modal, document.body);
     };
 
     // —— 工作流模板卡（未启动时显示）——

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -592,6 +592,35 @@ async function expand(page) {
   }));
   rec('①b 工作流可停止并预填原需求重开', stopButton && stopped.status === 'stopped' && stopped.sessionId === 's-zombie' && stopped.brief === '原始三省六部需求', JSON.stringify(stopped));
 
+  const workflowModalCoverage = await page.evaluate(() => {
+    const modal = document.querySelector('[data-testid="workflow-new-task-modal"]');
+    const sidebar = document.querySelector('[data-testid="app-sidebar"]');
+    if (!modal || !sidebar) return { found: !!modal, sidebarFound: !!sidebar };
+    const modalRect = modal.getBoundingClientRect();
+    const sidebarRect = sidebar.getBoundingClientRect();
+    const coveredElement = document.elementFromPoint(
+      sidebarRect.left + sidebarRect.width / 2,
+      sidebarRect.top + sidebarRect.height / 2,
+    );
+    return {
+      found: true,
+      sidebarFound: true,
+      mountedAtBody: modal.parentElement === document.body,
+      position: getComputedStyle(modal).position,
+      coversViewport: Math.abs(modalRect.left) < 1 && Math.abs(modalRect.top) < 1
+        && Math.abs(modalRect.width - window.innerWidth) < 1
+        && Math.abs(modalRect.height - window.innerHeight) < 1,
+      coversSidebar: !!coveredElement?.closest('[data-testid="workflow-new-task-modal"]'),
+    };
+  });
+  rec(
+    '①b-2 工作流新建任务弹窗遮罩覆盖包括左侧导航在内的整个窗口',
+    workflowModalCoverage.found && workflowModalCoverage.sidebarFound
+      && workflowModalCoverage.mountedAtBody && workflowModalCoverage.position === 'fixed'
+      && workflowModalCoverage.coversViewport && workflowModalCoverage.coversSidebar,
+    JSON.stringify(workflowModalCoverage),
+  );
+
   // ①c stop marker 是最终状态：迟到快照即使仍带 running/reviewing，也不能让角色卡回跳。
   const stoppedAfterLateSnapshot = await page.evaluate(async () => {
     const handlers = window.__TAURI_EVENT_HANDLERS__['workflow:full_state'] || [];


### PR DESCRIPTION
## 背景

工作流新建任务弹窗此前受内容区域的层叠上下文约束，遮罩只能覆盖主内容区域，左侧导航仍会露出并保持可交互。

## 变更

- 使用 React Portal 将新建任务弹窗挂载到 `document.body`
- 保留无 DOM 环境下的安全回退，不改变弹窗表单与启动流程
- 增加 UI 回归测试，校验遮罩覆盖完整视口及左侧导航区域

## 验证

- `npm run test:ui-smoke`（45 项通过）
- `npm run lint:ui`
- `npm run build:ui`
- `git diff --check`