### PR TITLE
fix(platform): 恢复 macos 下 unsupported 模块声明,修复 macOS 编译失败

### DIFF
--- a/pinvou3-app/src-tauri/src/platform/os/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/mod.rs
@@ -5,7 +5,10 @@ pub(crate) mod macos;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows;
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+// `unsupported` 是「尚未实现能力」的桩集合,供 macos 借用未实现的符号(见
+// `macos/mod.rs` 的 `pub use super::unsupported::*`),并在非三大桌面平台上作为
+// 默认 platform。因此除 linux/windows 外均需声明此模块。
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub(crate) mod unsupported;
 
 mod interface;


### PR DESCRIPTION
## 背景

#161（feat(knowledge): 支持会话挂载多个知识库）合并后,`origin/main` 在 **macOS** target 下无法编译,`cargo check` 报:

```
error[E0432]: unresolved import `super::unsupported`
 --> src/platform/os/macos/mod.rs:8:16
  |
8 | pub use super::unsupported::*;
  |                ^^^^^^^^^^^^^^^ could not find `unsupported` in `super`
```

CI 仅在 Linux 上运行,未触发此回归。

## 根因

`macos/mod.rs:8` 通过 `pub use super::unsupported::*` 借用「尚未实现能力」的桩函数(如 `external_application_path`、`file_url_from_path` 等,macos 暂未实现),因此 macos 必须能看到 `unsupported` 模块。

#161 把 `os/mod.rs` 中 `unsupported` 的声明条件从

```rust
#[cfg(not(any(target_os = "linux", target_os = "windows")))]   // #161 之前:macos 声明
pub(crate) mod unsupported;
```

误改为

```rust
#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]  // #161 之后:macos 被排除
pub(crate) mod unsupported;
```

即把 macos 也排除在 `unsupported` 模块声明之外,与 `macos/mod.rs` 的 glob 引用矛盾 → 编译失败。

## 变更

恢复 #161 之前的语义:除 linux/windows 外均声明 `unsupported` 模块(即 macos 与「未知平台」都声明),并补注释说明 macos 借用该模块桩函数的原因。

仅改 1 个文件、1 处 cfg,行为与 #161 之前等价。

## 验证

- `cargo check --lib`(macOS):干净。
- `cargo fmt --check`:干净。
- `cargo test --lib platform::`:168 过,无回归。
- `python3 scripts/architecture-guard.py`:passed。

## 风险

无。本改动仅恢复 #161 之前已正确的 cfg 语义,不改变任何已实现平台(linux/windows)的行为;`unsupported.rs` 内容未变。

## 备注

此 bug 独立于 #179(macos keychain 缓存)。#179 在 macOS 上的构建/验证此前被此 bug 阻断,本 PR 修复后 #179 即可在 macOS 上正常构建。