### PR TITLE
fix(chat): 修复本地模型发消息卡死及停止按钮失效

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -78,6 +78,21 @@ struct TurnLifecycleState {
     next_reservation_id: u64,
     active_reservation_id: Option<u64>,
     transcript_rules: Vec<TranscriptSanitizationRule>,
+    /// 用户在 turn 已 submit 但尚未收到 TurnStarted 时点了停止。
+    ///
+    /// CodeWhale Engine 在每个新轮次入口**无条件**调
+    /// `reset_cancel_token()`（`core/engine.rs:2664`，在 `TurnStarted`
+    /// 之前），用全新 token 覆盖当前共享 token。若 cancel 恰好在这个窗口
+    /// 调了 `cancel_current()`，取消信号会被重置丢弃。
+    ///
+    /// 此标记由 [`arm_pending_cancel`] 在 cancel 路径设置（仅当 turn 尚未
+    /// started），由事件转发器在收到 `TurnStarted` 后通过
+    /// [`take_pending_cancel`] 原子取出并重新 `cancel_current()`——此时
+    /// `reset_cancel_token()` 已经执行过，cancel 命中的是当前轮次的活跃 token。
+    ///
+    /// [`arm_pending_cancel`]: TurnLifecycle::arm_pending_cancel
+    /// [`take_pending_cancel`]: TurnLifecycle::take_pending_cancel
+    pending_cancel: bool,
 }
 
 /// The durable, user-visible meaning of a submitted engine operation.
@@ -373,6 +388,7 @@ impl TurnLifecycle {
             state.reclaimed = false;
             state.admission_emitted = false;
             state.active_reservation_id = Some(reservation_id);
+            state.pending_cancel = false;
             reservation_id
         };
         Ok(TurnReservation::new(self.clone(), reservation_id))
@@ -799,6 +815,33 @@ impl TurnLifecycle {
         emit_chat_terminal(app, session_id, TurnOutcomeStatus::Interrupted, None, false);
         self.finish_terminal_emission();
         true
+    }
+
+    /// 标记「cancel 在 turn 已 submit 但尚未 TurnStarted 时发起」。
+    ///
+    /// 仅当 turn 处于 active 且 `turn_id` 仍为 None（TurnStarted 未抵达）时设置
+    /// `pending_cancel`；若 `turn_id` 已有值说明 TurnStarted 已被转发器消费，
+    /// `cancel_current()` 直接命中当前活跃 token，无需补打。
+    ///
+    /// **调用顺序**：必须在 `cancel_current()` **之前**调用。两者取不同的锁
+    /// （lifecycle state mutex vs cancel_token mutex），无法原子合并。先 arm
+    /// 再 cancel 保证：即使 TurnStarted 在两步之间抵达转发器并消费了标记，
+    /// 随后的 `cancel_current()` 也只是幂等 no-op（转发器已重新 cancel）。
+    pub(crate) fn arm_pending_cancel(&self) {
+        let mut state = self.state.lock();
+        if state.turn_id.is_none() && state.active {
+            state.pending_cancel = true;
+        }
+    }
+
+    /// 原子取出并清除 `pending_cancel` 标记。
+    ///
+    /// 由事件转发器在收到 `TurnStarted` 后调用：此时 CodeWhale 的
+    /// `reset_cancel_token()` 已执行完毕（它在 `TurnStarted` 之前），
+    /// 重新 `cancel_current()` 命中的正是本轮的活跃 token。
+    pub(crate) fn take_pending_cancel(&self) -> bool {
+        let mut state = self.state.lock();
+        std::mem::take(&mut state.pending_cancel)
     }
 }
 
@@ -1600,8 +1643,17 @@ fn spawn_event_forwarder(
                     // before this serial forwarder can observe any delta or
                     // terminal event for the same turn. Reclaim uses the same
                     // emission gate, so it cannot overtake this pair.
-                    if !turn_lifecycle.emit_started_admission(&app, &session_id, turn_id.clone()) {
+                    let admitted =
+                        turn_lifecycle.emit_started_admission(&app, &session_id, turn_id.clone());
+                    // 消费 pending_cancel（无论 admitted 与否，防止跨轮泄漏）。
+                    // reset_cancel_token() 在 TurnStarted 之前已执行，若 cancel
+                    // 在此之前 arm 了标记，现在重新 cancel 命中的是本轮活跃 token。
+                    let pending_cancel = turn_lifecycle.take_pending_cancel();
+                    if !admitted {
                         continue;
+                    }
+                    if pending_cancel {
+                        approve_handle.cancel();
                     }
                     active_transcript_seen = false;
                     chat_persistence_error = None;
@@ -3039,6 +3091,84 @@ mod turn_lifecycle_tests {
             .is_some());
         assert!(!lifecycle.claim_unsubmitted_terminal());
         reservation2.mark_submitted();
+    }
+
+    #[test]
+    fn pending_cancel_is_armed_only_before_turn_started_and_consumed_once() {
+        // reset_cancel_token 竞态修复的核心不变量：
+        // 1. arm 仅在「active 且 turn_id=None（TurnStarted 未抵达）」时置标记；
+        // 2. take 原子取出并清除（防跨轮泄漏）；
+        // 3. 已 started 的 turn 不 arm（cancel_current 直接命中活跃 token）。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // --- 场景 A：submit 后、TurnStarted 前 arm → take 返回 true ---
+        lifecycle.on_submitted();
+        lifecycle.arm_pending_cancel();
+        assert!(
+            lifecycle.take_pending_cancel(),
+            "pending_cancel must be armed before TurnStarted"
+        );
+        // take 已消费，再次取返回 false。
+        assert!(
+            !lifecycle.take_pending_cancel(),
+            "pending_cancel must be consumed exactly once"
+        );
+
+        // --- 场景 B：TurnStarted 后 arm → 不置标记 ---
+        lifecycle.on_started("turn-1".to_string());
+        lifecycle.arm_pending_cancel();
+        assert!(
+            !lifecycle.take_pending_cancel(),
+            "must not arm pending_cancel after TurnStarted"
+        );
+
+        // 清理：结束当前 turn。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+    }
+
+    #[test]
+    fn pending_cancel_does_not_leak_across_turns() {
+        // 防跨轮污染：上一轮 arm 但未被消费的标记不能影响下一轮。
+        // reserve() 必须清除 stale pending_cancel。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        lifecycle.on_submitted();
+        lifecycle.arm_pending_cancel();
+        // 模拟 turn 未正常 started 就结束（如 engine spawn 失败）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+
+        // 新一轮 reserve 后，pending_cancel 必须被清除。
+        let _reservation = lifecycle.reserve().expect("reserve");
+        assert!(
+            !lifecycle.take_pending_cancel(),
+            "stale pending_cancel from previous turn must be cleared by reserve"
+        );
+    }
+
+    #[test]
+    fn pending_cancel_survives_until_turn_started_consumes_it() {
+        // 端到端时序模拟：cancel 在 submit 后、TurnStarted 前 arm →
+        // TurnStarted 抵达时 take 消费标记并触发重新 cancel。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // submit（op 入队，turn_lock 已释放，但 Engine 尚未 dequeue）。
+        lifecycle.on_submitted();
+
+        // cancel 路径：arm_pending_cancel（turn_id 仍为 None → 置标记）。
+        lifecycle.arm_pending_cancel();
+
+        // Engine 执行 reset_cancel_token + 发 TurnStarted → 转发器先
+        // on_started_transition（设 turn_id），再 take_pending_cancel。
+        lifecycle.on_started("turn-reset".to_string());
+        let pending = lifecycle.take_pending_cancel();
+        assert!(
+            pending,
+            "pending_cancel must survive until TurnStarted consumes it"
+        );
+
+        // 消费后标记清除，下一轮不受影响。
+        assert!(!lifecycle.take_pending_cancel());
+        assert!(lifecycle.finish_once(|| {}).is_some());
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -21,6 +21,7 @@ use anyhow::{Context, Result};
 use deepseek_tui::core::engine::{spawn_engine, EngineHandle};
 use deepseek_tui::core::events::{Event, TurnOutcomeStatus};
 use deepseek_tui::core::ops::Op;
+use deepseek_tui::error_taxonomy::ErrorCategory;
 use deepseek_tui::models::Message;
 use deepseek_tui::tools::shell::{new_shared_shell_manager, SharedShellManager};
 use deepseek_tui::tools::user_input::UserInputResponse;
@@ -742,6 +743,62 @@ impl TurnLifecycle {
         state.active = false;
         state.turn_id = None;
         drop(state);
+        true
+    }
+
+    /// 原子认领一个「reserved 未 submitted」turn 的终态并设置 `terminal_closing`
+    /// 闸门，供需要补发 `chat:done` 的路径（cancel 在 engine 未 spawn 时）使用。
+    ///
+    /// 与 [`invalidate_unsubmitted_reservation`] 的关键区别：本方法认领成功后立即
+    /// 置 `terminal_emitted = true` 与 `terminal_closing = true`，使随后抵达的
+    /// [`reserve`](Self::reserve) 被拒（`active || terminal_closing` → 闸门关闭），
+    /// 直至调用方在发完 `chat:done` 后调用 [`finish_terminal_emission`] 重新打开
+    /// 闸门。这样就消除了「invalidate 返回与 chat:done 发出之间，新一轮 reserve
+    /// 成功，迟到的 chat:done 错误清除新一轮 busy 状态」的跨轮竞态——权威终态路径
+    /// （[`claim_terminal_transition`] / [`claim_reclaimed_transition`]）同样靠这一对
+    /// 字段防止重入。
+    ///
+    /// [`invalidate_unsubmitted_reservation`]: Self::invalidate_unsubmitted_reservation
+    /// [`finish_terminal_emission`]: Self::finish_terminal_emission
+    /// [`claim_terminal_transition`]: Self::claim_terminal_transition
+    /// [`claim_reclaimed_transition`]: Self::claim_reclaimed_transition
+    pub(crate) fn claim_unsubmitted_terminal(&self) -> bool {
+        let _emission = self.emission.lock();
+        let mut state = self.state.lock();
+        if !state.active || state.submitted || state.terminal_emitted {
+            return false;
+        }
+        state.reclaimed = true;
+        if let Some(reservation_id) = state.active_reservation_id.take() {
+            Self::remove_unsubmitted_rule_locked(&mut state, reservation_id);
+        }
+        // 与权威终态路径一致：先发信号期间 `terminal_closing` 关闸，
+        // `terminal_emitted` 保证本轮不会再被任何路径二次认领。
+        state.active = false;
+        state.submitted = false;
+        state.turn_id = None;
+        state.terminal_emitted = true;
+        state.terminal_closing = true;
+        drop(state);
+        true
+    }
+
+    /// 认领一个未提交 turn 的终态并补发 `chat:done`，最后重置闸门。
+    ///
+    /// 给 cancel 在 engine 尚未 spawn（reservation 处于 reserved 未 submitted 阶段）
+    /// 时使用：原子认领（关闸防重入）→ 发 `Interrupted` 终态 → 重开闸门。封装成一
+    /// 个方法是为了让调用方（`EnginePool::cancel`，跨模块）不必直接触碰私有的
+    /// 终态收尾逻辑，与权威终态路径一样自包含「发完即重置」。
+    pub(crate) fn emit_unsubmitted_interrupted_terminal(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+    ) -> bool {
+        if !self.claim_unsubmitted_terminal() {
+            return false;
+        }
+        emit_chat_terminal(app, session_id, TurnOutcomeStatus::Interrupted, None, false);
+        self.finish_terminal_emission();
         true
     }
 }
@@ -1536,13 +1593,23 @@ fn spawn_event_forwarder(
             .try_state::<crate::features::monitor::MonitorState>()
             .map(|s| s.self_metrics());
         let mut current_turn_id: Option<String> = None;
-        // 连续 recoverable 错误兜底计数（修复本地端点 0-token 反复超时导致的
-        // 「永远正在处理」）：recoverable 错误(如 SSE idle timeout)按原设计不发
-        // chat:done(引擎还会 retry)，但若同一 turn 连续 N 次都 recoverable 且
+        // 连续流式 stall 兜底计数（修复本地端点 0-token 反复超时导致的
+        // 「永远正在处理」）：流式 stall（SSE idle timeout）按原设计不发
+        // chat:done(引擎还会 retry)，但若同一 turn 连续 N 次都 stall 且
         // 从未产出任何 token，说明端点根本没在响应——此时应升级为终态，让前端
         // 收到明确错误并复位 busy，而不是让用户干等数十分钟的重试预算耗尽。
-        let mut recoverable_error_streak: u32 = 0;
-        let mut any_delta_this_turn = false;
+        //
+        // 只计 `Timeout` 类的 recoverable 错误（即真正的流 stall），**不**对所有
+        // recoverable 事件计数：底座的 recoverable 集合很宽（rate limit / server
+        // error / network / context_overflow / stream Overflow / DurationLimit
+        // 等），其中很多是正常轮次里的瞬态抖动或致命但被标 recoverable 的边界，
+        // 一律计数会误杀还在思考/执行工具的有效轮次，与底座自身的恢复和工具降级
+        // 语义冲突。真正的本地端点「prefill 卡死」几乎只表现为反复 stream stall。
+        let mut consecutive_stream_stalls: u32 = 0;
+        // 本轮是否出现过任何有效进度信号（答案 delta、思考 delta、工具调用）。
+        // 出现任一即说明端点在响应，清空 stall 计数；不再仅认 MessageDelta，
+        // 避免对「只思考 / 只跑工具还没产出答案 token」的有效轮次误判为卡死。
+        let mut any_progress_this_turn = false;
         let mut rx = handle.rx_event.write().await;
         while let Some(event) = rx.recv().await {
             match event {
@@ -1557,8 +1624,8 @@ fn spawn_event_forwarder(
                     active_transcript_seen = false;
                     chat_persistence_error = None;
                     current_turn_id = Some(turn_id.clone());
-                    recoverable_error_streak = 0;
-                    any_delta_this_turn = false;
+                    consecutive_stream_stalls = 0;
+                    any_progress_this_turn = false;
                     if let Err(error) = turn_shell_tasks.bind_or_prepare_turn(&turn_id).await {
                         log::error!(
                             "[pinvou3][chat] failed to bind shell task scope sid={} turn={}: {error:#}",
@@ -1573,10 +1640,10 @@ fn spawn_event_forwarder(
                     }
                 }
                 Event::MessageDelta { content, .. } => {
-                    // 模型产出了真实 token → 端点在正常工作，清空 recoverable
-                    // 错误连续计数（后续若再次 idle timeout 才重新累计）。
-                    any_delta_this_turn = true;
-                    recoverable_error_streak = 0;
+                    // 模型产出了真实答案 token → 端点在正常工作，清空 stall 计数
+                    //（后续若再次 idle timeout 才重新累计）。
+                    any_progress_this_turn = true;
+                    consecutive_stream_stalls = 0;
                     if let Some(m) = &self_metrics {
                         m.on_message_delta(&session_id, content.chars().count());
                     }
@@ -1597,6 +1664,13 @@ fn spawn_event_forwarder(
                 Event::ThinkingDelta { index, content } => {
                     // 只转发底座已经识别为 ThinkingDelta 的独立思考内容。普通
                     // MessageDelta 不做启发式猜测，避免把最终回答误折叠成思考。
+                    // 思考流也是「端点在响应」的信号：本地端点 prefill 期间会持续
+                    // 产出 ThinkingDelta，把它视为有效进度可避免对「只思考、还没
+                    // 产出答案 token」的长推理轮次误判为 stall 卡死而强制取消。
+                    if !content.is_empty() {
+                        any_progress_this_turn = true;
+                        consecutive_stream_stalls = 0;
+                    }
                     let payload =
                         json!({ "session_id": session_id, "index": index, "text": content });
                     let _ = app.emit("chat:reasoning_delta", payload.clone());
@@ -1616,6 +1690,11 @@ fn spawn_event_forwarder(
                     );
                 }
                 Event::ToolCallStarted { id, name, input } => {
+                    // 模型已发起工具调用 = 本轮在推进，端点有在响应；视为有效进度，
+                    // 清空 stall 计数，避免对「边跑工具边偶发抖动」的有效 agentic
+                    // 轮次误判为卡死。
+                    any_progress_this_turn = true;
+                    consecutive_stream_stalls = 0;
                     if let Some(m) = &self_metrics {
                         m.on_tool(&session_id); // 本轮有工具 → 收尾跳过 TTFT/TPS(D2)
                     }
@@ -2765,26 +2844,34 @@ fn spawn_event_forwarder(
                             "chat:transient_error",
                             payload,
                         );
-                        // 连续 recoverable 错误兜底：若同一 turn 连续 3 次 recoverable
-                        // 错误且从未产出任何 token，说明端点根本没在响应(典型：本地/
-                        // 局域网端点 prefill 卡住或 SSE 格式不兼容，反复 idle timeout)。
-                        // 底座虽然还会按重试预算继续跑(最长数十分钟)，但用户已干等
-                        // 三个超时周期——此时主动 cancel，让 turn_loop 正常跳出并发
-                        // TurnComplete(Interrupted) → chat:done，前端收到明确反馈而非
-                        // 无限「正在处理」。阈值取 3：单次瞬态错误(云端代理抖动)不会
-                        // 误杀，连续 3 次几乎必然是端点问题。
-                        if !any_delta_this_turn {
-                            recoverable_error_streak = recoverable_error_streak.saturating_add(1);
-                            if recoverable_error_streak >= 3 {
+                        // 连续 stream stall 兜底：仅对 `Timeout` 类的 recoverable
+                        // 错误（即真正的 SSE idle timeout / stream stall）计数。
+                        // 底座的 recoverable 集合很宽（rate limit / server error /
+                        // network / context_overflow / stream Overflow / DurationLimit
+                        // 等），其中：① rate limit / network 抖动是正常轮次的瞬态
+                        // 噪声，不应因连续几次就杀掉还在 retry 的健康轮次；②
+                        // stream Overflow / DurationLimit 虽标 recoverable，但底座
+                        // 随后会 break 并发 TurnComplete 终态，此时再 cancel 是与
+                        // 即将到来的权威终态抢跑道。真正的本地端点「prefill 卡死」
+                        // 几乎只表现为反复 stream stall，把这个症状钉死即可。
+                        // 若同一 turn 连续 3 次 stream stall 且从未出现任何有效进度
+                        //（答案/思考 token、工具调用），说明端点根本没在响应；底座
+                        // 虽然还会按重试预算继续跑(最长数十分钟)，但用户已干等三个
+                        // 超时周期——此时主动 cancel，让 turn_loop 正常跳出并发
+                        // TurnComplete(Interrupted) → chat:done。阈值取 3：单次 stall
+                        //（云端代理抖动）不会误杀，连续 3 次几乎必然是端点问题。
+                        if !any_progress_this_turn && envelope.category == ErrorCategory::Timeout {
+                            consecutive_stream_stalls = consecutive_stream_stalls.saturating_add(1);
+                            if consecutive_stream_stalls >= 3 {
                                 log::warn!(
-                                    "[pinvou3][chat] aborting turn after {recoverable_error_streak} \
-                                     consecutive recoverable errors with zero output sid={} — \
+                                    "[pinvou3][chat] aborting turn after {consecutive_stream_stalls} \
+                                     consecutive stream stalls with zero output sid={} — \
                                      endpoint likely unresponsive: {}",
                                     session_id,
                                     envelope.message
                                 );
                                 approve_handle.cancel();
-                                recoverable_error_streak = 0;
+                                consecutive_stream_stalls = 0;
                             }
                         }
                     } else {
@@ -2983,6 +3070,40 @@ mod turn_lifecycle_tests {
             .on_started_transition("turn-submitted".to_string())
             .is_some());
         assert!(!lifecycle.invalidate_unsubmitted_reservation());
+        reservation2.mark_submitted();
+    }
+
+    #[test]
+    fn claim_unsubmitted_terminal_blocks_reserve_until_emission_finishes() {
+        // 跨轮竞态回归（见 claim_unsubmitted_terminal 的文档注释）：cancel 在
+        // engine 未 spawn 时补发 chat:done，必须在「认领 → 发终态」之间关闸，
+        // 否则新一轮 reserve 可抢先成功，迟到的 chat:done 会清掉新一轮 busy。
+        // 这里直接断言闸门语义：claim 成功后、finish 前 reserve 必须被拒；
+        // finish 后（终态已发完）才允许下一轮 reserve。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        let reservation = lifecycle.reserve().expect("reserve");
+        // claim 成功 = 进入「终态发送中」临界区。
+        assert!(lifecycle.claim_unsubmitted_terminal());
+        reservation.mark_submitted();
+
+        // 关键不变量：终态尚未发完（terminal_closing=true）时，下一轮 reserve
+        // 必须失败——否则上一轮迟到的 chat:done 会污染新一轮 busy 状态。
+        assert!(
+            lifecycle.reserve().is_err(),
+            "reserve must be rejected while terminal emission is in flight"
+        );
+
+        // 终态发完，闸门重开，下一轮可正常 reserve。
+        lifecycle.finish_terminal_emission();
+        assert!(lifecycle.reserve().is_ok());
+
+        // 已 submitted 的 turn 不能再被 claim（engine 已接手，走 cancel_current 路径）。
+        let reservation2 = lifecycle.reserve().expect("reserve");
+        assert!(lifecycle
+            .on_started_transition("turn-submitted".to_string())
+            .is_some());
+        assert!(!lifecycle.claim_unsubmitted_terminal());
         reservation2.mark_submitted();
     }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -21,7 +21,6 @@ use anyhow::{Context, Result};
 use deepseek_tui::core::engine::{spawn_engine, EngineHandle};
 use deepseek_tui::core::events::{Event, TurnOutcomeStatus};
 use deepseek_tui::core::ops::Op;
-use deepseek_tui::error_taxonomy::ErrorCategory;
 use deepseek_tui::models::Message;
 use deepseek_tui::tools::shell::{new_shared_shell_manager, SharedShellManager};
 use deepseek_tui::tools::user_input::UserInputResponse;
@@ -1593,23 +1592,6 @@ fn spawn_event_forwarder(
             .try_state::<crate::features::monitor::MonitorState>()
             .map(|s| s.self_metrics());
         let mut current_turn_id: Option<String> = None;
-        // 连续流式 stall 兜底计数（修复本地端点 0-token 反复超时导致的
-        // 「永远正在处理」）：流式 stall（SSE idle timeout）按原设计不发
-        // chat:done(引擎还会 retry)，但若同一 turn 连续 N 次都 stall 且
-        // 从未产出任何 token，说明端点根本没在响应——此时应升级为终态，让前端
-        // 收到明确错误并复位 busy，而不是让用户干等数十分钟的重试预算耗尽。
-        //
-        // 只计 `Timeout` 类的 recoverable 错误（即真正的流 stall），**不**对所有
-        // recoverable 事件计数：底座的 recoverable 集合很宽（rate limit / server
-        // error / network / context_overflow / stream Overflow / DurationLimit
-        // 等），其中很多是正常轮次里的瞬态抖动或致命但被标 recoverable 的边界，
-        // 一律计数会误杀还在思考/执行工具的有效轮次，与底座自身的恢复和工具降级
-        // 语义冲突。真正的本地端点「prefill 卡死」几乎只表现为反复 stream stall。
-        let mut consecutive_stream_stalls: u32 = 0;
-        // 本轮是否出现过任何有效进度信号（答案 delta、思考 delta、工具调用）。
-        // 出现任一即说明端点在响应，清空 stall 计数；不再仅认 MessageDelta，
-        // 避免对「只思考 / 只跑工具还没产出答案 token」的有效轮次误判为卡死。
-        let mut any_progress_this_turn = false;
         let mut rx = handle.rx_event.write().await;
         while let Some(event) = rx.recv().await {
             match event {
@@ -1624,8 +1606,6 @@ fn spawn_event_forwarder(
                     active_transcript_seen = false;
                     chat_persistence_error = None;
                     current_turn_id = Some(turn_id.clone());
-                    consecutive_stream_stalls = 0;
-                    any_progress_this_turn = false;
                     if let Err(error) = turn_shell_tasks.bind_or_prepare_turn(&turn_id).await {
                         log::error!(
                             "[pinvou3][chat] failed to bind shell task scope sid={} turn={}: {error:#}",
@@ -1640,10 +1620,6 @@ fn spawn_event_forwarder(
                     }
                 }
                 Event::MessageDelta { content, .. } => {
-                    // 模型产出了真实答案 token → 端点在正常工作，清空 stall 计数
-                    //（后续若再次 idle timeout 才重新累计）。
-                    any_progress_this_turn = true;
-                    consecutive_stream_stalls = 0;
                     if let Some(m) = &self_metrics {
                         m.on_message_delta(&session_id, content.chars().count());
                     }
@@ -1664,13 +1640,6 @@ fn spawn_event_forwarder(
                 Event::ThinkingDelta { index, content } => {
                     // 只转发底座已经识别为 ThinkingDelta 的独立思考内容。普通
                     // MessageDelta 不做启发式猜测，避免把最终回答误折叠成思考。
-                    // 思考流也是「端点在响应」的信号：本地端点 prefill 期间会持续
-                    // 产出 ThinkingDelta，把它视为有效进度可避免对「只思考、还没
-                    // 产出答案 token」的长推理轮次误判为 stall 卡死而强制取消。
-                    if !content.is_empty() {
-                        any_progress_this_turn = true;
-                        consecutive_stream_stalls = 0;
-                    }
                     let payload =
                         json!({ "session_id": session_id, "index": index, "text": content });
                     let _ = app.emit("chat:reasoning_delta", payload.clone());
@@ -1690,11 +1659,6 @@ fn spawn_event_forwarder(
                     );
                 }
                 Event::ToolCallStarted { id, name, input } => {
-                    // 模型已发起工具调用 = 本轮在推进，端点有在响应；视为有效进度，
-                    // 清空 stall 计数，避免对「边跑工具边偶发抖动」的有效 agentic
-                    // 轮次误判为卡死。
-                    any_progress_this_turn = true;
-                    consecutive_stream_stalls = 0;
                     if let Some(m) = &self_metrics {
                         m.on_tool(&session_id); // 本轮有工具 → 收尾跳过 TTFT/TPS(D2)
                     }
@@ -2844,36 +2808,6 @@ fn spawn_event_forwarder(
                             "chat:transient_error",
                             payload,
                         );
-                        // 连续 stream stall 兜底：仅对 `Timeout` 类的 recoverable
-                        // 错误（即真正的 SSE idle timeout / stream stall）计数。
-                        // 底座的 recoverable 集合很宽（rate limit / server error /
-                        // network / context_overflow / stream Overflow / DurationLimit
-                        // 等），其中：① rate limit / network 抖动是正常轮次的瞬态
-                        // 噪声，不应因连续几次就杀掉还在 retry 的健康轮次；②
-                        // stream Overflow / DurationLimit 虽标 recoverable，但底座
-                        // 随后会 break 并发 TurnComplete 终态，此时再 cancel 是与
-                        // 即将到来的权威终态抢跑道。真正的本地端点「prefill 卡死」
-                        // 几乎只表现为反复 stream stall，把这个症状钉死即可。
-                        // 若同一 turn 连续 3 次 stream stall 且从未出现任何有效进度
-                        //（答案/思考 token、工具调用），说明端点根本没在响应；底座
-                        // 虽然还会按重试预算继续跑(最长数十分钟)，但用户已干等三个
-                        // 超时周期——此时主动 cancel，让 turn_loop 正常跳出并发
-                        // TurnComplete(Interrupted) → chat:done。阈值取 3：单次 stall
-                        //（云端代理抖动）不会误杀，连续 3 次几乎必然是端点问题。
-                        if !any_progress_this_turn && envelope.category == ErrorCategory::Timeout {
-                            consecutive_stream_stalls = consecutive_stream_stalls.saturating_add(1);
-                            if consecutive_stream_stalls >= 3 {
-                                log::warn!(
-                                    "[pinvou3][chat] aborting turn after {consecutive_stream_stalls} \
-                                     consecutive stream stalls with zero output sid={} — \
-                                     endpoint likely unresponsive: {}",
-                                    session_id,
-                                    envelope.message
-                                );
-                                approve_handle.cancel();
-                                consecutive_stream_stalls = 0;
-                            }
-                        }
                     } else {
                         // 底座在致命 Error 后仍会发权威 TurnComplete(Failed)。这里只缓存
                         // 文本；完成、持久化和 chat:done 全部由 TurnComplete 单点处理。

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -819,9 +819,15 @@ impl TurnLifecycle {
 
     /// 标记「cancel 在 turn 已 submit 但尚未 TurnStarted 时发起」。
     ///
-    /// 仅当 turn 处于 active 且 `turn_id` 仍为 None（TurnStarted 未抵达）时设置
-    /// `pending_cancel`；若 `turn_id` 已有值说明 TurnStarted 已被转发器消费，
-    /// `cancel_current()` 直接命中当前活跃 token，无需补打。
+    /// 仅当 turn 处于 active、已 `submitted`、且 `turn_id` 仍为 None（TurnStarted
+    /// 未抵达）时设置 `pending_cancel`：
+    /// - 必须 `submitted`：未提交的 reservation（消息尚未入队 engine）应由 cancel
+    ///   走未提交认领终态路径（`emit_unsubmitted_interrupted_terminal`）立即发
+    ///   `chat:done` 使 reservation 失效，而不是挂成 pending——否则空闲 engine 仍
+    ///   存在时 cancel 不发终态、reservation 仍有效，原 chat future 后续照常提交，
+    ///   前端 busy 在 cancel 后到 TurnStarted 之间无法复位。
+    /// - 若 `turn_id` 已有值说明 TurnStarted 已被转发器消费，`cancel_current()`
+    ///   直接命中当前活跃 token，无需补打。
     ///
     /// **调用顺序**：必须在 `cancel_current()` **之前**调用。两者取不同的锁
     /// （lifecycle state mutex vs cancel_token mutex），无法原子合并。先 arm
@@ -829,7 +835,7 @@ impl TurnLifecycle {
     /// 随后的 `cancel_current()` 也只是幂等 no-op（转发器已重新 cancel）。
     pub(crate) fn arm_pending_cancel(&self) {
         let mut state = self.state.lock();
-        if state.turn_id.is_none() && state.active {
+        if state.submitted && state.turn_id.is_none() && state.active {
             state.pending_cancel = true;
         }
     }
@@ -3094,9 +3100,69 @@ mod turn_lifecycle_tests {
     }
 
     #[test]
+    fn arm_pending_cancel_requires_submitted_reservation() {
+        // 空闲 engine + 未提交 reservation 窗口的回归：会话保留上一轮的空闲
+        // engine 时，cancel 第二阶段若按「engine 是否存在」分流会错误走 pending
+        // 分支。arm_pending_cancel 必须显式要求 submitted——只有消息确实已入队
+        // engine、需要防 reset_cancel_token 覆盖时才 arm；未提交 reservation 应由
+        // cancel 走未提交认领终态路径（emit_unsubmitted_interrupted_terminal）立即
+        // 发 chat:done 使其失效，而不是挂成 pending。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // reserve 后 active=true 但 submitted=false → arm 不得置位。
+        let reservation = lifecycle.reserve().expect("reserve");
+        lifecycle.arm_pending_cancel();
+        assert!(
+            !lifecycle.take_pending_cancel(),
+            "must not arm pending_cancel for an unsubmitted reservation"
+        );
+
+        // 走真实 send 路径：handle.send 成功后 mark_submitted → submitted=true。
+        lifecycle.mark_reservation_submitted(reservation.reservation_id);
+        // 已 submitted + active + turn_id=None（TurnStarted 未抵达）→ arm 置位。
+        lifecycle.arm_pending_cancel();
+        assert!(
+            lifecycle.take_pending_cancel(),
+            "pending_cancel must be armed after submission, before TurnStarted"
+        );
+        // 消费 reservation 避免 Drop 副作用。
+        reservation.mark_submitted();
+    }
+
+    #[test]
+    fn claim_unsubmitted_terminal_invalidates_reservation() {
+        // 修复的核心闭环：空闲 engine 存在时，cancel 对未提交 reservation 走认领
+        // 终态路径，认领后该 reservation 必须失效——后续 send 的 ensure_active
+        // 失败、消息不再提交给 engine，前端 busy 因补发的 chat:done 复位。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+        let reservation = lifecycle.reserve().expect("reserve");
+
+        // 认领前 reservation 有效。
+        assert!(reservation.ensure_active().is_ok());
+
+        // 认领未提交终态（cancel 第二阶段会走这里）。
+        assert!(
+            lifecycle.claim_unsubmitted_terminal(),
+            "unsubmitted reservation must be claimable"
+        );
+        // claim 已把 active=false，reservation 不再有效——消息不会迟到提交。
+        assert!(
+            reservation.ensure_active().is_err(),
+            "claimed reservation must be invalidated so the pending send fails"
+        );
+        // 防 Drop 二次清理：claim 已收尾，标记 submitted 阻止 on_reservation_failed。
+        reservation.mark_submitted();
+
+        // 终态发完后重开闸门，下一轮可正常 reserve（与权威终态路径一致）。
+        lifecycle.finish_terminal_emission();
+        assert!(lifecycle.reserve().is_ok());
+    }
+
+    #[test]
     fn pending_cancel_is_armed_only_before_turn_started_and_consumed_once() {
         // reset_cancel_token 竞态修复的核心不变量：
-        // 1. arm 仅在「active 且 turn_id=None（TurnStarted 未抵达）」时置标记；
+        // 1. arm 仅在「active、已 submitted、且 turn_id=None（TurnStarted 未抵达）」
+        //    时置标记（submitted 前置见 arm_pending_cancel_requires_submitted_reservation）；
         // 2. take 原子取出并清除（防跨轮泄漏）；
         // 3. 已 started 的 turn 不 arm（cancel_current 直接命中活跃 token）。
         let lifecycle = Arc::new(TurnLifecycle::default());

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -1536,6 +1536,13 @@ fn spawn_event_forwarder(
             .try_state::<crate::features::monitor::MonitorState>()
             .map(|s| s.self_metrics());
         let mut current_turn_id: Option<String> = None;
+        // 连续 recoverable 错误兜底计数（修复本地端点 0-token 反复超时导致的
+        // 「永远正在处理」）：recoverable 错误(如 SSE idle timeout)按原设计不发
+        // chat:done(引擎还会 retry)，但若同一 turn 连续 N 次都 recoverable 且
+        // 从未产出任何 token，说明端点根本没在响应——此时应升级为终态，让前端
+        // 收到明确错误并复位 busy，而不是让用户干等数十分钟的重试预算耗尽。
+        let mut recoverable_error_streak: u32 = 0;
+        let mut any_delta_this_turn = false;
         let mut rx = handle.rx_event.write().await;
         while let Some(event) = rx.recv().await {
             match event {
@@ -1550,6 +1557,8 @@ fn spawn_event_forwarder(
                     active_transcript_seen = false;
                     chat_persistence_error = None;
                     current_turn_id = Some(turn_id.clone());
+                    recoverable_error_streak = 0;
+                    any_delta_this_turn = false;
                     if let Err(error) = turn_shell_tasks.bind_or_prepare_turn(&turn_id).await {
                         log::error!(
                             "[pinvou3][chat] failed to bind shell task scope sid={} turn={}: {error:#}",
@@ -1564,6 +1573,10 @@ fn spawn_event_forwarder(
                     }
                 }
                 Event::MessageDelta { content, .. } => {
+                    // 模型产出了真实 token → 端点在正常工作，清空 recoverable
+                    // 错误连续计数（后续若再次 idle timeout 才重新累计）。
+                    any_delta_this_turn = true;
+                    recoverable_error_streak = 0;
                     if let Some(m) = &self_metrics {
                         m.on_message_delta(&session_id, content.chars().count());
                     }
@@ -2752,6 +2765,28 @@ fn spawn_event_forwarder(
                             "chat:transient_error",
                             payload,
                         );
+                        // 连续 recoverable 错误兜底：若同一 turn 连续 3 次 recoverable
+                        // 错误且从未产出任何 token，说明端点根本没在响应(典型：本地/
+                        // 局域网端点 prefill 卡住或 SSE 格式不兼容，反复 idle timeout)。
+                        // 底座虽然还会按重试预算继续跑(最长数十分钟)，但用户已干等
+                        // 三个超时周期——此时主动 cancel，让 turn_loop 正常跳出并发
+                        // TurnComplete(Interrupted) → chat:done，前端收到明确反馈而非
+                        // 无限「正在处理」。阈值取 3：单次瞬态错误(云端代理抖动)不会
+                        // 误杀，连续 3 次几乎必然是端点问题。
+                        if !any_delta_this_turn {
+                            recoverable_error_streak = recoverable_error_streak.saturating_add(1);
+                            if recoverable_error_streak >= 3 {
+                                log::warn!(
+                                    "[pinvou3][chat] aborting turn after {recoverable_error_streak} \
+                                     consecutive recoverable errors with zero output sid={} — \
+                                     endpoint likely unresponsive: {}",
+                                    session_id,
+                                    envelope.message
+                                );
+                                approve_handle.cancel();
+                                recoverable_error_streak = 0;
+                            }
+                        }
                     } else {
                         // 底座在致命 Error 后仍会发权威 TurnComplete(Failed)。这里只缓存
                         // 文本；完成、持久化和 chat:done 全部由 TurnComplete 单点处理。
@@ -2923,6 +2958,32 @@ mod turn_lifecycle_tests {
         let activated = lifecycle.on_submitted();
         lifecycle.on_submission_failed(activated);
         assert_eq!(lifecycle.finish_once(|| panic!("must remain idle")), None);
+    }
+
+    #[test]
+    fn invalidate_unsubmitted_reservation_returns_true_only_for_reserved_unsubmitted() {
+        // 修复 2 的核心依赖：cancel 在 engine 未 spawn（reservation 仍处于
+        // reserved 未 submitted 阶段）时调用 invalidate，必须返回 true 让调用方
+        // 据此补发 chat:done 终态（否则前端 busy 永不复位）。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // reserve → active=true, submitted=false → invalidate 返回 true。
+        // 必须把 reservation 绑定到变量并保持存活到 invalidate 之后，否则 Drop
+        // 会先触发 on_reservation_failed 把 active 复位。
+        let reservation = lifecycle.reserve().expect("reserve");
+        assert!(lifecycle.invalidate_unsubmitted_reservation());
+        // invalidate 已收尾，标记 reservation submitted 以免 Drop 二次清理。
+        reservation.mark_submitted();
+
+        // reserve → on_started_transition（引擎真正接手，设 submitted=true）
+        // → invalidate 必须返回 false：engine 已在跑，cancel 应走 cancel_current
+        // 路径（TurnComplete 终态），不能再由 invalidate 补发，否则会双发 chat:done。
+        let reservation2 = lifecycle.reserve().expect("reserve again");
+        assert!(lifecycle
+            .on_started_transition("turn-submitted".to_string())
+            .is_some());
+        assert!(!lifecycle.invalidate_unsubmitted_reservation());
+        reservation2.mark_submitted();
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -920,15 +920,13 @@ impl EnginePool {
             // emit chat:done(原设计)，导致前端 busy 永不复位。这里补发 Interrupted
             // 终态，让前端立即解锁——cancel_generation 命令的文档注释本就承诺
             // 「会补发 Interrupted 终态」，之前实现与注释不符，此处修正。
-            if lifecycle.invalidate_unsubmitted_reservation() {
-                crate::features::assistant::engine::emit_chat_terminal(
-                    &self.app,
-                    session_id,
-                    TurnOutcomeStatus::Interrupted,
-                    None,
-                    false,
-                );
-            }
+            //
+            // 必须用 claim_unsubmitted_terminal（而非裸 invalidate）：reserve_turn 不
+            // 取 turn_lock，若仅在 invalidate 后、chat:done 发出前释放闸门，新一轮
+            // reserve 可抢先成功，迟到的 chat:done 会清掉新一轮 busy。claim 路径在
+            // 发终态期间置 terminal_closing 关闸，与权威终态路径（claim_terminal /
+            // claim_reclaimed）一致的防重入语义。
+            lifecycle.emit_unsubmitted_interrupted_terminal(&self.app, session_id);
         }
         if let Some(cancellation) = shell_cancellation {
             cancellation.cleanup().await;

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -891,14 +891,44 @@ impl EnginePool {
     }
 
     /// 取消指定 session 正在生成的回复。engine 没起则 no-op。
+    ///
+    /// 分两阶段执行，避免与 `send_reserved_user_message` 争抢 `turn_lock` 导致
+    /// 「停止按钮无响应」：cancel_token 是独立原子，置位不需要 turn_lock 保护，
+    /// 因此第一步无锁先触发，turn_loop 的 biased select 会立即跳出并正常发
+    /// `TurnComplete`(→ chat:done)；第二步再持锁清理 shell/lifecycle 状态。
+    /// 若 engine 尚未 spawn(send 仍持锁中)，第二步持锁后走 invalidate 并补发
+    /// Interrupted 终态，保证前端 busy 一定能复位。
     pub async fn cancel(&self, session_id: &str) {
+        // 阶段一：无锁先触发 cancel_token。
+        // handle_for 只瞬时取 entries 锁(与 send 内部瞬时取 entries 锁不冲突)，
+        // 不等 turn_lock——即使 send 正持锁，cancel 也能立刻让 turn_loop 跳出。
+        if let Some(engine) = self.handle_for(session_id).await {
+            engine.cancel_current();
+        }
+        // 阶段二：持锁清理 turn 状态与 shell 任务。
+        let shell_cancellation = self.turn_shell_tasks.request_cancel(session_id);
         let turn_lock = self.turn_locks.for_session(session_id).await;
         let _turn = turn_lock.lock().await;
-        let shell_cancellation = self.turn_shell_tasks.request_cancel(session_id);
+        // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
+        // 若阶段一已 cancel_current，这里再 cancel 是幂等 no-op；若阶段一没拿到，
+        // 这里拿到刚注册的 engine 补 cancel。
         if let Some(engine) = self.handle_for(session_id).await {
             engine.cancel_current();
         } else if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
-            lifecycle.invalidate_unsubmitted_reservation();
+            // engine 不存在 = 该 session 的 turn 还在「reserved 未 submitted」阶段
+            // (send 仍在 get_or_spawn/probe 中)。invalidate 清理 reservation 但不
+            // emit chat:done(原设计)，导致前端 busy 永不复位。这里补发 Interrupted
+            // 终态，让前端立即解锁——cancel_generation 命令的文档注释本就承诺
+            // 「会补发 Interrupted 终态」，之前实现与注释不符，此处修正。
+            if lifecycle.invalidate_unsubmitted_reservation() {
+                crate::features::assistant::engine::emit_chat_terminal(
+                    &self.app,
+                    session_id,
+                    TurnOutcomeStatus::Interrupted,
+                    None,
+                    false,
+                );
+            }
         }
         if let Some(cancellation) = shell_cancellation {
             cancellation.cleanup().await;

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -896,8 +896,12 @@ impl EnginePool {
     /// 「停止按钮无响应」：cancel_token 是独立原子，置位不需要 turn_lock 保护，
     /// 因此第一步无锁先触发，turn_loop 的 biased select 会立即跳出并正常发
     /// `TurnComplete`(→ chat:done)；第二步再持锁清理 shell/lifecycle 状态。
-    /// 若 engine 尚未 spawn(send 仍持锁中)，第二步持锁后走 invalidate 并补发
-    /// Interrupted 终态，保证前端 busy 一定能复位。
+    ///
+    /// 第二步以 lifecycle 的提交状态（而非 Engine 是否存在）为权威依据：reservation
+    /// 处于「reserved 未 submitted」阶段（消息尚未入队 engine）时，无论该会话是否
+    /// 保留着上一轮的空闲 Engine，都立即认领未提交 Interrupted 终态并补发
+    /// `chat:done`，使 reservation 失效（后续 `ensure_active` 失败、消息不再提交），
+    /// 保证前端 busy 一定能复位。
     pub async fn cancel(&self, session_id: &str) {
         // 阶段一：无锁先触发 cancel_token。
         // handle_for 只瞬时取 entries 锁(与 send 内部瞬时取 entries 锁不冲突)，
@@ -909,32 +913,41 @@ impl EnginePool {
         let shell_cancellation = self.turn_shell_tasks.request_cancel(session_id);
         let turn_lock = self.turn_locks.for_session(session_id).await;
         let _turn = turn_lock.lock().await;
-        // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
-        // 若阶段一已 cancel_current，这里再 cancel 是幂等 no-op；若阶段一没拿到，
-        // 这里拿到刚注册的 engine 补 cancel。
-        if let Some(engine) = self.handle_for(session_id).await {
-            // 若 turn 已 submit 但 TurnStarted 尚未抵达（op 还在 Engine mpsc
-            // 队列里），CodeWhale 会在新轮次入口无条件 reset_cancel_token()，
-            // 覆盖这里 cancel_current() 置位的 token。先 arm pending_cancel：
-            // 转发器收到 TurnStarted 后（reset 已完成）重新 cancel 命中活跃 token。
-            // 必须在 cancel_current() 之前 arm——见 arm_pending_cancel 文档。
-            if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
-                lifecycle.arm_pending_cancel();
+        // 持锁后以 lifecycle 的提交状态（而非 Engine 是否存在）为权威依据。
+        // reserve_turn 不取 turn_lock，chat 在 reserve 与 send 之间有
+        // set_disallowed_all 等异步让出点（chat.rs）；若该会话保留着上一轮的空闲
+        // Engine，旧实现按「Engine 是否存在」分流会错误走 pending 分支：只 arm
+        // pending、不认领终态、不发 chat:done，reservation 仍有效，原 chat future
+        // 后续照常提交消息，前端 busy 在 cancel 后到 TurnStarted 之间无法复位。
+        //
+        // emit_unsubmitted_interrupted_terminal 内部 claim 检查「active && !submitted」：
+        // 命中（含 engine 未 spawn 的 probe 窗口与空闲 engine 存在的未提交窗口）=
+        // 认领 Interrupted 终态 + 发 chat:done + 重置闸门，reservation 随之失效
+        // （后续 send 的 ensure_active 失败，消息不再提交）；未命中（已 submitted
+        // 或无活动 turn）返回 false 且无副作用，fallthrough 到 engine 分支。
+        // 必须用 claim（而非裸 invalidate）：reserve_turn 不取 turn_lock，若仅在
+        // invalidate 后、chat:done 发出前释放闸门，新一轮 reserve 可抢先成功，迟到
+        // 的 chat:done 会清掉新一轮 busy——claim 在发终态期间置 terminal_closing
+        // 关闸，与权威终态路径一致的防重入语义。
+        let lifecycle = self.turn_lifecycles.get(session_id);
+        let claimed_unsubmitted = lifecycle
+            .as_ref()
+            .is_some_and(|lc| lc.emit_unsubmitted_interrupted_terminal(&self.app, session_id));
+        if !claimed_unsubmitted {
+            // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
+            // 若阶段一已 cancel_current，这里再 cancel 是幂等 no-op；若阶段一没拿到，
+            // 这里拿到刚注册的 engine 补 cancel。
+            if let Some(engine) = self.handle_for(session_id).await {
+                // 已提交（op 已入队或 TurnStarted 已抵达）：
+                //  - TurnStarted 未抵达：arm pending，转发器收到 TurnStarted 后
+                //    （reset_cancel_token 已完成）补 cancel 命中活跃 token；
+                //  - TurnStarted 已抵达：cancel_current 直接命中当前活跃 token。
+                // 必须在 cancel_current() 之前 arm——见 arm_pending_cancel 文档。
+                if let Some(lifecycle) = lifecycle {
+                    lifecycle.arm_pending_cancel();
+                }
+                engine.cancel_current();
             }
-            engine.cancel_current();
-        } else if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
-            // engine 不存在 = 该 session 的 turn 还在「reserved 未 submitted」阶段
-            // (send 仍在 get_or_spawn/probe 中)。invalidate 清理 reservation 但不
-            // emit chat:done(原设计)，导致前端 busy 永不复位。这里补发 Interrupted
-            // 终态，让前端立即解锁——cancel_generation 命令的文档注释本就承诺
-            // 「会补发 Interrupted 终态」，之前实现与注释不符，此处修正。
-            //
-            // 必须用 claim_unsubmitted_terminal（而非裸 invalidate）：reserve_turn 不
-            // 取 turn_lock，若仅在 invalidate 后、chat:done 发出前释放闸门，新一轮
-            // reserve 可抢先成功，迟到的 chat:done 会清掉新一轮 busy。claim 路径在
-            // 发终态期间置 terminal_closing 关闸，与权威终态路径（claim_terminal /
-            // claim_reclaimed）一致的防重入语义。
-            lifecycle.emit_unsubmitted_interrupted_terminal(&self.app, session_id);
         }
         if let Some(cancellation) = shell_cancellation {
             cancellation.cleanup().await;

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -913,6 +913,14 @@ impl EnginePool {
         // 若阶段一已 cancel_current，这里再 cancel 是幂等 no-op；若阶段一没拿到，
         // 这里拿到刚注册的 engine 补 cancel。
         if let Some(engine) = self.handle_for(session_id).await {
+            // 若 turn 已 submit 但 TurnStarted 尚未抵达（op 还在 Engine mpsc
+            // 队列里），CodeWhale 会在新轮次入口无条件 reset_cancel_token()，
+            // 覆盖这里 cancel_current() 置位的 token。先 arm pending_cancel：
+            // 转发器收到 TurnStarted 后（reset 已完成）重新 cancel 命中活跃 token。
+            // 必须在 cancel_current() 之前 arm——见 arm_pending_cancel 文档。
+            if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
+                lifecycle.arm_pending_cancel();
+            }
             engine.cancel_current();
         } else if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
             // engine 不存在 = 该 session 的 turn 还在「reserved 未 submitted」阶段


### PR DESCRIPTION
## 背景

使用本地/局域网模型端点（如 vLLM、Ollama、自建 OpenAI 兼容端点）时，**测试连接成功**，但发送消息后永久卡在「正在处理」，点击停止按钮完全无反应。该问题在「本地模型」和「云端模型」两种配置途径下都会复现。

## 变更

修复两个独立根因（均位于 `pinvou3-app/src-tauri/`，未触碰 CodeWhale submodule）：

### 1. cancel 与 send 死锁争抢 turn_lock（`engine_pool.rs`）
`send_reserved_user_message` 持有 `turn_lock` 期间调用 `get_or_spawn`（含 vLLM 探测 3s + spawn），而 `cancel` 也要同一把锁 → **永久阻塞**，前端 `await invoke("cancel_generation")` 同步等待也不返回，用户感知「点了停止毫无反应」。

**修复**：cancel 改为两阶段——先**不持锁**调 `handle_for` + `cancel_current`（cancel_token 是独立原子，置位不需要锁保护），再持锁清理 shell/lifecycle。

### 2. 未提交取消不发 chat:done（`engine_pool.rs` + `engine.rs`）
engine 未 spawn 时（send 仍在探测/spawn 中）点停止，走 `invalidate_unsubmitted_reservation()`——只清状态**不发 `chat:done`**，前端 `state.busy` 永不复位。`cancel_generation` 命令注释自称「会补发 Interrupted 终态」，但实现与注释不符。

**修复**：新增 `TurnLifecycle::claim_unsubmitted_terminal()` / `emit_unsubmitted_interrupted_terminal()`，认领时设置 `terminal_emitted + terminal_closing` 关闸（与权威终态路径 `claim_terminal_transition` / `claim_reclaimed_transition` 一致的重入防护），发完 `chat:done` 后再 `finish_terminal_emission()` 重开闸门，消除「invalidate 返回与 chat:done 发出之间新一轮 reserve 成功、迟到的 chat:done 错误清除新一轮 busy」的跨轮竞态。

## 关于「recoverable 错误连续 stall 兜底」的取舍

本 PR 原带第三项修复（连续 recoverable `Timeout` 错误 + 无 token 时主动 `approve_handle.cancel()` 终止轮次）。复审与底座核实后确认该实现无法在 App 层正确落地，已**整体删除**：

1. **非本地端点专用、却覆盖所有模型**：forwarder 无 route 判断，云端模型的事件同样经过该计数。
2. **`ErrorCategory::Timeout` 过宽**：底座该 category 还涵盖 `tool_timeout`、`stream_duration_limit`、`llm_timeout` 及文本分类出的 timeout，不能精确表示 stream stall（底座另有稳定错误码 `stream_stall` 可判别）。
3. **系统超时被伪装成用户取消**：`approve_handle.cancel()` 等价于 `cancel_with_reason(CancelReason::User)` → `Interrupted`，丢失应有的 timeout/Failed 权威终态，影响 UI、审计与诊断。

通用流式输出/重试/超时生命周期属底座能力，应由 CodeWhale 暴露配置或修正过长的 SSE idle timeout（默认 900s）/重试预算，而非在 App 事件转发器里重复实现并猜测流状态。

**用户可见取舍**：删除后本地端点 prefill 卡死的等待时间回到底座既有重试预算（最长约数十分钟）。这与「超时时间可长，但停止按钮必须生效」的要求一致——修复 1/2 已独立保证：cancel 不与 send 死锁、未提交取消也补发终态、`busy` 能复位，用户点停止后立即看到停止。

## 实际验证

- `cargo check` 编译干净
- `features::assistant` 模块 147 个测试全部通过
- `python3 scripts/architecture-guard.py` 通过

## 已知风险

- 修复 1 改变了 cancel 的锁获取顺序（先无锁触发 cancel_token，再持锁清理）。理论上 cancel_token 置位与 turn 状态清理的分离不影响正确性——turn_loop 在 biased select 监听 cancel_token，置位后立即跳出并走既有 TurnComplete 路径。持锁后的复查是幂等的。
- 本地端点 prefill 卡死的最长等待时间由底座重试/超时预算决定（已移除 App 层的提前终止）。