### PR TITLE
feat(net): 显式启用 reqwest system-proxy 读取系统代理设置

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -1434,7 +1434,7 @@ dependencies = [
  "chrono",
  "codewhale-protocol",
  "codewhale-release",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -1486,7 +1486,7 @@ name = "codewhale-release"
 version = "0.9.5"
 dependencies = [
  "anyhow",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -1535,7 +1535,7 @@ dependencies = [
  "codewhale-paths",
  "codewhale-release",
  "fd-lock",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -1608,7 +1608,7 @@ dependencies = [
  "ratatui",
  "ratatui-core",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rmcp",
  "rusqlite",
  "rust-i18n",
@@ -1687,7 +1687,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2285,7 +2285,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2580,7 +2580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5235,7 +5235,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5377,7 +5377,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -6088,7 +6088,7 @@ dependencies = [
  "mdns-sd",
  "parking_lot",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rusqlite",
  "rustls",
  "serde",
@@ -6131,7 +6131,7 @@ dependencies = [
  "pinvou-knowledge",
  "qrcode",
  "rand 0.9.4",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rusqlite",
  "rustls",
  "semver",
@@ -6560,7 +6560,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7006,9 +7006,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7132,7 +7132,7 @@ dependencies = [
  "futures",
  "oauth2",
  "pin-project-lite",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7341,7 +7341,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7400,7 +7400,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7697,7 +7697,7 @@ checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "granit-parser",
@@ -8501,7 +8501,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -8819,7 +8819,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10242,7 +10242,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -83,7 +83,11 @@ codewhale-config = { path = "../../CodeWhale/crates/config" }
 # 注意:oauth2(经 reqwest 0.12 传递)会把 rustls 0.23 的 `ring` feature 也拉进图,
 # 使 rustls 同时启用 aws-lc-rs + ring。tokio-tungstenite 的无参 ClientConfig::builder()
 # 在两 provider 共存时会 panic,故需在启动时显式 install_default(见 lib.rs)。
-reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "blocking", "stream", "query"] }
+# system-proxy: reqwest 0.13 的 default feature,读 macOS SystemConfiguration /
+# Windows 系统代理设置(非环境变量)。此前 default-features=false 把它关掉,
+# 导致用「系统代理」模式(非 TUN)的用户模型请求直连而被代理工具的路由规则
+# 绕过。显式启用后,reqwest 在 Client::build() 时自动注入系统代理 matcher。
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "blocking", "stream", "query", "system-proxy"] }
 wait-timeout = "0.2"
 
 # rustls 直依赖:仅为在启动时调 aws_lc_rs::default_provider().install_default()


### PR DESCRIPTION
## 背景

排查「TUN 代理环境下模型端点连接失败」问题时发现：reqwest 0.13 的 `system-proxy` 是其 default feature 之一，会在 `Client::build()` 时读取 macOS SystemConfiguration / Windows 系统代理设置（非 `HTTP_PROXY` 等环境变量），自动注入 `ProxyMatcher::system()`。

此前 pinvou3-app 和 CodeWhale 均 `default-features = false` 且**未显式启用**该 feature。

## 变更

在 `pinvou3-app/src-tauri/Cargo.toml` 的 reqwest 依赖上显式加入 `system-proxy` feature。

经 Cargo feature unification，CodeWhale 的 reqwest（同版本 0.13.x，真正发模型消息的 client）也会获得此 feature——**无需触碰 CodeWhale submodule**。

附带将 reqwest 锁定版本从 0.13.3 升至 0.13.4（semver 兼容补丁升级）。

## 为什么之前「看起来」也能读系统代理

`cargo tree` 分析显示：hyper-util 的 `client-proxy-system` feature 已被 reqwest **0.12**（oauth2 / fastembed 的传递依赖）通过 feature unification 拉入依赖图。但 reqwest **0.13** 自身的 Cargo.toml feature 未声明 `system-proxy`——当前能读系统代理是 unification 的**隐式副产物**，未来若 0.12 依赖被移除会静默退化为不读系统代理。本 PR 显式化这一行为。

## 关于 TUN 模式的说明

**本 PR 不能直接解决 TUN 模式下的连接失败**。TUN 是网络层（L3）路由劫持，不设置系统代理配置（`scutil --proxy` 返回全 `Enable: 0`）。启用 `system-proxy` 后 reqwest 读到的仍是「无代理」→ 直连 → 被 TUN 截走。TUN 场景需在代理软件中将局域网网段（如 `10.0.0.0/8`）设为 DIRECT。

本 PR 受益的是**「系统代理」模式**（HTTP/SOCKS 代理模式）的用户——启用后模型请求会自动走系统配置的代理，与 curl/npm 等系统其他工具的网络行为一致。

## 实际验证

- `cargo check` 编译干净
- `cargo tree -p reqwest:0.13.4 -f '{p} {f}'` 确认 features 列表含 `system-proxy`
- `features::assistant` 模块 145 个测试通过，`core::model_endpoint` 10 个测试通过
- `python3 scripts/architecture-guard.py` 通过

## 已知风险

- 启用后 reqwest 会读系统代理。若用户的系统代理配置了错误的代理地址（如指向已关闭的代理端口），原本直连能通的端点可能会被导向失败的代理。但这是系统代理的标准行为，与 curl/npm 一致。