### PR TITLE
style(commands): ledger_root 改名残留的错误信息文案对齐

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -1067,7 +1067,7 @@ pub(super) fn resolve_artifact_path(
         Some(sid) => store
             .ledger_root(&sid)
             .map(|workspace| resolve_artifact_path_in_workspace(raw, &workspace))
-            .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}")),
+            .map_err(|error| format!("resolve ledger root for {sid}: {error:#}")),
         None => Ok(raw.to_string()),
     }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/interaction.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/interaction.rs
@@ -250,7 +250,7 @@ pub async fn add_run_materials(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let project = crate::features::assistant::harness::find_project_dir(&workspace)
         .ok_or_else(|| "当前 session 无工作流项目".to_string())?;
     let dst_dir = project.join("配套材料");
@@ -360,7 +360,7 @@ pub async fn summon_pinvou(
         .map_err(|e| format!("summon_pinvou prepare bridge({sid}): {e:#}"))?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     crate::features::review::summon(
         &bridge,
         &session.messages,

--- a/pinvou3-app/src-tauri/src/app/commands/workflows.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/workflows.rs
@@ -293,7 +293,7 @@ pub async fn start_workflow(
     //    定时任务使用 automation 私有目录；harness forwarder 必须读取同一路径。
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let project_dir = tokio::task::spawn_blocking({
         let workspace = workspace.clone();
         let scenario = scenario.clone();
@@ -371,7 +371,7 @@ pub async fn kick_workflow(
         .ok_or_else(|| "no active session".to_string())?;
     let ws = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let harness_workspace = ws.clone();
     let action = tokio::task::spawn_blocking(move || {
         crate::features::assistant::harness::step_fresh(&harness_workspace)
@@ -506,7 +506,7 @@ pub async fn retry_workflow_role(
         .ok_or_else(|| "no active session".to_string())?;
     let ws = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let rid = role_id.clone();
     let action = tokio::task::spawn_blocking(move || {
         crate::features::assistant::harness::retry_role(&ws, &rid)
@@ -1095,7 +1095,7 @@ pub async fn cancel_workflow_role(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let rid = role_id.clone();
     let result = tokio::task::spawn_blocking(move || {
         // 找到 project_dir
@@ -1158,7 +1158,7 @@ pub async fn stop_workflow(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let stop_reason = reason
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| "user_stopped".to_string());
@@ -1210,7 +1210,7 @@ pub async fn approve_workflow_gate(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let engine = pool
         .get_or_spawn(&sid)
         .await
@@ -1256,7 +1256,7 @@ pub async fn reject_workflow_gate(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     let engine = pool
         .get_or_spawn(&sid)
         .await
@@ -1298,7 +1298,7 @@ pub async fn get_workflow_state(
         .ok_or_else(|| "no active session".to_string())?;
     let workspace = store
         .ledger_root(&sid)
-        .map_err(|error| format!("resolve execution workspace for {sid}: {error:#}"))?;
+        .map_err(|error| format!("resolve ledger root for {sid}: {error:#}"))?;
     tokio::task::spawn_blocking(move || {
         crate::features::assistant::harness::read_full_agent_state(&workspace)
             .unwrap_or(serde_json::json!(null))


### PR DESCRIPTION
## Summary

`execution_workspace → ledger_root` 全量改名（#182）时，11 处 `.map_err` 的错误信息文案未同步更新，仍写 `"resolve execution workspace for {sid}"`，与 `sessions.rs` 既有写法及方法名 `ledger_root()` 不一致。本 PR 把文案对齐为 `"resolve ledger root for {sid}"`。

## Background

审阅 #170 时发现：#182 把 `SessionStore::execution_workspace` 改名为 `ledger_root` 并迁移了全部调用点，但 `workflows.rs`（8 处）/ `interaction.rs`（2 处）/ `artifacts.rs`（1 处）的 `.map_err` 文案漏改。纯文案，不影响行为，但调试日志里会误导。

## Changes

- `workflows.rs`：8 处 `map_err` 文案 `execution workspace` → `ledger root`
- `interaction.rs`：2 处
- `artifacts.rs`：1 处

## Verification

- `cargo check --lib`：通过（pinvou3-tauri 零新增警告）
- `python3 scripts/architecture-guard.py`：通过
- `./scripts/fork-guard.sh --fast`：通过
- 行为零变化（仅字符串字面量）

## Checklist

- [x] 基于 latest `main`（7863a51a）
- [x] commit 含 Signed-off-by
- [x] 无凭据/私有数据/敏感日志
- [x] CodeWhale gitlink / fork 行为未变化（fork-guard --fast 通过）
