### PR TITLE
feat(codex): code 界面默认 agent 改为品悟并持久化用户选择

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -558,7 +558,7 @@ pub async fn create_codex_acp_session(
     pool: State<'_, EnginePool>,
     acp_pool: State<'_, AcpPool>,
 ) -> Result<SessionMetadata, String> {
-    let backend = AgentBackend::parse(agent_id.as_deref().or(Some("codex")))
+    let backend = AgentBackend::parse(agent_id.as_deref().or(Some("pinvou")))
         .map_err(|error| format!("{error:#}"))?;
     if !backend.is_acp() {
         return create_code_native_session(workspace_path, &pool, &store, &acp_pool).await;

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -59,6 +59,8 @@ const RECENT_WORKSPACES_KEY = 'pinvou_codex_recent_workspaces';
 const UNIFIED_CONVERSATION_UI_KEY = 'pinvou_conversation_ui_v2';
 const DRAFT_ATTACHMENT_KEY = '__codex_draft__';
 const DRAFT_CONTROLS_CACHE_KEY = 'pinvou_codex_draft_controls';
+const AGENT_SELECTION_KEY = 'pinvou_codex_agent_selection';
+const CODE_AGENT_IDS = ['pinvou', 'codex', 'claude', 'kimi'];
 
 function unifiedConversationUiEnabled() {
   try {
@@ -102,6 +104,25 @@ function forgetWorkspace(path) {
     // localStorage 不可用时仍允许当前窗口继续创建新会话。
   }
   return next;
+}
+
+// 记住用户上次在 code 界面选择的 agent：重开界面/重启应用后沿用，直到用户再次切换。
+function loadAgentSelection() {
+  try {
+    const value = localStorage.getItem(AGENT_SELECTION_KEY);
+    return value && CODE_AGENT_IDS.includes(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveAgentSelection(agentId) {
+  if (!agentId) return;
+  try {
+    localStorage.setItem(AGENT_SELECTION_KEY, agentId);
+  } catch {
+    // 写不进去仅影响下次打开界面的默认值，本次会话不受影响。
+  }
 }
 
 // 草稿态（尚未创建会话）也需要展示模型/权限模式/推理强度等选项：ACP 的配置项是会话级的，
@@ -1068,7 +1089,7 @@ export function CodexAcpView({
 }) {
   const codexCopy = t.uiCodex;
   const [agents, setAgents] = useState([]);
-  const [draftAgentId, setDraftAgentId] = useState('codex');
+  const [draftAgentId, setDraftAgentId] = useState(loadAgentSelection() || 'pinvou');
   const [status, setStatus] = useState(null);
   const [events, setEvents] = useState([]);
   const [pending, setPending] = useState([]);
@@ -1475,6 +1496,7 @@ export function CodexAcpView({
   function selectDraftAgent(agentId) {
     if (activeId || !agentId) return;
     setDraftAgentId(agentId);
+    saveAgentSelection(agentId);
     setStatus(null);
     setError('');
   }

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -282,6 +282,8 @@ try {
   assert.ok(codexCommands.includes('agent_id: Option<String>')
     && codexCommands.includes('set_acp_workspace(&session.metadata.id, backend'),
   'code-session creation must bind the selected ACP Agent for the lifetime of the session');
+  assert.ok(codexCommands.includes('or(Some("pinvou"))'),
+    'code-session creation without an explicit agent must default to the built-in Pinwu backend');
   assert.ok(codexCommands.includes('pub async fn login_acp_agent')
     && codexCommands.includes('pub fn open_acp_agent_login_url')
     && codexCommands.includes('pub async fn submit_acp_agent_login_code'),
@@ -350,6 +352,10 @@ try {
     && codexView.includes('agentId: draftAgentId')
     && codexView.includes("invoke('list_acp_agents')"),
   'the top code tabs must be the only Agent selector and bind the selected Agent on first send');
+  assert.ok(codexView.includes("const AGENT_SELECTION_KEY = 'pinvou_codex_agent_selection'")
+    && codexView.includes("useState(loadAgentSelection() || 'pinvou')")
+    && codexView.includes('saveAgentSelection(agentId)'),
+  'code draft agent must default to Pinwu and persist the user-selected agent across reopens');
   assert.ok(codexView.includes("invoke('login_acp_agent'")
     && codexView.includes("invoke('open_acp_agent_login_url'")
     && codexView.includes("invoke('submit_acp_agent_login_code'")

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -57,7 +57,7 @@ function injectSource() {
       {id:'s-attachment',title:'看看这个\\n\\n📎 PINV',title_attachment_names:['PINVOU-M0-开源决策基线.md'],created_at:Date.now()-2000,updated_at:Date.now()-2000},
       {id:'s1',title:'第三季度财报分析',created_at:Date.now()-1000,updated_at:Date.now()}
     ];
-    let CODEX_SESSIONS=[{id:'codex-1',title:'Codex回归会话',created_at:new Date(Date.now()-1000).toISOString(),updated_at:new Date().toISOString(),workspace_kind:'temporary',workspace_path:''}];
+    let CODEX_SESSIONS=[{id:'codex-1',agent_id:'codex',title:'Codex回归会话',created_at:new Date(Date.now()-1000).toISOString(),updated_at:new Date().toISOString(),workspace_kind:'temporary',workspace_path:''}];
     let ARCHIVED_SESSIONS=[];
     let MOUNTED_COLLECTIONS=[];
     let MOUNTED_COLLECTIONS_REVISION=0;
@@ -88,6 +88,8 @@ function injectSource() {
         case 'list_sessions': return Promise.resolve(SESSIONS);
         case 'list_codex_acp_sessions': return Promise.resolve(CODEX_SESSIONS);
         case 'get_codex_acp_status': return Promise.resolve({installed:false,node_supported:false,authenticated:false});
+        case 'get_acp_agent_status': return Promise.resolve({agent_id:args.agentId||'codex',installed:true,node_supported:true,authenticated:true});
+        case 'get_codex_acp_session_info': return Promise.resolve({session_id:args.sessionId,models:[],current_model_id:'',modes:null,config_options:[]});
         case 'get_codex_acp_timeline': return Promise.resolve([
           {version:1,sessionId:'codex-1',turnId:'copy-turn',seq:1,timestamp:'2026-08-04T01:00:00Z',event:{type:'user_message',data:{content:[{type:'text',text:'Test copy layout'}]}}},
           {version:1,sessionId:'codex-1',turnId:'copy-turn',seq:2,timestamp:'2026-08-04T01:00:01Z',event:{type:'turn_started',data:{status:'running'}}},


### PR DESCRIPTION
## 背景

code 界面（CodexAcpView）草稿态默认 agent 硬编码为 codex，且用户切换 agent 的选择不持久化——切换视图或重启应用后回到 codex。需求：默认 agent 改为品悟（内置 Deepseek），并将用户的选择本地持久化，重开界面后沿用直到再次切换。

## 变更

- **前端**（`pinvou3-app/src/features/codex/CodexAcpView.jsx`）
  - 新增 `pinvou_codex_agent_selection` localStorage key；草稿态默认 agent 由 `codex` 改为 `loadAgentSelection() || 'pinvou'`（品悟）
  - `selectDraftAgent` 切换时写入 localStorage；读取带合法值白名单校验，读写均 try/catch，存储不可用时回退默认品悟
  - 沿用仓库既有 `pinvou_codex_draft_controls` 持久化模式
- **后端**（`pinvou3-app/src-tauri/src/app/commands/codex.rs`）：`create_codex_acp_session` 无显式 agent 时默认 `"codex"` → `"pinvou"`，与前端默认一致（品悟走原生代码会话路径，`AgentBackend::parse("pinvou")` 已有既有单测覆盖）
- **测试**（`pinvou3-app/tests/codex_acp_timeline.test.mjs`）：新增前后端契约断言（默认品悟 + 选择持久化）
- **测试 fixture 修复**（`pinvou3-app/tests/ui_smoke.js`）：harness 补齐缺失的 `get_acp_agent_status`/`get_codex_acp_session_info` stub（codex 会话加载在 main 上即抛 TypeError 的预存在问题，因门禁按 diff 选择而未暴露）；`codex-1` fixture 补齐 `agent_id:'codex'`，避免默认 agent 变更后被误判为品悟原生车道

## 实际验证

- ✅ `codex_acp_timeline` 契约测试通过（rebase 后重跑）
- ✅ `npm run test:codex-acp` 全组 6 个测试通过
- ✅ `ui_smoke` 48/48 通过（本机；修复前 1/48 失败与 CI 一致）
- ✅ eslint（CodexAcpView.jsx）通过
- ✅ `vite build` 通过
- ✅ 架构守卫 `scripts/architecture-guard.py` 通过
- ✅ `cargo fmt --check` 通过
- ⚠️ 未运行完整 `cargo test`（本地 Tauri 全量编译耗时且与开发构建争锁）；本次 Rust 改动仅为默认字符串字面量，`"pinvou"` 解析路径已有既有单测覆盖

## 已知风险 / 说明

- 持久化作用于**草稿态默认**：无激活会话时默认显示上次选择的 agent；已有会话仍以会话自身的 agent 为准（既有设计，`selectDraftAgent` 仅在无激活会话时可用）
- 行为变更：无显式 agent 参数创建的新 code 会话由 codex 变为品悟（原生代码会话）