### PR TITLE
fix(pet): 修复 macOS 桌宠展开气泡时向左上方闪现

### DIFF
--- a/pinvou3-app/src-tauri/src/features/pet/pet_window.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/pet_window.rs
@@ -561,7 +561,7 @@ pub async fn get_pet_scale() -> Result<f64, String> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScaleAnchor {
+pub(crate) enum ScaleAnchor {
     BottomCenter,
     BottomLeft,
     BottomRight,
@@ -570,7 +570,7 @@ enum ScaleAnchor {
     TopRight,
 }
 
-fn resized_position(
+pub(super) fn resized_position(
     position: (i32, i32),
     old_size: (u32, u32),
     new_size: (u32, u32),
@@ -661,43 +661,10 @@ fn window_edge_anchor(
 }
 
 fn resize_pet_window(win: &tauri::WebviewWindow, logical_size: (f64, f64), anchor: ScaleAnchor) {
-    let before = win.inner_size().ok().zip(win.inner_position().ok());
-    let work_area = win.current_monitor().ok().flatten().map(|monitor| {
-        let area = monitor.work_area();
-        (
-            area.position.x,
-            area.position.y,
-            area.size.width,
-            area.size.height,
-        )
-    });
-    let sf = win.scale_factor().unwrap_or(1.0);
-    let (nw, nh) = (
-        (logical_size.0 * sf).round() as u32,
-        (logical_size.1 * sf).round() as u32,
-    );
-    let _ = win.set_size(tauri::PhysicalSize::new(nw, nh));
-    // 诊断:X11 的 resize 异步生效,这里的回读多为旧值(GB10 实测会拿到上一个
-    // 状态的尺寸),只能当观测信号,绝不能拿来做定位数学——定位一律用请求值,
-    // 请求值已经过 pet_window_effective_size 与真实钳制对齐。
-    if let Ok(size) = win.inner_size() {
-        if (size.width, size.height) != (nw, nh) {
-            eprintln!(
-                "[pet resize] requested {nw}x{nh} readback {}x{} (async, stale ok)",
-                size.width, size.height
-            );
-        }
-    }
-    if let Some((size, pos)) = before {
-        let (nx, ny) = resized_position(
-            (pos.x, pos.y),
-            (size.width, size.height),
-            (nw, nh),
-            anchor,
-            work_area,
-        );
-        let _ = win.set_position(tauri::PhysicalPosition::new(nx, ny));
-    }
+    // 平台差异(是否原子提交、坐标系)收敛在 platform::resize_pet_window:macOS 用
+    // 单次 setFrame:display: 把尺寸与原点一并提交,消除气泡展开时人物向左上方
+    // 闪现一帧的中间合成帧;其他平台退化为既有的 set_size → set_position 两步。
+    super::platform::resize_pet_window(win, logical_size, anchor);
 }
 
 /// 人物锚点靠近工作区左/上边时,窗口左上角会被算成负坐标(活动卡展开且人物

--- a/pinvou3-app/src-tauri/src/features/pet/platform/linux.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/platform/linux.rs
@@ -5,6 +5,14 @@ pub(crate) fn effective_window_size(size: (f64, f64)) -> (f64, f64) {
 
 pub(crate) fn apply_pet_window_policy(_window: &tauri::WebviewWindow) {}
 
+pub(crate) fn resize_pet_window(
+    win: &tauri::WebviewWindow,
+    logical_size: (f64, f64),
+    anchor: crate::features::pet::pet_window::ScaleAnchor,
+) {
+    super::resize_pet_window_fallback(win, logical_size, anchor);
+}
+
 pub(crate) fn prepare_main_focus_raise(app: &tauri::AppHandle) {
     use tauri::Emitter;
 

--- a/pinvou3-app/src-tauri/src/features/pet/platform/macos.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/platform/macos.rs
@@ -123,9 +123,6 @@ fn resize_pet_window_impl(
         origin_x = origin_x.clamp(min_x, max_x);
         origin_y = origin_y.clamp(min_y, max_y);
     }
-    let frame = NSRect::new(
-        NSPoint::new(origin_x, origin_y),
-        NSSize::new(new_w, new_h),
-    );
+    let frame = NSRect::new(NSPoint::new(origin_x, origin_y), NSSize::new(new_w, new_h));
     ns_window.setFrame_display(frame, true);
 }

--- a/pinvou3-app/src-tauri/src/features/pet/platform/macos.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/platform/macos.rs
@@ -18,6 +18,34 @@ pub(crate) fn apply_pet_window_policy(window: &tauri::WebviewWindow) {
 
 pub(crate) fn prepare_main_focus_raise(_app: &tauri::AppHandle) {}
 
+/// 原子地设置桌宠窗口的尺寸与位置(单次 `setFrame:display:YES`)。
+///
+/// 见 `pet_window::resize_pet_window` 的 macOS 分支注释:tao 把 `set_size` 与
+/// `set_position` 各自 `dispatch_async` 到主队列,不是原子操作,展开气泡时会让
+/// 人物向左上方闪现一帧。这里在主线程上用一条 `setFrame:display:` 同时提交新
+/// 尺寸和新原点,`display:YES` 强制同步重绘,消除中间合成帧。
+///
+/// 锚点角固定:直接在 NSWindow 原生坐标(原点左下、y 朝上)里读当前 frame 做代数,
+/// 与 `pet_window::resized_position` 的六种锚点几何等价,但省去 Tauri 物理坐标
+/// 到 Cocoa 坐标的翻转转换。
+pub(crate) fn resize_pet_window(
+    window: &tauri::WebviewWindow,
+    logical_size: (f64, f64),
+    anchor: crate::features::pet::pet_window::ScaleAnchor,
+) {
+    if objc2::MainThreadMarker::new().is_some() {
+        resize_pet_window_impl(window, logical_size, anchor);
+    } else {
+        let app = window.app_handle().clone();
+        let window = window.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            resize_pet_window_impl(&window, logical_size, anchor);
+        }) {
+            eprintln!("[pet] macOS 原子设置窗口 frame 失败: {error}");
+        }
+    }
+}
+
 pub(crate) fn finish_main_focus_raise(window: &tauri::WebviewWindow) {
     let _ = window.set_always_on_top(false);
 }
@@ -40,4 +68,64 @@ fn apply_pet_window_policy_impl(window: &tauri::WebviewWindow) {
         | NSWindowCollectionBehavior::FullScreenAuxiliary;
     ns_window.setCollectionBehavior(behavior);
     ns_window.setLevel(NSStatusWindowLevel);
+}
+
+fn resize_pet_window_impl(
+    window: &tauri::WebviewWindow,
+    logical_size: (f64, f64),
+    anchor: crate::features::pet::pet_window::ScaleAnchor,
+) {
+    use objc2::rc::Retained;
+    use objc2_app_kit::NSWindow;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    use crate::features::pet::pet_window::ScaleAnchor;
+
+    let raw: *mut std::ffi::c_void = match window.ns_window() {
+        Ok(pointer) => pointer,
+        Err(_) => return,
+    };
+    let Some(ns_window): Option<Retained<NSWindow>> =
+        (unsafe { Retained::retain_autoreleased(raw.cast()) })
+    else {
+        return;
+    };
+
+    // NSWindow 的 frame 一律是 Cocoa 点(逻辑坐标),与 tao 调 setContentSize 前先
+    // to_logical 一致——这里直接用传入的 logical_size,无需 scale_factor。
+    let new_w = logical_size.0;
+    let new_h = logical_size.1;
+    let cur = ns_window.frame();
+    // 按锚点角固定:保持该角在屏幕上不动,反推新原点。原点在左下、y 朝上,
+    // 故底边锚点 origin.y 不动,顶边锚点 origin.y 上移 (旧高 - 新高)。
+    let (mut origin_x, mut origin_y) = match anchor {
+        ScaleAnchor::BottomLeft => (cur.origin.x, cur.origin.y),
+        ScaleAnchor::BottomCenter => (cur.origin.x + (cur.size.width - new_w) / 2.0, cur.origin.y),
+        ScaleAnchor::BottomRight => (cur.origin.x + cur.size.width - new_w, cur.origin.y),
+        ScaleAnchor::TopLeft => (cur.origin.x, cur.origin.y + cur.size.height - new_h),
+        ScaleAnchor::TopCenter => (
+            cur.origin.x + (cur.size.width - new_w) / 2.0,
+            cur.origin.y + cur.size.height - new_h,
+        ),
+        ScaleAnchor::TopRight => (
+            cur.origin.x + cur.size.width - new_w,
+            cur.origin.y + cur.size.height - new_h,
+        ),
+    };
+    // 与 pet_window::resized_position 的 work_area 钳制对齐:用窗口当前所在屏的
+    // visibleFrame(已扣除 Dock/菜单栏)把新原点夹在工作区内,避免长大后顶出屏幕。
+    if let Some(screen) = ns_window.screen() {
+        let vf = screen.visibleFrame();
+        let min_x = vf.origin.x;
+        let max_x = (vf.origin.x + vf.size.width - new_w).max(min_x);
+        let min_y = vf.origin.y;
+        let max_y = (vf.origin.y + vf.size.height - new_h).max(min_y);
+        origin_x = origin_x.clamp(min_x, max_x);
+        origin_y = origin_y.clamp(min_y, max_y);
+    }
+    let frame = NSRect::new(
+        NSPoint::new(origin_x, origin_y),
+        NSSize::new(new_w, new_h),
+    );
+    ns_window.setFrame_display(frame, true);
 }

--- a/pinvou3-app/src-tauri/src/features/pet/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/platform/mod.rs
@@ -15,12 +15,14 @@ pub(super) use linux::effective_window_size;
 pub(super) use linux::finish_main_focus_raise;
 #[cfg(target_os = "linux")]
 pub(super) use linux::prepare_main_focus_raise;
+#[cfg(target_os = "linux")]
+pub(super) use linux::resize_pet_window;
 #[cfg(target_os = "macos")]
 pub(super) use macos::finish_main_focus_raise;
 #[cfg(target_os = "macos")]
 pub(super) use macos::prepare_main_focus_raise;
 #[cfg(target_os = "macos")]
-pub(super) use macos::{apply_pet_window_policy, effective_window_size};
+pub(super) use macos::{apply_pet_window_policy, effective_window_size, resize_pet_window};
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub(super) use standard::apply_pet_window_policy;
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -29,3 +31,52 @@ pub(super) use standard::effective_window_size;
 pub(super) use standard::finish_main_focus_raise;
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub(super) use standard::prepare_main_focus_raise;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(super) use standard::resize_pet_window;
+
+/// 非 macOS 平台共享的两步 resize:set_size(保持窗口左上原点)后再按锚点角把
+/// 原点移到目标位置。X11/Win32 的 resize 与定位本就独立原生调用,这里保持既有
+/// 行为;macOS 的非原子问题由该平台单独的 setFrame:display: 路径处理。
+pub(super) fn resize_pet_window_fallback(
+    win: &tauri::WebviewWindow,
+    logical_size: (f64, f64),
+    anchor: super::pet_window::ScaleAnchor,
+) {
+    let before = win.inner_size().ok().zip(win.inner_position().ok());
+    let work_area = win.current_monitor().ok().flatten().map(|monitor| {
+        let area = monitor.work_area();
+        (
+            area.position.x,
+            area.position.y,
+            area.size.width,
+            area.size.height,
+        )
+    });
+    let sf = win.scale_factor().unwrap_or(1.0);
+    let (nw, nh) = (
+        (logical_size.0 * sf).round() as u32,
+        (logical_size.1 * sf).round() as u32,
+    );
+    let _ = win.set_size(tauri::PhysicalSize::new(nw, nh));
+    // 诊断:X11 的 resize 异步生效,这里的回读多为旧值(GB10 实测会拿到上一个
+    // 状态的尺寸),只能当观测信号,绝不能拿来做定位数学——定位一律用请求值,
+    // 请求值已经过 pet_window_effective_size 与真实钳制对齐。
+    if let Ok(size) = win.inner_size() {
+        if (size.width, size.height) != (nw, nh) {
+            eprintln!(
+                "[pet resize] requested {nw}x{nh} readback {}x{} (async, stale ok)",
+                size.width, size.height
+            );
+        }
+    }
+    if let Some((size, pos)) = before {
+        let (nx, ny) = super::pet_window::resized_position(
+            (pos.x, pos.y),
+            (size.width, size.height),
+            (nw, nh),
+            anchor,
+            work_area,
+        );
+        let _ = win.set_position(tauri::PhysicalPosition::new(nx, ny));
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/pet/platform/standard.rs
+++ b/pinvou3-app/src-tauri/src/features/pet/platform/standard.rs
@@ -4,6 +4,14 @@ pub(crate) fn effective_window_size(size: (f64, f64)) -> (f64, f64) {
 
 pub(crate) fn apply_pet_window_policy(_window: &tauri::WebviewWindow) {}
 
+pub(crate) fn resize_pet_window(
+    win: &tauri::WebviewWindow,
+    logical_size: (f64, f64),
+    anchor: crate::features::pet::pet_window::ScaleAnchor,
+) {
+    super::resize_pet_window_fallback(win, logical_size, anchor);
+}
+
 pub(crate) fn prepare_main_focus_raise(_app: &tauri::AppHandle) {}
 
 pub(crate) fn finish_main_focus_raise(window: &tauri::WebviewWindow) {


### PR DESCRIPTION
## 背景

品悟 macOS 版桌宠放在右下角时,桌宠「说话」(展开气泡)的瞬间,桌宠会向**左上方闪现一下**,然后落回原位。单击、拖动桌宠均正常,不闪。

## 根因

桌宠说话时窗口需要**同时变大 + 把原点向左上方移动**(`BottomRight` 锚点保持右下角不动),原实现在 `resize_pet_window` 里用两次独立原生调用完成:

```rust
win.set_size(...)       // 窗口变大
win.set_position(...)   // 原点左上移
```

macOS 的 Tauri 窗口后端 `tao 0.35.2` 把这两个调用分别 `dispatch_async` 到主队列(`set_content_size_async` / `set_frame_top_left_point_async`),**不是原子操作**:

- 位置移动是窗口服务立即合成的**位图平移**;
- 而内嵌 WebView 重新排版**至少滞后一帧**。

于是出现一帧「旧小窗排版 + 新左上原点」的中间合成帧——人物 bitmap 还在旧小窗的右下角,却被画到了新原点,看起来就是向左上方闪现一下,再随 WebView 重排版落回原位。单击、拖动只调用 `setPosition`(不涉及 resize),所以不闪。

## 变更

在 macOS 改用单次原生 `setFrame:display:YES`(`display:YES` 强制同步重绘)把尺寸与原点**一并提交**,消除中间合成帧;在 `NSWindow` 原生坐标(原点左下、y 朝上)里按锚点角做帧代数,与 `resized_position` 的六种锚点几何等价,并用所在屏 `visibleFrame` 钳制到工作区。其他平台保持既有的两步行为。

按架构边界(OS 差异收敛在 `features/pet/platform/`),把平台差异封装进适配层:

| 文件 | 改动 |
|---|---|
| `pet_window.rs` | `resize_pet_window` 无条件委托 `platform::resize_pet_window`,去掉平台分支;`ScaleAnchor`→`pub(crate)`、`resized_position`→`pub(super)` 供适配层复用 |
| `platform/macos.rs` | 新增 `resize_pet_window` → objc2 `setFrame:display:` 原子提交 |
| `platform/mod.rs` | 新增共享 `resize_pet_window_fallback`(非 macOS 的两步路径),统一导出 |
| `platform/linux.rs` / `standard.rs` | 各加 `resize_pet_window` 委托 fallback,保持既有行为 |

## 实际验证

- `cargo check --lib`:零 error、零 warning
- `architecture-guard.py`:passed(无新增 debt)
- pet 模块测试:32 passed
- 全库 lib 测试:958 passed, 0 failed

> 手动 GUI 验证(气泡展开无闪现)待合入后在实机上确认。

## 已知风险 / 范围说明

- 缩放手柄拖拽走的是另一条路径 `resize_pet_window_at_character_anchor`,不在本次 bug 触发路径(用户已确认拖动正常),未改动。
- macOS 的 `setFrame:display:YES` 会强制同步重绘一次,理论上比异步路径开销略高,但桌宠窗口极小、仅在气泡显隐瞬间触发,无性能影响。