### PR TITLE
chore(fork): 接入 CodeWhale r4 能力配置基线

### DIFF
--- a/docs/fork-modifications.en.md
+++ b/docs/fork-modifications.en.md
@@ -8,11 +8,11 @@
 | Item | Value |
 |---|---|
 | Upstream | `Hmbown/CodeWhale` tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
-| Public release | `Pinvou/CodeWhale` tag `pinvou-v0.9.0-r3` |
-| Pinned commit | `9a31dcdfad71172ab4fdf00a4d8bd106cfaa47da` |
+| Public release | `Pinvou/CodeWhale` tag `pinvou-v0.9.0-r4` |
+| Pinned commit | `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` |
 | Maintenance branch | `pinvou3-clean` |
-| Organization | 6 long-lived product themes, 8 follow-up behavior/maintenance commits, and 3 public baseline/security commits |
-| Diff from upstream tag | 4,632 insertions, 611 deletions, 58 files |
+| Organization | 6 long-lived product themes, 11 follow-up behavior/maintenance commits, and 3 public baseline/security commits |
+| Diff from upstream tag | 4,839 insertions, 616 deletions, 58 files |
 
 The delta exceeds the 1,500-line soft limit and has therefore received a mandatory boundary review. The retained code owns behavior that cannot be reconstructed safely in the desktop wrapper: task persistence, workflow completion, prompt-source sealing, and engine-level safety. Shell rendering and platform-specific desktop behavior remain in the parent repository and do not add fork drift.
 
@@ -24,11 +24,11 @@ Exposes the upstream bin-first crate as a library for the desktop host. It expor
 
 ### T2 — Tool surface and execution safety
 
-Defines the Pinvou tool surface, write-size limits, truncated-argument guidance, wildcard tool restrictions, and fail-closed handling for dangerous commands and required approvals. `append_file` emits a bounded inline unified diff with byte-summary, oversized-file, and non-UTF-8 fallbacks. Result-oriented golden and safety tests protect the behavior.
+Defines the Pinvou tool surface, write-size limits, truncated-argument guidance, wildcard tool restrictions, and fail-closed handling for dangerous commands and required approvals. Session-scoped `hidden_tools` may release entries from the fixed Pinvou hidden list but cannot hide tools outside it; the `tool_search` gate remains fixed. `append_file` emits a bounded inline unified diff with byte-summary, oversized-file, and non-UTF-8 fallbacks. Result-oriented golden and safety tests protect the behavior.
 
 ### T3 — Sealed prompts and one context source
 
-Lets the app own the static prompt composer, accepts only explicitly injected project instructions, loads Skills from the Pinvou runtime bundle, filters disabled Skills, and keeps internal reminders out of the working set.
+Lets the app own the static prompt composer, accepts only explicitly injected project instructions, and discovers Skills only from the explicit `EngineConfig.skills_dir` root. The current app injects the Pinvou runtime bundle and filters disabled Skills; CodeWhale no longer adds an implicit bundle fallback. Internal reminders stay out of the working set.
 
 ### T4 — Scheduled execution and history lifecycle
 
@@ -50,7 +50,7 @@ The three public baseline/security commits add:
 - `PINVOU_FORK.md` and the README fork notice;
 - removal of one internal project-name comment without changing behavior.
 
-They do not introduce a seventh product theme. The `cb93e0f44` follow-up extends T2 with `append_file` inline diffs; the four commits ending at `9a31dcdfa` extend T5 with reliable Agent mailbox lifecycle handling.
+They do not introduce a seventh product theme. The `cb93e0f44` follow-up extends T2 with `append_file` inline diffs; the four commits ending at `9a31dcdfa` extend T5 with reliable Agent mailbox lifecycle handling. The three commits ending at `03e9e1027` update the existing T2/T3 boundaries with bounded session tool visibility and a single explicit Skill root.
 
 ## Verification
 
@@ -66,6 +66,6 @@ The parent repository additionally verifies that:
 - `.gitmodules` uses `https://github.com/Pinvou/CodeWhale.git`;
 - no floating submodule branch is configured;
 - the gitlink commit is publicly reachable;
-- `pinvou-v0.9.0-r3^{}` equals the pinned gitlink.
+- `pinvou-v0.9.0-r4^{}` equals the pinned gitlink.
 
 For any future gitlink or fork-behavior change, update this inventory, the Chinese source-of-truth inventory, fingerprints, and result-oriented tests in the same PR.

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -4,15 +4,15 @@
 > 基线、主题边界、守护指纹和每次 sync 结论都以本文与 `docs/fork-policy.md` 为准。
 > English: [`docs/fork-modifications.en.md`](fork-modifications.en.md)
 
-## 0. 当前状态（2026-08-03 · v0.9.0）
+## 0. 当前状态（2026-08-07 · v0.9.0）
 
 | 项 | 当前值 |
 |---|---|
 | 上游基线 | tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f` |
-| 公开固定基线 | tag `pinvou-v0.9.0-r3`，commit `9a31dcdfad71172ab4fdf00a4d8bd106cfaa47da` |
-| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `9a31dcdfad71` |
-| 组织方式 | **6 个长期主题 commit + 8 个行为补充/维护 commit + 3 个公开基线/安全维护 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
-| drift | 对 `v0.9.0`：**+4632 / -611，58 文件** |
+| 公开固定基线 | tag `pinvou-v0.9.0-r4`，commit `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` |
+| fork 分支 | `Pinvou/CodeWhale` 的 `pinvou3-clean`，当前 head `03e9e1027c03` |
+| 组织方式 | **6 个长期主题 commit + 11 个行为补充/维护 commit + 3 个公开基线/安全维护 commit**；公开历史从上游 `v0.9.0` 重放，不复用私有 fork SHA |
+| drift | 对 `v0.9.0`：**+4839 / -616，58 文件** |
 | 守护 | `scripts/fork-guard.sh`：v0.9 主题指纹 + 宿主 ShellManager 观察器与生命周期指纹 + submodule/app `forkguard_` 行为测试 |
 | app 状态 | `pinvou3-tauri` 主库编译通过，lib test target 可完整编译；macOS 适配保留在父仓平台抽象中，不增加 fork drift |
 
@@ -45,12 +45,13 @@
 - **核心文件**：`tools/pinvou3_blocklist.rs`、`core/engine/tool_catalog.rs`、`tools/file.rs`、`core/engine/dispatch.rs`、`tools/shell.rs`、`core/engine/turn_loop.rs`、`command_safety.rs`、审批策略相关文件。
 - **内容**：
   - pinvou3 native 工具黑名单与 deferred activator 结果式 golden。
+  - `EngineConfig.hidden_tools` 支持按会话从固定黑名单中放出工具；注入只能收窄编译期名单，不能隐藏 `request_user_input`、`read_file` 等名单外工具，`tool_search` gate 仍恒查固定名单。
   - `write_file` / `append_file` 64KB 单次内容上限和缺字段修复提示。
   - `append_file` 与 `write_file` 一样输出 inline unified diff(尾部 context + 追加行,字节摘要保留在末尾);已存文件超过 512KB(`APPEND_FILE_INLINE_DIFF_LIMIT_BYTES`)或非 UTF-8 时回退 `[diff omitted]` / 纯字节摘要。
   - `disallowed_tools` 支持 `*` 前缀规则。
   - Dangerous 命令在所有模式阻断；审批缓存、workflow plan 审批保持 fail-closed。
 - **为什么留 fork**：工具面是 pinvou3 产品定位；append_file 与大产物引导耦合。Shell 展示能力已经移到 app，不再作为本主题的 fork-distinct 代码维护。
-- **守护**：`forkguard_blocklist_golden`、`forkguard_yolo_no_deferred_activator_first_class`、`forkguard_append_file_emits_inline_diff`、文件上限测试和命令安全测试。
+- **守护**：`forkguard_blocklist_golden`、`forkguard_yolo_no_deferred_activator_first_class`、`forkguard_hidden_tools_injectable`、`forkguard_hidden_tools_cannot_expand_compile_time_blocklist`、`forkguard_tool_search_always_gated`、`forkguard_append_file_emits_inline_diff`、文件上限测试和命令安全测试。
 
 ### T3 `fork`：提示词密封与 context / skill 单一来源
 
@@ -59,11 +60,11 @@
 - **内容**：
   - 静态 prompt composer 由 app 接管，默认层和运行时策略按 composer gate 密封。
   - 不再扫描仓库 constitution / AGENTS / CLAUDE 等外部 project context；pinvou3 只用 app 注入的 inline instructions，项目规则（`AGENTS.md`）由 app 侧受限注入（仅绑项目代码会话，root→cwd 各层；不越过用户家目录——project_root 与 home 同函数归一化后比较，Windows 上边界真实生效；symlink/非普通文件拒读；归一化失败 fail-closed；见 `docs/code-native-agent.md` §8.5）。
-  - skill 来源收敛到 `~/.pinvou3/bundle/skills`，并保留市场停用过滤。
+  - skill 发现只使用显式注入的 `EngineConfig.skills_dir`，不再隐式并入 `~/.pinvou3/bundle/skills`；当前 app 仍把 bundle 目录作为唯一配置根，并保留市场停用过滤。
   - 内部 `<system-reminder>` 不参与 Working Set 路径提取。
   - instructions/用户记忆 fragment 沿用 100KB 指令上限，避免被 v0.9 WorldState 默认 4KB 静默截断。
 - **为什么留 fork**：这是 pinvou3 的单一知识/指令来源和 prefix-cache 稳定性约束，上游通用 CLI 不能默认采用。
-- **守护**：static composer 前后字节测试、inline context 测试、skill union/停用测试、Working Set 两条回归；sync 后仍需跑 `dump_system_prompt` 前后 diff。
+- **守护**：static composer 前后字节测试、inline context 测试、skill 单根/停用测试、Working Set 两条回归；sync 后仍需跑 `dump_system_prompt` 前后 diff。
 
 ### T4 `fork`：定时任务执行与历史生命周期
 
@@ -116,7 +117,7 @@
 - `23d4c9b5 docs(fork): 记录 Pinvou 公开基线`
 - `070f4413 chore(fork): 清理内部项目注释`
 
-这三个提交只增加公开 fork 的说明、全历史 Gitleaks 门禁与精确测试夹具白名单，并移除一处内部项目代号注释；不改变 T1–T6 的产品行为。`cb93e0f44` 是 T2 的行为补充，`749cafc9e` 至 `9a31dcdfa` 是 T5 的可靠 mailbox 生命周期补充，均不新增长期主题。父仓只固定到稳定标签 `pinvou-v0.9.0-r3`，不跟随维护分支漂移。
+这三个提交只增加公开 fork 的说明、全历史 Gitleaks 门禁与精确测试夹具白名单，并移除一处内部项目代号注释；不改变 T1–T6 的产品行为。`cb93e0f44` 是 T2 的行为补充，`749cafc9e` 至 `9a31dcdfa` 是 T5 的可靠 mailbox 生命周期补充；`45befd55f` 至 `03e9e1027` 更新 T2/T3 的会话工具隐藏集和 skill 单根注入，均不新增长期主题。父仓只固定到稳定标签 `pinvou-v0.9.0-r4`，不跟随维护分支漂移。
 
 ### T7 macOS 平台目标支持 (2026-07)
 
@@ -198,6 +199,14 @@ diff /tmp/pre-sync-prompt.txt /tmp/post-sync-prompt.txt
 本地 `/tmp` 空间不足时，显式把 `TMPDIR` 和 `CARGO_TARGET_DIR` 指到项目盘；不要用清理用户目录解决构建问题。
 
 ## 5. Sync 历史
+
+### v0.9.0 r4 会话能力配置入口（2026-08-07）
+
+- `Pinvou/CodeWhale#7` 以 rebase merge 合入 `pinvou3-clean`，发布不可变标签 `pinvou-v0.9.0-r4@03e9e102`。
+- T3 的 skill 发现改为只使用 `EngineConfig.skills_dir` 单根注入，移除底座对 `~/.pinvou3/bundle/skills` 的隐式并入；父仓当前仍显式注入 bundle 根，缺省产品行为不变。
+- T2 新增 `EngineConfig.hidden_tools` 会话入口，但注入只能收窄固定黑名单；评审中补齐 `request_user_input` / `read_file` 不可被越界隐藏和 `tool_search` gate 不可注入的回归，并撤回未形成跨 provider 闭环的子代理传播扩展。
+- 父仓本次显式使用 `hidden_tools: None`，继续采用固定名单；能力档案的按会话计算不在本次基线接入范围。
+- 验证：CodeWhale workspace 全目标检查、44 项 `forkguard_`、格式、DCO、Gitleaks 与 contribution gate；父仓 app 编译、fork guard 和公开 tag/gitlink 一致性检查。
 
 ### v0.9.0 r3 Agent mailbox 生命周期（2026-08-03）
 

--- a/docs/fork-policy.en.md
+++ b/docs/fork-policy.en.md
@@ -1,15 +1,15 @@
 # CodeWhale Fork Maintenance Policy
 
-> Last updated: 2026-08-03
-> Released baseline: `pinvou-v0.9.0-r3@9a31dcdf`
+> Last updated: 2026-08-07
+> Released baseline: `pinvou-v0.9.0-r4@03e9e102`
 > Detailed inventory: [`fork-modifications.en.md`](fork-modifications.en.md)
 
 ## 1. Baseline and ownership
 
 - Upstream: [`Hmbown/CodeWhale`](https://github.com/Hmbown/CodeWhale), tag `v0.9.0`, commit `d167c07c96282411956ea7f35ddb8227afa1402f`.
 - Public fork: [`Pinvou/CodeWhale`](https://github.com/Pinvou/CodeWhale).
-- Maintenance branch: `pinvou3-clean`, currently at `9a31dcdfad71172ab4fdf00a4d8bd106cfaa47da`.
-- Pinvou Agent pins the immutable tag `pinvou-v0.9.0-r3`, which dereferences to that commit.
+- Maintenance branch: `pinvou3-clean`, currently at `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624`.
+- Pinvou Agent pins the immutable tag `pinvou-v0.9.0-r4`, which dereferences to that commit.
 - `.gitmodules` intentionally has no `branch` entry. A parent-repository checkout must never move merely because the maintenance branch moved.
 
 The fork is maintained as six long-lived themes:

--- a/docs/fork-policy.md
+++ b/docs/fork-policy.md
@@ -1,6 +1,6 @@
 # pinvou3 对 CodeWhale 底座的 fork 维护策略
 
-> 最后更新：2026-08-03（公开发布基线 `pinvou-v0.9.0-r3@9a31dcdf`）
+> 最后更新：2026-08-07（公开发布基线 `pinvou-v0.9.0-r4@03e9e102`）
 > 配套：`docs/fork-modifications.md`、`scripts/fork-guard.sh`、`docs/底座升级验收清单.md`
 > English: [`docs/fork-policy.en.md`](fork-policy.en.md)
 
@@ -8,8 +8,8 @@
 
 - 上游：`Hmbown/CodeWhale` tag `v0.9.0`，commit `d167c07c96282411956ea7f35ddb8227afa1402f`。
 - 公开 fork：`https://github.com/Pinvou/CodeWhale`。
-- 维护分支：`pinvou3-clean`，当前 head `9a31dcdfad71172ab4fdf00a4d8bd106cfaa47da`。
-- 父仓固定标签：`pinvou-v0.9.0-r3`，解引用后必须是上述 commit；`.gitmodules` 不配置浮动 `branch`。
+- 维护分支：`pinvou3-clean`，当前 head `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624`。
+- 父仓固定标签：`pinvou-v0.9.0-r4`，解引用后必须是上述 commit；`.gitmodules` 不配置浮动 `branch`。
 - fork 不再按历史 C1–C12 / W1–W13 批量编号维护，当前只保留 **6 个长期主题**：
 
   1. 宿主 library facade
@@ -39,7 +39,7 @@ Engine、ToolRegistry、SSE、Session、SkillRegistry、Commands、MCP client、
 - 总 drift 软上限：1500 行。
 - 单文件 fork-distinct 改动软上限：200 行。
 - 超过不是自动拒绝，但必须在 `fork-modifications.md` 记录：为什么不能放 app/skill/MCP、哪些已 harvest、后续减量顺序。
-- 当前公开基线相对 v0.9.0 为 `+4632/-611，58 文件`，已经完成强制评估；结论见修改清单 §0。
+- 当前公开基线相对 v0.9.0 为 `+4839/-616，58 文件`，已经完成强制评估；结论见修改清单 §0。
 
 ### 1.3 主题提交
 

--- a/pinvou3-app/src-tauri/src/app/commands/workflows.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/workflows.rs
@@ -6,9 +6,8 @@
 /// 工作流卡片不显示的 skill 名单。这些是 pinvou3 自带的基础能力组件
 /// (review 流程内部用),不应作为用户主动启用的工作流入口。
 ///
-/// 后续真正物理隔离会把这俩从 `bundle/skills/` 移到独立目录 +
-/// CodeWhale fork patch 让 EngineConfig 支持多 skills_dir。当前
-/// 用 skiplist 软隔离,工作量小,效果一致。
+/// 后续真正物理隔离需要由 app 按会话生成组合目录，再通过 CodeWhale 的单一
+/// `EngineConfig.skills_dir` 注入。当前用 skiplist 软隔离，工作量小、效果一致。
 const WORKFLOW_HIDDEN_SKILLS: &[&str] = &["pinvou-review-plan", "pinvou-review-final"];
 
 /// 工作流视图卡片渲染需要的 skill 摘要 — 跟 CodeWhale runtime_api 的

--- a/pinvou3-app/src-tauri/src/bin/dump_system_prompt.rs
+++ b/pinvou3-app/src-tauri/src/bin/dump_system_prompt.rs
@@ -43,9 +43,9 @@ fn main() -> Result<()> {
         //   verbosity: None = GUI 不用 concise 输出模式(与 bridge Op::SendMessage 一致)。
         context_window_override: None,
         verbosity: None,
-        // v0.8.65 上游新增(C5):skills 扫描 CodeWhale-only 开关。pinvou3 #41 已把扫描
-        // 收窄成只 ~/.pinvou3/bundle/skills(技能市场私有区,两 mode 行为一致),此值无
-        // 实际影响,取 false(Compatible)。
+        // CodeWhale r4 后技能发现只使用显式 EngineConfig.skills_dir；当前 app 注入
+        // ~/.pinvou3/bundle/skills(技能市场私有区,两 mode 行为一致)。底座不再追加
+        // 其他根，因此此兼容扫描开关无实际影响，取 false。
         skills_scan_codewhale_only: false,
     };
 

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -1057,6 +1057,7 @@ impl Pinvou3Bridge {
             goal_token_budget,
             goal_status,
             disallowed_tools: _, // pinvou3 从持久列表算初值(见构造处),默认值忽略
+            hidden_tools: _,     // pinvou3 暂不启用会话裁剪,显式保持底座固定隐藏集
             // —— v0.8.65 上游新增字段,透传 default ——
             //   subagents_enabled: default true(三省六部走 SpawnSubAgent,必须开)。
             //   launch_concurrency/max_admitted_subagents/subagent_token_budget: subagent
@@ -1244,6 +1245,9 @@ impl Pinvou3Bridge {
                     Some(n)
                 }
             },
+            // CodeWhale r4 新增会话隐藏集注入。父仓本次只接入底座基线，继续使用
+            // 编译期 PINVOU3_HIDDEN_TOOLS；能力档案启用另行在 app 层按会话计算。
+            hidden_tools: None,
             // [pinvou3-fork] 透传 default(空);kb_search 在 spawn_for_session 按 session 注入
             // —— v0.8.65 上游新增字段,透传 default ——
             //   subagents_enabled: default true(三省六部走 SpawnSubAgent,必须开)。

--- a/scripts/fork-guard.sh
+++ b/scripts/fork-guard.sh
@@ -25,12 +25,15 @@ fingerprints=(
   "T2|截断参数修复提示                   |CodeWhale/crates/tui/src/core/engine/dispatch.rs|truncated_args_hint"
   "T2|工具黑名单结果 golden              |CodeWhale/crates/tui/src/tools/pinvou3_blocklist.rs|fn forkguard_blocklist_golden"
   "T2|deferred 激活面 golden             |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_yolo_no_deferred_activator_first_class"
+  "T2|会话隐藏集可收窄固定名单           |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_hidden_tools_injectable"
+  "T2|会话隐藏集不可扩大固定名单         |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_hidden_tools_cannot_expand_compile_time_blocklist"
+  "T2|tool_search gate 不可注入          |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_tool_search_always_gated"
   "T2|disallowed_tools 前缀规则          |CodeWhale/crates/tui/src/core/engine/turn_loop.rs|rule.strip_suffix('*')"
   "T2|Dangerous 命令全模式阻断           |CodeWhale/crates/tui/src/tools/shell.rs|Dangerous commands are BLOCKED in ALL modes"
   "T3|项目上下文仅走 inline              |CodeWhale/crates/tui/src/project_context.rs|fn forkguard_pinvou3_uses_only_inline_project_context"
   "T3|密封静态 prompt composer           |CodeWhale/crates/tui/src/prompts.rs|pub fn set_static_prompt_composer_override"
   "T3|instructions 不受 4KB fragment 截断|CodeWhale/crates/tui/src/prompts.rs|fn forkguard_permissions_fragment_preserves_instructions_beyond_default_fragment_cap"
-  "T3|skill 来源收敛到 bundle            |CodeWhale/crates/tui/src/skills/mod.rs|home.join(\".pinvou3\").join(\"bundle\").join(\"skills\")"
+  "T3|skill 发现仅使用显式注入根         |CodeWhale/crates/tui/src/skills/mod.rs|fn forkguard_skill_discovery_is_single_root_engine_config_skills_dir"
   "T3|停用 skill 不进入目录              |CodeWhale/crates/tui/src/skills/mod.rs|if is_skill_disabled(&skill.name)"
   "T3|内部提醒不污染 Working Set         |CodeWhale/crates/tui/src/working_set.rs|fn strip_leading_system_reminder(text: &str) -> &str"
 
@@ -69,7 +72,7 @@ fingerprints=(
   "T6|automation reconcile shared API    |CodeWhale/crates/tui/src/automation_manager.rs|pub async fn reconcile_run_statuses_shared("
 
   "CI|公开 fork 全目标编译门禁           |CodeWhale/.github/workflows/pinvou-fork-ci.yml|cargo check --workspace --all-targets --locked"
-  "CI|父仓固定公开 CodeWhale 标签         |scripts/verify-public-submodule.sh|PINVOU_CODEWHALE_TAG=\"pinvou-v0.9.0-r3\""
+  "CI|父仓固定公开 CodeWhale 标签         |scripts/verify-public-submodule.sh|PINVOU_CODEWHALE_TAG=\"pinvou-v0.9.0-r4\""
 
   "APP|消息携带 resolved route            |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|resolve_runtime_route_for_model"
   "APP|部署级 route profile               |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|fn route_limits_for_model("
@@ -79,6 +82,7 @@ fingerprints=(
   "APP|定时任务使用 shared run API        |pinvou3-app/src-tauri/src/features/scheduled/tasks.rs|run_now_shared(&self.automations"
   "APP|敏感目录 hard deny 为 exit 2       |pinvou3-app/src-tauri/resources/common/bundle/deny_sensitive_paths.sh|hard-deny 必须 **exit 2**"
   "APP|静态层 composer 仍由 app 安装      |pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs|set_static_prompt_composer_override"
+  "APP|会话隐藏集保持固定名单缺省         |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|hidden_tools: None"
   "APP|内置技能写入 bundle 单一来源        |pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs|fn forkguard_builtin_visual_skill_uses_bundle_root_and_safe_name"
   "APP|前端终端跨分片解析状态             |pinvou3-app/src/platform/tauri/bridge/terminal.js|function terminalParserState(item, stream)"
   "APP|前端终端跨分片 UI 回归             |pinvou3-app/tests/ui_smoke.js|terminal parser preserves CRLF and ANSI state across live chunks"

--- a/scripts/verify-public-submodule.sh
+++ b/scripts/verify-public-submodule.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PINVOU_CODEWHALE_PATH="CodeWhale"
 PINVOU_CODEWHALE_URL="https://github.com/Pinvou/CodeWhale.git"
-PINVOU_CODEWHALE_TAG="pinvou-v0.9.0-r3"
+PINVOU_CODEWHALE_TAG="pinvou-v0.9.0-r4"
 
 actual_path="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.path)"
 actual_url="$(git -C "$REPO" config -f .gitmodules --get submodule.CodeWhale.url)"


### PR DESCRIPTION
## 背景

CodeWhale PR #7 已合入 `pinvou3-clean`。父仓需要固定新的不可变基线，并同步 fork 现状与守卫，避免继续停留在 r3。

## 变更

- 发布并固定 `pinvou-v0.9.0-r4@03e9e102`，更新 CodeWhale gitlink。
- 对新增 `EngineConfig.hidden_tools` 显式传入 `None`，保持父仓现有固定工具隐藏集不变。
- 更新中英文 fork 策略、修改清单、漂移数据、同步记录及对应指纹。
- 修正两处关于 Skill 目录行为的失效注释。

## 验证

- `./scripts/fork-guard.sh`：CodeWhale 44 项、父仓 15 项 forkguard 回归全部通过。
- `./scripts/fork-guard.sh --fast`
- `./scripts/verify-public-submodule.sh`
- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --locked`
- `cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run --locked`
- `cargo fmt --all --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `python3 scripts/architecture-guard.py`
- `git diff --check`

## 边界与风险

本 PR 只接入底座基线，不实现能力档案、按会话工具裁剪或子代理/provider 传播；产品运行行为保持不变。主要风险为底座 gitlink 升级，已由 fork 行为测试、父仓编译和不可变标签校验覆盖。
