### PR TITLE
fix(ui): 归一化模型选择器的「管理模型」入口

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -2051,13 +2051,14 @@ function workspaceDisplayName(path) {
                 onSwitchHomeMode={handleSwitchHomeMode}
                 bs={bs}
                 onGotoTools={() => navigateFromScheduledRun('toolStore')}
+                onGotoModelSettings={() => openSettingsSection('model')}
               />
             )}
             {SCHEDULED_TASKS_ENTRY_ENABLED && currentView === 'scheduled' && (
               bs && bs.scheduledRunContext ? (
                 <ChatView theme={activeTheme} t={t} bs={bs} prefill="" onPrefillConsumed={() => {}} onOpenEditor={(initial) => setPersonaEditor({ initial })} justInstalledTool={justInstalledTool} setJustInstalledTool={setJustInstalledTool} onGotoSettings={() => openSettingsSection('general')} onGotoModelSettings={() => openSettingsSection('model')} onGotoTools={() => navigateFromScheduledRun('toolStore')} onBackScheduledRun={() => navigateFromScheduledRun('scheduled')} />
               ) : (
-                <ScheduledTasksView theme={activeTheme} t={t} onOpenChat={() => setCurrentView('chat')} />
+                <ScheduledTasksView theme={activeTheme} t={t} onOpenChat={() => setCurrentView('chat')} onGotoModelSettings={() => openSettingsSection('model')} />
               )
             )}
             {/* 草稿态(无 session)也渲染挂件,但强制空态——让欢迎页保留「＋加持卡牌」入口。

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
 import {
-  AlertTriangle, Brain, Check, CheckCircle2, ChevronDown, FileText, FolderOpen, Paperclip, Send,
+  AlertTriangle, Brain, Check, CheckCircle2, ChevronDown, FileText, FolderOpen, Paperclip, Plus, Send,
   RefreshCw, Sparkles, StopCircle, Terminal, User, Wrench,
 } from '../../components/icons.jsx';
 import { AcpAgentLogo } from './AcpAgentLogo.jsx';
@@ -16,6 +16,7 @@ import {
   runtimeOperationFor,
 } from './runtimeNoticeState.js';
 import { ComposerPopover } from '../../components/ComposerPopover.jsx';
+import { can } from '../../shared/platform.js';
 import {
   appendAcpEvent,
   commandExecutionDetails,
@@ -191,6 +192,7 @@ function CodexComposerConfigSelect({
   title,
   unsetLabel,
   testId,
+  footerAction,
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
@@ -249,6 +251,19 @@ function CodexComposerConfigSelect({
             </button>
           );
         })}
+        {footerAction && (
+          <>
+            <div className="my-1 mx-2 h-px bg-black/5 dark:bg-white/10" />
+            <button
+              type="button"
+              onClick={() => { setOpen(false); footerAction.onClick(); }}
+              className="group flex w-full items-center gap-2.5 rounded-xl px-3 py-2.5 text-left text-[13px] text-gray-700 transition-colors hover:bg-[#007AFF] hover:text-white dark:text-gray-200"
+            >
+              <Plus size={15} className="shrink-0 text-gray-400 group-hover:text-white/90" />
+              <span className="min-w-0 truncate">{footerAction.label}</span>
+            </button>
+          </>
+        )}
       </ComposerPopover>
     </div>
   );
@@ -1086,6 +1101,7 @@ export function CodexAcpView({
   onSwitchHomeMode,
   bs = null,
   onGotoTools,
+  onGotoModelSettings,
 }) {
   const codexCopy = t.uiCodex;
   const [agents, setAgents] = useState([]);
@@ -1269,6 +1285,9 @@ export function CodexAcpView({
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.modelId : null)
     : (nativeDraftControls.modelId || null);
   const nativeModelValue = nativeSessionModelId || (bs && bs.activeModelId) || '';
+  const nativeManageModelsAction = can('modelManagement') && onGotoModelSettings
+    ? { label: t.manageModels, onClick: onGotoModelSettings }
+    : undefined;
   const nativeMountedId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.mountedId : null)
     : (nativeDraftControls.mountedId ?? null);
@@ -2787,6 +2806,7 @@ export function CodexAcpView({
                           onChange={modelId => switchNativeModel(activeId, String(modelId))}
                           disabled={busy || working}
                           title={busy || working ? t.modelSwitchBusy : undefined}
+                          footerAction={nativeManageModelsAction}
                         />
                       )}
                       <ComposerToolMenu

--- a/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
+++ b/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
@@ -114,6 +114,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
     const ScheduledSelect = ({
       value, options, onChange, testId, ariaLabel, theme, minWidth = 180,
       multiple = false, minSelected = 0, onClose, emptyLabel = '—', separator = '、',
+      footerAction,
     }) => {
       const [open, setOpen] = useState(false);
       const [menuStyle, setMenuStyle] = useState(null);
@@ -220,6 +221,17 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
               </button>
             );
           })}
+          {footerAction && (
+            <>
+              <div className={`my-1 mx-2 h-px ${isDark ? 'bg-[#3A3B3E]' : 'bg-[#DFE1E5]'}`} />
+              <button type="button"
+                onClick={() => { closeMenu(); footerAction.onClick(); }}
+                className={`flex w-full min-h-9 items-center gap-3 rounded-[8px] px-3 py-2 text-left text-[14px] transition-colors ${isDark ? 'text-[#E3E3E3] hover:bg-[#303134]' : 'text-[#202124] hover:bg-[#F1F3F4]'}`}>
+                <Plus size={15} className={`shrink-0 ${isDark ? 'text-[#9AA0A6]' : 'text-[#5F6368]'}`} />
+                <span className="min-w-0 flex-1 truncate">{footerAction.label}</span>
+              </button>
+            </>
+          )}
         </div>,
         document.body
       ) : null;
@@ -369,7 +381,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
       );
     };
 
-    const ScheduledTasksView = ({ theme, t, onOpenChat }) => {
+    const ScheduledTasksView = ({ theme, t, onOpenChat, onGotoModelSettings }) => {
       const bs = useBridgeState(['scheduled', 'models']);
       const appState = bs || {};
       const realTasks = appState.scheduledTasks || [];
@@ -380,6 +392,9 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
       const error = appState.scheduledTaskError || null;
       const isDark = theme === 'dark';
       const scheduledCopy = t.uiScheduled;
+      const modelManageAction = can('modelManagement') && onGotoModelSettings
+        ? { label: t.manageModels, onClick: onGotoModelSettings }
+        : undefined;
       const weekdayOptions = WEEKDAY_OPTIONS.map((option, index) => ({
         ...option,
         label: scheduledCopy.weekdays[index][0],
@@ -1344,7 +1359,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
                     <div className="flex items-center gap-1.5">
                       <ScheduledSelect value={detailForm.modelId || ''} options={modelOptions}
                         onChange={value => editModel(value)}
-                        testId="scheduled-live-model" ariaLabel={scheduledCopy.chooseModel} theme={theme} minWidth={220} emptyLabel={scheduledCopy.choose} />
+                        testId="scheduled-live-model" ariaLabel={scheduledCopy.chooseModel} theme={theme} minWidth={220} emptyLabel={scheduledCopy.choose} footerAction={modelManageAction} />
                       <ChevronRight className={`h-3.5 w-3.5 ${isDark ? 'text-[#EBEBF5]/30' : 'text-[#C5C5C7]'}`} />
                     </div>
                   </div>

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -474,64 +474,7 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
       );
     };
 
-    // 聊天输入框上方:当前会话模型 chip + 下拉热切。
-    const ModelChip = ({ isDark, t, bs, onGotoSettings }) => {
-      const [open, setOpen] = useState(false);
-      const canManageModels = can('modelManagement');
-      const canSwitchModels = can('sessionModelSwitch');
-      const savedModels = visibleUserModels((bs && bs.savedModels) || []);
-      const activeSessionId = bs ? bs.activeSessionId : null;
-      const activeModelId = bs && bs.activeModelId;
-      const currentSessionModelId = bs && bs.currentSessionModelId;
-      const busy = bs ? bs.busy : false;
-      const effectiveId = currentSessionModelId || activeModelId;
-      const current = savedModels.find(m => m.id === effectiveId);
-      if (!savedModels.length) return null;
-      function pick(id) {
-        setOpen(false);
-        if (id === effectiveId) return;
-        if (bridge.available) bridge.models.switchModel(activeSessionId, id);
-      }
-      return (
-        <div className="relative px-2 mb-2">
-          <button onClick={() => { if (!busy && canSwitchModels) setOpen(o => !o); }} disabled={busy || !canSwitchModels}
-            title={busy ? t.modelSwitchBusy : t.switchModelTitle}
-            className={`inline-flex items-center gap-1.5 pl-3 pr-2 py-1 rounded-full text-[12px] font-medium transition-colors disabled:opacity-50 ${isDark ? 'bg-[#2A2B2D] text-[#E3E3E3] hover:bg-[#333537]' : 'bg-[#EAEDF1] text-[#1F1F1F] hover:bg-[#E0E3E7]'}`}>
-            <span className="w-1.5 h-1.5 rounded-full bg-[#34A853]"></span>
-            <span className="max-w-[220px] truncate">{current ? selectorMainLabel(current, t) : t.modelNonePick}</span>
-            <ChevronDown size={13} />
-          </button>
-          {open && canSwitchModels && (
-            <div>
-              <div className="fixed inset-0 z-40" onClick={() => setOpen(false)}></div>
-              <div className={`absolute bottom-full left-2 mb-1 z-50 min-w-[240px] max-h-[340px] overflow-y-auto rounded-xl border shadow-lg py-1 ${isDark ? 'bg-[#1E1F20] border-[#333537]' : 'bg-white border-[#E0E3E7]'}`}>
-                {savedModels.map(m => (
-                  <button key={m.id} onClick={() => pick(m.id)}
-                    className={`w-full flex items-center gap-2 px-3 py-2 text-left transition-colors ${isDark ? 'hover:bg-[#2A2B2D]' : 'hover:bg-[#F0F4F9]'}`}>
-                    <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${m.id === effectiveId ? 'bg-[#34A853]' : 'bg-transparent'}`}></span>
-                    <span className="flex-1 min-w-0">
-                      <span className={`block text-[13px] truncate ${isDark ? 'text-[#E3E3E3]' : 'text-[#1F1F1F]'}`}>{selectorMainLabel(m, t)}</span>
-                      <span className={`block text-[11px] truncate ${isDark ? 'text-[#9AA0A6]' : 'text-[#5F6368]'}`}>{selectorSubLabel(m, t)}</span>
-                    </span>
-                    {m.id === activeModelId && <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${isDark ? 'bg-[#37393B] text-[#9AA0A6]' : 'bg-[#E8EAED] text-[#5F6368]'}`}>{t.modelActiveTag}</span>}
-                  </button>
-                ))}
-                {canManageModels && (
-                  <div className={`border-t mt-1 pt-1 ${isDark ? 'border-[#333537]' : 'border-[#E8EAED]'}`}>
-                    <button onClick={() => { setOpen(false); if (onGotoSettings) onGotoSettings(); }}
-                      className={`w-full px-3 py-1.5 text-left text-[12px] ${isDark ? 'text-[#9AA0A6] hover:bg-[#2A2B2D]' : 'text-[#5F6368] hover:bg-[#F0F4F9]'}`}>
-                      {t.manageModels}
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      );
-    };
-
-    // 输入框底栏:模型选择器(iOS 化,复用 ModelChip 的 switchModel 逻辑;darkMode:'class' 故用 dark: 变体)。
+    // 输入框底栏:模型选择器(iOS 化;darkMode:'class' 故用 dark: 变体)。
     // 可选“显式会话态驱动”props（代码模块原生车道用）：sessionId/sessionModelId/
     // busy/onSwitchModel 传入时绕开 bridge 聊天 active 绑定；不传走原 bs/bridge 路径。
     const ComposerModelSelector = ({ t, bs, onGotoSettings, compact, sessionId: sessionIdProp, sessionModelId: sessionModelIdProp, busy: busyProp, onSwitchModel }) => {
@@ -2842,4 +2785,4 @@ const SCard = React.forwardRef(({ isDark, title, titleAdornment, children, id, s
     // ==========================================
     // 安装工具后新建会话弹出的介绍卡片（纯前端，不发 LLM query，点 chip 才发消息）
 
-export { SCard, SRow, SField, SSegmented, SActionBar, MemorySettingsCard, MODEL_PRESET_DEFS, presetOptionsI18n, presetProviderLabel, ModelChip, ComposerModelSelector, WebAccessModal, ScaledHtmlPreview, ComposerModeMenu, notifyComposerToolsChanged, ComposerToolMenu, ModelFormModal, SettingsView };
+export { SCard, SRow, SField, SSegmented, SActionBar, MemorySettingsCard, MODEL_PRESET_DEFS, presetOptionsI18n, presetProviderLabel, ComposerModelSelector, WebAccessModal, ScaledHtmlPreview, ComposerModeMenu, notifyComposerToolsChanged, ComposerToolMenu, ModelFormModal, SettingsView };


### PR DESCRIPTION
## 背景

工作模式的模型选择器下拉底部有「管理模型」入口（跳转设置→模型面板），但代码模式和定时任务这两个同样消费品悟 `savedModels` 的模型选择器却没有，UI 不一致。

## 变更

把「管理模型」入口归一到所有同源（品悟 `savedModels`）的模型选择器：

- **CodexAcpView**：`CodexComposerConfigSelect` 新增可选 `footerAction` prop（分隔线 + Plus 图标 + 文案）；原生（品悟）车道模型下拉补「管理模型」入口，受 `can('modelManagement')` 守卫。
- **ScheduledTasksView**：`ScheduledSelect` 新增可选 `footerAction` prop；定时任务详情的模型选择器补「管理模型」入口。
- **main.jsx**：为 `CodexAcpView`、`ScheduledTasksView` 传入 `onGotoModelSettings={() => openSettingsSection('model')}`（与 ChatView 同写法）。
- **SettingsView**：删除已被 `ComposerModelSelector` 取代的 `ModelChip` 死代码（组件定义 + export，全仓无渲染点）。

两个通用下拉的 footer 各自匹配所在组件的既有调色（Codex 蓝色 `#007AFF` hover / Scheduled Material `#F1F3F4` hover）。i18n 复用既有 `manageModels`（中/英/日），无新增 key。

### 范围说明

- 代码模式 **ACP fallback 车道**未动：其模型来自外部 ACP 进程后端配置，与品悟 `savedModels` 不同源，跳转后列表可能对不上，语义不对应。
- 其余 `CodexComposerConfigSelect` / `ScheduledSelect` 的调用点（权限模式/知识库/星期/间隔等）不传 `footerAction`，行为不变。

## 验证

- `npm run lint:ui` ✅
- `python3 scripts/architecture-guard.py` ✅
- 工作模式不变；代码模式 native 车道与定时任务详情的模型下拉新增「管理模型」入口，点击跳转设置→模型面板
- web 端（`can('modelManagement')===false`）入口不显示

## 已知限制（非本次范围）

撕离窗口 `DetachedShell.jsx` 渲染 ChatView 时 `onGotoSettings` 为空函数、未传 `onGotoModelSettings`，工作模式的「管理模型」入口在撕离窗口里点击无效。该注释明确是有意设计（单视图，无 settings 可导航），性质属「特定上下文功能受限」而非 UI 不统一，故未在本 PR 处理。