### PR TITLE
fix(chat): 取消请求绑定 turn generation 防止跨轮误取消

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -973,6 +973,46 @@ impl TurnLifecycle {
         true
     }
 
+    /// 在 lifecycle state 锁内原子完成「epoch 校验 + arm pending + 同步取消」。
+    ///
+    /// 与 [`arm_pending_cancel`] 的区别：`cancel` 闭包在**同一临界区内**持锁
+    /// 执行。单独 arm 时锁在校验后即释放，调用方随后才执行 `cancel_current`，
+    /// 两条同步调用之间没有 `.await` 也不构成原子性保证——多线程 runtime/OS
+    /// 可以在任意指令边界切换线程。若另一 worker 在该窗口内完成「旧轮终态
+    /// 收口 + 新轮 reserve/send + `reset_cancel_token`」，恢复后的旧 cancel 会
+    /// 命中新轮活跃 token（reviewer 点 8）。把取消闭包移入同一临界区后，
+    /// `reserve_turn`（取同一把 state 锁）无法插入「校验/arm」与「取消」之间，
+    /// 跨轮窗口闭合。
+    ///
+    /// 锁序：本方法持 lifecycle state 锁调用 `cancel` 闭包，闭包内
+    /// `engine.cancel_current()` 取 engine 的 cancel_token 锁（与 state 锁无
+    /// 反向依赖，forwarder 消费 pending 也是先 state 后 token），无死锁。
+    /// `cancel` 必须同步、不 panic（panic 会使 Mutex 中毒），且不得再次获取
+    /// 本 lifecycle 的 state 锁。
+    ///
+    /// 其余语义与 [`arm_pending_cancel`] 一致：epoch 匹配则设置 pending（条件
+    /// 满足时）并执行 `cancel` 后返回 `true`；epoch 不匹配返回 `false` 且
+    /// **不执行** `cancel`，调用方必须整体 no-op。
+    ///
+    /// [`arm_pending_cancel`]: Self::arm_pending_cancel
+    pub(crate) fn arm_pending_cancel_and_cancel<F>(&self, epoch: u64, cancel: F) -> bool
+    where
+        F: FnOnce(),
+    {
+        let mut state = self.state.lock();
+        if state.turn_epoch != epoch {
+            // 轮次已切换（目标轮已结束、新轮已 reserve）：不 arm、不取消。
+            return false;
+        }
+        if state.submitted && state.turn_id.is_none() && state.active {
+            state.pending_cancel = Some(epoch);
+        }
+        // 持锁执行同步取消：reserve_turn 需要同一把 state 锁，无法在
+        // 「校验/arm」与「取消」之间插入轮次切换，旧 cancel 不可能命中新轮。
+        cancel();
+        true
+    }
+
     /// 原子取出并清除 `pending_cancel` 标记。
     ///
     /// 由事件转发器在收到 `TurnStarted` 后调用：此时 CodeWhale 的
@@ -3237,6 +3277,7 @@ mod turn_lifecycle_tests {
     use crate::core::mode_state::SessionModeState;
     use deepseek_tui::models::{ContentBlock, Message};
     use std::cell::Cell;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
     fn message(role: &str, text: &str) -> Message {
@@ -3533,6 +3574,108 @@ mod turn_lifecycle_tests {
         assert!(
             lifecycle.take_pending_cancel(epoch2).is_some(),
             "accepted arm must set pending for the current turn"
+        );
+
+        // 防 Drop 副作用。
+        reservation2.mark_submitted();
+    }
+
+    #[test]
+    fn arm_pending_cancel_and_cancel_holds_state_lock_through_cancel() {
+        // reviewer 点 8 的确定性回归：epoch 校验/arm 与取消副作用必须在同一
+        // lifecycle state 锁临界区内原子完成。若 arm 后释放锁、再单独执行
+        // cancel_current，两条同步调用之间没有 await 也不构成原子性保证——
+        // 另一 worker 可在该窗口内收口旧轮、reserve/发送新轮并
+        // reset_cancel_token，恢复后旧 cancel 命中新轮活跃 token。
+        //
+        // 编排：cancel 闭包（持锁）进入后阻塞，期间另一线程尝试 reserve——
+        // 必须被 state 锁挡住；放行 cancel 后 reserve 才得以完成。若实现把
+        // cancel 放在锁外，reserve 会在 cancel 完成前成功，断言失败。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+        // turn1：on_submitted 激活（active+submitted+epoch=1），cancel 目标轮。
+        assert!(lifecycle.on_submitted());
+        let target = lifecycle.current_turn_generation().expect("turn1 epoch");
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
+        // cancel 线程：arm_pending_cancel_and_cancel 持锁执行 cancel 闭包，
+        // 闭包通知「已进入临界区」后阻塞，模拟取消副作用执行中。
+        let lc_for_cancel = lifecycle.clone();
+        let cancel_thread = std::thread::spawn(move || {
+            let ok = lc_for_cancel.arm_pending_cancel_and_cancel(target, || {
+                entered_tx.send(()).expect("entered");
+                release_rx.recv().expect("release");
+            });
+            assert!(ok, "epoch must match when the cancel side effect runs");
+        });
+
+        // 等 cancel 进入临界区（已持 state 锁）。
+        entered_rx.recv().expect("cancel entered");
+
+        // 另一 worker 尝试 reserve 新轮：应被 state 锁阻塞，直到 cancel 完成。
+        let (reserve_done_tx, reserve_done_rx) = std::sync::mpsc::channel::<()>();
+        let lc_for_reserve = lifecycle.clone();
+        let reserve_thread = std::thread::spawn(move || {
+            let _ = lc_for_reserve.reserve();
+            reserve_done_tx.send(()).expect("reserve done");
+        });
+
+        // 确定性断言：cancel 持锁期间 reserve 不能完成。
+        assert!(
+            reserve_done_rx
+                .recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "reserve must be blocked while the cancel side effect holds the state lock"
+        );
+
+        // 放行 cancel → reserve 随后完成。
+        release_tx.send(()).expect("release cancel");
+        cancel_thread.join().expect("cancel thread joins");
+        reserve_thread.join().expect("reserve thread joins");
+        assert!(
+            reserve_done_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .is_ok(),
+            "reserve must complete after the cancel side effect releases the state lock"
+        );
+    }
+
+    #[test]
+    fn arm_pending_cancel_and_cancel_skips_cancel_on_stale_epoch() {
+        // reviewer 点 6 + 8：epoch 不匹配（轮次已切换）时，cancel 闭包不得
+        // 执行——stale 的取消不能落到新轮已 reset_cancel_token 的活跃 token 上。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+        // turn1：on_submitted 激活（epoch=1）。
+        assert!(lifecycle.on_submitted());
+        let target = lifecycle.current_turn_generation().expect("turn1 epoch");
+
+        // 轮次切换：turn1 终态 → turn2 reserve + 提交（epoch=2）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+        lifecycle.mark_reservation_submitted(reservation2.reservation_id);
+        let epoch2 = lifecycle
+            .current_turn_generation()
+            .expect("turn2 active epoch");
+        assert_eq!(epoch2, target + 1, "turn2 must bump the epoch past target");
+
+        // 用发起时快照 target 组合 arm+cancel：epoch 不匹配 → 返回 false 且
+        // cancel 闭包不执行（若误执行，探针会置位）。
+        let cancel_ran = Arc::new(AtomicBool::new(false));
+        let probe = cancel_ran.clone();
+        assert!(
+            !lifecycle.arm_pending_cancel_and_cancel(target, move || {
+                probe.store(true, Ordering::Release);
+            }),
+            "stale epoch must be rejected and the cancel closure skipped"
+        );
+        assert!(
+            !cancel_ran.load(Ordering::Acquire),
+            "cancel closure must not run when the epoch no longer matches"
+        );
+        assert!(
+            lifecycle.take_pending_cancel(epoch2).is_none(),
+            "stale cancel must not bind pending to the new turn"
         );
 
         // 防 Drop 副作用。

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -850,8 +850,27 @@ impl TurnLifecycle {
     /// [`claim_terminal_transition`]: Self::claim_terminal_transition
     /// [`claim_reclaimed_transition`]: Self::claim_reclaimed_transition
     pub(crate) fn claim_unsubmitted_terminal(&self) -> bool {
+        self.claim_unsubmitted_terminal_impl(None)
+    }
+
+    /// 带目标 epoch 的原子认领：在 lifecycle state 锁内**同时**校验
+    /// `turn_epoch == target` 并认领，二者之间不存在可插入轮次切换的窗口。
+    ///
+    /// 供 cancel 阶段二使用（`reserve_turn` 不取 `turn_lock`，generation 检查
+    /// 与认领若分离，另一 worker 可在检查通过后结束旧轮并 reserve 新轮，
+    /// 无 epoch 校验的认领会把新轮 reservation 误认领为 Interrupted）：
+    /// epoch 不匹配时返回 `false` 且不产生任何副作用，调用方必须整体 no-op。
+    pub(crate) fn claim_unsubmitted_terminal_for_epoch(&self, target: u64) -> bool {
+        self.claim_unsubmitted_terminal_impl(Some(target))
+    }
+
+    fn claim_unsubmitted_terminal_impl(&self, expected_epoch: Option<u64>) -> bool {
         let _emission = self.emission.lock();
         let mut state = self.state.lock();
+        if expected_epoch.is_some_and(|epoch| state.turn_epoch != epoch) {
+            // 轮次已切换（目标轮已结束、新轮已 reserve）：不得认领新轮。
+            return false;
+        }
         if !state.active || state.submitted || state.terminal_emitted {
             return false;
         }
@@ -889,6 +908,23 @@ impl TurnLifecycle {
         true
     }
 
+    /// 带目标 epoch 的未提交认领 + 补发 `chat:done`：认领在 state 锁内与
+    /// `turn_epoch == target` 校验原子完成，目标轮已结束（新轮已 reserve）时
+    /// 返回 `false` 且无副作用，避免把新轮 reservation 误认领为 Interrupted。
+    pub(crate) fn emit_unsubmitted_interrupted_terminal_for_epoch(
+        &self,
+        app: &AppHandle,
+        session_id: &str,
+        target: u64,
+    ) -> bool {
+        if !self.claim_unsubmitted_terminal_for_epoch(target) {
+            return false;
+        }
+        emit_chat_terminal(app, session_id, TurnOutcomeStatus::Interrupted, None, false);
+        self.finish_terminal_emission();
+        true
+    }
+
     /// 标记「cancel 在 turn 已 submit 但尚未 TurnStarted 时发起」。
     ///
     /// 仅当 turn 处于 active、已 `submitted`、且 `turn_id` 仍为 None（TurnStarted
@@ -912,13 +948,29 @@ impl TurnLifecycle {
     /// 再 cancel 保证：即使 TurnStarted 在两步之间抵达转发器并消费了标记，
     /// 随后的 `cancel_current()` 也只是幂等 no-op（转发器已重新 cancel）。
     ///
+    /// **返回值**：`false` 表示 `state.turn_epoch != epoch`——generation 复查
+    /// 通过之后、arm 之前另一 worker 已结束目标轮并启动新轮（`reserve_turn`
+    /// 不取 `turn_lock`，可在 cancel 的同步段中间完成切换）。调用方**必须**
+    /// 在收到 `false` 时跳过 `cancel_current` 及其级联副作用，否则取消会命中
+    /// 新轮已 `reset_cancel_token` 的活跃 token，造成跨轮误取消。
+    ///
+    /// 其余条件不满足（未 submitted / 已 started / 非 active）时仍返回 `true`：
+    /// 这些情况 epoch 匹配、仍是目标轮，`cancel_current` 命中目标轮 token
+    /// （已 started 直接命中活跃 token；未 submitted 时 engine 尚无该轮 token，
+    /// 取消是幂等 no-op），调用方可以安全继续。
+    ///
     /// [`current_turn_generation`]: Self::current_turn_generation
     /// [`take_pending_cancel`]: Self::take_pending_cancel
-    pub(crate) fn arm_pending_cancel(&self, epoch: u64) {
+    pub(crate) fn arm_pending_cancel(&self, epoch: u64) -> bool {
         let mut state = self.state.lock();
-        if state.submitted && state.turn_id.is_none() && state.active && state.turn_epoch == epoch {
+        if state.turn_epoch != epoch {
+            // 轮次已切换（目标轮已结束、新轮已 reserve）：调用方必须跳过取消。
+            return false;
+        }
+        if state.submitted && state.turn_id.is_none() && state.active {
             state.pending_cancel = Some(epoch);
         }
+        true
     }
 
     /// 原子取出并清除 `pending_cancel` 标记。
@@ -3431,8 +3483,13 @@ mod turn_lifecycle_tests {
             .expect("turn2 active epoch");
         assert_eq!(epoch2, target + 1, "turn2 must bump the epoch past target");
 
-        // 用发起时快照 target arm：turn_epoch 已是 epoch2 != target → 拒绝。
-        lifecycle.arm_pending_cancel(target);
+        // 用发起时快照 target arm：turn_epoch 已是 epoch2 != target → 拒绝并
+        // 返回 false（reviewer 点 6：调用方据返回值跳过 cancel_current，否则
+        // 取消会命中新轮已 reset_cancel_token 的活跃 token）。
+        assert!(
+            !lifecycle.arm_pending_cancel(target),
+            "arm with the stale target snapshot must report epoch mismatch"
+        );
         assert!(
             lifecycle.take_pending_cancel(epoch2).is_none(),
             "arm with the stale target snapshot must not bind pending to the new turn"
@@ -3440,6 +3497,94 @@ mod turn_lifecycle_tests {
 
         // 防 Drop 副作用。
         reservation2.mark_submitted();
+    }
+
+    #[test]
+    fn arm_pending_cancel_reports_epoch_mismatch_and_arms_current() {
+        // reviewer 点 6 的原子边界：arm 在 state 锁内校验 turn_epoch == epoch。
+        // 轮次已切换 → 返回 false 且不置 pending（调用方必须跳过取消副作用）；
+        // epoch 匹配 → 返回 true 并正常 arm（submitted 未 started 时置 pending）。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // turn1：on_submitted 激活（active+submitted+epoch=1，turn_id=None）。
+        assert!(lifecycle.on_submitted());
+        let target = lifecycle
+            .current_turn_generation()
+            .expect("turn1 active epoch");
+
+        // 轮次切换：turn1 终态 → turn2 reserve + 提交（epoch=2）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+        lifecycle.mark_reservation_submitted(reservation2.reservation_id);
+        let epoch2 = lifecycle
+            .current_turn_generation()
+            .expect("turn2 active epoch");
+        assert_eq!(epoch2, target + 1, "turn2 must bump the epoch past target");
+
+        // stale target：拒绝 + pending 不落到新轮。
+        assert!(!lifecycle.arm_pending_cancel(target));
+        assert!(
+            lifecycle.take_pending_cancel(epoch2).is_none(),
+            "rejected arm must not set pending on the new turn"
+        );
+
+        // 当前 epoch：接受 + pending 置位（turn2 仍 submitted 未 started）。
+        assert!(lifecycle.arm_pending_cancel(epoch2));
+        assert!(
+            lifecycle.take_pending_cancel(epoch2).is_some(),
+            "accepted arm must set pending for the current turn"
+        );
+
+        // 防 Drop 副作用。
+        reservation2.mark_submitted();
+    }
+
+    #[test]
+    fn claim_unsubmitted_terminal_for_epoch_rejects_stale_target() {
+        // reviewer 点 7 的原子边界：未提交认领必须在 state 锁内与
+        // turn_epoch == target 同时校验。generation 检查与认领分离时，
+        // reserve_turn（不取 turn_lock）可在两者之间完成切轮，无 epoch 校验
+        // 的认领会把新轮 reservation 误认领为 Interrupted、清掉新轮 busy。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // turn1：reserve 未提交（epoch=1），cancel 阶段二走认领路径。
+        let reservation1 = lifecycle.reserve().expect("turn1 reserve");
+        let target = lifecycle
+            .current_turn_generation()
+            .expect("turn1 active epoch");
+        assert_eq!(target, 1);
+
+        // 模拟「generation 检查通过后、认领前」另一 worker 切轮：
+        // turn1 终态（未提交认领路径）→ turn2 reserve（epoch=2，未提交）。
+        assert!(lifecycle.finish_unsubmitted_once());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+        assert_eq!(
+            lifecycle.current_turn_generation(),
+            Some(target + 1),
+            "turn2 must bump the epoch past target"
+        );
+
+        // stale target 认领被拒：返回 false 且无副作用，turn2 完好。
+        assert!(
+            !lifecycle.claim_unsubmitted_terminal_for_epoch(target),
+            "claim with a stale target must no-op"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn unsubmitted reservation must survive a stale claim"
+        );
+
+        // 当前 epoch 认领成功：原子校验通过后正常认领，turn2 被失效。
+        assert!(lifecycle.claim_unsubmitted_terminal_for_epoch(target + 1));
+        assert!(
+            reservation2.ensure_active().is_err(),
+            "claimed reservation must be invalidated"
+        );
+        lifecycle.finish_terminal_emission();
+
+        // 防 Drop 副作用：turn1/turn2 均已认领终态（reservation 幂等）。
+        drop(reservation1);
+        drop(reservation2);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -3403,6 +3403,46 @@ mod turn_lifecycle_tests {
     }
 
     #[test]
+    fn arm_pending_cancel_uses_target_snapshot_not_reread_current() {
+        // reviewer 点 3 的确定性回归：cancel 在 generation 复查通过后 arm
+        // pending 时，必须使用发起时快照 target，而不是此刻重读的当前 epoch。
+        // 若重读 current：复查通过后、arm 前另一 worker 结束旧轮并启动新轮，
+        // 读到的是新轮 epoch，arm_pending_cancel(新epoch) 会把 pending 绑定到
+        // 新轮（新轮恰好处于 submitted 未 started 时），后面的 cancel_current
+        // 命中新 token → 原始跨轮误取消窗口仍未关闭。
+        //
+        // 这里直接编排「复查通过后轮次切换」：turn1 处于 submitted 未 started
+        // （arm 前置满足），快照 target=epoch1；切换 turn2 并提交后，用 target
+        // arm 必须被拒绝（turn_epoch 已 != target），pending 不落到新轮。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // turn1：on_submitted 激活（active+submitted+epoch=1，turn_id=None）。
+        assert!(lifecycle.on_submitted());
+        let target = lifecycle
+            .current_turn_generation()
+            .expect("turn1 active epoch");
+
+        // 复查通过后、arm 前轮次切换：turn1 终态 → turn2 reserve + 提交。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+        lifecycle.mark_reservation_submitted(reservation2.reservation_id);
+        let epoch2 = lifecycle
+            .current_turn_generation()
+            .expect("turn2 active epoch");
+        assert_eq!(epoch2, target + 1, "turn2 must bump the epoch past target");
+
+        // 用发起时快照 target arm：turn_epoch 已是 epoch2 != target → 拒绝。
+        lifecycle.arm_pending_cancel(target);
+        assert!(
+            lifecycle.take_pending_cancel(epoch2).is_none(),
+            "arm with the stale target snapshot must not bind pending to the new turn"
+        );
+
+        // 防 Drop 副作用。
+        reservation2.mark_submitted();
+    }
+
+    #[test]
     fn pending_cancel_does_not_leak_across_turns() {
         // 防跨轮污染：上一轮 arm 但未被消费的标记不能影响下一轮。
         // reserve() 必须清除 stale pending_cancel。

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -114,7 +114,7 @@ struct TurnLifecycleState {
     /// C2 在恢复后读到的是「当前 lifecycle」（可能已是新轮）。`take_pending_cancel`
     /// 会校验 epoch 仍是当前轮，跨轮泄漏的 stale pending 被丢弃，不误取消新轮。
     ///
-    /// [`arm_pending_cancel`]: TurnLifecycle::arm_pending_cancel
+    /// [`arm_pending_cancel`]: TurnLifecycle::arm_pending_cancel_and_cancel
     /// [`take_pending_cancel`]: TurnLifecycle::take_pending_cancel
     /// [`turn_epoch`]: TurnLifecycleState::turn_epoch
     pending_cancel: Option<u64>,
@@ -970,18 +970,7 @@ impl TurnLifecycle {
     ///
     /// [`current_turn_generation`]: Self::current_turn_generation
     /// [`take_pending_cancel`]: Self::take_pending_cancel
-    pub(crate) fn arm_pending_cancel(&self, epoch: u64) -> bool {
-        let mut state = self.state.lock();
-        if state.turn_epoch != epoch {
-            // 轮次已切换（目标轮已结束、新轮已 reserve）：调用方必须跳过取消。
-            return false;
-        }
-        if state.submitted && state.turn_id.is_none() && state.active {
-            state.pending_cancel = Some(epoch);
-        }
-        true
-    }
-
+    ///
     /// 在 lifecycle state 锁内原子完成「epoch 校验 + arm pending + 同步取消」。
     ///
     /// 与 [`arm_pending_cancel`] 的区别：`cancel` 闭包在**同一临界区内**持锁
@@ -993,6 +982,17 @@ impl TurnLifecycle {
     /// `reserve_turn`（取同一把 state 锁）无法插入「校验/arm」与「取消」之间，
     /// 跨轮窗口闭合。
     ///
+    /// **idle 守卫**（G2/epoch-0 哨兵）：`turn_epoch` 从 1 起自增，但 fresh
+    /// 会话（从未有过 turn）初始为 0。此时发起 cancel 快照 `target = None`，
+    /// 调用方以 `target.unwrap_or(0)` 传入后，`turn_epoch != epoch` 校验（0 != 0
+    /// 不成立）会通过——若 engine 已为「即将启动的定时轮」在场（`run_scheduled_turn`
+    /// 的 spawn→submit 窗口），执行 `cancel_current` 会命中该新 token，取消信号
+    /// 与 `reset_cancel_token` 竞速、结果不确定（定时轮被意外取消或停止丢失）。
+    /// 因此 epoch 匹配后仍需 `state.active || state.terminal_closing` 才执行
+    /// `cancel` 闭包：空闲（无活跃轮）时跳过取消（幂等 no-op），但返回 `true`
+    /// 让调用方继续（级联取消仍由调用方按 armed 路径执行，只取消 engine 遗留
+    /// 子代理、不取消尚未启动的轮）。
+    ///
     /// 锁序：本方法持 lifecycle state 锁调用 `cancel` 闭包，闭包内
     /// `engine.cancel_current()` 取 engine 的 cancel_token 锁（与 state 锁无
     /// 反向依赖，forwarder 消费 pending 也是先 state 后 token），无死锁。
@@ -1003,7 +1003,7 @@ impl TurnLifecycle {
     /// 满足时）并执行 `cancel` 后返回 `true`；epoch 不匹配返回 `false` 且
     /// **不执行** `cancel`，调用方必须整体 no-op。
     ///
-    /// [`arm_pending_cancel`]: Self::arm_pending_cancel
+    /// [`arm_pending_cancel`]: Self::arm_pending_cancel_and_cancel
     pub(crate) fn arm_pending_cancel_and_cancel<F>(&self, epoch: u64, cancel: F) -> bool
     where
         F: FnOnce(),
@@ -1012,6 +1012,14 @@ impl TurnLifecycle {
         if state.turn_epoch != epoch {
             // 轮次已切换（目标轮已结束、新轮已 reserve）：不 arm、不取消。
             return false;
+        }
+        if !state.active && !state.terminal_closing {
+            // idle（无活跃轮、非终态收口期）：target 快照为 None 时以 0 哨兵
+            // 传入，epoch 校验通过但并无可取消的轮。执行 cancel 会命中「即将
+            // 启动的定时轮」的新 token（G2）。跳过取消闭包、不 arm（idle 也
+            // 不满足 submitted 前置），但返回 true：调用方按 armed 路径继续，
+            // 级联取消只清 engine 遗留子代理，不误伤尚未启动的轮。
+            return true;
         }
         if state.submitted && state.turn_id.is_none() && state.active {
             state.pending_cancel = Some(epoch);
@@ -3421,7 +3429,7 @@ mod turn_lifecycle_tests {
         // reserve 后 active=true 但 submitted=false → arm 不得置位。
         let reservation = lifecycle.reserve().expect("reserve");
         let epoch = lifecycle.current_turn_generation().expect("active epoch");
-        lifecycle.arm_pending_cancel(epoch);
+        lifecycle.arm_pending_cancel_and_cancel(epoch, || {});
         assert!(
             lifecycle.take_pending_cancel(epoch).is_none(),
             "must not arm pending_cancel for an unsubmitted reservation"
@@ -3430,7 +3438,7 @@ mod turn_lifecycle_tests {
         // 走真实 send 路径：handle.send 成功后 mark_submitted → submitted=true。
         lifecycle.mark_reservation_submitted(reservation.reservation_id);
         // 已 submitted + active + turn_id=None（TurnStarted 未抵达）→ arm 置位。
-        lifecycle.arm_pending_cancel(epoch);
+        lifecycle.arm_pending_cancel_and_cancel(epoch, || {});
         assert!(
             lifecycle.take_pending_cancel(epoch).is_some(),
             "pending_cancel must be armed after submission, before TurnStarted"
@@ -3480,7 +3488,7 @@ mod turn_lifecycle_tests {
         // --- 场景 A：submit 后、TurnStarted 前 arm → take 返回 Some ---
         lifecycle.on_submitted();
         let epoch_a = lifecycle.current_turn_generation().expect("active epoch");
-        lifecycle.arm_pending_cancel(epoch_a);
+        lifecycle.arm_pending_cancel_and_cancel(epoch_a, || {});
         assert!(
             lifecycle.take_pending_cancel(epoch_a).is_some(),
             "pending_cancel must be armed before TurnStarted"
@@ -3494,7 +3502,7 @@ mod turn_lifecycle_tests {
         // --- 场景 B：TurnStarted 后 arm → 不置标记 ---
         lifecycle.on_started("turn-1".to_string());
         let epoch_b = lifecycle.current_turn_generation().expect("active epoch");
-        lifecycle.arm_pending_cancel(epoch_b);
+        lifecycle.arm_pending_cancel_and_cancel(epoch_b, || {});
         assert!(
             lifecycle.take_pending_cancel(epoch_b).is_none(),
             "must not arm pending_cancel after TurnStarted"
@@ -3537,7 +3545,7 @@ mod turn_lifecycle_tests {
         // 返回 false（reviewer 点 6：调用方据返回值跳过 cancel_current，否则
         // 取消会命中新轮已 reset_cancel_token 的活跃 token）。
         assert!(
-            !lifecycle.arm_pending_cancel(target),
+            !lifecycle.arm_pending_cancel_and_cancel(target, || {}),
             "arm with the stale target snapshot must report epoch mismatch"
         );
         assert!(
@@ -3572,14 +3580,14 @@ mod turn_lifecycle_tests {
         assert_eq!(epoch2, target + 1, "turn2 must bump the epoch past target");
 
         // stale target：拒绝 + pending 不落到新轮。
-        assert!(!lifecycle.arm_pending_cancel(target));
+        assert!(!lifecycle.arm_pending_cancel_and_cancel(target, || {}));
         assert!(
             lifecycle.take_pending_cancel(epoch2).is_none(),
             "rejected arm must not set pending on the new turn"
         );
 
         // 当前 epoch：接受 + pending 置位（turn2 仍 submitted 未 started）。
-        assert!(lifecycle.arm_pending_cancel(epoch2));
+        assert!(lifecycle.arm_pending_cancel_and_cancel(epoch2, || {}));
         assert!(
             lifecycle.take_pending_cancel(epoch2).is_some(),
             "accepted arm must set pending for the current turn"
@@ -3692,6 +3700,43 @@ mod turn_lifecycle_tests {
     }
 
     #[test]
+    fn arm_pending_cancel_and_cancel_skips_cancel_when_idle_epoch_zero() {
+        // G2/epoch-0 哨兵守卫：fresh 会话（从未有过 turn，turn_epoch==0）时
+        // 发起 cancel，调用方以 target.unwrap_or(0) 传入 0，`turn_epoch != 0`
+        // 校验会通过（0 == 0）。若 engine 已为「即将启动的定时轮」在场
+        // （run_scheduled_turn 的 spawn→submit 窗口），执行 cancel 闭包会命中
+        // 该新 token，取消信号与 reset_cancel_token 竞速、结果不确定。
+        // idle 守卫必须跳过取消闭包（返回 true 但不执行），且不 arm pending。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+        // fresh 会话：Default 的 TurnLifecycleState.turn_epoch == 0、active == false。
+        assert_eq!(
+            lifecycle.current_turn_generation(),
+            None,
+            "idle fresh session"
+        );
+
+        let cancel_ran = Arc::new(AtomicBool::new(false));
+        let probe = cancel_ran.clone();
+        // target=None 时调用方以 0 哨兵传入；epoch 匹配（0==0）但 idle →
+        // 不执行 cancel 闭包、返回 true（调用方按 armed 路径继续，只清遗留
+        // 子代理，不误伤尚未启动的定时轮）。
+        assert!(
+            lifecycle.arm_pending_cancel_and_cancel(0, move || {
+                probe.store(true, Ordering::Release);
+            }),
+            "idle must report success so the caller can continue (cascade only)"
+        );
+        assert!(
+            !cancel_ran.load(Ordering::Acquire),
+            "cancel closure must not run on an idle fresh session (epoch-0 sentinel)"
+        );
+        assert!(
+            lifecycle.take_pending_cancel(0).is_none(),
+            "idle must not arm pending_cancel"
+        );
+    }
+
+    #[test]
     fn claim_unsubmitted_terminal_for_epoch_rejects_stale_target() {
         // reviewer 点 7 的原子边界：未提交认领必须在 state 锁内与
         // turn_epoch == target 同时校验。generation 检查与认领分离时，
@@ -3747,7 +3792,7 @@ mod turn_lifecycle_tests {
 
         lifecycle.on_submitted();
         let epoch_prev = lifecycle.current_turn_generation().expect("active epoch");
-        lifecycle.arm_pending_cancel(epoch_prev);
+        lifecycle.arm_pending_cancel_and_cancel(epoch_prev, || {});
         // 模拟 turn 未正常 started 就结束（如 engine spawn 失败）。
         assert!(lifecycle.finish_once(|| {}).is_some());
 
@@ -3771,7 +3816,7 @@ mod turn_lifecycle_tests {
 
         // cancel 路径：arm_pending_cancel（turn_id 仍为 None → 置标记）。
         let epoch = lifecycle.current_turn_generation().expect("active epoch");
-        lifecycle.arm_pending_cancel(epoch);
+        lifecycle.arm_pending_cancel_and_cancel(epoch, || {});
 
         // Engine 执行 reset_cancel_token + 发 TurnStarted → 转发器先
         // on_started_transition（设 turn_id），再 take_pending_cancel。
@@ -3845,7 +3890,7 @@ mod turn_lifecycle_tests {
         // 旧轮：submit（epoch=1），arm pending_cancel 绑定到 epoch=1。
         lifecycle.on_submitted();
         let epoch_old = lifecycle.current_turn_generation().expect("old epoch");
-        lifecycle.arm_pending_cancel(epoch_old);
+        lifecycle.arm_pending_cancel_and_cancel(epoch_old, || {});
 
         // 结束旧轮，新一轮 reserve（epoch=2）。
         assert!(lifecycle.finish_once(|| {}).is_some());

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -417,6 +417,15 @@ impl TurnLifecycle {
         }
     }
 
+    /// 当前活动轮是否已提交（`SendMessage` 已入队 / `TurnStarted` 已抵达）。
+    /// 供 cancel 阶段二在 generation mismatch（新轮已 reserve）时判断新轮是否
+    /// 已经真正开始：仅 reserve 未 send 时，engine 里仍是旧轮遗留的子代理，
+    /// 补发级联取消（CancelSubAgents）不会误杀新轮刚启动的子代理（reviewer 点 9）。
+    pub(crate) fn is_current_turn_submitted(&self) -> bool {
+        let state = self.state.lock();
+        state.active && state.submitted
+    }
+
     pub(crate) fn reserve(self: &Arc<Self>) -> Result<TurnReservation> {
         let reservation_id = {
             let mut state = self.state.lock();

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -82,6 +82,20 @@ struct TurnLifecycleState {
     reclaimed: bool,
     admission_emitted: bool,
     next_reservation_id: u64,
+    /// 单调递增的轮次身份（turn generation）。每次 turn 从 idle 变 active
+    /// 时自增（[`reserve`](TurnLifecycle::reserve) / [`on_submitted`] /
+    /// [`on_started_transition`] 的 newly_active 分支），用于把 cancel 请求
+    /// 绑定到发起时刻的轮次：cancel 在取 `turn_lock` 前后比对 epoch，不匹配
+    /// 说明目标轮已结束（新一轮已 reserve），当前请求必须 no-op，避免跨轮
+    /// 误取消随后启动的新 turn。
+    ///
+    /// 不能复用 `next_reservation_id`：`on_submitted`（定时任务路径）与
+    /// `on_started_transition`（stale TurnStarted）激活 turn 时都不碰它，
+    /// 会让定时 turn 的 generation 恒为旧值。
+    ///
+    /// [`on_submitted`]: TurnLifecycle::on_submitted
+    /// [`on_started_transition`]: TurnLifecycle::on_started_transition
+    turn_epoch: u64,
     active_reservation_id: Option<u64>,
     transcript_rules: Vec<TranscriptSanitizationRule>,
     /// 用户在 turn 已 submit 但尚未收到 TurnStarted 时点了停止。
@@ -96,9 +110,14 @@ struct TurnLifecycleState {
     /// [`take_pending_cancel`] 原子取出并重新 `cancel_current()`——此时
     /// `reset_cancel_token()` 已经执行过，cancel 命中的是当前轮次的活跃 token。
     ///
+    /// 携带 arming 时的 [`turn_epoch`]：并发取消请求（C1/C2）中，排队较晚的
+    /// C2 在恢复后读到的是「当前 lifecycle」（可能已是新轮）。`take_pending_cancel`
+    /// 会校验 epoch 仍是当前轮，跨轮泄漏的 stale pending 被丢弃，不误取消新轮。
+    ///
     /// [`arm_pending_cancel`]: TurnLifecycle::arm_pending_cancel
     /// [`take_pending_cancel`]: TurnLifecycle::take_pending_cancel
-    pending_cancel: bool,
+    /// [`turn_epoch`]: TurnLifecycleState::turn_epoch
+    pending_cancel: Option<u64>,
 }
 
 /// The durable, user-visible meaning of a submitted engine operation.
@@ -385,6 +404,19 @@ impl TurnLifecycle {
         state.active || state.terminal_closing
     }
 
+    /// 当前活动轮的 turn generation（epoch），供 cancel 请求绑定发起时刻的
+    /// 轮次身份。与 [`is_active`](Self::is_active) 同口径：turn 活动期间
+    /// （`active` 或终态发送临界区 `terminal_closing`）返回 `Some(epoch)`，
+    /// 空闲返回 `None`。cancel 在取 `turn_lock` 前后各读一次，不匹配则 no-op。
+    pub(crate) fn current_turn_generation(&self) -> Option<u64> {
+        let state = self.state.lock();
+        if state.active || state.terminal_closing {
+            Some(state.turn_epoch)
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn reserve(self: &Arc<Self>) -> Result<TurnReservation> {
         let reservation_id = {
             let mut state = self.state.lock();
@@ -393,6 +425,7 @@ impl TurnLifecycle {
             }
             state.next_reservation_id = state.next_reservation_id.wrapping_add(1).max(1);
             let reservation_id = state.next_reservation_id;
+            state.turn_epoch = state.turn_epoch.wrapping_add(1).max(1);
             state.active = true;
             state.submitted = false;
             state.turn_id = None;
@@ -401,7 +434,7 @@ impl TurnLifecycle {
             state.reclaimed = false;
             state.admission_emitted = false;
             state.active_reservation_id = Some(reservation_id);
-            state.pending_cancel = false;
+            state.pending_cancel = None;
             reservation_id
         };
         Ok(TurnReservation::new(self.clone(), reservation_id))
@@ -582,6 +615,7 @@ impl TurnLifecycle {
     pub(crate) fn on_submitted(&self) -> bool {
         let mut state = self.state.lock();
         if !state.active && !state.terminal_closing {
+            state.turn_epoch = state.turn_epoch.wrapping_add(1).max(1);
             state.active = true;
             state.submitted = true;
             state.turn_id = None;
@@ -616,6 +650,10 @@ impl TurnLifecycle {
         let newly_active = !state.active;
         if newly_active {
             state.admission_emitted = false;
+            // forwarder 收到 stale/repeat TurnStarted 时可能从 idle 激活 turn
+            // （reserve/on_submitted 之外的第三个 active 入口）。同样推进 epoch
+            // 保证 cancel generation 严格单调，覆盖该边缘路径。
+            state.turn_epoch = state.turn_epoch.wrapping_add(1).max(1);
         }
         state.active = true;
         state.submitted = true;
@@ -725,6 +763,20 @@ impl TurnLifecycle {
     pub(crate) fn claim_terminal(&self) -> Option<EmittedTerminal> {
         self.claim_terminal_transition()
             .map(|transition| transition.terminal)
+    }
+
+    /// 测试专用：认领一个未提交 turn 的终态并立即重开闸门，等价于
+    /// `emit_unsubmitted_interrupted_terminal` 去掉发 `chat:done` 的副作用，
+    /// 供跨模块测试（engine_pool 的 cancel 并发测试）驱动 turn 收尾而无需 AppHandle。
+    /// 不发终态信号——这些测试只关心 lifecycle 状态机的轮次切换，不验证 emit。
+    #[cfg(test)]
+    pub(crate) fn finish_unsubmitted_once(&self) -> bool {
+        if self.claim_unsubmitted_terminal() {
+            self.finish_terminal_emission();
+            true
+        } else {
+            false
+        }
     }
 
     fn claim_terminal_with_admission(
@@ -840,7 +892,8 @@ impl TurnLifecycle {
     /// 标记「cancel 在 turn 已 submit 但尚未 TurnStarted 时发起」。
     ///
     /// 仅当 turn 处于 active、已 `submitted`、且 `turn_id` 仍为 None（TurnStarted
-    /// 未抵达）时设置 `pending_cancel`：
+    /// 未抵达）、且 `turn_epoch == epoch`（仍是发起 cancel 的那一轮）时设置
+    /// `pending_cancel = Some(epoch)`：
     /// - 必须 `submitted`：未提交的 reservation（消息尚未入队 engine）应由 cancel
     ///   走未提交认领终态路径（`emit_unsubmitted_interrupted_terminal`）立即发
     ///   `chat:done` 使 reservation 失效，而不是挂成 pending——否则空闲 engine 仍
@@ -848,15 +901,23 @@ impl TurnLifecycle {
     ///   前端 busy 在 cancel 后到 TurnStarted 之间无法复位。
     /// - 若 `turn_id` 已有值说明 TurnStarted 已被转发器消费，`cancel_current()`
     ///   直接命中当前活跃 token，无需补打。
+    /// - 必须 `turn_epoch == epoch`：并发取消请求（C1/C2）中，排队较晚的 C2 在
+    ///   持锁恢复后读到的是「当前 lifecycle」。cancel 已在取 `turn_lock` 前后比对
+    ///   过 epoch（见 [`current_turn_generation`]/cancel 路径），此处传入**当前**
+    ///   epoch 作二次锚定，确保 pending 只 arm 到目标轮，不跨轮泄漏到新轮的
+    ///   TurnStarted（forwarder 经 [`take_pending_cancel`] 校验 epoch 后才重放）。
     ///
     /// **调用顺序**：必须在 `cancel_current()` **之前**调用。两者取不同的锁
     /// （lifecycle state mutex vs cancel_token mutex），无法原子合并。先 arm
     /// 再 cancel 保证：即使 TurnStarted 在两步之间抵达转发器并消费了标记，
     /// 随后的 `cancel_current()` 也只是幂等 no-op（转发器已重新 cancel）。
-    pub(crate) fn arm_pending_cancel(&self) {
+    ///
+    /// [`current_turn_generation`]: Self::current_turn_generation
+    /// [`take_pending_cancel`]: Self::take_pending_cancel
+    pub(crate) fn arm_pending_cancel(&self, epoch: u64) {
         let mut state = self.state.lock();
-        if state.submitted && state.turn_id.is_none() && state.active {
-            state.pending_cancel = true;
+        if state.submitted && state.turn_id.is_none() && state.active && state.turn_epoch == epoch {
+            state.pending_cancel = Some(epoch);
         }
     }
 
@@ -865,9 +926,20 @@ impl TurnLifecycle {
     /// 由事件转发器在收到 `TurnStarted` 后调用：此时 CodeWhale 的
     /// `reset_cancel_token()` 已执行完毕（它在 `TurnStarted` 之前），
     /// 重新 `cancel_current()` 命中的正是本轮的活跃 token。
-    pub(crate) fn take_pending_cancel(&self) -> bool {
+    ///
+    /// 仅当记录的 epoch 仍是 `current_epoch`（仍是 arming 时的那一轮）时才取出
+    /// 并返回 `Some`，否则清空并返回 `None`：跨轮泄漏的 stale pending（cancel
+    /// arm 到旧轮后，新一轮 TurnStarted 先抵达）被丢弃，不误取消新轮。空闲时
+    /// `current_epoch` 由调用方传 0（epoch 自增从 1 起，恒不匹配）。
+    pub(crate) fn take_pending_cancel(&self, current_epoch: u64) -> Option<u64> {
         let mut state = self.state.lock();
-        std::mem::take(&mut state.pending_cancel)
+        match state.pending_cancel {
+            Some(epoch) if epoch == current_epoch => state.pending_cancel.take(),
+            _ => {
+                state.pending_cancel = None;
+                None
+            }
+        }
     }
 }
 
@@ -1758,11 +1830,16 @@ fn spawn_event_forwarder(
                     // 消费 pending_cancel（无论 admitted 与否，防止跨轮泄漏）。
                     // reset_cancel_token() 在 TurnStarted 之前已执行，若 cancel
                     // 在此之前 arm 了标记，现在重新 cancel 命中的是本轮活跃 token。
-                    let pending_cancel = turn_lifecycle.take_pending_cancel();
+                    //
+                    // 仅当 pending_cancel 记录的 epoch 仍是当前轮（emit_started_admission
+                    // 刚为该轮推进了 epoch）才取出重放；并发取消请求在旧轮 arm 的
+                    // stale pending 会被丢弃，不误取消新轮。
+                    let current_epoch = turn_lifecycle.current_turn_generation().unwrap_or(0);
+                    let pending_cancel = turn_lifecycle.take_pending_cancel(current_epoch);
                     if !admitted {
                         continue;
                     }
-                    if pending_cancel {
+                    if pending_cancel.is_some() {
                         approve_handle.cancel();
                     }
                     active_transcript_seen = false;
@@ -3241,18 +3318,19 @@ mod turn_lifecycle_tests {
 
         // reserve 后 active=true 但 submitted=false → arm 不得置位。
         let reservation = lifecycle.reserve().expect("reserve");
-        lifecycle.arm_pending_cancel();
+        let epoch = lifecycle.current_turn_generation().expect("active epoch");
+        lifecycle.arm_pending_cancel(epoch);
         assert!(
-            !lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch).is_none(),
             "must not arm pending_cancel for an unsubmitted reservation"
         );
 
         // 走真实 send 路径：handle.send 成功后 mark_submitted → submitted=true。
         lifecycle.mark_reservation_submitted(reservation.reservation_id);
         // 已 submitted + active + turn_id=None（TurnStarted 未抵达）→ arm 置位。
-        lifecycle.arm_pending_cancel();
+        lifecycle.arm_pending_cancel(epoch);
         assert!(
-            lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch).is_some(),
             "pending_cancel must be armed after submission, before TurnStarted"
         );
         // 消费 reservation 避免 Drop 副作用。
@@ -3297,24 +3375,26 @@ mod turn_lifecycle_tests {
         // 3. 已 started 的 turn 不 arm（cancel_current 直接命中活跃 token）。
         let lifecycle = Arc::new(TurnLifecycle::default());
 
-        // --- 场景 A：submit 后、TurnStarted 前 arm → take 返回 true ---
+        // --- 场景 A：submit 后、TurnStarted 前 arm → take 返回 Some ---
         lifecycle.on_submitted();
-        lifecycle.arm_pending_cancel();
+        let epoch_a = lifecycle.current_turn_generation().expect("active epoch");
+        lifecycle.arm_pending_cancel(epoch_a);
         assert!(
-            lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch_a).is_some(),
             "pending_cancel must be armed before TurnStarted"
         );
-        // take 已消费，再次取返回 false。
+        // take 已消费，再次取返回 None。
         assert!(
-            !lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch_a).is_none(),
             "pending_cancel must be consumed exactly once"
         );
 
         // --- 场景 B：TurnStarted 后 arm → 不置标记 ---
         lifecycle.on_started("turn-1".to_string());
-        lifecycle.arm_pending_cancel();
+        let epoch_b = lifecycle.current_turn_generation().expect("active epoch");
+        lifecycle.arm_pending_cancel(epoch_b);
         assert!(
-            !lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch_b).is_none(),
             "must not arm pending_cancel after TurnStarted"
         );
 
@@ -3329,14 +3409,16 @@ mod turn_lifecycle_tests {
         let lifecycle = Arc::new(TurnLifecycle::default());
 
         lifecycle.on_submitted();
-        lifecycle.arm_pending_cancel();
+        let epoch_prev = lifecycle.current_turn_generation().expect("active epoch");
+        lifecycle.arm_pending_cancel(epoch_prev);
         // 模拟 turn 未正常 started 就结束（如 engine spawn 失败）。
         assert!(lifecycle.finish_once(|| {}).is_some());
 
         // 新一轮 reserve 后，pending_cancel 必须被清除。
         let _reservation = lifecycle.reserve().expect("reserve");
+        let epoch_next = lifecycle.current_turn_generation().expect("active epoch");
         assert!(
-            !lifecycle.take_pending_cancel(),
+            lifecycle.take_pending_cancel(epoch_next).is_none(),
             "stale pending_cancel from previous turn must be cleared by reserve"
         );
     }
@@ -3351,20 +3433,96 @@ mod turn_lifecycle_tests {
         lifecycle.on_submitted();
 
         // cancel 路径：arm_pending_cancel（turn_id 仍为 None → 置标记）。
-        lifecycle.arm_pending_cancel();
+        let epoch = lifecycle.current_turn_generation().expect("active epoch");
+        lifecycle.arm_pending_cancel(epoch);
 
         // Engine 执行 reset_cancel_token + 发 TurnStarted → 转发器先
         // on_started_transition（设 turn_id），再 take_pending_cancel。
+        // 同一轮内 on_started 不 bump epoch（active 已 true），take 仍匹配。
         lifecycle.on_started("turn-reset".to_string());
-        let pending = lifecycle.take_pending_cancel();
+        let pending = lifecycle.take_pending_cancel(epoch);
         assert!(
-            pending,
+            pending.is_some(),
             "pending_cancel must survive until TurnStarted consumes it"
         );
 
         // 消费后标记清除，下一轮不受影响。
-        assert!(!lifecycle.take_pending_cancel());
+        assert!(lifecycle.take_pending_cancel(epoch).is_none());
         assert!(lifecycle.finish_once(|| {}).is_some());
+    }
+
+    #[test]
+    fn turn_epoch_advances_on_every_admission_path_and_survives_terminal() {
+        // turn_epoch 是 cancel generation 的身份来源，必须在三个 active 入口
+        // （reserve / on_submitted / on_started_transition newly_active）都单调
+        // 自增，且与 is_active() 同口径：终态发送临界区（terminal_closing）内
+        // 仍是本轮 epoch，finish 后才回 None。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // 空闲 → None。
+        assert_eq!(lifecycle.current_turn_generation(), None);
+
+        // reserve 推进到 epoch=1（reserve 后未 submitted，走未提交认领终态）。
+        let reservation = lifecycle.reserve().expect("reserve");
+        assert_eq!(lifecycle.current_turn_generation(), Some(1));
+
+        // 结束本轮（claim_unsubmitted 进入 terminal_closing 临界区，epoch 仍是 1）。
+        // claim 成功后 reservation 失效（ensure_active 失败），无需 mark_submitted。
+        assert!(lifecycle.claim_unsubmitted_terminal());
+        assert_eq!(
+            lifecycle.current_turn_generation(),
+            Some(1),
+            "terminal_closing 临界区内 generation 仍是本轮 epoch"
+        );
+        // finish 释放闸门后回到空闲 → None。
+        lifecycle.finish_terminal_emission();
+        drop(reservation);
+        assert_eq!(lifecycle.current_turn_generation(), None);
+
+        // finish 释放闸门后回到空闲 → None。
+        assert_eq!(lifecycle.current_turn_generation(), None);
+
+        // on_submitted（定时任务路径，非 reservation）推进到 epoch=2。
+        assert!(lifecycle.on_submitted());
+        assert_eq!(lifecycle.current_turn_generation(), Some(2));
+        assert!(lifecycle.finish_once(|| {}).is_some());
+
+        // on_started_transition 从 idle 激活（newly_active 分支）推进到 epoch=3。
+        assert!(lifecycle
+            .on_started_transition("turn-stale".to_string())
+            .is_some());
+        assert_eq!(lifecycle.current_turn_generation(), Some(3));
+        assert!(lifecycle.finish_once(|| {}).is_some());
+    }
+
+    #[test]
+    fn pending_cancel_tied_to_epoch_is_dropped_after_turn_change() {
+        // reviewer 点 4 的核心回归：并发取消请求 C2 在旧轮 arm 了 pending_cancel，
+        // 恢复时已变成新轮。pending_cancel 携带 epoch，take 时校验不匹配 → 丢弃，
+        // 不误取消新轮（不触发 approve_handle.cancel 重放）。
+        //
+        // 现有 pending_cancel_does_not_leak_across_turns 只测 reserve 清除，不覆盖
+        // 「新轮已 reserve 后 C2 才 arm」的窗口——此测试直接覆盖该缺口。
+        let lifecycle = Arc::new(TurnLifecycle::default());
+
+        // 旧轮：submit（epoch=1），arm pending_cancel 绑定到 epoch=1。
+        lifecycle.on_submitted();
+        let epoch_old = lifecycle.current_turn_generation().expect("old epoch");
+        lifecycle.arm_pending_cancel(epoch_old);
+
+        // 结束旧轮，新一轮 reserve（epoch=2）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let _reservation = lifecycle.reserve().expect("new turn");
+        let epoch_new = lifecycle.current_turn_generation().expect("new epoch");
+        assert_ne!(epoch_old, epoch_new);
+
+        // forwarder 在新轮 TurnStarted 后用新轮 epoch 取 pending_cancel：
+        // C2 留下的 stale pending（epoch_old）必须被丢弃，不重放 cancel。
+        assert_eq!(
+            lifecycle.take_pending_cancel(epoch_new),
+            None,
+            "stale pending_cancel bound to a previous epoch must be dropped, not replayed onto the new turn"
+        );
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -211,24 +211,40 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// 请求（C1/C2）中排队较晚的 C2 在 `turn_lock` 释放后会读到「当前 lifecycle」
 /// （可能已是新轮），无差别取消新轮。这里在两阶段各比对一次 epoch：
 ///
-/// - 阶段一（无锁 `cancel_engine`）前快照 `target`，与即时 `current` 比对；
+/// - 阶段一（无锁 `get_engine`）前快照 `target`，与即时 `current` 比对；
 /// - 阶段二（持 `turn_lock`）后再次比对，不匹配则在 `request_cancel` /
 ///   `claim_unsubmitted` / `arm_pending_cancel` / `cancel_engine` 全部之前
 ///   early-return，避免误取消新轮的 engine 与 shell scope。
 ///
-/// `cancel_engine` 闭包返回 `true` 表示已对在场 engine 触发取消；`false` 表示
-/// 无 engine（走未提交认领终态）。`claim_unsubmitted` 在「未提交 reservation」
-/// 时认领 Interrupted 终态并补发 `chat:done`，返回是否认领。
-async fn cancel_turn_with_gates<E, EFut, C>(
+/// **阶段一的 TOCTOU 防护**：`get_engine` 闭包内部有 await（`handle_for` 取
+/// entries 锁），await 期间旧轮可能结束、新轮可能 reserve 并
+/// `reset_cancel_token()`。因此 epoch 校验必须放在 `get_engine().await`
+/// **之后**、`cancel_current` **之前**（发起时的快照 `target` 与 await 后重读
+/// 的 `current` 比对，不匹配则整体 no-op）——不能先校验后 await 再取消，
+/// 否则 `cancel_current` 会命中新轮的活跃 token，阶段二发现不匹配也撤不回。
+///
+/// **arm 顺序约束**：每次 `cancel_current` 之前必须先 `arm_pending_cancel`
+/// （见 [`TurnLifecycle::arm_pending_cancel`] 文档）。若先 cancel 后 arm：
+/// cancel 命中旧 token → engine `reset_cancel_token()` 并发 TurnStarted →
+/// forwarder 因尚未 arm 不补 cancel → 此处再 arm 时 `turn_id` 已存在被拒，
+/// 停止请求丢失。先 arm 则 TurnStarted 在两步之间抵达时，forwarder 能
+/// `take_pending_cancel` 并重放 cancel（随后的 cancel 只是幂等 no-op）。
+///
+/// `get_engine` 返回在场 engine 句柄（`None` 表示无 engine，走未提交认领
+/// 终态）。`claim_unsubmitted` 在「未提交 reservation」时认领 Interrupted
+/// 终态并补发 `chat:done`，返回是否认领。
+async fn cancel_turn_with_gates<G, E, EFut, X, C>(
     turn_locks: &SessionTurnLocks,
     turn_lifecycles: &SessionTurnLifecycles,
     turn_shell_tasks: &SessionTurnShellTasks,
     session_id: &str,
-    mut cancel_engine: E,
+    mut get_engine: E,
+    mut cancel_current: X,
     claim_unsubmitted: C,
 ) where
     E: FnMut() -> EFut,
-    EFut: Future<Output = bool>,
+    EFut: Future<Output = Option<G>>,
+    X: FnMut(G),
     C: Fn(&Arc<TurnLifecycle>) -> bool,
 {
     // 阶段一：无锁先触发 cancel_token——仅在仍是发起时刻那一轮时才取消，
@@ -242,9 +258,24 @@ async fn cancel_turn_with_gates<E, EFut, C>(
             .get(session_id)
             .and_then(|lc| lc.current_turn_generation()),
     ) {
-        // 仅取一次副作用：cancel_engine 返回是否真取消了 engine。
-        // 这里忽略返回值——是否补未提交终态以持锁后的权威 lifecycle 为准。
-        let _ = cancel_engine().await;
+        // get_engine 内部有 await（handle_for 取 entries 锁），await 期间轮次
+        // 可能切换：必须在 await 之后、cancel 之前重新校验 epoch（TOCTOU）。
+        if let Some(engine) = get_engine().await {
+            if generation_matches(
+                target,
+                turn_lifecycles
+                    .get(session_id)
+                    .and_then(|lc| lc.current_turn_generation()),
+            ) {
+                // 先 arm 再 cancel：TurnStarted 在两步之间抵达转发器时，
+                // forwarder 能 take 到 pending 并重放 cancel，停止请求不丢失。
+                if let Some(lifecycle) = turn_lifecycles.get(session_id) {
+                    let epoch = lifecycle.current_turn_generation().unwrap_or(0);
+                    lifecycle.arm_pending_cancel(epoch);
+                }
+                cancel_current(engine);
+            }
+        }
     }
 
     // 阶段二：持锁清理 turn 状态与 shell 任务。
@@ -268,12 +299,22 @@ async fn cancel_turn_with_gates<E, EFut, C>(
     if !claimed_unsubmitted {
         // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
         // 幂等：阶段一已取消则再 cancel 是 no-op；阶段一未取消则这里补 cancel。
-        if cancel_engine().await {
-            if let Some(lifecycle) = lifecycle {
-                // arm 到当前 epoch（已校验仍是 target 轮），转发器在 TurnStarted
-                // 后 take_pending_cancel 时再次校验 epoch，跨轮 stale pending 被丢弃。
-                let epoch = lifecycle.current_turn_generation().unwrap_or(0);
-                lifecycle.arm_pending_cancel(epoch);
+        // 与阶段一同理：get_engine 的 await 之后重新校验 epoch，再先 arm 后 cancel。
+        if let Some(engine) = get_engine().await {
+            if generation_matches(
+                target,
+                turn_lifecycles
+                    .get(session_id)
+                    .and_then(|lc| lc.current_turn_generation()),
+            ) {
+                if let Some(lifecycle) = lifecycle.as_ref() {
+                    // arm 到当前 epoch（已校验仍是 target 轮），转发器在
+                    // TurnStarted 后 take_pending_cancel 时再次校验 epoch，
+                    // 跨轮 stale pending 被丢弃。
+                    let epoch = lifecycle.current_turn_generation().unwrap_or(0);
+                    lifecycle.arm_pending_cancel(epoch);
+                }
+                cancel_current(engine);
             }
         }
     }
@@ -1189,23 +1230,24 @@ impl EnginePool {
             &self.turn_lifecycles,
             &self.turn_shell_tasks,
             session_id,
-            // cancel_engine：取在场 engine 并 cancel_current，返回是否取消了 engine。
-            // 同时级联取消该 engine 的后台子智能体（multiagent，ADR-0006）：「停止」
-            // 按钮是子智能体唯一的确定性停止入口（卡片上没有取消按钮，自然语言指令
-            // 只是建议），只取消宿主轮会留下继续烧钱的后台子智能体。
+            // get_engine：取在场 engine 句柄（不取消，epoch 校验由
+            // cancel_turn_with_gates 在 await 之后、cancel 之前执行，消除
+            // handle_for 取 entries 锁期间的 TOCTOU 窗口）。
             // handle_for 只瞬时取 entries 锁（与 send 内部瞬时取 entries 锁不冲突），
-            // 不等 turn_lock——阶段一无锁先触发，turn_loop 的 biased select 立即跳出；
-            // 阶段二持锁复检 generation 后补 cancel + 级联（CancelSubAgents 幂等，
-            // 与 evict 路径 shutdown_cancel_cascade_ops 语义一致，双发无害）。
-            || async move {
-                if let Some(engine) = self.handle_for(session_id).await {
-                    engine.cancel_current();
-                    if let Err(e) = engine.handle.send(Op::CancelSubAgents).await {
-                        eprintln!("[engine_pool] cancel subagents {session_id} failed: {e:?}");
-                    }
-                    true
-                } else {
-                    false
+            // 不等 turn_lock——阶段一无锁先触发，turn_loop 的 biased select 立即跳出。
+            || async move { self.handle_for(session_id).await },
+            // cancel_current：对在场 engine 触发同步取消（幂等），并级联取消
+            // 该 engine 的后台子智能体（multiagent，ADR-0006）：「停止」按钮是子
+            // 智能体唯一的确定性停止入口（卡片上没有取消按钮，自然语言指令只是
+            // 建议），只取消宿主轮会留下继续烧钱的后台子智能体。
+            // try_send：cancel_current 是同步闭包（generation 守护要求 get_engine
+            // 与 cancel 之间不可有 await），ops 通道有界且此刻几乎不会满；即使
+            // 发送失败，引擎回收路径 shutdown_cancel_cascade_ops 仍会再发一次
+            // CancelSubAgents，双发无害（幂等）。
+            |engine| {
+                engine.cancel_current();
+                if let Err(e) = engine.handle.try_send(Op::CancelSubAgents) {
+                    eprintln!("[engine_pool] cancel subagents {session_id} failed: {e:?}");
                 }
             },
             // claim_unsubmitted：未提交 reservation 的认领终态路径（同步认领+发终态）。
@@ -2033,7 +2075,8 @@ mod scheduled_model_tests {
         let phase_one_count = Arc::new(AtomicU64::new(0));
         let probe2 = phase_two_cancel_called.clone();
         let probe1 = phase_one_count.clone();
-        // C2：阶段一无锁快照 target=Some(1) → 匹配 → cancel_engine（probe1++）；
+        // C2：阶段一无锁快照 target=Some(1) → 匹配 → get_engine 返回在场 engine
+        //     → 校验 epoch 仍匹配 → arm + cancel_current（probe1++）；
         //     阶段二持锁（被 blocker 阻塞），恢复后比对 current ≠ target → early return。
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2041,17 +2084,14 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                move || {
-                    let probe2 = probe2.clone();
-                    let probe1 = probe1.clone();
-                    async move {
-                        // 阶段一与阶段二复查都走这里：用计数区分。
-                        // 阶段一（turn1）probe1 0→1；阶段二若误执行 probe2 置位。
-                        let prev = probe1.fetch_add(1, Ordering::AcqRel);
-                        if prev >= 1 {
-                            probe2.store(true, Ordering::Release);
-                        }
-                        true
+                // get_engine：engine 在场（阶段一与阶段二复查都返回 Some）。
+                || async { Some(()) },
+                // cancel_current：阶段一与阶段二复查都走这里：用计数区分。
+                // 阶段一（turn1）probe1 0→1；阶段二若误执行 probe2 置位。
+                move |_engine| {
+                    let prev = probe1.fetch_add(1, Ordering::AcqRel);
+                    if prev >= 1 {
+                        probe2.store(true, Ordering::Release);
                     }
                 },
                 // claim_unsubmitted 不应被调用（turn1 已 submitted）。
@@ -2110,18 +2150,17 @@ mod scheduled_model_tests {
             &lifecycles,
             &shell_tasks,
             sid,
-            move || {
-                let probe = probe.clone();
-                async move {
-                    probe.store(true, Ordering::Release);
-                    true
-                }
+            // get_engine：engine 在场。
+            || async { Some(()) },
+            // cancel_current：记录触发。
+            move |_engine| {
+                probe.store(true, Ordering::Release);
             },
             |_lc| false,
         )
         .await;
 
-        // target=Some(2)=current → 匹配 → cancel_engine 触发。
+        // target=Some(2)=current → 匹配 → get_engine 返回 Some → cancel_current 触发。
         assert!(
             cancel_called.load(Ordering::Acquire),
             "a fresh cancel on the current turn must still cancel its engine"
@@ -2151,8 +2190,10 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                // engine 不在场 → 返回 false → 走 claim_unsubmitted 分支。
-                || async { false },
+                // engine 不在场 → get_engine 返回 None → 不取消，走 claim_unsubmitted 分支。
+                || async { None::<()> },
+                // cancel_current：engine 不在场时不应被调用。
+                |_engine: ()| {},
                 move |lc| {
                     probe.store(true, Ordering::Release);
                     // 复用真实的未提交认领路径以观察副作用。
@@ -2179,6 +2220,136 @@ mod scheduled_model_tests {
         assert!(
             reservation2.ensure_active().is_ok(),
             "new turn unsubmitted reservation must survive a stale cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_during_phase_one_engine_lookup_leaves_new_turn_intact() {
+        // reviewer 点 1（阶段一 TOCTOU）的确定性回归：generation 校验不能只
+        // 发生在 `get_engine().await` **之前**——`get_engine` 内部有 await
+        // （`handle_for` 取 entries 锁），await 期间旧轮可能结束、新轮可能
+        // reserve 并 `reset_cancel_token()`，随后 `cancel_current()` 会命中
+        // 新轮的活跃 token，阶段二发现 epoch 不匹配也撤不回已发生的取消。
+        //
+        // 这里把轮次切换安排在阶段一的 `get_engine` await **期间**（原测试
+        // `stale_cancel_after_turn_change_leaves_new_turn_intact` 只覆盖了
+        // 阶段一完成之后的切换，漏掉此窗口）：get_engine 探针挂起在一个
+        // oneshot 上模拟取 entries 锁的等待，主线程在此期间推进 turn1 终态 +
+        // turn2 reserve，再放行 get_engine → 阶段一 await 后重新校验 epoch
+        // 发现不匹配 → 不 cancel；阶段二同样 early-return，turn2 完好。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-phase1-toctou";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：on_submitted 激活（active+submitted+epoch=1）。
+        assert!(lifecycle.on_submitted());
+
+        // 用 Notify 协调：探针先通知「已进入 get_engine 的 await」，挂起等待
+        // release；主线程收到 entered 后推进轮次，再放行探针。
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        // 主线程侧副本（spawn 的 async move 会把原件移入任务）。
+        let entered_main = entered.clone();
+        let release_main = release.clone();
+        let cancel_called = Arc::new(AtomicBool::new(false));
+        let probe = cancel_called.clone();
+
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                // get_engine：通知已进入后挂起（模拟 handle_for 取 entries 锁的
+                // await）；放行后返回「engine 在场」。
+                move || {
+                    let entered = entered.clone();
+                    let release = release.clone();
+                    async move {
+                        entered.notify_waiters();
+                        release.notified().await;
+                        Some(())
+                    }
+                },
+                // cancel_current：不应被调用（阶段一 await 后 epoch 不匹配）。
+                move |_engine: ()| {
+                    probe.store(true, Ordering::Release);
+                },
+                |_lc| false,
+            )
+            .await
+        });
+        // 等 C2 阶段一进入 get_engine 的 await（即拿到 entries 锁前的挂起点）。
+        entered_main.notified().await;
+
+        // 在 await 窗口内切换轮次：turn1 终态（submitted → claim 路径）→ turn2 reserve。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        // 放行 get_engine：阶段一 await 后重新校验 epoch → target=Some(1) ≠ current=Some(2)
+        // → 不 cancel；阶段二同样 early-return。
+        release_main.notify_waiters();
+        cancel_task.await.expect("cancel task joins");
+
+        assert!(
+            !cancel_called.load(Ordering::Acquire),
+            "phase one must not cancel the new turn when the turn switched during the engine lookup await"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn reservation must remain valid after a phase-one TOCTOU"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_cancel_is_armed_before_cancel_current_in_phase_two() {
+        // reviewer 点 2 的确定性回归：阶段二必须先 `arm_pending_cancel` 再
+        // `cancel_current`。若顺序颠倒（先 cancel 后 arm）：
+        //   cancel 命中旧 token → engine reset_cancel_token + TurnStarted →
+        //   forwarder 因尚未 arm 不补 cancel → 此处再 arm 时 `turn_id` 已存在
+        //   被拒 → 停止请求丢失。
+        //
+        // 这里让 get_engine 在场、turn 处于「submitted 未 started」，并在
+        // cancel_current 探针里消费 pending_cancel：若实现先 arm 后 cancel，
+        // 探针能取到 Some(epoch)（模拟 forwarder 在 TurnStarted 时补 cancel）；
+        // 若实现先 cancel 后 arm，探针取到 None，停止请求丢失可被确定性捕获。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-arm-order";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn：on_submitted 激活（submitted 未 started，turn_id 仍为 None，
+        // epoch=1）——arm_pending_cancel 的前置条件满足。
+        assert!(lifecycle.on_submitted());
+
+        let pending_seen_at_cancel = Arc::new(AtomicBool::new(false));
+        let probe = pending_seen_at_cancel.clone();
+        let probe_lifecycle = lifecycle.clone();
+        cancel_turn_with_gates(
+            &locks,
+            &lifecycles,
+            &shell_tasks,
+            sid,
+            // get_engine：engine 在场。
+            || async { Some(()) },
+            // cancel_current 探针：模拟 forwarder 在 TurnStarted 时消费 pending。
+            // 阶段一与阶段二都走这里；只要任一时刻 pending 已 arm 即证明顺序正确。
+            move |_engine: ()| {
+                let epoch = probe_lifecycle.current_turn_generation().unwrap_or(0);
+                if probe_lifecycle.take_pending_cancel(epoch).is_some() {
+                    probe.store(true, Ordering::Release);
+                }
+            },
+            |_lc| false,
+        )
+        .await;
+
+        assert!(
+            pending_seen_at_cancel.load(Ordering::Acquire),
+            "pending_cancel must be armed before cancel_current so a TurnStarted between them can be replayed"
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -202,6 +202,17 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
     }
 }
 
+/// 级联取消补发的守卫：mismatch 后是否仍可安全补发 `CancelSubAgents`。
+///
+/// 新轮尚未提交（`SendMessage` 需等同一把 `turn_lock`，cancel 持锁期间 engine
+/// 里仍是旧轮遗留子代理）或当前空闲时补发不会命中新轮刚启动的子代理；新轮已
+/// 提交（`submitted=true`）则 engine 可能已启动新轮子代理，补发会误杀，必须
+/// 跳过。所有 mismatch 发现点（入口复查 / `get_engine` await 后复查 / arm 被拒）
+/// 统一用本谓词，保证补发路径在 G1 漏发点（`get_engine` await 后切轮）同样生效。
+fn should_retry_cascade(lifecycle: Option<&TurnLifecycle>) -> bool {
+    !lifecycle.is_some_and(|lc| lc.is_current_turn_submitted())
+}
+
 /// 取消逻辑的可测主体，从 [`EnginePool::cancel`] 抽出以便用裸 Default 组件
 /// （`SessionTurnLocks` / `SessionTurnLifecycles` / `SessionTurnShellTasks`）+
 /// 闭包注入确定性测试，绕开 `Pinvou3Bridge::boot` / `AppHandle` / 真实
@@ -254,21 +265,24 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// 级联取消不会误杀新轮刚启动的子智能体（reviewer 点 4：spawn 异步发送
 /// 失去相对下一轮 SendMessage 的入队顺序保证）。
 ///
-/// **级联取消送达守护**（reviewer 点 9）：phase 1 的 best-effort `try_send`
-/// 在 ops 通道满（容量 32）时可能失败且被静默忽略，`CancelSubAgents` 从未
-/// 入队。若随后旧轮结束、新轮在 phase 2 取得 turn gate 前完成 `reserve`，
+/// **级联取消送达守护**（reviewer 点 9 + G1 补发收敛）：phase 1 的 best-effort
+/// `try_send` 在 ops 通道满（容量 32）时可能失败且被静默忽略，`CancelSubAgents`
+/// 从未入队。若随后旧轮结束、新轮在 phase 2 取得 turn gate 前完成 `reserve`，
 /// 阶段二会因 generation mismatch 直接 return，`cascade_cancel` 永不执行——
-/// 旧轮派生的 detached 子代理继续运行。为此 `cascade_queued` 记录 phase 1
-/// 级联取消是否已成功入队（调用方在 `cancel_current` 闭包内 set）：mismatch
-/// 分支在 return 前，若 phase 1 未送达且新轮尚未提交（仅 reserve 未 send，
-/// `SendMessage` 需等同一把 `turn_lock`，engine 里仍是旧轮遗留子代理）或
-/// 当前空闲，则持锁补发一次 `cascade_cancel`，不会命中新轮子代理。
+/// 旧轮派生的 detached 子代理继续运行。因此**所有** mismatch 发现点（入口
+/// 复查 L330、`get_engine` await 后复查、`arm_pending_cancel_and_cancel` 返回
+/// false）统一按 [`should_retry_cascade`] 判定：新轮尚未提交（仅 reserve 未
+/// send，`SendMessage` 需等同一把 `turn_lock`，engine 里仍是旧轮遗留子代理）
+/// 或当前空闲时持锁补发一次 `cascade_cancel`，不会命中新轮子代理。不再需要
+/// `cascade_queued` 标志：`CancelSubAgents` 幂等，phase 1 已入队时再补发一次
+/// 是 no-op（简化③）。
+///
+/// [`should_retry_cascade`]: fn@should_retry_cascade
 async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
     turn_locks: &SessionTurnLocks,
     turn_lifecycles: &SessionTurnLifecycles,
     turn_shell_tasks: &SessionTurnShellTasks,
     session_id: &str,
-    cascade_queued: &AtomicBool,
     mut get_engine: E,
     mut cancel_current: X,
     mut cascade_cancel: F,
@@ -286,35 +300,30 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
     let target = turn_lifecycles
         .get(session_id)
         .and_then(|lc| lc.current_turn_generation());
-    if generation_matches(
-        target,
-        turn_lifecycles
-            .get(session_id)
-            .and_then(|lc| lc.current_turn_generation()),
-    ) {
+    // 精简①：前置校验可省——get_engine 不产生副作用，await 后的复查 +
+    // arm_pending_cancel_and_cancel 的锁内原子校验已闭合同一 TOCTOU 窗口，
+    // 前置仅多一次 entries 锁读。
+    if let Some(engine) = get_engine().await {
         // get_engine 内部有 await（handle_for 取 entries 锁），await 期间轮次
         // 可能切换：必须在 await 之后、cancel 之前重新校验 epoch（TOCTOU）。
-        if let Some(engine) = get_engine().await {
-            if generation_matches(
-                target,
-                turn_lifecycles
-                    .get(session_id)
-                    .and_then(|lc| lc.current_turn_generation()),
-            ) {
-                // 先 arm 再 cancel，且二者在同一 state 锁临界区内原子完成：
-                // arm_pending_cancel_and_cancel 持锁校验 turn_epoch == target、
-                // 设置 pending（条件满足时）、并执行 cancel_current——reserve_turn
-                // 需要同一把 state 锁，无法在「校验/arm」与「取消」之间插入轮次
-                // 切换，旧 cancel 不会命中新轮已 reset_cancel_token 的活跃 token
-                // （reviewer 点 8）。epoch 不匹配时返回 false 且不执行取消闭包，
-                // 阶段二持锁复查 generation 会整体 no-op（reviewer 点 6）。
-                if let Some(lifecycle) = turn_lifecycles.get(session_id) {
-                    lifecycle.arm_pending_cancel_and_cancel(target.unwrap_or(0), || {
-                        cancel_current(&engine)
-                    });
-                } else {
-                    cancel_current(&engine);
-                }
+        if generation_matches(
+            target,
+            turn_lifecycles
+                .get(session_id)
+                .and_then(|lc| lc.current_turn_generation()),
+        ) {
+            // 先 arm 再 cancel，且二者在同一 state 锁临界区内原子完成：
+            // arm_pending_cancel_and_cancel 持锁校验 turn_epoch == target、
+            // 设置 pending（条件满足时）、并执行 cancel_current——reserve_turn
+            // 需要同一把 state 锁，无法在「校验/arm」与「取消」之间插入轮次
+            // 切换，旧 cancel 不会命中新轮已 reset_cancel_token 的活跃 token
+            // （reviewer 点 8）。epoch 不匹配时返回 false 且不执行取消闭包，
+            // 阶段二持锁复查 generation 会整体 no-op（reviewer 点 6）。
+            if let Some(lifecycle) = turn_lifecycles.get(session_id) {
+                lifecycle
+                    .arm_pending_cancel_and_cancel(target.unwrap_or(0), || cancel_current(&engine));
+            } else {
+                cancel_current(&engine);
             }
         }
     }
@@ -332,16 +341,13 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
         // request_cancel / claim_unsubmitted / cancel_engine 之前——request_cancel
         // 会取消当前 active shell scope，若已是新轮会误清理新轮的 shell 任务。
         //
-        // 例外（reviewer 点 9）：phase 1 的 best-effort try_send 若因 ops 通道满
-        // 而未送达（cascade_queued == false），旧轮派生的 detached 子代理未被
-        // 取消。此时若新轮尚未提交（仅 reserve 未 send：SendMessage 需等同一把
-        // turn_lock、被本函数持有，engine 里仍是旧轮遗留子代理）或当前空闲，
-        // 持锁补发一次级联取消是安全的——不会命中新轮刚启动的子代理。
-        if !cascade_queued.load(Ordering::Acquire)
-            && !lifecycle
-                .as_ref()
-                .is_some_and(|lc| lc.is_current_turn_submitted())
-        {
+        // 例外（reviewer 点 9 + G1）：phase 1 的 best-effort try_send 若因 ops
+        // 通道满而未送达，旧轮派生的 detached 子代理未被取消。此时若新轮尚未
+        // 提交（仅 reserve 未 send：SendMessage 需等同一把 turn_lock、被本函数
+        // 持有，engine 里仍是旧轮遗留子代理）或当前空闲，持锁补发一次级联取消
+        // 是安全的——不会命中新轮刚启动的子代理。幂等：phase 1 已入队时再补发
+        // 一次是 no-op（简化③，无需 cascade_queued 标志）。
+        if should_retry_cascade(lifecycle.as_deref()) {
             if let Some(engine) = get_engine().await {
                 cascade_cancel(&engine).await;
             }
@@ -386,6 +392,13 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                         // 下一轮 SendMessage 需等同一把 turn_lock，级联取消必先入队，
                         // FIFO 保证 engine 先取消旧轮子智能体、后启动新轮。
                         cascade_cancel(&engine).await;
+                    } else if should_retry_cascade(Some(lifecycle.as_ref())) {
+                        // G1 漏发点：arm 被拒 = 复查通过后轮次已切换。phase-1 的
+                        // best-effort try_send 若未送达（通道满）且新轮尚未提交
+                        // （engine 里仍是旧轮遗留子代理），补发级联取消，避免
+                        // 旧轮 detached 子代理继续运行（与入口 mismatch 分支同一
+                        // 谓词，见 should_retry_cascade）。
+                        cascade_cancel(&engine).await;
                     }
                     // 被拒：轮次已切换，不得取消新轮 engine / 子智能体。
                 } else {
@@ -394,6 +407,12 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                     // CancelSubAgents 针对的是 engine 当前子智能体，空闲 engine
                     // 上没有活跃子智能体，不发也无损（保持原行为）。
                 }
+            } else if should_retry_cascade(lifecycle.as_deref()) {
+                // G1 漏发点：get_engine await 之后复查 mismatch（T2 在 await 期间
+                // reserve）。phase-1 的 try_send 若未送达且新轮尚未提交，补发级联
+                // 取消——入口 mismatch 分支的补发在此发现点不会被评估，必须单独
+                // 补上（reviewer 点 9 的同类窗口）。
+                cascade_cancel(&engine).await;
             }
         }
     }
@@ -1304,17 +1323,11 @@ impl EnginePool {
         // 时刻的轮次 epoch，并发请求中排队较晚的 C2 在 turn_lock 释放后若发现
         // 目标轮已结束（新轮已 reserve），整体 no-op，不误取消新轮。
         let app = &self.app;
-        // phase 1 的 best-effort try_send 级联取消是否已成功入队（ops 通道满时
-        // 可能失败）。阶段二 generation mismatch 时据此决定是否持锁补发级联
-        // 取消（reviewer 点 9）——旧轮派生的 detached 子代理不能被静默丢弃。
-        let cascade_queued = Arc::new(AtomicBool::new(false));
-        let cascade_flag = cascade_queued.clone();
         cancel_turn_with_gates(
             &self.turn_locks,
             &self.turn_lifecycles,
             &self.turn_shell_tasks,
             session_id,
-            &cascade_queued,
             // get_engine：取在场 engine 句柄（不取消，epoch 校验由
             // cancel_turn_with_gates 在 await 之后、cancel 之前执行，消除
             // handle_for 取 entries 锁期间的 TOCTOU 窗口）。
@@ -1327,13 +1340,10 @@ impl EnginePool {
             // 没有取消按钮，自然语言指令只是建议），只取消宿主轮会留下继续
             // 烧钱的后台子智能体。try_send 不阻塞、通道有空位时立即入队
             // （早于下一轮 SendMessage）；通道满（容量 32）时放弃，由阶段二
-            // cascade_cancel 持锁 await 补发保证送达；mismatch 分支据
-            // cascade_queued 决定是否补发（reviewer 点 9）。
+            // 及 mismatch 补发路径持锁 await 保证送达（reviewer 点 9 + G1）。
             |engine| {
                 engine.cancel_current();
-                if engine.handle.try_send(Op::CancelSubAgents).is_ok() {
-                    cascade_flag.store(true, Ordering::Release);
-                }
+                let _ = engine.handle.try_send(Op::CancelSubAgents);
             },
             // cascade_cancel：阶段二持 turn_lock 时 await 发送级联取消，保证在
             // 释放 turn gate 前完成入队——下一轮 SendMessage 必须等同一把
@@ -2186,7 +2196,6 @@ mod scheduled_model_tests {
         let probe_cascade = cascade_called.clone();
         // phase 1 级联取消视为已成功入队（本测试不覆盖 reviewer 点 9 的
         // try_send 失败场景；保持 mismatch early-return 的既有断言语义）。
-        let cascade_queued = AtomicBool::new(true);
         // C2：阶段一无锁快照 target=Some(1) → 匹配 → get_engine 返回在场 engine
         //     → 校验 epoch 仍匹配 → arm + cancel_current（probe1++）；
         //     阶段二持锁（被 blocker 阻塞），恢复后比对 current ≠ target → early return。
@@ -2196,7 +2205,6 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                &cascade_queued,
                 // get_engine：engine 在场（阶段一与阶段二复查都返回 Some）。
                 || async { Some(()) },
                 // cancel_current：阶段一与阶段二复查都走这里：用计数区分。
@@ -2240,9 +2248,13 @@ mod scheduled_model_tests {
             !phase_two_cancel_called.load(Ordering::Acquire),
             "phase two must not cancel the engine of a turn that started after the cancel was issued"
         );
+        // 简化③后（删 cascade_queued）：新轮仅 reserve 未提交时，mismatch 分支
+        // 按 should_retry_cascade 补发级联——engine 里仍是旧轮遗留子代理
+        // （SendMessage 需等同一把 turn_lock、被本函数持有），补发只取消旧轮
+        // 子代理、不命中新轮（submitted=false）。CancelSubAgents 幂等，安全。
         assert!(
-            !cascade_called.load(Ordering::Acquire),
-            "a stale cancel must not cascade-cancel subagents of a turn that started after the cancel was issued"
+            cascade_called.load(Ordering::Acquire),
+            "stale cancel must still cascade old subagents when the new turn is only reserved (not submitted)"
         );
         assert!(
             reservation2.ensure_active().is_ok(),
@@ -2271,13 +2283,11 @@ mod scheduled_model_tests {
         let cascade_called = Arc::new(AtomicBool::new(false));
         let probe_cascade = cascade_called.clone();
         // phase 1 级联取消视为已成功入队（本测试不覆盖 reviewer 点 9 场景）。
-        let cascade_queued = AtomicBool::new(true);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
-            &cascade_queued,
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current：记录触发。
@@ -2308,12 +2318,13 @@ mod scheduled_model_tests {
     #[tokio::test]
     async fn stale_cancel_retries_cascade_when_phase_one_try_send_failed() {
         // reviewer 点 9 的确定性回归：phase 1 的 best-effort try_send 因 ops
-        // 通道满（容量 32）而失败时（cascade_queued == false），CancelSubAgents
-        // 从未入队；若随后旧轮结束、新轮在 phase 2 取得 turn gate 前完成
-        // reserve，阶段二 generation mismatch 直接 return 会让级联取消永久丢失，
-        // 旧轮派生的 detached 子代理继续运行。修复后 mismatch 分支必须在
-        // 新轮尚未提交（仅 reserve 未 send——SendMessage 需等同一把 turn_lock、
-        // 被本函数持有，engine 里仍是旧轮遗留子代理）时持锁补发一次 cascade。
+        // 通道满（容量 32）而失败时，CancelSubAgents 从未入队；若随后旧轮结束、
+        // 新轮在 phase 2 取得 turn gate 前完成 reserve，阶段二 generation
+        // mismatch 直接 return 会让级联取消永久丢失，旧轮派生的 detached 子代理
+        // 继续运行。修复后 mismatch 分支必须在新轮尚未提交（仅 reserve 未
+        // send——SendMessage 需等同一把 turn_lock、被本函数持有，engine 里仍是
+        // 旧轮遗留子代理）时持锁补发一次 cascade（简化③后不再区分 try_send
+        // 是否失败，按 should_retry_cascade 统一补发，幂等无害）。
         let locks = SessionTurnLocks::default();
         let lifecycles = SessionTurnLifecycles::default();
         let shell_tasks = SessionTurnShellTasks::default();
@@ -2330,8 +2341,8 @@ mod scheduled_model_tests {
         let probe_cascade = cascade_called.clone();
         let cancel_called = Arc::new(AtomicBool::new(false));
         let probe_cancel = cancel_called.clone();
-        // phase 1 的 try_send 失败（ops 通道满）：cascade_queued 保持 false。
-        let cascade_queued = AtomicBool::new(false);
+        // phase 1 的 try_send 失败（ops 通道满）：补发路径不依赖失败记录，
+        // 由 should_retry_cascade（新轮未提交）统一判定。
 
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2339,15 +2350,14 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                &cascade_queued,
                 // get_engine：engine 在场（阶段一与补发复查都返回 Some）。
                 || async { Some(()) },
                 // cancel_current：阶段一执行一次（取消旧轮）。
                 move |_engine: &()| {
                     probe_cancel.store(true, Ordering::Release);
                 },
-                // cascade_cancel：phase 1 送达失败 + 新轮未提交 → mismatch 分支
-                // 必须补发，不能因 generation mismatch 直接丢弃级联取消。
+                // cascade_cancel：新轮未提交 → mismatch 分支必须补发，不能因
+                // generation mismatch 直接丢弃级联取消。
                 move |_engine: &()| {
                     probe_cascade.store(true, Ordering::Release);
                     async {}
@@ -2366,7 +2376,7 @@ mod scheduled_model_tests {
         let reservation2 = lifecycle.reserve().expect("turn2 reserve");
 
         // 释放 turn_lock：阶段二恢复，current=Some(2) ≠ target=Some(1) → mismatch
-        // → cascade_queued==false 且新轮未提交 → 补发级联取消。
+        // → should_retry_cascade（新轮未提交）→ 补发级联取消。
         drop(blocker);
         drop(gate);
         cancel_task.await.expect("cancel task joins");
@@ -2407,7 +2417,6 @@ mod scheduled_model_tests {
         let probe_cascade = cascade_called.clone();
         let cancel_called = Arc::new(AtomicBool::new(false));
         let probe_cancel = cancel_called.clone();
-        let cascade_queued = AtomicBool::new(false);
 
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2415,7 +2424,6 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                &cascade_queued,
                 || async { Some(()) },
                 move |_engine: &()| {
                     probe_cancel.store(true, Ordering::Release);
@@ -2453,6 +2461,112 @@ mod scheduled_model_tests {
     }
 
     #[tokio::test]
+    async fn stale_cancel_retries_cascade_when_mismatch_surfaces_after_phase_two_engine_lookup() {
+        // G1 的确定性回归：mismatch 首次在**阶段二 get_engine await 之后**的
+        // 复查（而非入口复查）被发现时，级联补发必须仍然执行。
+        //
+        // 旧实现只在阶段二入口 mismatch 分支补发；若入口复查仍匹配（T1 仍
+        // active，current_turn_generation 报 Some(T1)）、claim no-op（T1 已
+        // submitted）、随后 get_engine().await 期间 T2 reserve，后置复查
+        // mismatch 会直接跳过——phase-1 的 best-effort try_send 失败时旧轮
+        // detached 子代理被静默丢弃。
+        //
+        // 修复：get_engine await 后复查 mismatch 处，与入口 mismatch 分支共用
+        // should_retry_cascade 谓词补发级联。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-g1-mismatch-after-engine-lookup";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：on_submitted 激活（active+submitted+epoch=1）。
+        assert!(lifecycle.on_submitted());
+        let target = lifecycle.current_turn_generation().expect("turn1 epoch");
+        assert_eq!(target, 1_u64);
+
+        // 阶段二 get_engine await 的挂起点：阶段一第一次调用直接返回；阶段二
+        // 第二次调用通知 entered 后挂起，主线程在 await 窗口内切轮，再放行。
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let entered_main = entered.clone();
+        let release_main = release.clone();
+        let get_engine_calls = Arc::new(AtomicU64::new(0));
+        let probe_engine = get_engine_calls.clone();
+
+        let cascade_called = Arc::new(AtomicBool::new(false));
+        let probe_cascade = cascade_called.clone();
+        let cancel_calls = Arc::new(AtomicU64::new(0));
+        let probe_cancel = cancel_calls.clone();
+
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                move || {
+                    let entered = entered.clone();
+                    let release = release.clone();
+                    let probe = probe_engine.clone();
+                    async move {
+                        if probe.fetch_add(1, Ordering::SeqCst) == 1 {
+                            // 阶段二复查前的 get_engine：模拟 handle_for 取
+                            // entries 锁的 await，挂起等待主线程切轮。
+                            entered.notify_one();
+                            release.notified().await;
+                        }
+                        Some(())
+                    }
+                },
+                // cancel_current：阶段一触发一次（取消 T1），阶段二应因后置
+                // mismatch 跳过。
+                move |_engine: &()| {
+                    probe_cancel.fetch_add(1, Ordering::SeqCst);
+                },
+                // cascade_cancel：后置复查 mismatch + 新轮未提交 → 必须补发。
+                move |_engine: &()| {
+                    probe_cascade.store(true, Ordering::Release);
+                    async {}
+                },
+                // claim_unsubmitted：T1 已 submitted → no-op（不认领）。
+                |_lc, _target| false,
+            )
+            .await
+        });
+        // 让 cancel 完成阶段一（第一次 get_engine 直接返回 + arm+cancel），
+        // 阶段二取得 turn_lock 并完成入口复查（current=Some(1)==target，匹配），
+        // 再进入第二次 get_engine 挂起。
+        entered_main.notified().await;
+
+        // 此刻阶段二入口复查已匹配通过、正挂起在 get_engine await 内：切轮。
+        // T1 终态 → T2 reserve（epoch=2，未提交——SendMessage 被 turn_lock 阻塞）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        // 放行 get_engine：后置复查 current=Some(2)≠Some(1) → mismatch →
+        // should_retry_cascade（新轮未提交）→ 补发级联。
+        release_main.notify_one();
+        cancel_task.await.expect("cancel task joins");
+
+        assert!(
+            get_engine_calls.load(Ordering::SeqCst) >= 2,
+            "get_engine must be consulted in phase one and phase two"
+        );
+        assert!(
+            cascade_called.load(Ordering::Acquire),
+            "G1: cascade retry must fire when the mismatch is first observed after the phase-two engine lookup"
+        );
+        assert!(
+            cancel_calls.load(Ordering::SeqCst) == 1,
+            "phase one cancels turn1; phase two must skip cancel_current on mismatch"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn reservation must remain valid after the G1 cascade retry"
+        );
+    }
+
+    #[tokio::test]
     async fn stale_cancel_skips_unsubmitted_claim_and_leaves_new_turn_intact() {
         // invalidate 路径：cancel_engine 返回 false（模拟 engine 不在场）时，
         // generation 不匹配必须阻止 claim_unsubmitted（认领未提交终态使 reservation
@@ -2471,14 +2585,12 @@ mod scheduled_model_tests {
         let probe = claimed.clone();
         // phase 1 无 engine，级联取消未送达；但新轮已 reserve 未 send 时
         // mismatch 分支会补发（reviewer 点 9）——engine 不在场则补发 no-op。
-        let cascade_queued = AtomicBool::new(false);
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
                 &locks,
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                &cascade_queued,
                 // engine 不在场 → get_engine 返回 None → 不取消，走 claim_unsubmitted 分支。
                 || async { None::<()> },
                 // cancel_current：engine 不在场时不应被调用。
@@ -2535,13 +2647,11 @@ mod scheduled_model_tests {
         let probe = new_turn_intact.clone();
         // phase 1 无 engine，级联取消未送达；engine 不在场时 mismatch 分支
         // 的补发是 no-op，不影响本测试的 claim 语义。
-        let cascade_queued = AtomicBool::new(false);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
-            &cascade_queued,
             // engine 不在场 → get_engine 返回 None → 不 cancel，走 claim_unsubmitted。
             || async { None::<()> },
             // cancel_current：engine 不在场，不应被调用。
@@ -2609,7 +2719,6 @@ mod scheduled_model_tests {
         // phase 1 级联取消视为已成功入队（本测试聚焦阶段一 TOCTOU 守护，
         // 不覆盖 reviewer 点 9 的 try_send 失败补发路径；保持 mismatch
         // early-return 不级联的既有断言）。
-        let cascade_queued = AtomicBool::new(true);
 
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2617,7 +2726,6 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                &cascade_queued,
                 // get_engine：第一次调用（阶段一）通知已进入后挂起（模拟
                 // handle_for 取 entries 锁的 await），放行后返回「engine 在场」。
                 // 若实现退化（阶段二缺 generation 守护，即 #205 原始 bug），
@@ -2701,13 +2809,11 @@ mod scheduled_model_tests {
         let probe_calls = cancel_calls.clone();
         // phase 1 级联取消视为已成功入队（本测试聚焦 arm 顺序不变量，
         // 不覆盖 reviewer 点 9 的 try_send 失败补发路径）。
-        let cascade_queued = AtomicBool::new(true);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
-            &cascade_queued,
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current 探针：仅计数。cancel 在 state 锁内执行，探针不能

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -231,8 +231,15 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// `take_pending_cancel` 并重放 cancel（随后的 cancel 只是幂等 no-op）。
 ///
 /// `get_engine` 返回在场 engine 句柄（`None` 表示无 engine，走未提交认领
-/// 终态）。`claim_unsubmitted` 在「未提交 reservation」时认领 Interrupted
-/// 终态并补发 `chat:done`，返回是否认领。
+/// 终态）。`claim_unsubmitted` 接收目标 epoch，在「未提交 reservation」时于
+/// lifecycle state 锁内与 `turn_epoch == target` 原子校验后认领 Interrupted
+/// 终态并补发 `chat:done`，返回是否认领；epoch 不匹配（轮次已切换）必须
+/// no-op，不得认领新轮（reviewer 点 7）。
+///
+/// `arm_pending_cancel` 返回 `false` 表示 generation 复查通过后、arm 前轮次
+/// 已切换（`reserve_turn` 不取 `turn_lock`，可在 cancel 同步段中间完成切换）。
+/// 此时必须跳过 `cancel_current` / `cascade_cancel`，否则取消会命中新轮已
+/// `reset_cancel_token` 的活跃 token（reviewer 点 6）。
 ///
 /// `cancel_current` 同步取消 engine 的当前 token（幂等，阶段一、二都执行；
 /// 实现方可顺带 try_send 级联取消，尽力而为）。`cascade_cancel` 异步发送
@@ -257,7 +264,7 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
     X: FnMut(&G),
     F: FnMut(&G) -> FFut,
     FFut: Future<Output = ()>,
-    C: Fn(&Arc<TurnLifecycle>) -> bool,
+    C: Fn(&Arc<TurnLifecycle>, u64) -> bool,
 {
     // 阶段一：无锁先触发 cancel_token——仅在仍是发起时刻那一轮时才取消，
     // 否则会误命中随后已 reset_cancel_token 的新轮活跃 token。
@@ -285,11 +292,17 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                     // 用发起时快照 target（而非此刻重读的 current）arm：
                     // 复查与 arm 之间另一 worker 可能结束旧轮并启动新轮，
                     // 重读 current 会把 pending 绑定到新轮（reviewer 点 3）。
-                    // arm_pending_cancel 内部校验 turn_epoch == epoch，
-                    // 轮次已切换时 target 恒不匹配 → 拒绝 arm。
-                    lifecycle.arm_pending_cancel(target.unwrap_or(0));
+                    // arm_pending_cancel 在 state 锁内校验 turn_epoch == target，
+                    // 返回 false = 复查通过后轮次已切换（新轮已 reserve 并可能
+                    // reset_cancel_token）：必须跳过 cancel 及其级联副作用，
+                    // 否则取消会命中新轮活跃 token（reviewer 点 6）。
+                    if lifecycle.arm_pending_cancel(target.unwrap_or(0)) {
+                        cancel_current(&engine);
+                    }
+                    // 被拒：不 cancel，阶段二持锁复查 generation 会整体 no-op。
+                } else {
+                    cancel_current(&engine);
                 }
-                cancel_current(&engine);
             }
         }
     }
@@ -311,7 +324,13 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
 
     // generation 匹配，目标轮仍是发起时刻那一轮：清理它的 shell 任务。
     let shell_cancellation = turn_shell_tasks.request_cancel(session_id);
-    let claimed_unsubmitted = lifecycle.as_ref().is_some_and(|lc| claim_unsubmitted(lc));
+    // claim_unsubmitted 在 lifecycle state 锁内与 target epoch 原子校验并认领：
+    // 本行与上方 generation 复查之间另一 worker 可能已结束旧轮并 reserve 新轮
+    // （reserve_turn 不取 turn_lock），epoch 不匹配时认领必须 no-op，不得把
+    // 新轮 reservation 误认领为 Interrupted（reviewer 点 7）。
+    let claimed_unsubmitted = lifecycle
+        .as_ref()
+        .is_some_and(|lc| claim_unsubmitted(lc, target.unwrap_or(0)));
     if !claimed_unsubmitted {
         // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
         // 幂等：阶段一已取消则再 cancel 是 no-op；阶段一未取消则这里补 cancel。
@@ -328,13 +347,22 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                     // TurnStarted 后 take_pending_cancel 时再次校验 epoch，
                     // 跨轮 stale pending 被丢弃。重读 current 会把 pending
                     // 绑定到复查后启动的新轮（reviewer 点 3，与阶段一同理）。
-                    lifecycle.arm_pending_cancel(target.unwrap_or(0));
+                    // arm 返回 false = 复查通过后轮次已切换：跳过 cancel 及
+                    // 级联副作用，避免命中新轮活跃 token（reviewer 点 6）。
+                    if lifecycle.arm_pending_cancel(target.unwrap_or(0)) {
+                        cancel_current(&engine);
+                        // 级联取消必须在释放 turn gate 前完成入队（reviewer 点 4）：
+                        // 下一轮 SendMessage 需等同一把 turn_lock，级联取消必先入队，
+                        // FIFO 保证 engine 先取消旧轮子智能体、后启动新轮。
+                        cascade_cancel(&engine).await;
+                    }
+                    // 被拒：轮次已切换，不得取消新轮 engine / 子智能体。
+                } else {
+                    cancel_current(&engine);
+                    // lifecycle 缺失（无活跃轮）时 cascade 无意义：级联取消
+                    // CancelSubAgents 针对的是 engine 当前子智能体，空闲 engine
+                    // 上没有活跃子智能体，不发也无损（保持原行为）。
                 }
-                cancel_current(&engine);
-                // 级联取消必须在释放 turn gate 前完成入队（reviewer 点 4）：
-                // 下一轮 SendMessage 需等同一把 turn_lock，级联取消必先入队，
-                // FIFO 保证 engine 先取消旧轮子智能体、后启动新轮。
-                cascade_cancel(&engine).await;
             }
         }
     }
@@ -1283,7 +1311,11 @@ impl EnginePool {
                 }
             },
             // claim_unsubmitted：未提交 reservation 的认领终态路径（同步认领+发终态）。
-            |lifecycle| lifecycle.emit_unsubmitted_interrupted_terminal(app, session_id),
+            // 携带 target epoch：认领与 turn_epoch 校验在 state 锁内原子完成，
+            // 复查后已切轮（新轮已 reserve）时认领 no-op，不误杀新轮。
+            |lifecycle, target| {
+                lifecycle.emit_unsubmitted_interrupted_terminal_for_epoch(app, session_id, target)
+            },
         )
         .await
     }
@@ -2137,7 +2169,7 @@ mod scheduled_model_tests {
                     async {}
                 },
                 // claim_unsubmitted 不应被调用（turn1 已 submitted）。
-                |_lc| false,
+                |_lc, _target| false,
             )
             .await
         });
@@ -2211,7 +2243,7 @@ mod scheduled_model_tests {
                 probe_cascade.store(true, Ordering::Release);
                 async {}
             },
-            |_lc| false,
+            |_lc, _target| false,
         )
         .await;
 
@@ -2255,7 +2287,7 @@ mod scheduled_model_tests {
                 |_engine: &()| {},
                 // cascade_cancel：engine 不在场，阶段二不调用。
                 |_engine: &()| async {},
-                move |lc| {
+                move |lc, _target| {
                     probe.store(true, Ordering::Release);
                     // 复用真实的未提交认领路径以观察副作用。
                     lc.claim_unsubmitted_terminal()
@@ -2281,6 +2313,60 @@ mod scheduled_model_tests {
         assert!(
             reservation2.ensure_active().is_ok(),
             "new turn unsubmitted reservation must survive a stale cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_claim_with_epoch_guard_rejects_new_turn() {
+        // reviewer 点 7 的集成验证：阶段二 generation 检查通过后、认领前轮次
+        // 切换时（reserve_turn 不取 turn_lock），claim_unsubmitted 必须与发起时
+        // 快照 target 在 state 锁内原子校验——epoch 不匹配则 no-op，不得把新轮
+        // reservation 认领为 Interrupted。这里在 claim 闭包内模拟「检查后切轮」
+        // （真实场景由另一 worker 完成），验证 for_epoch 拒绝 stale target 且
+        // 新轮 reservation 保持有效。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-claim-epoch-guard";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：reserve 未提交（epoch=1），engine 不在场 → cancel 走 claim 分支。
+        let _reservation1 = lifecycle.reserve().expect("turn1 reserve");
+
+        let new_turn_intact = Arc::new(AtomicBool::new(false));
+        let probe = new_turn_intact.clone();
+        cancel_turn_with_gates(
+            &locks,
+            &lifecycles,
+            &shell_tasks,
+            sid,
+            // engine 不在场 → get_engine 返回 None → 不 cancel，走 claim_unsubmitted。
+            || async { None::<()> },
+            // cancel_current：engine 不在场，不应被调用。
+            |_engine: &()| {},
+            // cascade_cancel：engine 不在场，阶段二不调用。
+            |_engine: &()| async {},
+            // claim 闭包：模拟「generation 检查通过后、认领前」切轮，再用发起
+            // 时快照 target 认领——必须被拒（epoch 不匹配），新轮完好。
+            move |lc, target| {
+                assert!(lc.finish_unsubmitted_once(), "turn1 terminal");
+                let new_reservation = lc.reserve().expect("turn2 reserve");
+                let claimed = lc.claim_unsubmitted_terminal_for_epoch(target);
+                probe.store(
+                    !claimed && new_reservation.ensure_active().is_ok(),
+                    Ordering::Release,
+                );
+                // 闭包结束时 new_reservation drop：未 submitted → on_reservation_failed
+                // 回滚 turn2 的 active 状态。此时 claim 已被拒、阶段二后续不再
+                // 触碰 lifecycle（engine 不在场），回滚幂等无害。
+                claimed
+            },
+        )
+        .await;
+
+        assert!(
+            new_turn_intact.load(Ordering::Acquire),
+            "stale claim must reject the new turn and leave its reservation intact"
         );
     }
 
@@ -2354,7 +2440,7 @@ mod scheduled_model_tests {
                 },
                 // cascade_cancel：generation 不匹配，不应被调用。
                 |_engine: &()| async {},
-                |_lc| false,
+                |_lc, _target| false,
             )
             .await
         });
@@ -2433,7 +2519,7 @@ mod scheduled_model_tests {
             },
             // cascade_cancel：正常取消路径，阶段二会调用；此处 no-op 探针。
             |_engine: &()| async {},
-            |_lc| false,
+            |_lc, _target| false,
         )
         .await;
 

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -236,9 +236,13 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// 终态并补发 `chat:done`，返回是否认领；epoch 不匹配（轮次已切换）必须
 /// no-op，不得认领新轮（reviewer 点 7）。
 ///
-/// `arm_pending_cancel` 返回 `false` 表示 generation 复查通过后、arm 前轮次
-/// 已切换（`reserve_turn` 不取 `turn_lock`，可在 cancel 同步段中间完成切换）。
-/// 此时必须跳过 `cancel_current` / `cascade_cancel`，否则取消会命中新轮已
+/// `arm_pending_cancel_and_cancel` 把「epoch 校验 + arm + 同步取消」合并为
+/// 同一 lifecycle state 锁临界区内的原子操作：`cancel_current` 持锁执行，
+/// `reserve_turn` 需要同一把 state 锁，无法在「校验/arm」与「取消」之间
+/// 插入轮次切换（reviewer 点 8——单独 arm 时锁已释放，到 cancel 之间的
+/// 同步调用段仍可被多线程 runtime 抢占）。返回 `false` 表示 generation 复查
+/// 通过后、arm 前轮次已切换（新轮已 reserve），此时取消闭包不执行，必须
+/// 跳过 `cancel_current` / `cascade_cancel`，否则会命中新轮已
 /// `reset_cancel_token` 的活跃 token（reviewer 点 6）。
 ///
 /// `cancel_current` 同步取消 engine 的当前 token（幂等，阶段一、二都执行；
@@ -286,20 +290,17 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                     .get(session_id)
                     .and_then(|lc| lc.current_turn_generation()),
             ) {
-                // 先 arm 再 cancel：TurnStarted 在两步之间抵达转发器时，
-                // forwarder 能 take 到 pending 并重放 cancel，停止请求不丢失。
+                // 先 arm 再 cancel，且二者在同一 state 锁临界区内原子完成：
+                // arm_pending_cancel_and_cancel 持锁校验 turn_epoch == target、
+                // 设置 pending（条件满足时）、并执行 cancel_current——reserve_turn
+                // 需要同一把 state 锁，无法在「校验/arm」与「取消」之间插入轮次
+                // 切换，旧 cancel 不会命中新轮已 reset_cancel_token 的活跃 token
+                // （reviewer 点 8）。epoch 不匹配时返回 false 且不执行取消闭包，
+                // 阶段二持锁复查 generation 会整体 no-op（reviewer 点 6）。
                 if let Some(lifecycle) = turn_lifecycles.get(session_id) {
-                    // 用发起时快照 target（而非此刻重读的 current）arm：
-                    // 复查与 arm 之间另一 worker 可能结束旧轮并启动新轮，
-                    // 重读 current 会把 pending 绑定到新轮（reviewer 点 3）。
-                    // arm_pending_cancel 在 state 锁内校验 turn_epoch == target，
-                    // 返回 false = 复查通过后轮次已切换（新轮已 reserve 并可能
-                    // reset_cancel_token）：必须跳过 cancel 及其级联副作用，
-                    // 否则取消会命中新轮活跃 token（reviewer 点 6）。
-                    if lifecycle.arm_pending_cancel(target.unwrap_or(0)) {
-                        cancel_current(&engine);
-                    }
-                    // 被拒：不 cancel，阶段二持锁复查 generation 会整体 no-op。
+                    lifecycle.arm_pending_cancel_and_cancel(target.unwrap_or(0), || {
+                        cancel_current(&engine)
+                    });
                 } else {
                     cancel_current(&engine);
                 }
@@ -345,12 +346,16 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
                 if let Some(lifecycle) = lifecycle.as_ref() {
                     // arm 用发起时快照 target（已校验仍是 target 轮），转发器在
                     // TurnStarted 后 take_pending_cancel 时再次校验 epoch，
-                    // 跨轮 stale pending 被丢弃。重读 current 会把 pending
-                    // 绑定到复查后启动的新轮（reviewer 点 3，与阶段一同理）。
-                    // arm 返回 false = 复查通过后轮次已切换：跳过 cancel 及
-                    // 级联副作用，避免命中新轮活跃 token（reviewer 点 6）。
-                    if lifecycle.arm_pending_cancel(target.unwrap_or(0)) {
-                        cancel_current(&engine);
+                    // 跨轮 stale pending 被丢弃。arm + cancel_current 在 state
+                    // 锁内原子完成（与阶段一同理，reviewer 点 8）：reserve_turn
+                    // 需要同一把 state 锁，无法在「校验/arm」与「取消」之间插入
+                    // 轮次切换。返回 false = 复查通过后轮次已切换：跳过 cancel
+                    // 及级联副作用，避免命中新轮活跃 token（reviewer 点 6）。
+                    let armed = lifecycle
+                        .arm_pending_cancel_and_cancel(target.unwrap_or(0), || {
+                            cancel_current(&engine)
+                        });
+                    if armed {
                         // 级联取消必须在释放 turn gate 前完成入队（reviewer 点 4）：
                         // 下一轮 SendMessage 需等同一把 turn_lock，级联取消必先入队，
                         // FIFO 保证 engine 先取消旧轮子智能体、后启动新轮。
@@ -2475,10 +2480,11 @@ mod scheduled_model_tests {
         //   forwarder 因尚未 arm 不补 cancel → 此处再 arm 时 `turn_id` 已存在
         //   被拒 → 停止请求丢失。
         //
-        // 这里让 get_engine 在场、turn 处于「submitted 未 started」，并在
-        // cancel_current 探针里消费 pending_cancel：若实现先 arm 后 cancel，
-        // 探针能取到 Some(epoch)（模拟 forwarder 在 TurnStarted 时补 cancel）；
-        // 若实现先 cancel 后 arm，探针取到 None，停止请求丢失可被确定性捕获。
+        // 原子化后（reviewer 点 8）arm 与 cancel_current 在同一个 state 锁
+        // 临界区内完成，顺序由 `arm_pending_cancel_and_cancel` 内部保证，
+        // TurnStarted 无法插入两步之间（forwarder 消费 pending 也需同一把锁）。
+        // 这里验证送达性不变量：cancel 执行后 pending 仍可被 forwarder 消费
+        // （take 得到 Some）——即「先 arm 后 cancel」的效果保持。
         let locks = SessionTurnLocks::default();
         let lifecycles = SessionTurnLifecycles::default();
         let shell_tasks = SessionTurnShellTasks::default();
@@ -2489,9 +2495,6 @@ mod scheduled_model_tests {
         // epoch=1）——arm_pending_cancel 的前置条件满足。
         assert!(lifecycle.on_submitted());
 
-        let pending_seen_at_cancel = Arc::new(AtomicBool::new(false));
-        let probe = pending_seen_at_cancel.clone();
-        let probe_lifecycle = lifecycle.clone();
         let cancel_calls = Arc::new(AtomicU64::new(0));
         let probe_calls = cancel_calls.clone();
         cancel_turn_with_gates(
@@ -2501,21 +2504,11 @@ mod scheduled_model_tests {
             sid,
             // get_engine：engine 在场。
             || async { Some(()) },
-            // cancel_current 探针：模拟 forwarder 在 TurnStarted 时消费 pending。
-            // 阶段一与阶段二都会调用本探针，但只有阶段二才是 reviewer 点 2
-            // 的目标（阶段一自己「先 arm 后 cancel」就能让任一时刻的断言通过，
-            // 掩盖阶段二的顺序颠倒）。因此两次调用都消费 pending（阶段一先
-            // 取走自己 arm 的标记，阶段二重新 arm 后才能再取到），但只把阶段二
-            // 的结果计入断言：若阶段二先 cancel 后 arm，探针取到 None，停止
-            // 请求丢失被确定性捕获。
+            // cancel_current 探针：仅计数。cancel 在 state 锁内执行，探针不能
+            // 再取 lifecycle 锁（std Mutex 非重入，会死锁），改为在调用结束后
+            // 验证 pending 仍可被 forwarder 消费。
             move |_engine: &()| {
-                let call = probe_calls.fetch_add(1, Ordering::SeqCst);
-                let epoch = probe_lifecycle.current_turn_generation().unwrap_or(0);
-                let took = probe_lifecycle.take_pending_cancel(epoch).is_some();
-                if call == 1 {
-                    // 阶段二：仅此时校验 pending 是否已 arm。
-                    probe.store(took, Ordering::Release);
-                }
+                probe_calls.fetch_add(1, Ordering::SeqCst);
             },
             // cascade_cancel：正常取消路径，阶段二会调用；此处 no-op 探针。
             |_engine: &()| async {},
@@ -2523,9 +2516,17 @@ mod scheduled_model_tests {
         )
         .await;
 
+        // 阶段一、阶段二各 cancel 一次（engine 在场、epoch 匹配）。
         assert!(
-            pending_seen_at_cancel.load(Ordering::Acquire),
-            "pending_cancel must be armed before cancel_current so a TurnStarted between them can be replayed"
+            cancel_calls.load(Ordering::Acquire) >= 1,
+            "cancel_current must run on the originating turn"
+        );
+        // arm 先于 cancel：cancel 执行后 pending 仍可被 forwarder 消费
+        // （模拟 TurnStarted 到达时 take 并重放）。
+        let epoch = lifecycle.current_turn_generation().unwrap_or(0);
+        assert!(
+            lifecycle.take_pending_cancel(epoch).is_some(),
+            "pending_cancel must be armed before cancel_current so a TurnStarted can be replayed"
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -1240,15 +1240,21 @@ impl EnginePool {
             // 该 engine 的后台子智能体（multiagent，ADR-0006）：「停止」按钮是子
             // 智能体唯一的确定性停止入口（卡片上没有取消按钮，自然语言指令只是
             // 建议），只取消宿主轮会留下继续烧钱的后台子智能体。
-            // try_send：cancel_current 是同步闭包（generation 守护要求 get_engine
-            // 与 cancel 之间不可有 await），ops 通道有界且此刻几乎不会满；即使
-            // 发送失败，引擎回收路径 shutdown_cancel_cascade_ops 仍会再发一次
-            // CancelSubAgents，双发无害（幂等）。
+            // CancelSubAgents 改用 spawn + async send：cancel_current 必须同步
+            // （generation 守护要求 get_engine 与 cancel 之间不可有 await），但
+            // try_send 在 ops 通道满（容量 32）时会静默丢弃级联取消——常规停止
+            // 后 engine 不回收，shutdown_cancel_cascade_ops 不会补发，子智能体
+            // 会继续烧钱。同步取消后 spawn 异步 send 恢复保证送达（双发无害，
+            // 回收路径再发 CancelSubAgents 只是幂等 no-op）。
             |engine| {
                 engine.cancel_current();
-                if let Err(e) = engine.handle.try_send(Op::CancelSubAgents) {
-                    eprintln!("[engine_pool] cancel subagents {session_id} failed: {e:?}");
-                }
+                let handle = engine.handle.clone();
+                let sid = session_id.to_string();
+                tokio::spawn(async move {
+                    if let Err(e) = handle.send(Op::CancelSubAgents).await {
+                        eprintln!("[engine_pool] cancel subagents {sid} failed: {e:?}");
+                    }
+                });
             },
             // claim_unsubmitted：未提交 reservation 的认领终态路径（同步认领+发终态）。
             |lifecycle| lifecycle.emit_unsubmitted_interrupted_terminal(app, session_id),
@@ -2255,6 +2261,8 @@ mod scheduled_model_tests {
         let release_main = release.clone();
         let cancel_called = Arc::new(AtomicBool::new(false));
         let probe = cancel_called.clone();
+        let get_engine_calls = Arc::new(AtomicU64::new(0));
+        let probe_calls = get_engine_calls.clone();
 
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2262,14 +2270,21 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
-                // get_engine：通知已进入后挂起（模拟 handle_for 取 entries 锁的
-                // await）；放行后返回「engine 在场」。
+                // get_engine：第一次调用（阶段一）通知已进入后挂起（模拟
+                // handle_for 取 entries 锁的 await），放行后返回「engine 在场」。
+                // 若实现退化（阶段二缺 generation 守护，即 #205 原始 bug），
+                // 阶段二会再次调用 get_engine——此时直接返回「engine 在场」让
+                // cancel_current 探针触发、测试红；若这里仍 park 于 Notify，
+                // 会二次挂起成死锁（CI 表现为超时而非断言失败）。
                 move || {
                     let entered = entered.clone();
                     let release = release.clone();
+                    let calls = probe_calls.clone();
                     async move {
-                        entered.notify_waiters();
-                        release.notified().await;
+                        if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                            entered.notify_waiters();
+                            release.notified().await;
+                        }
                         Some(())
                     }
                 },
@@ -2328,6 +2343,8 @@ mod scheduled_model_tests {
         let pending_seen_at_cancel = Arc::new(AtomicBool::new(false));
         let probe = pending_seen_at_cancel.clone();
         let probe_lifecycle = lifecycle.clone();
+        let cancel_calls = Arc::new(AtomicU64::new(0));
+        let probe_calls = cancel_calls.clone();
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
@@ -2336,11 +2353,19 @@ mod scheduled_model_tests {
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current 探针：模拟 forwarder 在 TurnStarted 时消费 pending。
-            // 阶段一与阶段二都走这里；只要任一时刻 pending 已 arm 即证明顺序正确。
+            // 阶段一与阶段二都会调用本探针，但只有阶段二才是 reviewer 点 2
+            // 的目标（阶段一自己「先 arm 后 cancel」就能让任一时刻的断言通过，
+            // 掩盖阶段二的顺序颠倒）。因此两次调用都消费 pending（阶段一先
+            // 取走自己 arm 的标记，阶段二重新 arm 后才能再取到），但只把阶段二
+            // 的结果计入断言：若阶段二先 cancel 后 arm，探针取到 None，停止
+            // 请求丢失被确定性捕获。
             move |_engine: ()| {
+                let call = probe_calls.fetch_add(1, Ordering::SeqCst);
                 let epoch = probe_lifecycle.current_turn_generation().unwrap_or(0);
-                if probe_lifecycle.take_pending_cancel(epoch).is_some() {
-                    probe.store(true, Ordering::Release);
+                let took = probe_lifecycle.take_pending_cancel(epoch).is_some();
+                if call == 1 {
+                    // 阶段二：仅此时校验 pending 是否已 arm。
+                    probe.store(took, Ordering::Release);
                 }
             },
             |_lc| false,

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -233,18 +233,30 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// `get_engine` 返回在场 engine 句柄（`None` 表示无 engine，走未提交认领
 /// 终态）。`claim_unsubmitted` 在「未提交 reservation」时认领 Interrupted
 /// 终态并补发 `chat:done`，返回是否认领。
-async fn cancel_turn_with_gates<G, E, EFut, X, C>(
+///
+/// `cancel_current` 同步取消 engine 的当前 token（幂等，阶段一、二都执行；
+/// 实现方可顺带 try_send 级联取消，尽力而为）。`cascade_cancel` 异步发送
+/// 级联取消（CancelSubAgents），**只在阶段二持 `turn_lock` 时 await 调用**：
+/// 保证级联取消在释放 turn gate 前完成入队——下一轮 `SendMessage` 必须等
+/// 同一把 `turn_lock`（`send_reserved_user_message`），因此级联取消必先于
+/// 新轮消息入队，FIFO 保证 engine 先取消旧轮子智能体、后启动新轮，迟到的
+/// 级联取消不会误杀新轮刚启动的子智能体（reviewer 点 4：spawn 异步发送
+/// 失去相对下一轮 SendMessage 的入队顺序保证）。
+async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
     turn_locks: &SessionTurnLocks,
     turn_lifecycles: &SessionTurnLifecycles,
     turn_shell_tasks: &SessionTurnShellTasks,
     session_id: &str,
     mut get_engine: E,
     mut cancel_current: X,
+    mut cascade_cancel: F,
     claim_unsubmitted: C,
 ) where
     E: FnMut() -> EFut,
     EFut: Future<Output = Option<G>>,
-    X: FnMut(G),
+    X: FnMut(&G),
+    F: FnMut(&G) -> FFut,
+    FFut: Future<Output = ()>,
     C: Fn(&Arc<TurnLifecycle>) -> bool,
 {
     // 阶段一：无锁先触发 cancel_token——仅在仍是发起时刻那一轮时才取消，
@@ -270,10 +282,14 @@ async fn cancel_turn_with_gates<G, E, EFut, X, C>(
                 // 先 arm 再 cancel：TurnStarted 在两步之间抵达转发器时，
                 // forwarder 能 take 到 pending 并重放 cancel，停止请求不丢失。
                 if let Some(lifecycle) = turn_lifecycles.get(session_id) {
-                    let epoch = lifecycle.current_turn_generation().unwrap_or(0);
-                    lifecycle.arm_pending_cancel(epoch);
+                    // 用发起时快照 target（而非此刻重读的 current）arm：
+                    // 复查与 arm 之间另一 worker 可能结束旧轮并启动新轮，
+                    // 重读 current 会把 pending 绑定到新轮（reviewer 点 3）。
+                    // arm_pending_cancel 内部校验 turn_epoch == epoch，
+                    // 轮次已切换时 target 恒不匹配 → 拒绝 arm。
+                    lifecycle.arm_pending_cancel(target.unwrap_or(0));
                 }
-                cancel_current(engine);
+                cancel_current(&engine);
             }
         }
     }
@@ -308,13 +324,17 @@ async fn cancel_turn_with_gates<G, E, EFut, X, C>(
                     .and_then(|lc| lc.current_turn_generation()),
             ) {
                 if let Some(lifecycle) = lifecycle.as_ref() {
-                    // arm 到当前 epoch（已校验仍是 target 轮），转发器在
+                    // arm 用发起时快照 target（已校验仍是 target 轮），转发器在
                     // TurnStarted 后 take_pending_cancel 时再次校验 epoch，
-                    // 跨轮 stale pending 被丢弃。
-                    let epoch = lifecycle.current_turn_generation().unwrap_or(0);
-                    lifecycle.arm_pending_cancel(epoch);
+                    // 跨轮 stale pending 被丢弃。重读 current 会把 pending
+                    // 绑定到复查后启动的新轮（reviewer 点 3，与阶段一同理）。
+                    lifecycle.arm_pending_cancel(target.unwrap_or(0));
                 }
-                cancel_current(engine);
+                cancel_current(&engine);
+                // 级联取消必须在释放 turn gate 前完成入队（reviewer 点 4）：
+                // 下一轮 SendMessage 需等同一把 turn_lock，级联取消必先入队，
+                // FIFO 保证 engine 先取消旧轮子智能体、后启动新轮。
+                cascade_cancel(&engine).await;
             }
         }
     }
@@ -1236,25 +1256,31 @@ impl EnginePool {
             // handle_for 只瞬时取 entries 锁（与 send 内部瞬时取 entries 锁不冲突），
             // 不等 turn_lock——阶段一无锁先触发，turn_loop 的 biased select 立即跳出。
             || async move { self.handle_for(session_id).await },
-            // cancel_current：对在场 engine 触发同步取消（幂等），并级联取消
-            // 该 engine 的后台子智能体（multiagent，ADR-0006）：「停止」按钮是子
-            // 智能体唯一的确定性停止入口（卡片上没有取消按钮，自然语言指令只是
-            // 建议），只取消宿主轮会留下继续烧钱的后台子智能体。
-            // CancelSubAgents 改用 spawn + async send：cancel_current 必须同步
-            // （generation 守护要求 get_engine 与 cancel 之间不可有 await），但
-            // try_send 在 ops 通道满（容量 32）时会静默丢弃级联取消——常规停止
-            // 后 engine 不回收，shutdown_cancel_cascade_ops 不会补发，子智能体
-            // 会继续烧钱。同步取消后 spawn 异步 send 恢复保证送达（双发无害，
-            // 回收路径再发 CancelSubAgents 只是幂等 no-op）。
+            // cancel_current：对在场 engine 触发同步取消（幂等），并尽力
+            // try_send 级联取消该 engine 的后台子智能体（multiagent，
+            // ADR-0006）：「停止」按钮是子智能体唯一的确定性停止入口（卡片上
+            // 没有取消按钮，自然语言指令只是建议），只取消宿主轮会留下继续
+            // 烧钱的后台子智能体。try_send 不阻塞、通道有空位时立即入队
+            // （早于下一轮 SendMessage）；通道满（容量 32）时放弃，由阶段二
+            // cascade_cancel 持锁 await 补发保证送达。
             |engine| {
                 engine.cancel_current();
+                let _ = engine.handle.try_send(Op::CancelSubAgents);
+            },
+            // cascade_cancel：阶段二持 turn_lock 时 await 发送级联取消，保证在
+            // 释放 turn gate 前完成入队——下一轮 SendMessage 必须等同一把
+            // turn_lock（send_reserved_user_message），因此级联取消必先于新轮
+            // 消息入队，engine 先取消旧轮子智能体、后启动新轮，不会误杀新轮
+            // 刚启动的子智能体（reviewer 点 4）。双发无害：与阶段一 try_send
+            // 及回收路径的 CancelSubAgents 都是幂等 no-op。
+            |engine| {
                 let handle = engine.handle.clone();
                 let sid = session_id.to_string();
-                tokio::spawn(async move {
+                async move {
                     if let Err(e) = handle.send(Op::CancelSubAgents).await {
                         eprintln!("[engine_pool] cancel subagents {sid} failed: {e:?}");
                     }
-                });
+                }
             },
             // claim_unsubmitted：未提交 reservation 的认领终态路径（同步认领+发终态）。
             |lifecycle| lifecycle.emit_unsubmitted_interrupted_terminal(app, session_id),
@@ -2081,6 +2107,11 @@ mod scheduled_model_tests {
         let phase_one_count = Arc::new(AtomicU64::new(0));
         let probe2 = phase_two_cancel_called.clone();
         let probe1 = phase_one_count.clone();
+        // cascade 探针：阶段二 early-return（新轮已 reserve）时级联取消
+        // 不得执行——此时 CancelSubAgents 若发出会误杀新轮刚启动的子智能体
+        // （reviewer 点 4）。
+        let cascade_called = Arc::new(AtomicBool::new(false));
+        let probe_cascade = cascade_called.clone();
         // C2：阶段一无锁快照 target=Some(1) → 匹配 → get_engine 返回在场 engine
         //     → 校验 epoch 仍匹配 → arm + cancel_current（probe1++）；
         //     阶段二持锁（被 blocker 阻塞），恢复后比对 current ≠ target → early return。
@@ -2094,11 +2125,16 @@ mod scheduled_model_tests {
                 || async { Some(()) },
                 // cancel_current：阶段一与阶段二复查都走这里：用计数区分。
                 // 阶段一（turn1）probe1 0→1；阶段二若误执行 probe2 置位。
-                move |_engine| {
+                move |_engine: &()| {
                     let prev = probe1.fetch_add(1, Ordering::AcqRel);
                     if prev >= 1 {
                         probe2.store(true, Ordering::Release);
                     }
+                },
+                // cascade_cancel：阶段二 early-return，不应被调用。
+                move |_engine: &()| {
+                    probe_cascade.store(true, Ordering::Release);
+                    async {}
                 },
                 // claim_unsubmitted 不应被调用（turn1 已 submitted）。
                 |_lc| false,
@@ -2129,6 +2165,10 @@ mod scheduled_model_tests {
             "phase two must not cancel the engine of a turn that started after the cancel was issued"
         );
         assert!(
+            !cascade_called.load(Ordering::Acquire),
+            "a stale cancel must not cascade-cancel subagents of a turn that started after the cancel was issued"
+        );
+        assert!(
             reservation2.ensure_active().is_ok(),
             "new turn reservation must remain valid after a stale cancel's phase two recovered"
         );
@@ -2151,6 +2191,9 @@ mod scheduled_model_tests {
 
         let cancel_called = Arc::new(AtomicBool::new(false));
         let probe = cancel_called.clone();
+        // cascade 探针：正常取消路径（fresh cancel）必须执行级联取消。
+        let cascade_called = Arc::new(AtomicBool::new(false));
+        let probe_cascade = cascade_called.clone();
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
@@ -2159,8 +2202,14 @@ mod scheduled_model_tests {
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current：记录触发。
-            move |_engine| {
+            move |_engine: &()| {
                 probe.store(true, Ordering::Release);
+            },
+            // cascade_cancel：fresh cancel 在阶段二 generation 匹配后必须被
+            // 调用（在 turn gate 内 await 完成入队，reviewer 点 4）。
+            move |_engine: &()| {
+                probe_cascade.store(true, Ordering::Release);
+                async {}
             },
             |_lc| false,
         )
@@ -2170,6 +2219,10 @@ mod scheduled_model_tests {
         assert!(
             cancel_called.load(Ordering::Acquire),
             "a fresh cancel on the current turn must still cancel its engine"
+        );
+        assert!(
+            cascade_called.load(Ordering::Acquire),
+            "a fresh cancel on the current turn must also cascade-cancel its subagents inside the turn gate"
         );
     }
 
@@ -2199,7 +2252,9 @@ mod scheduled_model_tests {
                 // engine 不在场 → get_engine 返回 None → 不取消，走 claim_unsubmitted 分支。
                 || async { None::<()> },
                 // cancel_current：engine 不在场时不应被调用。
-                |_engine: ()| {},
+                |_engine: &()| {},
+                // cascade_cancel：engine 不在场，阶段二不调用。
+                |_engine: &()| async {},
                 move |lc| {
                     probe.store(true, Ordering::Release);
                     // 复用真实的未提交认领路径以观察副作用。
@@ -2282,16 +2337,23 @@ mod scheduled_model_tests {
                     let calls = probe_calls.clone();
                     async move {
                         if calls.fetch_add(1, Ordering::SeqCst) == 0 {
-                            entered.notify_waiters();
+                            // notify_one 会为未来的 waiter 保留 permit：即使
+                            // spawned task 先执行到这里而主线程尚未注册
+                            // notified().await，信号也不丢失（reviewer 点 5：
+                            // notify_waiters 不为后注册的 waiter 保留通知，
+                            // 会永久等待）。
+                            entered.notify_one();
                             release.notified().await;
                         }
                         Some(())
                     }
                 },
                 // cancel_current：不应被调用（阶段一 await 后 epoch 不匹配）。
-                move |_engine: ()| {
+                move |_engine: &()| {
                     probe.store(true, Ordering::Release);
                 },
+                // cascade_cancel：generation 不匹配，不应被调用。
+                |_engine: &()| async {},
                 |_lc| false,
             )
             .await
@@ -2305,7 +2367,8 @@ mod scheduled_model_tests {
 
         // 放行 get_engine：阶段一 await 后重新校验 epoch → target=Some(1) ≠ current=Some(2)
         // → 不 cancel；阶段二同样 early-return。
-        release_main.notify_waiters();
+        // notify_one 与 entered 侧同理：为已注册/未来 waiter 都保留 permit。
+        release_main.notify_one();
         cancel_task.await.expect("cancel task joins");
 
         assert!(
@@ -2359,7 +2422,7 @@ mod scheduled_model_tests {
             // 取走自己 arm 的标记，阶段二重新 arm 后才能再取到），但只把阶段二
             // 的结果计入断言：若阶段二先 cancel 后 arm，探针取到 None，停止
             // 请求丢失被确定性捕获。
-            move |_engine: ()| {
+            move |_engine: &()| {
                 let call = probe_calls.fetch_add(1, Ordering::SeqCst);
                 let epoch = probe_lifecycle.current_turn_generation().unwrap_or(0);
                 let took = probe_lifecycle.take_pending_cancel(epoch).is_some();
@@ -2368,6 +2431,8 @@ mod scheduled_model_tests {
                     probe.store(took, Ordering::Release);
                 }
             },
+            // cascade_cancel：正常取消路径，阶段二会调用；此处 no-op 探针。
+            |_engine: &()| async {},
             |_lc| false,
         )
         .await;

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -189,6 +189,99 @@ where
     finish_reclaimed().await
 }
 
+/// 两个 epoch 快照是否仍指向同一轮次，供 cancel 跨 turn_lock 边界守护使用。
+///
+/// `(None, None)`（空闲→空闲）视为匹配：空闲会话的 cancel 本就是 no-op，
+/// 走原逻辑无副作用；`(Some, Some)` 且相等才匹配；跨 `Some`/`None` 或不相等
+/// 都表示目标轮已结束、新轮已 reserve，cancel 必须整体 no-op。
+fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
+    match (target, current) {
+        (Some(a), Some(b)) => a == b,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// 取消逻辑的可测主体，从 [`EnginePool::cancel`] 抽出以便用裸 Default 组件
+/// （`SessionTurnLocks` / `SessionTurnLifecycles` / `SessionTurnShellTasks`）+
+/// 闭包注入确定性测试，绕开 `Pinvou3Bridge::boot` / `AppHandle` / 真实
+/// `EngineHandle`（跨 crate 私有不可构造）。
+///
+/// **两阶段 generation 守护**：cancel 不绑定发起时刻的轮次身份时，并发取消
+/// 请求（C1/C2）中排队较晚的 C2 在 `turn_lock` 释放后会读到「当前 lifecycle」
+/// （可能已是新轮），无差别取消新轮。这里在两阶段各比对一次 epoch：
+///
+/// - 阶段一（无锁 `cancel_engine`）前快照 `target`，与即时 `current` 比对；
+/// - 阶段二（持 `turn_lock`）后再次比对，不匹配则在 `request_cancel` /
+///   `claim_unsubmitted` / `arm_pending_cancel` / `cancel_engine` 全部之前
+///   early-return，避免误取消新轮的 engine 与 shell scope。
+///
+/// `cancel_engine` 闭包返回 `true` 表示已对在场 engine 触发取消；`false` 表示
+/// 无 engine（走未提交认领终态）。`claim_unsubmitted` 在「未提交 reservation」
+/// 时认领 Interrupted 终态并补发 `chat:done`，返回是否认领。
+async fn cancel_turn_with_gates<E, EFut, C>(
+    turn_locks: &SessionTurnLocks,
+    turn_lifecycles: &SessionTurnLifecycles,
+    turn_shell_tasks: &SessionTurnShellTasks,
+    session_id: &str,
+    mut cancel_engine: E,
+    claim_unsubmitted: C,
+) where
+    E: FnMut() -> EFut,
+    EFut: Future<Output = bool>,
+    C: Fn(&Arc<TurnLifecycle>) -> bool,
+{
+    // 阶段一：无锁先触发 cancel_token——仅在仍是发起时刻那一轮时才取消，
+    // 否则会误命中随后已 reset_cancel_token 的新轮活跃 token。
+    let target = turn_lifecycles
+        .get(session_id)
+        .and_then(|lc| lc.current_turn_generation());
+    if generation_matches(
+        target,
+        turn_lifecycles
+            .get(session_id)
+            .and_then(|lc| lc.current_turn_generation()),
+    ) {
+        // 仅取一次副作用：cancel_engine 返回是否真取消了 engine。
+        // 这里忽略返回值——是否补未提交终态以持锁后的权威 lifecycle 为准。
+        let _ = cancel_engine().await;
+    }
+
+    // 阶段二：持锁清理 turn 状态与 shell 任务。
+    let turn_lock = turn_locks.for_session(session_id).await;
+    let _turn = turn_lock.lock().await;
+
+    let lifecycle = turn_lifecycles.get(session_id);
+    let current = lifecycle
+        .as_ref()
+        .and_then(|lc| lc.current_turn_generation());
+    if !generation_matches(target, current) {
+        // 目标轮已结束（新轮已 reserve）：整体 no-op。此 early-return 必须在
+        // request_cancel / claim_unsubmitted / cancel_engine 之前——request_cancel
+        // 会取消当前 active shell scope，若已是新轮会误清理新轮的 shell 任务。
+        return;
+    }
+
+    // generation 匹配，目标轮仍是发起时刻那一轮：清理它的 shell 任务。
+    let shell_cancellation = turn_shell_tasks.request_cancel(session_id);
+    let claimed_unsubmitted = lifecycle.as_ref().is_some_and(|lc| claim_unsubmitted(lc));
+    if !claimed_unsubmitted {
+        // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
+        // 幂等：阶段一已取消则再 cancel 是 no-op；阶段一未取消则这里补 cancel。
+        if cancel_engine().await {
+            if let Some(lifecycle) = lifecycle {
+                // arm 到当前 epoch（已校验仍是 target 轮），转发器在 TurnStarted
+                // 后 take_pending_cancel 时再次校验 epoch，跨轮 stale pending 被丢弃。
+                let epoch = lifecycle.current_turn_generation().unwrap_or(0);
+                lifecycle.arm_pending_cancel(epoch);
+            }
+        }
+    }
+    if let Some(cancellation) = shell_cancellation {
+        cancellation.cleanup().await;
+    }
+}
+
 /// 池里一个 session 的常驻条目:engine + 它专属的 event forwarder task。
 struct EngineEntry {
     engine: AppEngine,
@@ -1087,63 +1180,38 @@ impl EnginePool {
     /// 「停止」按钮是子智能体唯一的确定性停止入口（卡片上没有取消按钮，
     /// 自然语言指令只是建议）；只取消宿主轮会留下继续烧钱的后台子智能体。
     pub async fn cancel(&self, session_id: &str) {
-        // 阶段一：无锁先触发 cancel_token。
-        // handle_for 只瞬时取 entries 锁(与 send 内部瞬时取 entries 锁不冲突)，
-        // 不等 turn_lock——即使 send 正持锁，cancel 也能立刻让 turn_loop 跳出。
-        if let Some(engine) = self.handle_for(session_id).await {
-            engine.cancel_current();
-        }
-        // 阶段二：持锁清理 turn 状态与 shell 任务。
-        let shell_cancellation = self.turn_shell_tasks.request_cancel(session_id);
-        let turn_lock = self.turn_locks.for_session(session_id).await;
-        let _turn = turn_lock.lock().await;
-        // 持锁后以 lifecycle 的提交状态（而非 Engine 是否存在）为权威依据。
-        // reserve_turn 不取 turn_lock，chat 在 reserve 与 send 之间有
-        // set_disallowed_all 等异步让出点（chat.rs）；若该会话保留着上一轮的空闲
-        // Engine，旧实现按「Engine 是否存在」分流会错误走 pending 分支：只 arm
-        // pending、不认领终态、不发 chat:done，reservation 仍有效，原 chat future
-        // 后续照常提交消息，前端 busy 在 cancel 后到 TurnStarted 之间无法复位。
-        //
-        // emit_unsubmitted_interrupted_terminal 内部 claim 检查「active && !submitted」：
-        // 命中（含 engine 未 spawn 的 probe 窗口与空闲 engine 存在的未提交窗口）=
-        // 认领 Interrupted 终态 + 发 chat:done + 重置闸门，reservation 随之失效
-        // （后续 send 的 ensure_active 失败，消息不再提交）；未命中（已 submitted
-        // 或无活动 turn）返回 false 且无副作用，fallthrough 到 engine 分支。
-        // 必须用 claim（而非裸 invalidate）：reserve_turn 不取 turn_lock，若仅在
-        // invalidate 后、chat:done 发出前释放闸门，新一轮 reserve 可抢先成功，迟到
-        // 的 chat:done 会清掉新一轮 busy——claim 在发终态期间置 terminal_closing
-        // 关闸，与权威终态路径一致的防重入语义。
-        let lifecycle = self.turn_lifecycles.get(session_id);
-        let claimed_unsubmitted = lifecycle
-            .as_ref()
-            .is_some_and(|lc| lc.emit_unsubmitted_interrupted_terminal(&self.app, session_id));
-        let engine = self.handle_for(session_id).await;
-        if !claimed_unsubmitted {
-            // 持锁后复查 engine：阶段一可能因 send 正在 spawn 而拿不到。
-            // 若阶段一已 cancel_current，这里再 cancel 是幂等 no-op；若阶段一没拿到，
-            // 这里拿到刚注册的 engine 补 cancel。
-            if let Some(engine) = engine.as_ref() {
-                // 已提交（op 已入队或 TurnStarted 已抵达）：
-                //  - TurnStarted 未抵达：arm pending，转发器收到 TurnStarted 后
-                //    （reset_cancel_token 已完成）补 cancel 命中活跃 token；
-                //  - TurnStarted 已抵达：cancel_current 直接命中当前活跃 token。
-                // 必须在 cancel_current() 之前 arm——见 arm_pending_cancel 文档。
-                if let Some(lifecycle) = lifecycle {
-                    lifecycle.arm_pending_cancel();
+        // 两阶段 generation 守护见 cancel_turn_with_gates：cancel 请求绑定发起
+        // 时刻的轮次 epoch，并发请求中排队较晚的 C2 在 turn_lock 释放后若发现
+        // 目标轮已结束（新轮已 reserve），整体 no-op，不误取消新轮。
+        let app = &self.app;
+        cancel_turn_with_gates(
+            &self.turn_locks,
+            &self.turn_lifecycles,
+            &self.turn_shell_tasks,
+            session_id,
+            // cancel_engine：取在场 engine 并 cancel_current，返回是否取消了 engine。
+            // 同时级联取消该 engine 的后台子智能体（multiagent，ADR-0006）：「停止」
+            // 按钮是子智能体唯一的确定性停止入口（卡片上没有取消按钮，自然语言指令
+            // 只是建议），只取消宿主轮会留下继续烧钱的后台子智能体。
+            // handle_for 只瞬时取 entries 锁（与 send 内部瞬时取 entries 锁不冲突），
+            // 不等 turn_lock——阶段一无锁先触发，turn_loop 的 biased select 立即跳出；
+            // 阶段二持锁复检 generation 后补 cancel + 级联（CancelSubAgents 幂等，
+            // 与 evict 路径 shutdown_cancel_cascade_ops 语义一致，双发无害）。
+            || async move {
+                if let Some(engine) = self.handle_for(session_id).await {
+                    engine.cancel_current();
+                    if let Err(e) = engine.handle.send(Op::CancelSubAgents).await {
+                        eprintln!("[engine_pool] cancel subagents {session_id} failed: {e:?}");
+                    }
+                    true
+                } else {
+                    false
                 }
-                engine.cancel_current();
-            }
-        }
-        // 在 turn_lock 内对当前权威 engine 发级联取消，避免锁等待期间发生的
-        // engine 替换让后台子智能体漏取消，也避免取消误伤随后开始的新一轮。
-        if let Some(engine) = engine {
-            if let Err(e) = engine.handle.send(Op::CancelSubAgents).await {
-                eprintln!("[engine_pool] cancel subagents {session_id} failed: {e:?}");
-            }
-        }
-        if let Some(cancellation) = shell_cancellation {
-            cancellation.cleanup().await;
-        }
+            },
+            // claim_unsubmitted：未提交 reservation 的认领终态路径（同步认领+发终态）。
+            |lifecycle| lifecycle.emit_unsubmitted_interrupted_terminal(app, session_id),
+        )
+        .await
     }
 
     /// pinvou3 工具开关(全局持久):把"被禁用的工具全名"(模型可见全名,小写)广播给
@@ -1508,18 +1576,18 @@ fn resolve_spawn_model(
 #[allow(clippy::await_holding_lock)]
 mod scheduled_model_tests {
     use super::{
-        delete_chat_session_with_gate, delete_scheduled_run_with_gate,
-        quiesce_engine_before_reclaim, resolve_scheduled_model, resolve_spawn_model,
-        scheduled_profile_after_turn_gate, should_sync_session, ModelUpdateRevisions,
-        PreparedRuntimeState, ScheduledUnattendedGuard, SessionShellManagers,
-        SessionTurnLifecycles, SessionTurnLocks,
+        cancel_turn_with_gates, delete_chat_session_with_gate, delete_scheduled_run_with_gate,
+        generation_matches, quiesce_engine_before_reclaim, resolve_scheduled_model,
+        resolve_spawn_model, scheduled_profile_after_turn_gate, should_sync_session,
+        ModelUpdateRevisions, PreparedRuntimeState, ScheduledUnattendedGuard, SessionShellManagers,
+        SessionTurnLifecycles, SessionTurnLocks, SessionTurnShellTasks,
     };
     use crate::features::assistant::runtime_model::PreparedRuntimeModel;
     use crate::features::sessions::{ScheduledRunMode, ScheduledRunProfile, SessionStore};
     use crate::platform::credential_store::{CredentialEditAction, CredentialState};
     use crate::platform::prefs::{ModelPreset, SavedModel};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     use std::sync::{Arc, Mutex as StdMutex};
 
     /// ADR-0006：引擎回收必须**先**取消全部子智能体、**后**发 Shutdown。
@@ -1914,6 +1982,203 @@ mod scheduled_model_tests {
         assert!(
             locks.locks.lock().await.len() <= 1,
             "dead per-session turn gates must be reclaimed"
+        );
+    }
+
+    // ── cancel turn generation 守护(review #4872749559 跨轮误取消回归)──────
+    // cancel_turn_with_gates 把 cancel 主体从 EnginePool::cancel 抽出，使这三组
+    // 测试能用裸 Default 组件 + 探针闭包确定性编排 C1/C2 时序，绕开 bridge /
+    // AppHandle / 真实 EngineHandle（跨 crate 私有）。
+
+    #[test]
+    fn generation_matches_treats_idle_to_idle_as_match() {
+        // (None, None)：空闲会话的 cancel 本就是 no-op，视为匹配走原逻辑。
+        assert!(generation_matches(None, None));
+        // 同一轮 epoch：匹配。
+        assert!(generation_matches(Some(1), Some(1)));
+        // 不同 epoch（目标轮已结束、新轮已 reserve）：不匹配 → no-op。
+        assert!(!generation_matches(Some(1), Some(2)));
+        // 跨 Some/None（目标轮活动、当前空闲，或反之）：不匹配 → no-op。
+        assert!(!generation_matches(Some(1), None));
+        assert!(!generation_matches(None, Some(1)));
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_after_turn_change_leaves_new_turn_intact() {
+        // reviewer 时序的正向验证（review #4872749559）：
+        //   C1/C2 并发取消 turn1。C1 先完整跑完（取消 turn1 + 发终态 + 清 shell），
+        //   turn2 在 C1 释放锁前 reserve_turn（不取 turn_lock）抢先 reserve。
+        //   C2 的**阶段一**（无锁 cancel_current）此时仍属 turn1（正确，会取消 turn1）；
+        //   真正的缺陷窗口在**阶段二**：C2 拿锁后已变 turn2，原实现会无差别
+        //   cancel/arm pending 到 turn2。generation 守护让阶段二 early-return。
+        //
+        // 这里直接编排「C2 快照 turn1 → turn1 终态 → turn2 reserve → C2 阶段二」：
+        // 先用 blocker 占住 turn_lock，让 C2 的阶段一快照 turn1 后在阶段二挂起，
+        // 主线程推进到 turn2，再释放锁让 C2 阶段二恢复。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-stale-cancel";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：on_submitted 激活（active+submitted+epoch 自增），使阶段一 cancel_engine
+        // 能匹配 generation，且 finish_once 可 claim（需 submitted）。
+        assert!(lifecycle.on_submitted());
+
+        let gate = locks.for_session(sid).await;
+        let blocker = gate.lock().await;
+
+        // 阶段二侧探针：阶段二若执行 cancel_engine 复查会置位。
+        let phase_two_cancel_called = Arc::new(AtomicBool::new(false));
+        let phase_one_count = Arc::new(AtomicU64::new(0));
+        let probe2 = phase_two_cancel_called.clone();
+        let probe1 = phase_one_count.clone();
+        // C2：阶段一无锁快照 target=Some(1) → 匹配 → cancel_engine（probe1++）；
+        //     阶段二持锁（被 blocker 阻塞），恢复后比对 current ≠ target → early return。
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                move || {
+                    let probe2 = probe2.clone();
+                    let probe1 = probe1.clone();
+                    async move {
+                        // 阶段一与阶段二复查都走这里：用计数区分。
+                        // 阶段一（turn1）probe1 0→1；阶段二若误执行 probe2 置位。
+                        let prev = probe1.fetch_add(1, Ordering::AcqRel);
+                        if prev >= 1 {
+                            probe2.store(true, Ordering::Release);
+                        }
+                        true
+                    }
+                },
+                // claim_unsubmitted 不应被调用（turn1 已 submitted）。
+                |_lc| false,
+            )
+            .await
+        });
+        // 让 C2 进展到阶段一完成、阶段二 gate.lock().await 挂起。
+        tokio::task::yield_now().await;
+
+        // turn1 终态（submitted，走 claim 路径）→ turn2 reserve（epoch=2）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        // 释放 turn_lock，C2 阶段二恢复：current=Some(2) ≠ target=Some(1) → early return。
+        drop(blocker);
+        drop(gate);
+        cancel_task.await.expect("cancel task joins");
+
+        // 阶段一执行了一次（取消 turn1，正确）。
+        assert_eq!(
+            phase_one_count.load(Ordering::Acquire),
+            1,
+            "phase one cancel on the originating turn must run exactly once"
+        );
+        // 阶段二未误执行 cancel_engine（守护生效），turn2 不被误取消。
+        assert!(
+            !phase_two_cancel_called.load(Ordering::Acquire),
+            "phase two must not cancel the engine of a turn that started after the cancel was issued"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn reservation must remain valid after a stale cancel's phase two recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_cancel_after_turn_change_still_cancels_new_turn() {
+        // 对照测试，防止 generation 守护过度：用户在新轮启动**后**才点停止，
+        // 快照到新轮 epoch，匹配 → 合法取消新轮（cancel_engine 触发）。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-fresh-cancel";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1 reserve → 终态（未提交认领路径）→ turn2 reserve（epoch=2）。
+        let _reservation1 = lifecycle.reserve().expect("turn1 reserve");
+        assert!(lifecycle.finish_unsubmitted_once());
+        let _reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        let cancel_called = Arc::new(AtomicBool::new(false));
+        let probe = cancel_called.clone();
+        cancel_turn_with_gates(
+            &locks,
+            &lifecycles,
+            &shell_tasks,
+            sid,
+            move || {
+                let probe = probe.clone();
+                async move {
+                    probe.store(true, Ordering::Release);
+                    true
+                }
+            },
+            |_lc| false,
+        )
+        .await;
+
+        // target=Some(2)=current → 匹配 → cancel_engine 触发。
+        assert!(
+            cancel_called.load(Ordering::Acquire),
+            "a fresh cancel on the current turn must still cancel its engine"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_skips_unsubmitted_claim_and_leaves_new_turn_intact() {
+        // invalidate 路径：cancel_engine 返回 false（模拟 engine 不在场）时，
+        // generation 不匹配必须阻止 claim_unsubmitted（认领未提交终态使 reservation
+        // 失效），否则新轮未提交 reservation 会被误清。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-stale-invalidate";
+
+        let lifecycle = lifecycles.for_session(sid);
+        let _reservation1 = lifecycle.reserve().expect("turn1 reserve");
+        let gate = locks.for_session(sid).await;
+        let blocker = gate.lock().await;
+
+        let claimed = Arc::new(AtomicBool::new(false));
+        let probe = claimed.clone();
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                // engine 不在场 → 返回 false → 走 claim_unsubmitted 分支。
+                || async { false },
+                move |lc| {
+                    probe.store(true, Ordering::Release);
+                    // 复用真实的未提交认领路径以观察副作用。
+                    lc.claim_unsubmitted_terminal()
+                },
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+
+        // turn1 终态（未提交认领路径）→ turn2 未提交 reservation（epoch=2）。
+        assert!(lifecycle.finish_unsubmitted_once());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        drop(blocker);
+        drop(gate);
+        cancel_task.await.expect("cancel task joins");
+
+        // 断言：claim_unsubmitted 闭包未被调用，turn2 reservation 仍有效。
+        assert!(
+            !claimed.load(Ordering::Acquire),
+            "stale cancel must not claim an unsubmitted terminal on a new turn"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn unsubmitted reservation must survive a stale cancel"
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -253,11 +253,22 @@ fn generation_matches(target: Option<u64>, current: Option<u64>) -> bool {
 /// 新轮消息入队，FIFO 保证 engine 先取消旧轮子智能体、后启动新轮，迟到的
 /// 级联取消不会误杀新轮刚启动的子智能体（reviewer 点 4：spawn 异步发送
 /// 失去相对下一轮 SendMessage 的入队顺序保证）。
+///
+/// **级联取消送达守护**（reviewer 点 9）：phase 1 的 best-effort `try_send`
+/// 在 ops 通道满（容量 32）时可能失败且被静默忽略，`CancelSubAgents` 从未
+/// 入队。若随后旧轮结束、新轮在 phase 2 取得 turn gate 前完成 `reserve`，
+/// 阶段二会因 generation mismatch 直接 return，`cascade_cancel` 永不执行——
+/// 旧轮派生的 detached 子代理继续运行。为此 `cascade_queued` 记录 phase 1
+/// 级联取消是否已成功入队（调用方在 `cancel_current` 闭包内 set）：mismatch
+/// 分支在 return 前，若 phase 1 未送达且新轮尚未提交（仅 reserve 未 send，
+/// `SendMessage` 需等同一把 `turn_lock`，engine 里仍是旧轮遗留子代理）或
+/// 当前空闲，则持锁补发一次 `cascade_cancel`，不会命中新轮子代理。
 async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
     turn_locks: &SessionTurnLocks,
     turn_lifecycles: &SessionTurnLifecycles,
     turn_shell_tasks: &SessionTurnShellTasks,
     session_id: &str,
+    cascade_queued: &AtomicBool,
     mut get_engine: E,
     mut cancel_current: X,
     mut cascade_cancel: F,
@@ -320,6 +331,21 @@ async fn cancel_turn_with_gates<G, E, EFut, X, F, FFut, C>(
         // 目标轮已结束（新轮已 reserve）：整体 no-op。此 early-return 必须在
         // request_cancel / claim_unsubmitted / cancel_engine 之前——request_cancel
         // 会取消当前 active shell scope，若已是新轮会误清理新轮的 shell 任务。
+        //
+        // 例外（reviewer 点 9）：phase 1 的 best-effort try_send 若因 ops 通道满
+        // 而未送达（cascade_queued == false），旧轮派生的 detached 子代理未被
+        // 取消。此时若新轮尚未提交（仅 reserve 未 send：SendMessage 需等同一把
+        // turn_lock、被本函数持有，engine 里仍是旧轮遗留子代理）或当前空闲，
+        // 持锁补发一次级联取消是安全的——不会命中新轮刚启动的子代理。
+        if !cascade_queued.load(Ordering::Acquire)
+            && !lifecycle
+                .as_ref()
+                .is_some_and(|lc| lc.is_current_turn_submitted())
+        {
+            if let Some(engine) = get_engine().await {
+                cascade_cancel(&engine).await;
+            }
+        }
         return;
     }
 
@@ -1278,11 +1304,17 @@ impl EnginePool {
         // 时刻的轮次 epoch，并发请求中排队较晚的 C2 在 turn_lock 释放后若发现
         // 目标轮已结束（新轮已 reserve），整体 no-op，不误取消新轮。
         let app = &self.app;
+        // phase 1 的 best-effort try_send 级联取消是否已成功入队（ops 通道满时
+        // 可能失败）。阶段二 generation mismatch 时据此决定是否持锁补发级联
+        // 取消（reviewer 点 9）——旧轮派生的 detached 子代理不能被静默丢弃。
+        let cascade_queued = Arc::new(AtomicBool::new(false));
+        let cascade_flag = cascade_queued.clone();
         cancel_turn_with_gates(
             &self.turn_locks,
             &self.turn_lifecycles,
             &self.turn_shell_tasks,
             session_id,
+            &cascade_queued,
             // get_engine：取在场 engine 句柄（不取消，epoch 校验由
             // cancel_turn_with_gates 在 await 之后、cancel 之前执行，消除
             // handle_for 取 entries 锁期间的 TOCTOU 窗口）。
@@ -1295,10 +1327,13 @@ impl EnginePool {
             // 没有取消按钮，自然语言指令只是建议），只取消宿主轮会留下继续
             // 烧钱的后台子智能体。try_send 不阻塞、通道有空位时立即入队
             // （早于下一轮 SendMessage）；通道满（容量 32）时放弃，由阶段二
-            // cascade_cancel 持锁 await 补发保证送达。
+            // cascade_cancel 持锁 await 补发保证送达；mismatch 分支据
+            // cascade_queued 决定是否补发（reviewer 点 9）。
             |engine| {
                 engine.cancel_current();
-                let _ = engine.handle.try_send(Op::CancelSubAgents);
+                if engine.handle.try_send(Op::CancelSubAgents).is_ok() {
+                    cascade_flag.store(true, Ordering::Release);
+                }
             },
             // cascade_cancel：阶段二持 turn_lock 时 await 发送级联取消，保证在
             // 释放 turn gate 前完成入队——下一轮 SendMessage 必须等同一把
@@ -2149,6 +2184,9 @@ mod scheduled_model_tests {
         // （reviewer 点 4）。
         let cascade_called = Arc::new(AtomicBool::new(false));
         let probe_cascade = cascade_called.clone();
+        // phase 1 级联取消视为已成功入队（本测试不覆盖 reviewer 点 9 的
+        // try_send 失败场景；保持 mismatch early-return 的既有断言语义）。
+        let cascade_queued = AtomicBool::new(true);
         // C2：阶段一无锁快照 target=Some(1) → 匹配 → get_engine 返回在场 engine
         //     → 校验 epoch 仍匹配 → arm + cancel_current（probe1++）；
         //     阶段二持锁（被 blocker 阻塞），恢复后比对 current ≠ target → early return。
@@ -2158,6 +2196,7 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
+                &cascade_queued,
                 // get_engine：engine 在场（阶段一与阶段二复查都返回 Some）。
                 || async { Some(()) },
                 // cancel_current：阶段一与阶段二复查都走这里：用计数区分。
@@ -2231,11 +2270,14 @@ mod scheduled_model_tests {
         // cascade 探针：正常取消路径（fresh cancel）必须执行级联取消。
         let cascade_called = Arc::new(AtomicBool::new(false));
         let probe_cascade = cascade_called.clone();
+        // phase 1 级联取消视为已成功入队（本测试不覆盖 reviewer 点 9 场景）。
+        let cascade_queued = AtomicBool::new(true);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
+            &cascade_queued,
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current：记录触发。
@@ -2264,6 +2306,153 @@ mod scheduled_model_tests {
     }
 
     #[tokio::test]
+    async fn stale_cancel_retries_cascade_when_phase_one_try_send_failed() {
+        // reviewer 点 9 的确定性回归：phase 1 的 best-effort try_send 因 ops
+        // 通道满（容量 32）而失败时（cascade_queued == false），CancelSubAgents
+        // 从未入队；若随后旧轮结束、新轮在 phase 2 取得 turn gate 前完成
+        // reserve，阶段二 generation mismatch 直接 return 会让级联取消永久丢失，
+        // 旧轮派生的 detached 子代理继续运行。修复后 mismatch 分支必须在
+        // 新轮尚未提交（仅 reserve 未 send——SendMessage 需等同一把 turn_lock、
+        // 被本函数持有，engine 里仍是旧轮遗留子代理）时持锁补发一次 cascade。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-try-send-failure";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：on_submitted 激活（active+submitted+epoch=1）。
+        assert!(lifecycle.on_submitted());
+
+        let gate = locks.for_session(sid).await;
+        let blocker = gate.lock().await;
+
+        let cascade_called = Arc::new(AtomicBool::new(false));
+        let probe_cascade = cascade_called.clone();
+        let cancel_called = Arc::new(AtomicBool::new(false));
+        let probe_cancel = cancel_called.clone();
+        // phase 1 的 try_send 失败（ops 通道满）：cascade_queued 保持 false。
+        let cascade_queued = AtomicBool::new(false);
+
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                &cascade_queued,
+                // get_engine：engine 在场（阶段一与补发复查都返回 Some）。
+                || async { Some(()) },
+                // cancel_current：阶段一执行一次（取消旧轮）。
+                move |_engine: &()| {
+                    probe_cancel.store(true, Ordering::Release);
+                },
+                // cascade_cancel：phase 1 送达失败 + 新轮未提交 → mismatch 分支
+                // 必须补发，不能因 generation mismatch 直接丢弃级联取消。
+                move |_engine: &()| {
+                    probe_cascade.store(true, Ordering::Release);
+                    async {}
+                },
+                // claim_unsubmitted 不应被调用（turn1 已 submitted）。
+                |_lc, _target| false,
+            )
+            .await
+        });
+        // 让 cancel 进展到阶段一完成、阶段二 gate.lock().await 挂起。
+        tokio::task::yield_now().await;
+
+        // turn1 终态（submitted，走 claim 路径）→ turn2 reserve（epoch=2，
+        // 未提交——SendMessage 被阶段二持有的 turn_lock 阻塞）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        let reservation2 = lifecycle.reserve().expect("turn2 reserve");
+
+        // 释放 turn_lock：阶段二恢复，current=Some(2) ≠ target=Some(1) → mismatch
+        // → cascade_queued==false 且新轮未提交 → 补发级联取消。
+        drop(blocker);
+        drop(gate);
+        cancel_task.await.expect("cancel task joins");
+
+        assert!(
+            cascade_called.load(Ordering::Acquire),
+            "a stale cancel must retry the cascade when phase one try_send failed and the new turn has not started"
+        );
+        assert!(
+            cancel_called.load(Ordering::Acquire),
+            "phase one must still cancel the originating turn's engine"
+        );
+        assert!(
+            reservation2.ensure_active().is_ok(),
+            "new turn reservation must remain valid after the cascade retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_skips_cascade_retry_when_new_turn_already_submitted() {
+        // reviewer 点 9 的补发边界：phase 1 try_send 失败 + 新轮**已提交**
+        // （SendMessage 已入 engine，新轮可能已启动子代理）时，mismatch 分支
+        // 不得补发级联取消——否则 CancelSubAgents 会误杀新轮刚启动的子代理。
+        // 补发仅在「新轮尚未提交」的窗口内安全（engine 里仍是旧轮遗留子代理）。
+        let locks = SessionTurnLocks::default();
+        let lifecycles = SessionTurnLifecycles::default();
+        let shell_tasks = SessionTurnShellTasks::default();
+        let sid = "session-try-send-failure-submitted";
+
+        let lifecycle = lifecycles.for_session(sid);
+        // turn1：on_submitted 激活（epoch=1）。
+        assert!(lifecycle.on_submitted());
+
+        let gate = locks.for_session(sid).await;
+        let blocker = gate.lock().await;
+
+        let cascade_called = Arc::new(AtomicBool::new(false));
+        let probe_cascade = cascade_called.clone();
+        let cancel_called = Arc::new(AtomicBool::new(false));
+        let probe_cancel = cancel_called.clone();
+        let cascade_queued = AtomicBool::new(false);
+
+        let cancel_task = tokio::spawn(async move {
+            cancel_turn_with_gates(
+                &locks,
+                &lifecycles,
+                &shell_tasks,
+                sid,
+                &cascade_queued,
+                || async { Some(()) },
+                move |_engine: &()| {
+                    probe_cancel.store(true, Ordering::Release);
+                },
+                move |_engine: &()| {
+                    probe_cascade.store(true, Ordering::Release);
+                    async {}
+                },
+                |_lc, _target| false,
+            )
+            .await
+        });
+        // 让 cancel 进展到阶段一完成、阶段二 gate.lock().await 挂起。
+        tokio::task::yield_now().await;
+
+        // turn1 终态 → turn2 on_submitted 激活（epoch=2，submitted=true——
+        // SendMessage 已入 engine，可能已启动新轮子代理）。
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        assert!(lifecycle.on_submitted());
+
+        // 释放 turn_lock：阶段二 current=Some(2) ≠ target=Some(1) → mismatch；
+        // 新轮已提交 → 不得补发级联取消。
+        drop(blocker);
+        drop(gate);
+        cancel_task.await.expect("cancel task joins");
+
+        assert!(
+            !cascade_called.load(Ordering::Acquire),
+            "cascade retry must be skipped when the new turn has already been submitted"
+        );
+        assert!(
+            cancel_called.load(Ordering::Acquire),
+            "phase one must still cancel the originating turn's engine"
+        );
+    }
+
+    #[tokio::test]
     async fn stale_cancel_skips_unsubmitted_claim_and_leaves_new_turn_intact() {
         // invalidate 路径：cancel_engine 返回 false（模拟 engine 不在场）时，
         // generation 不匹配必须阻止 claim_unsubmitted（认领未提交终态使 reservation
@@ -2280,12 +2469,16 @@ mod scheduled_model_tests {
 
         let claimed = Arc::new(AtomicBool::new(false));
         let probe = claimed.clone();
+        // phase 1 无 engine，级联取消未送达；但新轮已 reserve 未 send 时
+        // mismatch 分支会补发（reviewer 点 9）——engine 不在场则补发 no-op。
+        let cascade_queued = AtomicBool::new(false);
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
                 &locks,
                 &lifecycles,
                 &shell_tasks,
                 sid,
+                &cascade_queued,
                 // engine 不在场 → get_engine 返回 None → 不取消，走 claim_unsubmitted 分支。
                 || async { None::<()> },
                 // cancel_current：engine 不在场时不应被调用。
@@ -2340,11 +2533,15 @@ mod scheduled_model_tests {
 
         let new_turn_intact = Arc::new(AtomicBool::new(false));
         let probe = new_turn_intact.clone();
+        // phase 1 无 engine，级联取消未送达；engine 不在场时 mismatch 分支
+        // 的补发是 no-op，不影响本测试的 claim 语义。
+        let cascade_queued = AtomicBool::new(false);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
+            &cascade_queued,
             // engine 不在场 → get_engine 返回 None → 不 cancel，走 claim_unsubmitted。
             || async { None::<()> },
             // cancel_current：engine 不在场，不应被调用。
@@ -2409,6 +2606,10 @@ mod scheduled_model_tests {
         let probe = cancel_called.clone();
         let get_engine_calls = Arc::new(AtomicU64::new(0));
         let probe_calls = get_engine_calls.clone();
+        // phase 1 级联取消视为已成功入队（本测试聚焦阶段一 TOCTOU 守护，
+        // 不覆盖 reviewer 点 9 的 try_send 失败补发路径；保持 mismatch
+        // early-return 不级联的既有断言）。
+        let cascade_queued = AtomicBool::new(true);
 
         let cancel_task = tokio::spawn(async move {
             cancel_turn_with_gates(
@@ -2416,6 +2617,7 @@ mod scheduled_model_tests {
                 &lifecycles,
                 &shell_tasks,
                 sid,
+                &cascade_queued,
                 // get_engine：第一次调用（阶段一）通知已进入后挂起（模拟
                 // handle_for 取 entries 锁的 await），放行后返回「engine 在场」。
                 // 若实现退化（阶段二缺 generation 守护，即 #205 原始 bug），
@@ -2497,11 +2699,15 @@ mod scheduled_model_tests {
 
         let cancel_calls = Arc::new(AtomicU64::new(0));
         let probe_calls = cancel_calls.clone();
+        // phase 1 级联取消视为已成功入队（本测试聚焦 arm 顺序不变量，
+        // 不覆盖 reviewer 点 9 的 try_send 失败补发路径）。
+        let cascade_queued = AtomicBool::new(true);
         cancel_turn_with_gates(
             &locks,
             &lifecycles,
             &shell_tasks,
             sid,
+            &cascade_queued,
             // get_engine：engine 在场。
             || async { Some(()) },
             // cancel_current 探针：仅计数。cancel 在 state 锁内执行，探针不能

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -575,6 +575,10 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const chatItems = bs ? bs.chatItems : [];
       const activeSessionId = bs ? bs.activeSessionId : null;
       const busy = bs ? bs.busy : false;
+      // 停止按钮 single-flight:busy 在首次 cancel_generation 返回前就复位,
+      // 双击会发第二个并发取消请求。cancelling 在 invoke 完成前禁用按钮,
+      // 配合后端 turn generation 守护,消除跨轮误取消窗口。
+      const [cancelling, setCancelling] = useState(false);
       const activeModelLocal = activeModelIsLocal(bs);
       const hasMessages = chatItems.length > 0;
       const attachments = (bs && bs.attachments) || [];
@@ -1282,8 +1286,15 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         }
       }
 
-      function handleCancel() {
-        if (bridge.available) bridge.chat.cancelGeneration();
+      async function handleCancel() {
+        // single-flight:已在取消中则忽略后续点击，避免并发 cancel_generation。
+        if (!bridge.available || cancelling) return;
+        setCancelling(true);
+        try {
+          await bridge.chat.cancelGeneration();
+        } finally {
+          setCancelling(false);
+        }
       }
 
       function finishFloatingVoicePointer(pointerId, event, releaseCapture, reason) {
@@ -1913,8 +1924,8 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                   </button>
                 )}
                 {busy ? (
-                  <button onClick={handleCancel}
-                    className="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-black/5 dark:bg-white/10 text-[#C5221F] dark:text-[#F28B82] hover:bg-black/10 dark:hover:bg-white/20 transition-colors">
+                  <button onClick={handleCancel} disabled={cancelling}
+                    className="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-black/5 dark:bg-white/10 text-[#C5221F] dark:text-[#F28B82] hover:bg-black/10 dark:hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                     <StopCircle size={20} />
                   </button>
                 ) : (() => {

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -576,9 +576,12 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const activeSessionId = bs ? bs.activeSessionId : null;
       const busy = bs ? bs.busy : false;
       // 停止按钮 single-flight:busy 在首次 cancel_generation 返回前就复位,
-      // 双击会发第二个并发取消请求。cancelling 在 invoke 完成前禁用按钮,
-      // 配合后端 turn generation 守护,消除跨轮误取消窗口。
-      const [cancelling, setCancelling] = useState(false);
+      // 双击会发第二个并发取消请求。cancellingSessionId 在 invoke 完成前禁用
+      // **当前 session** 的按钮（按 session 记录而非全局布尔：ChatView 在切换
+      // active session 时不 remount，全局 single-flight 会阻断新会话的停止，
+      // 直到旧会话的 invoke 返回；绑定到 session 后取消 A 期间切到 B 仍可取消
+      // B，配合后端 turn generation 守护,消除跨轮误取消窗口）。
+      const [cancellingSessionId, setCancellingSessionId] = useState(null);
       const activeModelLocal = activeModelIsLocal(bs);
       const hasMessages = chatItems.length > 0;
       const attachments = (bs && bs.attachments) || [];
@@ -1287,13 +1290,19 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       }
 
       async function handleCancel() {
-        // single-flight:已在取消中则忽略后续点击，避免并发 cancel_generation。
-        if (!bridge.available || cancelling) return;
-        setCancelling(true);
+        // single-flight:同一 session 已在取消中则忽略后续点击，避免并发
+        // cancel_generation。按 session 记录（而非全局布尔）——取消会话 A
+        // 期间切到仍在运行的会话 B，B 的停止按钮不因 A 的 invoke 未返回而
+        // 被禁用，B 的取消请求不被丢弃。
+        if (!bridge.available || cancellingSessionId === activeSessionId) return;
+        const cancellingSid = activeSessionId;
+        setCancellingSessionId(cancellingSid);
         try {
           await bridge.chat.cancelGeneration();
         } finally {
-          setCancelling(false);
+          // 只清当前 session 自己的取消标记；若期间已切到别的会话并开始了
+          // 新的取消（cancellingSessionId 已变），不要误清对方的标记。
+          setCancellingSessionId(prev => (prev === cancellingSid ? null : prev));
         }
       }
 
@@ -1924,7 +1933,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                   </button>
                 )}
                 {busy ? (
-                  <button onClick={handleCancel} disabled={cancelling}
+                  <button onClick={handleCancel} disabled={cancellingSessionId === activeSessionId}
                     className="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-black/5 dark:bg-white/10 text-[#C5221F] dark:text-[#F28B82] hover:bg-black/10 dark:hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                     <StopCircle size={20} />
                   </button>

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -576,12 +576,14 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const activeSessionId = bs ? bs.activeSessionId : null;
       const busy = bs ? bs.busy : false;
       // 停止按钮 single-flight:busy 在首次 cancel_generation 返回前就复位,
-      // 双击会发第二个并发取消请求。cancellingSessionId 在 invoke 完成前禁用
-      // **当前 session** 的按钮（按 session 记录而非全局布尔：ChatView 在切换
-      // active session 时不 remount，全局 single-flight 会阻断新会话的停止，
-      // 直到旧会话的 invoke 返回；绑定到 session 后取消 A 期间切到 B 仍可取消
-      // B，配合后端 turn generation 守护,消除跨轮误取消窗口）。
-      const [cancellingSessionId, setCancellingSessionId] = useState(null);
+      // 双击会发第二个并发取消请求。cancellingSessionIds 在 invoke 完成前禁用
+      // **对应 session** 的按钮（按 session 集合记录而非全局布尔或单个 sid：
+      // ChatView 在切换 active session 时不 remount，全局 single-flight 会阻断
+      // 新会话的停止，直到旧会话的 invoke 返回；单个 sid 无法表示多个会话
+      // 并发取消——A 取消中切到 B 发起取消再切回 A，A 的标记会被 B 覆盖导致
+      // 按钮误启用。Set 让各会话独立记录，配合后端 turn generation 守护，
+      // 消除跨轮误取消窗口）。
+      const [cancellingSessionIds, setCancellingSessionIds] = useState(() => new Set());
       const activeModelLocal = activeModelIsLocal(bs);
       const hasMessages = chatItems.length > 0;
       const attachments = (bs && bs.attachments) || [];
@@ -1291,18 +1293,23 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
 
       async function handleCancel() {
         // single-flight:同一 session 已在取消中则忽略后续点击，避免并发
-        // cancel_generation。按 session 记录（而非全局布尔）——取消会话 A
-        // 期间切到仍在运行的会话 B，B 的停止按钮不因 A 的 invoke 未返回而
-        // 被禁用，B 的取消请求不被丢弃。
-        if (!bridge.available || cancellingSessionId === activeSessionId) return;
+        // cancel_generation。按 session 集合记录（而非全局布尔或单个 sid）——
+        // 多个会话可以同时处于取消中（取消 A 期间切到 B 发起取消，再切回 A，
+        // A 的标记不能被 B 覆盖）。各自 Promise 完成时只删除对应 sid。
+        if (!bridge.available || cancellingSessionIds.has(activeSessionId)) return;
         const cancellingSid = activeSessionId;
-        setCancellingSessionId(cancellingSid);
+        setCancellingSessionIds(prev => new Set(prev).add(cancellingSid));
         try {
           await bridge.chat.cancelGeneration();
         } finally {
           // 只清当前 session 自己的取消标记；若期间已切到别的会话并开始了
-          // 新的取消（cancellingSessionId 已变），不要误清对方的标记。
-          setCancellingSessionId(prev => (prev === cancellingSid ? null : prev));
+          // 新的取消（cancellingSessionIds 里已有其他 sid），不要误清对方。
+          setCancellingSessionIds(prev => {
+            if (!prev.has(cancellingSid)) return prev;
+            const next = new Set(prev);
+            next.delete(cancellingSid);
+            return next;
+          });
         }
       }
 
@@ -1933,7 +1940,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                   </button>
                 )}
                 {busy ? (
-                  <button onClick={handleCancel} disabled={cancellingSessionId === activeSessionId}
+                  <button onClick={handleCancel} disabled={cancellingSessionIds.has(activeSessionId)}
                     className="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-black/5 dark:bg-white/10 text-[#C5221F] dark:text-[#F28B82] hover:bg-black/10 dark:hover:bg-white/20 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                     <StopCircle size={20} />
                   </button>

--- a/pinvou3-app/tests/chat_cancel_session_scope.test.mjs
+++ b/pinvou3-app/tests/chat_cancel_session_scope.test.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// 评论 9（PR #207 reviewer 点 9）的回归：ChatView 的取消中状态必须按
+// session 记录（cancellingSessionId），而不是全局 single-flight 布尔。
+// ChatView 在切换 active session 时不 remount，全局布尔会让「取消会话 A
+// 期间切到仍在运行的会话 B」时 B 的停止按钮保持禁用、handleCancel 早退
+// 丢弃 B 的取消，直到 A 的 invoke 返回（后端通道背压时可能较长）。
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const chatPath = path.join(here, '..', 'src', 'features', 'chat', 'ChatView.jsx');
+const chatSource = fs.readFileSync(chatPath, 'utf8');
+
+// 1. 取消中状态按 session 记录：state 是 cancellingSessionId 而非全局布尔。
+assert.match(
+  chatSource,
+  /const \[cancellingSessionId, setCancellingSessionId\] = useState\(null\);/,
+  'cancelling state must be bound to a session id, not a global boolean',
+);
+
+// 2. handleCancel 的 single-flight 早退按 session 判断：只有当前 session 已在
+//    取消中才忽略点击；切到别的会话后不再被旧会话的取消挡住。
+assert.match(
+  chatSource,
+  /if \(!bridge\.available \|\| cancellingSessionId === activeSessionId\) return;/,
+  'handleCancel must early-return only when the same session is already cancelling',
+);
+
+// 3. 取消标记在 invoke 期间只禁用当前 session 的按钮。
+assert.match(
+  chatSource,
+  /disabled=\{cancellingSessionId === activeSessionId\}/,
+  'stop button must be disabled only for the session being cancelled',
+);
+
+// 4. finally 清理按发起时快照清自己的标记：切换 session 后旧 invoke 返回
+//    不会误清新 session 正在进行的取消标记（函数式更新 + 快照比较）。
+assert.match(
+  chatSource,
+  /setCancellingSessionId\(prev => \(prev === cancellingSid \? null : prev\)\);/,
+  'finally must clear only the cancelling flag armed for its own session',
+);
+
+// 5. 旧全局布尔不应残留（防回归到全局 single-flight）。
+assert.ok(
+  !/useState\(false\);[\s\S]{0,400}handleCancel/.test(chatSource) ||
+    !/const \[cancelling, setCancelling\] = useState\(false\)/.test(chatSource),
+  'no global cancelling boolean state may remain in ChatView',
+);
+
+// 6. 提取 handleCancel 函数体做行为验证：同一 session 双击被忽略，切 session
+//    后允许新取消（用文本级模拟，避免渲染 JSX）。
+const start = chatSource.indexOf('async function handleCancel()');
+assert.notStrictEqual(start, -1, 'handleCancel must exist');
+const end = chatSource.indexOf('\n      }', start);
+const handleCancelBody = chatSource.slice(start, end);
+assert.match(handleCancelBody, /cancellingSessionId === activeSessionId/);
+assert.match(handleCancelBody, /setCancellingSessionId\(cancellingSid\)/);
+assert.match(handleCancelBody, /await bridge\.chat\.cancelGeneration\(\)/);
+assert.match(handleCancelBody, /prev === cancellingSid \? null : prev/);
+
+console.log('ok: cancel state is scoped per session (reviewer point 9)');

--- a/pinvou3-app/tests/chat_cancel_session_scope.test.mjs
+++ b/pinvou3-app/tests/chat_cancel_session_scope.test.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
-// 评论 9（PR #207 reviewer 点 9）的回归：ChatView 的取消中状态必须按
-// session 记录（cancellingSessionId），而不是全局 single-flight 布尔。
-// ChatView 在切换 active session 时不 remount，全局布尔会让「取消会话 A
-// 期间切到仍在运行的会话 B」时 B 的停止按钮保持禁用、handleCancel 早退
-// 丢弃 B 的取消，直到 A 的 invoke 返回（后端通道背压时可能较长）。
+// 评论 9/12（PR #207 reviewer 点 9 + 协作者评论 12）的回归：ChatView 的取消中
+// 状态必须按 session 记录（cancellingSessionIds 集合），而不是全局 single-flight
+// 布尔或单个 sid。ChatView 在切换 active session 时不 remount，全局布尔会让
+// 「取消会话 A 期间切到仍在运行的会话 B」时 B 的停止按钮保持禁用、handleCancel
+// 早退丢弃 B 的取消，直到 A 的 invoke 返回（后端通道背压时可能较长）。单个 sid
+// 则无法表示多个会话同时处于取消中：A 发起取消 → 切到 B 发起取消 → 切回 A 时
+// state 已被 B 覆盖，A 的按钮重新启用、可重复触发取消。必须用按 sid 的 Set
+// 记录，并在各自 Promise 完成时只删除对应 sid。
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -13,52 +16,95 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const chatPath = path.join(here, '..', 'src', 'features', 'chat', 'ChatView.jsx');
 const chatSource = fs.readFileSync(chatPath, 'utf8');
 
-// 1. 取消中状态按 session 记录：state 是 cancellingSessionId 而非全局布尔。
+// 1. 取消中状态按 session 集合记录：state 是 cancellingSessionIds（Set），
+//    而非全局布尔或单个 sid。
 assert.match(
   chatSource,
-  /const \[cancellingSessionId, setCancellingSessionId\] = useState\(null\);/,
-  'cancelling state must be bound to a session id, not a global boolean',
+  /const \[cancellingSessionIds, setCancellingSessionIds\] = useState\(\(\) => new Set\(\)\);/,
+  'cancelling state must be a per-session id set, not a global boolean or single id',
 );
 
 // 2. handleCancel 的 single-flight 早退按 session 判断：只有当前 session 已在
 //    取消中才忽略点击；切到别的会话后不再被旧会话的取消挡住。
 assert.match(
   chatSource,
-  /if \(!bridge\.available \|\| cancellingSessionId === activeSessionId\) return;/,
+  /if \(!bridge\.available \|\| cancellingSessionIds\.has\(activeSessionId\)\) return;/,
   'handleCancel must early-return only when the same session is already cancelling',
 );
 
-// 3. 取消标记在 invoke 期间只禁用当前 session 的按钮。
+// 3. 取消标记在 invoke 期间只禁用当前 session 的按钮（按集合成员判断）。
 assert.match(
   chatSource,
-  /disabled=\{cancellingSessionId === activeSessionId\}/,
+  /disabled=\{cancellingSessionIds\.has\(activeSessionId\)\}/,
   'stop button must be disabled only for the session being cancelled',
 );
 
-// 4. finally 清理按发起时快照清自己的标记：切换 session 后旧 invoke 返回
-//    不会误清新 session 正在进行的取消标记（函数式更新 + 快照比较）。
+// 4. 发起取消时把 sid 加入集合（不可变更新，保留其他会话的标记）。
 assert.match(
   chatSource,
-  /setCancellingSessionId\(prev => \(prev === cancellingSid \? null : prev\)\);/,
+  /setCancellingSessionIds\(prev => new Set\(prev\)\.add\(cancellingSid\)\);/,
+  'starting a cancel must add the sid to the set without dropping other sids',
+);
+
+// 5. finally 清理按发起时快照只删自己的 sid：切换 session 后旧 invoke 返回
+//    不会误清其他会话正在进行的取消标记（函数式更新 + 快照比较）。
+assert.match(
+  chatSource,
+  /setCancellingSessionIds\(prev => \{[\s\S]{0,200}next\.delete\(cancellingSid\);[\s\S]{0,120}return next;\s*\}\);/,
   'finally must clear only the cancelling flag armed for its own session',
 );
 
-// 5. 旧全局布尔不应残留（防回归到全局 single-flight）。
+// 6. 旧全局布尔 / 单个 sid 不应残留（防回归到旧实现）。
 assert.ok(
   !/useState\(false\);[\s\S]{0,400}handleCancel/.test(chatSource) ||
     !/const \[cancelling, setCancelling\] = useState\(false\)/.test(chatSource),
   'no global cancelling boolean state may remain in ChatView',
 );
+assert.ok(
+  !/cancellingSessionId === activeSessionId/.test(chatSource),
+  'no single-session cancelling comparison may remain in ChatView',
+);
 
-// 6. 提取 handleCancel 函数体做行为验证：同一 session 双击被忽略，切 session
+// 7. 提取 handleCancel 函数体做行为验证：同一 session 双击被忽略，切 session
 //    后允许新取消（用文本级模拟，避免渲染 JSX）。
 const start = chatSource.indexOf('async function handleCancel()');
 assert.notStrictEqual(start, -1, 'handleCancel must exist');
 const end = chatSource.indexOf('\n      }', start);
 const handleCancelBody = chatSource.slice(start, end);
-assert.match(handleCancelBody, /cancellingSessionId === activeSessionId/);
-assert.match(handleCancelBody, /setCancellingSessionId\(cancellingSid\)/);
+assert.match(handleCancelBody, /cancellingSessionIds\.has\(activeSessionId\)/);
+assert.match(handleCancelBody, /setCancellingSessionIds\(prev => new Set\(prev\)\.add\(cancellingSid\)\)/);
 assert.match(handleCancelBody, /await bridge\.chat\.cancelGeneration\(\)/);
-assert.match(handleCancelBody, /prev === cancellingSid \? null : prev/);
+assert.match(handleCancelBody, /next\.delete\(cancellingSid\)/);
 
-console.log('ok: cancel state is scoped per session (reviewer point 9)');
+// 8. A→B→A 序列行为验证：单个 sid 会被 B 覆盖导致 A 的按钮误启用；Set 语义
+//    下 A 的标记在 B 取消期间保留，只有 A 自己的 Promise 完成才清除。
+//    用与组件相同的不可变更新语义模拟。
+{
+  let cancelling = new Set();
+  const setCancelling = (updater) => { cancelling = updater(cancelling); };
+  const activeSessionId = 'A';
+
+  // A 发起取消：加入集合，按钮应禁用。
+  setCancelling(prev => new Set(prev).add('A'));
+  assert.ok(cancelling.has('A'), 'A cancelling after its invoke starts');
+  assert.ok(cancelling.has(activeSessionId), 'A button must be disabled while A is cancelling');
+
+  // 切到 B 并发起取消：B 加入集合，A 的标记必须保留。
+  setCancelling(prev => new Set(prev).add('B'));
+  assert.ok(cancelling.has('A') && cancelling.has('B'), 'A and B may cancel concurrently');
+
+  // 切回 A：A 仍在集合中，按钮必须保持禁用（不能被 B 的标记覆盖而误启用）。
+  assert.ok(cancelling.has(activeSessionId), 'switching back to A must keep A disabled');
+
+  // A 的 invoke 返回：只删 A，B 的标记不受影响。
+  setCancelling(prev => {
+    if (!prev.has('A')) return prev;
+    const next = new Set(prev);
+    next.delete('A');
+    return next;
+  });
+  assert.ok(!cancelling.has('A'), 'A cleared when its own invoke resolves');
+  assert.ok(cancelling.has('B'), 'B cancelling flag must survive A completion');
+}
+
+console.log('ok: cancel state is scoped per session and survives concurrent cancels (reviewer points 9/12)');


### PR DESCRIPTION
## 背景

Closes #205。

PR #183 修复「本地模型发消息卡死及停止按钮失效」时,第 5 轮独立审计(review [#4872749559](https://github.com/Pinvou/pinvou-agent/pull/183#pullrequestreview-4872749559))发现一个与取消流程直接相关的高优先级跨轮竞态,并在最终 approve review 的「非阻断后续」中建议单独建后续 issue + PR 修复。本 PR 据此实现 reviewer 提出的修复方向。

## 根因

`EnginePool::cancel()`(`engine_pool.rs`)分两阶段:阶段一无锁 `cancel_current`,阶段二持 `turn_lock` 按 lifecycle 提交状态分流(`emit_unsubmitted_interrupted_terminal` / `arm_pending_cancel` + `cancel_current`)。两阶段都**不绑定发起时刻的轮次身份**。

合法但错误的时序:双击停止产生 C1/C2 → C1 拿锁取消旧轮、发 chat:done、busy 复位、持锁清理 shell → 用户发新消息,`reserve_turn()`(**不取 turn_lock**)新轮抢先 reserve → C1 释放锁 → C2 恢复后读到「当前 lifecycle」(已变新轮),无差别 `cancel_current` / `arm_pending_cancel` / `emit_unsubmitted` 作用于新轮 → **误取消新 turn**。上游每个新轮由 `reset_cancel_token()` 换全新 `CancellationToken`,无身份的取消会落到随后启动的新轮上。

## 变更

均位于 `pinvou3-app/src-tauri/src/features/assistant/`(engine.rs / engine_pool.rs),未触碰 CodeWhale submodule。

### 后端:turn generation 绑定

- **新增 `turn_epoch: u64`**(`TurnLifecycleState`):在三个 active 入口(`reserve` / `on_submitted` / `on_started_transition` 的 newly_active 分支)各单调自增。新增 `current_turn_generation()` 与 `is_active()` 同口径(终态发送临界区 `terminal_closing` 内仍是本轮 epoch)。
  - **不复用 `next_reservation_id`**:`on_submitted`(定时任务 `run_scheduled_turn` 路径)激活 turn 时不碰它,会让定时 turn 的 generation 恒为旧值,守护失效。
- **`pending_cancel` 从裸 `bool` 改为 `Option<u64>`** 携带 arming 时的 epoch(reviewer 点 4)。`arm_pending_cancel(epoch)` 仅当 epoch 仍是当前轮才 arm;`take_pending_cancel(current_epoch)` 仅当 epoch 匹配才取出,跨轮泄漏的 stale pending 被丢弃,不误取消新轮。
- **cancel 主体提取为 module-level `cancel_turn_with_gates`**:两阶段各比对 generation——发起时刻快照 `target` 与持锁后 `current` 不匹配则**整体 no-op**(含 `request_cancel` 在内的所有副作用之前 early-return,避免误清理新轮 shell scope);匹配则 `arm_pending_cancel` 传当前 epoch。提取为自由函数使并发测试能用裸 `Default` 组件 + 探针闭包确定性编排,绕开 `Pinvou3Bridge::boot` / `AppHandle` / 真实 `EngineHandle`(跨 crate 私有不可构造)。
- **forwarder**(`engine.rs`):`TurnStarted` 消费 `pending_cancel` 时校验 epoch 仍属当前轮才重放 `approve_handle.cancel()`,丢弃 stale pending。

### 测试

- 新增 `turn_epoch_advances_on_every_admission_path_and_survives_terminal`、`pending_cancel_tied_to_epoch_is_dropped_after_turn_change`(直接覆盖 reviewer 点 4 缺口,补现有 `pending_cancel_does_not_leak_across_turns` 未覆盖的「新轮已 reserve 后 C2 才 arm」场景)。
- 新增 `cancel_turn_with_gates` 并发回归:`stale_cancel_after_turn_change_leaves_new_turn_intact`(C2 阶段一正常取消 turn1、阶段二 early-return 不误伤 turn2)、`fresh_cancel_after_turn_change_still_cancels_new_turn`(防过度守护误杀合法取消)、`stale_cancel_skips_unsubmitted_claim_and_leaves_new_turn_intact`(未提交路径)、`generation_matches_treats_idle_to_idle_as_match`。
- 更新现有 4 个 `pending_cancel` 测试以匹配新 API(arm/take 带 epoch 参数、返回 Option)。

### 前端:single-flight(`ChatView.jsx`)

停止按钮加 `cancelling` state(`useState` + `try/await/finally`),`handleCancel` 改 async 在 invoke 完成前禁用按钮,消除双击并发。仅改善交互——reviewer 点 5 明确前端 single-flight **不能替代后端 generation 校验**(远程控制等调用方可并发),后端守护才是正确性保证。不动 i18n(仅 disabled,不新增可见文案)。

## 实际验证

- `cargo fmt --check`、`cargo clippy -p pinvou3-tauri --lib --tests`(仅 CodeWhale submodule 22 个预存 warning,本次改动 0 warning)
- `cargo test -p pinvou3-tauri --lib features::assistant -- --skip sample_all_keeps_other_fields`:**169 passed, 0 failed**(1 ignored 为预存真机测试)
- `python3 scripts/architecture-guard.py`:无新增架构债务
- `./scripts/fork-guard.sh --fast`:指纹层全过
- 前端 `npm run lint:ui`、`npm run build:ui`:通过

## 已知风险

- **级联取消补发的残余窗口(评审评论 11)**:phase 1 的 best-effort `try_send(CancelSubAgents)` 因 ops 通道满(容量 32)失败后,若取消任务在请求 `turn_lock` 前被调度出去、新 SendMessage 抢先取得 gate 完成提交,phase 2 会因 generation mismatch + 新轮已 submitted 跳过补发,旧轮 detached 子代理可能遗留。这是「不误杀新轮」的保守取舍:此时补发全量 `cancel_all_running()` 会取消新轮刚启动的子代理。要同时满足「不误杀新轮 + 不漏旧轮」需按子代理 ID 精确取消,需要底座暴露子代理与 turn generation 的归属关系(当前 `CancelSubAgents` 无此能力),超出本 PR「不触碰 CodeWhale submodule」边界,建议后续单独 issue 推进。
- **engine 路径(`cancel_current`)的 generation 守护无真实 engine 集成测试**:`EngineHandle` 是外部 crate 具体类型(跨 crate 私有不可构造)。靠 `cancel_turn_with_gates` 的 generation 比对并发测试(用 `Arc<AtomicBool>` / `AtomicU64` 探针验证阶段二闭包未触发)+ 逻辑论证覆盖。如评审认为需要,可后续在底座补 generation 配置或 mock 注入点。
- generation 守护对定时 turn(`on_submitted` 路径)有效——这是用 `turn_epoch` 而非 `next_reservation_id` 的根本原因。
- 不影响 `composer-controls.jsx`(Plan→Yolo 的 cancel)与 Codex 车道,独立路径,本次不改。
