### PR TITLE
fix(chat): 放开云端模型输出上限，落底座 64K 兜底

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -2660,6 +2660,64 @@ mod tests {
         );
     }
 
+    /// PR #210 回归：云端模型不再被全局 DEEPSEEK_MAX_OUTPUT_TOKENS 钉死 24576。
+    /// clean env（无该 env）下云端 SavedModel.max_output_tokens 为 None →
+    /// route_limits.output_tokens 必须为 None（不声明 → 底座 64K/厂商能力兜底）；
+    /// 本地 vLLM 的 24576 由 is_local_vllm 分支显式携带（不依赖 env），两者都要锁。
+    /// 同时锁"env 残留也不影响云端"——防止 boot/release 后续重新注入该变量
+    /// 把云端打回 24576（对应 CHANGES_REQUESTED：clean env 云端 effective cap 回归）。
+    #[test]
+    fn forkguard_cloud_route_output_not_pinned_by_global_env() {
+        let (_lock, _env) =
+            locked_env(&["DEEPSEEK_MAX_OUTPUT_TOKENS", "PINVOU3_MAX_OUTPUT_TOKENS"]);
+        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
+
+        // A. 云端（Deepseek preset）：SavedModel.max_output_tokens=None（保存云端模型
+        //    时前端存 null）→ route_limits.output_tokens=None → 底座 64K/厂商能力兜底。
+        let mut cloud = fixture_bridge();
+        set_active_model(
+            &mut cloud,
+            ModelPreset::Deepseek,
+            "deepseek-v4-pro",
+            "https://api.deepseek.com",
+            "",
+        );
+        let cloud_limits = cloud.route_limits_for_model("deepseek-v4-pro");
+        let cloud_output = cloud_limits.as_ref().and_then(|l| l.output_tokens);
+        assert_eq!(
+            cloud_output, None,
+            "clean env 下云端 route_limits.output_tokens 必须为 None（不声明，落底座兜底）"
+        );
+
+        // B. 本地 vLLM：is_local_vllm 分支显式携带 24K 预算，不依赖 env → 仍 24576。
+        let mut local = fixture_bridge();
+        set_active_model(
+            &mut local,
+            ModelPreset::LocalVllm,
+            ModelPreset::LocalVllm.default_model(),
+            ModelPreset::LocalVllm.default_base_url(),
+            "",
+        );
+        let local_limits = local.route_limits_for_model(&local.model());
+        assert_eq!(
+            local_limits.as_ref().and_then(|l| l.output_tokens),
+            Some(24_576),
+            "本地 vLLM 仍显式携带 24K 预算（不依赖 DEEPSEEK_MAX_OUTPUT_TOKENS env）"
+        );
+
+        // C. env 残留（旧生产双保险未清干净 / 未来有人重新注入）也不影响云端：
+        //    品悟 route_limits 的云端分支不读该 env，只有底座在无 route 声明时才读。
+        std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576");
+        let cloud_limits_env = cloud.route_limits_for_model("deepseek-v4-pro");
+        assert_eq!(
+            cloud_limits_env.as_ref().and_then(|l| l.output_tokens),
+            None,
+            "env 残留 24576 不得把云端 route 打回 24576（品悟不读该 env）"
+        );
+        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+    }
+
     /// route profile 属于具体部署，不属于 vLLM/Qwen 特例。任何 OpenAI-compatible
     /// 本地引擎只要在 SavedModel 声明能力，都必须走同一预算链。
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -883,8 +883,9 @@ impl Pinvou3Bridge {
 
     /// 为一个具体 wire model 生成宿主已知的 route facts：
     /// SavedModel 显式能力与实时 probe 取更小值；两者都没有时复用运行状态页同一份
-    /// 模型 catalog，未知本地 vLLM 才使用 128K 保守值。output 始终不超过 Pinvou
-    /// 全局 24K 请求意图。
+    /// 模型 catalog，未知本地 vLLM 才使用 128K 保守值。
+    /// output_tokens：本地 vLLM 显式携带 Pinvou 24K 预算（防 SSE timeout 既有约束），
+    /// 云端模型不声明（SavedModel.max_output_tokens 默认 None）→ 底座按 64K/厂商能力兜底。
     fn route_limits_for_model(&self, model: &str) -> Option<codewhale_config::route::RouteLimits> {
         let saved = self.effective_model().filter(|saved| saved.model == model);
         let configured_context = saved.and_then(|saved| saved.context_window_tokens);

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -185,10 +185,21 @@ impl Pinvou3Bridge {
     /// 找到用户在桌面/文档/下载里的真实文件。配套敏感目录禁令在
     /// `bundle/instructions.md` 里引导，硬拦截后续走 deepseek-tui hook 注册。
     ///
-    /// **$PINVOU3_SESSION_ARTIFACTS** 环境变量在这里 set 到公共 MCP 产物目录。
-    /// PPT / 公文等 MCP server 是 stdio 子进程，不能可靠感知当前 GUI session；
-    /// 因此二进制办公产物固定落到 `sessions/default/artifacts/`，具体归属由带
-    /// `session_id` 的工具事件和前端持久化决定。
+    /// boot 路径的 env 注入唯一收口（PR #210 守卫目标）：只写会话产物目录
+    /// `PINVOU3_SESSION_ARTIFACTS`。PPT / 公文等 MCP server 是 stdio 子进程，
+    /// 不能可靠感知当前 GUI session，故二进制办公产物固定落到
+    /// `sessions/default/artifacts/`，具体归属由带 `session_id` 的工具事件和前端
+    /// 持久化决定。
+    ///
+    /// ⚠️ 不得在这里（或 boot 其它位置）注入 `DEEPSEEK_MAX_OUTPUT_TOKENS` /
+    /// `PINVOU3_MAX_OUTPUT_TOKENS`：底座 `effective_max_output_tokens()` 优先读
+    /// 前者，一旦回归会把所有模型（含云端）输出上限重新钉死 24576——正是本 PR
+    /// 移除的根因。lib.rs `release_env_defaults_guard` 守 run() 的 release env 注入，
+    /// 本函数 + `forkguard_boot_env_must_not_pin_global_output_cap` 守 boot 注入源头。
+    fn wire_boot_env(artifacts_dir: &std::path::Path) {
+        std::env::set_var("PINVOU3_SESSION_ARTIFACTS", artifacts_dir);
+    }
+
     pub fn boot() -> Result<Self> {
         // ⓪ 注入 pinvou3 版 prompt 文案到底座 prompt 合成层(base/locale/authority)。
         // 幂等(底座 OnceLock 首次生效、后续 Err 被忽略),必须早于任何 engine spawn。
@@ -221,7 +232,7 @@ impl Pinvou3Bridge {
             prefs.save().ok();
         }
         let artifacts = paths::default_session_artifacts_dir();
-        std::env::set_var("PINVOU3_SESSION_ARTIFACTS", &artifacts);
+        Self::wire_boot_env(&artifacts);
         let this = Self {
             prefs,
             bundle,
@@ -2668,7 +2679,8 @@ mod tests {
     /// ⚠️ C 段语义（评审修正 2026-08-11）：品悟中间层确实不读该 env，但底座
     /// `effective_max_output_tokens_for_route` **优先**读它——env 残留仍会把云端
     /// **最终请求**的 max_tokens 钉回 24576。因此不能声称"残留 env 不影响云端"；
-    /// 真正的防线是 release/boot 不再注入（见 lib.rs `release_env_defaults_guard`）。
+    /// 真正的防线是 release/boot 不再注入（见 lib.rs `release_env_defaults_guard`
+    /// 与下方 `forkguard_boot_env_must_not_pin_global_output_cap`）。
     /// C 段只锁"中间层不被 env 污染"这一层事实，D 段沿底座公开预算链验证 env
     /// 确实生效（对应 CHANGES_REQUESTED：补沿最终预算/请求构造链的回归）。
     #[test]
@@ -2761,6 +2773,43 @@ mod tests {
             "reservation 差应恰为底座 64K 兜底 − 本地 24K（clamp/headroom 两侧相同）"
         );
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+    }
+
+    /// PR #210 守卫（第三轮评审修正 2026-08-11）：bridge boot 的 env 注入源头
+    /// （`wire_boot_env`）不得重新注入输出上限 env。lib.rs `release_env_defaults_guard`
+    /// 只覆盖 run() 的 release env 注入路径；若未来有人在 boot 路径直接 set_var
+    /// `DEEPSEEK_MAX_OUTPUT_TOKENS`，那边的守卫抓不到——故把 boot 的 env 写入收口到
+    /// `wire_boot_env` 单一源头，这里锁死该源头。
+    ///
+    /// 不直接跑 `Pinvou3Bridge::boot()`：boot 会 mutate PINVOU3_HOME（写盘到隔离 home
+    /// + 全量解包 bundle），成本高且与既有单测约定冲突（见
+    /// `engine_config_workspace_follows_bridge_field` 注释）。
+    #[test]
+    fn forkguard_boot_env_must_not_pin_global_output_cap() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MAX_OUTPUT_TOKENS",
+            "PINVOU3_MAX_OUTPUT_TOKENS",
+            "PINVOU3_SESSION_ARTIFACTS",
+        ]);
+        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
+
+        let artifacts = std::env::temp_dir().join("pinvou3-boot-env-guard-artifacts");
+        super::Pinvou3Bridge::wire_boot_env(&artifacts);
+
+        assert_eq!(
+            std::env::var("PINVOU3_SESSION_ARTIFACTS").as_deref(),
+            Ok(artifacts.to_str().expect("artifacts 目录路径必须是 UTF-8")),
+            "boot 注入源头仍应写 PINVOU3_SESSION_ARTIFACTS（收口函数行为不变）"
+        );
+        assert!(
+            std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS").is_none(),
+            "boot 注入源头（wire_boot_env）不得注入 DEEPSEEK_MAX_OUTPUT_TOKENS（会重新钉死云端输出上限）"
+        );
+        assert!(
+            std::env::var_os("PINVOU3_MAX_OUTPUT_TOKENS").is_none(),
+            "boot 注入源头（wire_boot_env）不得注入 PINVOU3_MAX_OUTPUT_TOKENS"
+        );
     }
 
     /// route profile 属于具体部署，不属于 vLLM/Qwen 特例。任何 OpenAI-compatible

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -2775,41 +2775,63 @@ mod tests {
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
     }
 
-    /// PR #210 守卫（第三轮评审修正 2026-08-11）：bridge boot 的 env 注入源头
-    /// （`wire_boot_env`）不得重新注入输出上限 env。lib.rs `release_env_defaults_guard`
-    /// 只覆盖 run() 的 release env 注入路径；若未来有人在 boot 路径直接 set_var
+    /// PR #210 守卫（第四轮评审修正 2026-08-12）：bridge boot 的 env 注入结果
+    /// 不得包含输出上限 env。lib.rs `release_env_defaults_guard` 只覆盖 run() 的
+    /// release env 注入路径；若未来有人在 boot 路径直接 set_var
     /// `DEEPSEEK_MAX_OUTPUT_TOKENS`，那边的守卫抓不到——故把 boot 的 env 写入收口到
-    /// `wire_boot_env` 单一源头，这里锁死该源头。
+    /// `wire_boot_env` 单一源头，并在**隔离 PINVOU3_HOME + HOME 下实际执行
+    /// `Pinvou3Bridge::boot()`** 后断言最终 env 状态：无论注入发生在 boot 哪一行，
+    /// 只要重新注入 24576，守卫即失败。
     ///
-    /// 不直接跑 `Pinvou3Bridge::boot()`：boot 会 mutate PINVOU3_HOME（写盘到隔离 home
-    /// + 全量解包 bundle），成本高且与既有单测约定冲突（见
-    /// `engine_config_workspace_follows_bridge_field` 注释）。
+    /// 第四轮评审此前指出：旧版守卫只直接调用 `wire_boot_env` helper，wire_boot_env
+    /// 不是由类型/编译器强制的唯一 env 写入口，未来若有人在 boot 其他位置直接
+    /// set_var、重建旧 helper 或调用其他 helper，该测试仍会通过。本版改为跑真实
+    /// boot：boot 在隔离临时目录下执行（bundle 解包 / settings 写入 / legacy 清扫全落
+    /// 隔离目录，不触碰真实 `~/.pinvou3` 与 `$HOME` 文件），断言 boot 后进程 env 无
+    /// 这两个 key 且 `PINVOU3_SESSION_ARTIFACTS` 正常写入。
     #[test]
     fn forkguard_boot_env_must_not_pin_global_output_cap() {
+        // 需要写 PINVOU3_HOME / HOME（隔离目录），锁 + 恢复这两者与目标 key。
         let (_lock, _env) = locked_env(&[
             "DEEPSEEK_MAX_OUTPUT_TOKENS",
             "PINVOU3_MAX_OUTPUT_TOKENS",
             "PINVOU3_SESSION_ARTIFACTS",
+            "PINVOU3_HOME",
+            "HOME",
         ]);
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
         std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
 
-        let artifacts = std::env::temp_dir().join("pinvou3-boot-env-guard-artifacts");
-        super::Pinvou3Bridge::wire_boot_env(&artifacts);
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-boot-env-guard-{}",
+            crate::bridge::paths::tests::unique_suffix()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("创建隔离 home");
+        std::env::set_var("PINVOU3_HOME", &root);
+        std::env::set_var("HOME", &root);
 
-        assert_eq!(
-            std::env::var("PINVOU3_SESSION_ARTIFACTS").as_deref(),
-            Ok(artifacts.to_str().expect("artifacts 目录路径必须是 UTF-8")),
-            "boot 注入源头仍应写 PINVOU3_SESSION_ARTIFACTS（收口函数行为不变）"
-        );
+        let bridge =
+            super::Pinvou3Bridge::boot().expect("隔离 PINVOU3_HOME + HOME 下 boot 必须成功");
+
         assert!(
             std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS").is_none(),
-            "boot 注入源头（wire_boot_env）不得注入 DEEPSEEK_MAX_OUTPUT_TOKENS（会重新钉死云端输出上限）"
+            "boot 执行后不得注入 DEEPSEEK_MAX_OUTPUT_TOKENS（会重新钉死云端输出上限）"
         );
         assert!(
             std::env::var_os("PINVOU3_MAX_OUTPUT_TOKENS").is_none(),
-            "boot 注入源头（wire_boot_env）不得注入 PINVOU3_MAX_OUTPUT_TOKENS"
+            "boot 执行后不得注入 PINVOU3_MAX_OUTPUT_TOKENS"
         );
+        // boot 仍应写 PINVOU3_SESSION_ARTIFACTS（收口函数行为不变）。
+        let artifacts = paths::default_session_artifacts_dir();
+        assert_eq!(
+            std::env::var("PINVOU3_SESSION_ARTIFACTS").as_deref(),
+            Ok(artifacts.to_str().expect("隔离 home 路径必须是 UTF-8")),
+            "boot 仍应写 PINVOU3_SESSION_ARTIFACTS（收口函数行为不变）"
+        );
+
+        drop(bridge);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// route profile 属于具体部署，不属于 vLLM/Qwen 特例。任何 OpenAI-compatible

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -232,7 +232,6 @@ impl Pinvou3Bridge {
             execution_root_resolver: None,
             code_session_predicate: None,
         };
-        this.wire_max_output_tokens_env();
         // C 方案(P-no-disk)最终版: 清理所有 pinvou3 历史 disk 残留:
         //   • `~/.pinvou3/sessions/<sid>/instructions.md`(per-session inline 前路径)
         //   • `~/.pinvou3/workspace_context.md`(workspace context 已合并进 INSTRUCTIONS_MD §0)
@@ -284,26 +283,6 @@ impl Pinvou3Bridge {
             eprintln!(
                 "[pinvou3-app] cleaned up {removed} legacy disk file(s) \
                  (C-fork P-no-disk: prompt content now Inline in memory)"
-            );
-        }
-    }
-
-    /// 把 `self.max_output_tokens()` 写到底座读取的 `DEEPSEEK_MAX_OUTPUT_TOKENS`
-    /// env (核心:底座 `effective_max_output_tokens()` 只读这个 env)。
-    ///
-    /// 生产 Tauri 启动不走 run-dev.sh (clean env), 没这一步会让底座回到
-    /// 模型表启发式。这里显式写入 pinvou3 的本地 vLLM 输出预算,确保 dev /
-    /// release / headless harness 行为一致。
-    ///
-    /// 已有 env 时不覆盖 (允许 run-dev.sh / L1 harness / 用户 override)。
-    ///
-    /// 单独抽 helper 让测试可以不走 boot() (避免 ensure_dirs / extract_bundle
-    /// 写盘到真实 ~/.pinvou3 + 不需要拿 PINVOU3_HOME ENV_LOCK)。
-    pub fn wire_max_output_tokens_env(&self) {
-        if std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS").is_none() {
-            std::env::set_var(
-                "DEEPSEEK_MAX_OUTPUT_TOKENS",
-                self.max_output_tokens().to_string(),
             );
         }
     }
@@ -2580,11 +2559,11 @@ mod tests {
     fn forkguard_compaction_128k_scenarios() {
         let (_lock, _env) =
             locked_env(&["DEEPSEEK_MAX_OUTPUT_TOKENS", "PINVOU3_MAX_OUTPUT_TOKENS"]);
-        // [根治后] derive_compaction_threshold 经底座 context_input_budget_for_route 读
-        // DEEPSEEK_MAX_OUTPUT_TOKENS 算 output 预留(不再镜像 24576)。测试须钉死生产 env 值,
-        // 否则底座默认 API_MAX_OUTPUT_TOKENS=65536 → E 偏小 → T 偏小(fixture 的 wire 用 is_none
-        // 检查,env 被其它测试污染时不覆盖)。生产由 Bridge::boot → wire_max_output_tokens_env 保证。
-        std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576");
+        // [根因] derive_compaction_threshold 经底座 context_input_budget_for_route 算
+        // output 预留：本地 vLLM 的 24576 由 route_limits_for_model 的 is_local_vllm
+        // 分支显式携带进 RouteLimits.output_tokens，主导预留计算（min(requested_cap,
+        // route_cap)=24576），不依赖 DEEPSEEK_MAX_OUTPUT_TOKENS env。云端模型不再
+        // 被品悟钉死 24576，落底座 64K 兜底。
         // A. 真实 128K 部署:探测拿到 131072
         // 默认预设已平台感知(macOS/Windows→Deepseek),显式设 LocalVllm 才测 128K vLLM compaction。
         let mut a = fixture_bridge();
@@ -2912,41 +2891,6 @@ mod tests {
             Some(crate::features::assistant::tool_policy::allowed_tool_names()),
             "code 会话未限制时必须恢复 Pinvou 基础白名单"
         );
-    }
-
-    /// `wire_max_output_tokens_env` 必须把 self.max_output_tokens() 设给底座
-    /// env,让 dev / release / headless harness 对同一个本地 vLLM cap 达成一致。
-    ///
-    /// 走 fixture_bridge() + helper (而非 boot()),避免:
-    ///   - 写真实 ~/.pinvou3 (codex round 5 finding)
-    ///   - 跟 PINVOU3_HOME ENV_LOCK 持有者冲突
-    ///
-    /// 两个语义合并一个测试避免并发 race (Rust env process-global,
-    /// 后续多测试可以拿 DEEPSEEK_MAX_OUTPUT_TOKENS 专属锁,但目前只此一处)。
-    #[test]
-    fn wire_max_output_tokens_env_sets_default_then_respects_existing() {
-        let (_lock, _env) =
-            locked_env(&["DEEPSEEK_MAX_OUTPUT_TOKENS", "PINVOU3_MAX_OUTPUT_TOKENS"]);
-        // clean env 路径:helper 应 set 默认 24576
-        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
-        std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
-        fixture_bridge().wire_max_output_tokens_env();
-        assert_eq!(
-            std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS").as_deref(),
-            Ok("24576"),
-            "wire helper 必须 set DEEPSEEK_MAX_OUTPUT_TOKENS=24576, 让底座 \
-             effective_max_output_tokens 走 pinvou3 显式 cap (24K,见 max_output_tokens 注释)"
-        );
-
-        // 已有 env 不覆盖路径:helper 是 no-op
-        std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", "32768");
-        fixture_bridge().wire_max_output_tokens_env();
-        assert_eq!(
-            std::env::var("DEEPSEEK_MAX_OUTPUT_TOKENS").as_deref(),
-            Ok("32768"),
-            "已有 env 必须保留,不能被 helper 覆盖 (允许 run-dev.sh / L1 / 用户 override)"
-        );
-        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
     }
 
     /// 安全敏感字段必须固定——这些值改了会让 pinvou3 出现奇怪行为或越权。

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -2779,40 +2779,66 @@ mod tests {
     /// 不得包含输出上限 env。lib.rs `release_env_defaults_guard` 只覆盖 run() 的
     /// release env 注入路径；若未来有人在 boot 路径直接 set_var
     /// `DEEPSEEK_MAX_OUTPUT_TOKENS`，那边的守卫抓不到——故把 boot 的 env 写入收口到
-    /// `wire_boot_env` 单一源头，并在**隔离 PINVOU3_HOME + HOME 下实际执行
-    /// `Pinvou3Bridge::boot()`** 后断言最终 env 状态：无论注入发生在 boot 哪一行，
-    /// 只要重新注入 24576，守卫即失败。
+    /// `wire_boot_env` 单一源头，并在**隔离 home 下实际执行 `Pinvou3Bridge::boot()`**
+    /// 后断言最终 env 状态：无论注入发生在 boot 哪一行，只要重新注入 24576，守卫即失败。
     ///
     /// 第四轮评审此前指出：旧版守卫只直接调用 `wire_boot_env` helper，wire_boot_env
     /// 不是由类型/编译器强制的唯一 env 写入口，未来若有人在 boot 其他位置直接
     /// set_var、重建旧 helper 或调用其他 helper，该测试仍会通过。本版改为跑真实
     /// boot：boot 在隔离临时目录下执行（bundle 解包 / settings 写入 / legacy 清扫全落
-    /// 隔离目录，不触碰真实 `~/.pinvou3` 与 `$HOME` 文件），断言 boot 后进程 env 无
+    /// 隔离目录，不触碰真实 `~/.pinvou3` 与用户 home 文件），断言 boot 后进程 env 无
     /// 这两个 key 且 `PINVOU3_SESSION_ARTIFACTS` 正常写入。
+    ///
+    /// 第五轮评审修正 2026-08-13：此前只隔离 `HOME`——Windows 的 `user_home_dir()`
+    /// 优先读 `USERPROFILE`、其次 `HOMEDRIVE`+`HOMEPATH`、最后才 `HOME`，只设 `HOME`
+    /// 会让 `boot()` 的 `workspace`（= `user_home_dir()`）在 Windows 上仍指向真实
+    /// 用户目录，legacy 清扫可能删除真实目录里带管理标识的文件。现把三平台 home
+    /// 来源全部隔离到临时目录；临时目录命名叠加 `std::process::id()`（跨进程唯一），
+    /// 并用 RAII guard 保证 boot/断言 panic 时仍回收整份解包 bundle。
     #[test]
     fn forkguard_boot_env_must_not_pin_global_output_cap() {
-        // 需要写 PINVOU3_HOME / HOME（隔离目录），锁 + 恢复这两者与目标 key。
+        // 需要写 PINVOU3_HOME / HOME / Windows home 来源（隔离目录），锁 + 恢复这些与目标 key。
         let (_lock, _env) = locked_env(&[
             "DEEPSEEK_MAX_OUTPUT_TOKENS",
             "PINVOU3_MAX_OUTPUT_TOKENS",
             "PINVOU3_SESSION_ARTIFACTS",
             "PINVOU3_HOME",
             "HOME",
+            "USERPROFILE",
+            "HOMEDRIVE",
+            "HOMEPATH",
         ]);
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
         std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
 
+        // RAII 清理：boot 会全量解包 bundle 到隔离 home，断言/panic 时也须回收
+        // （此前仅在正常结尾 remove_dir_all，中途失败会残留整份 bundle）。
+        struct TempDirGuard(std::path::PathBuf);
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+        // 叠加 pid + 进程内原子后缀：unique_suffix 只保证单进程内唯一，双终端并发
+        // cargo test 会跨进程碰撞（见 paths::tests::unique_suffix 文档）。
         let root = std::env::temp_dir().join(format!(
-            "pinvou3-boot-env-guard-{}",
+            "pinvou3-boot-env-guard-{}-{}",
+            std::process::id(),
             crate::bridge::paths::tests::unique_suffix()
         ));
+        let _temp = TempDirGuard(root.clone());
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).expect("创建隔离 home");
         std::env::set_var("PINVOU3_HOME", &root);
+        // 三平台 user_home_dir() 来源全部隔离到 root：macOS/Linux 读 HOME；Windows
+        // 优先 USERPROFILE，其次 HOMEDRIVE+HOMEPATH，最后 HOME。若不隔离 Windows 的
+        // 前两项，boot 的 workspace 仍指向真实用户目录，legacy 清扫会触碰真实文件。
         std::env::set_var("HOME", &root);
+        std::env::set_var("USERPROFILE", &root);
+        std::env::remove_var("HOMEDRIVE");
+        std::env::remove_var("HOMEPATH");
 
-        let bridge =
-            super::Pinvou3Bridge::boot().expect("隔离 PINVOU3_HOME + HOME 下 boot 必须成功");
+        let bridge = super::Pinvou3Bridge::boot().expect("隔离 home 下 boot 必须成功");
 
         assert!(
             std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS").is_none(),
@@ -2830,8 +2856,9 @@ mod tests {
             "boot 仍应写 PINVOU3_SESSION_ARTIFACTS（收口函数行为不变）"
         );
 
+        // bridge 先于 TempDirGuard 回收（guard 声明更早、drop 更晚），避免删目录时
+        // bridge 仍持有其中的 bundle 路径。
         drop(bridge);
-        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// route profile 属于具体部署，不属于 vLLM/Qwen 特例。任何 OpenAI-compatible

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -2664,8 +2664,13 @@ mod tests {
     /// clean env（无该 env）下云端 SavedModel.max_output_tokens 为 None →
     /// route_limits.output_tokens 必须为 None（不声明 → 底座 64K/厂商能力兜底）；
     /// 本地 vLLM 的 24576 由 is_local_vllm 分支显式携带（不依赖 env），两者都要锁。
-    /// 同时锁"env 残留也不影响云端"——防止 boot/release 后续重新注入该变量
-    /// 把云端打回 24576（对应 CHANGES_REQUESTED：clean env 云端 effective cap 回归）。
+    ///
+    /// ⚠️ C 段语义（评审修正 2026-08-11）：品悟中间层确实不读该 env，但底座
+    /// `effective_max_output_tokens_for_route` **优先**读它——env 残留仍会把云端
+    /// **最终请求**的 max_tokens 钉回 24576。因此不能声称"残留 env 不影响云端"；
+    /// 真正的防线是 release/boot 不再注入（见 lib.rs `release_env_defaults_guard`）。
+    /// C 段只锁"中间层不被 env 污染"这一层事实，D 段沿底座公开预算链验证 env
+    /// 确实生效（对应 CHANGES_REQUESTED：补沿最终预算/请求构造链的回归）。
     #[test]
     fn forkguard_cloud_route_output_not_pinned_by_global_env() {
         let (_lock, _env) =
@@ -2706,14 +2711,54 @@ mod tests {
             "本地 vLLM 仍显式携带 24K 预算（不依赖 DEEPSEEK_MAX_OUTPUT_TOKENS env）"
         );
 
-        // C. env 残留（旧生产双保险未清干净 / 未来有人重新注入）也不影响云端：
-        //    品悟 route_limits 的云端分支不读该 env，只有底座在无 route 声明时才读。
+        // C. env 残留（旧生产双保险未清干净 / 未来有人重新注入）：品悟中间层不读
+        //    该 env（route 仍不声明）——但这只是中间层事实，底座最终预算链会读
+        //    （见 D 段）。此处只锁"中间层不被 env 污染"，不能据此声称残留无害。
         std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576");
         let cloud_limits_env = cloud.route_limits_for_model("deepseek-v4-pro");
         assert_eq!(
             cloud_limits_env.as_ref().and_then(|l| l.output_tokens),
             None,
-            "env 残留 24576 不得把云端 route 打回 24576（品悟不读该 env）"
+            "品悟中间层不读该 env（云端 route 仍不声明）；env 影响发生在底座最终预算链（见 D 段）"
+        );
+
+        // D. 沿底座公开预算链（context_input_budget_for_route，品悟 derive_compaction_threshold
+        //    同款 API）验证：env 残留 24576 会把底座 output reservation 从 clean env 的 64K
+        //    压回 24K → 可用输入预算随之变大。证明"残留 env 不影响云端"不成立——真正防线是
+        //    release/boot 不再注入（lib.rs release_env_defaults_guard）。用显式 256K RouteLimits
+        //    （<500K 窗口才走 effective_max_output_tokens_for_route，≥500K 走 TURN 分支不读 env），
+        //    deepseek-v4-pro 的 provider max_output=384K 不会钳制 64K/24K 中的任一个。
+        let route_limits_256k = codewhale_config::route::RouteLimits {
+            context_tokens: Some(256_000),
+            input_tokens: None,
+            output_tokens: None,
+        };
+        // 先回到 clean env 基准（C 段末尾已 set 24576）。
+        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        let budget_clean = deepseek_tui::core::engine::context_input_budget_for_route(
+            deepseek_tui::config::ApiProvider::Deepseek,
+            "deepseek-v4-pro",
+            Some(route_limits_256k),
+            0,
+        )
+        .expect("显式 256K route 必须能算出输入预算");
+        std::env::set_var("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576");
+        let budget_env = deepseek_tui::core::engine::context_input_budget_for_route(
+            deepseek_tui::config::ApiProvider::Deepseek,
+            "deepseek-v4-pro",
+            Some(route_limits_256k),
+            0,
+        )
+        .expect("显式 256K route 必须能算出输入预算");
+        assert!(
+            budget_env > budget_clean,
+            "env 残留 24576 使底座 output reservation 变小（64K→24K），输入预算必须变大：\
+             clean={budget_clean} env={budget_env}"
+        );
+        assert_eq!(
+            budget_env - budget_clean,
+            65_536 - 24_576,
+            "reservation 差应恰为底座 64K 兜底 − 本地 24K（clamp/headroom 两侧相同）"
         );
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
     }

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -1134,11 +1134,68 @@ mod release_env_defaults_guard {
     ///
     /// 两层检查（评审修正 2026-08-11）：
     /// 1. 常量表本身不含这两个 key（防常量里重新出现）；
-    /// 2. 走**实际注入路径** `ensure_release_env`（boot/release 唯一 env 注入函数，
-    ///    无写盘副作用）后断言进程 env 仍无这两个 key——即使未来有人在注入函数里
-    ///    绕过常量表直接 set_var，这里也能抓到。
+    /// 2. 走**实际注入路径** `ensure_release_env`（run() 启动路径的 release env
+    ///    注入函数，无写盘副作用）后断言进程 env 仍无这两个 key——即使未来有人在
+    ///    注入函数里绕过常量表直接 set_var，这里也能抓到。
+    ///
+    /// 第三轮评审修正 2026-08-11：本测试此前直接删进程级 env 且不还原，未借 crate
+    /// 级唯一 ENV_LOCK（会与 bridge.rs 等 env 写测试并发竞态），也不还原
+    /// ensure_release_env 写入的 RELEASE_ENV_DEFAULTS / PATH / 平台 UI env（串行 CI
+    /// 下造成后续测试顺序依赖）。现改为：先取 ENV_LOCK 再全量快照 env，退出（含
+    /// panic）时按快照完整还原。bridge boot 侧的 env 注入源头由 bridge.rs
+    /// `forkguard_boot_env_must_not_pin_global_output_cap` 单独守卫（boot 不直接
+    /// 进单测：会 mutate PINVOU3_HOME 写盘 + 全量解包 bundle，见
+    /// `engine_config_workspace_follows_bridge_field` 注释）。
+    ///
+    /// 进程 env 全量快照：ensure_release_env 会 set RELEASE_ENV_DEFAULTS、重写 PATH、
+    /// Linux 上还会 set GDK_BACKEND 等 UI env——只有全量快照才能完整还原，且不随
+    /// 各常量表增删漂移。
+    struct EnvSnapshot(std::collections::HashMap<String, Option<String>>);
+
+    impl EnvSnapshot {
+        fn take() -> Self {
+            let mut map = std::collections::HashMap::new();
+            for (k, v) in std::env::vars() {
+                map.insert(k, Some(v));
+            }
+            // 显式记录"当前不存在"的 key，还原时统一按快照恢复原状（set / remove）。
+            for key in ["DEEPSEEK_MAX_OUTPUT_TOKENS", "PINVOU3_MAX_OUTPUT_TOKENS"] {
+                map.entry(key.to_string()).or_insert(None);
+            }
+            Self(map)
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+            // ensure_release_env 可能 set 了快照中原本不存在的 key（PATH 分支、Linux
+            // UI env 等）——全部移除，回到快照状态，杜绝后续测试的顺序依赖。
+            let keep: std::collections::HashSet<&String> = self.0.keys().collect();
+            let stale: Vec<String> = std::env::vars()
+                .map(|(k, _)| k)
+                .filter(|k| !keep.contains(k))
+                .collect();
+            for k in stale {
+                std::env::remove_var(&k);
+            }
+        }
+    }
+
     #[test]
     fn release_env_defaults_must_not_pin_global_output_cap() {
+        // crate 级唯一 env 锁：与所有 env 写测试串行（同 bridge.rs locked_env 约定），
+        // 避免与 DEEPSEEK_* / PINVOU3_HOME 写测试并发竞态。
+        let _lock = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let _snapshot = EnvSnapshot::take();
+
         // 第一层：常量表
         assert!(
             !super::RELEASE_ENV_DEFAULTS
@@ -1153,8 +1210,8 @@ mod release_env_defaults_guard {
             "RELEASE_ENV_DEFAULTS 不得包含 PINVOU3_MAX_OUTPUT_TOKENS（品悟侧上限仅经 prefs/route 携带）"
         );
 
-        // 第二层：实际注入路径（ensure_release_env 是 boot/release 唯一 env 注入函数）。
-        // 先清掉外部可能残留的 env，确保断言的是注入函数自身的行为。
+        // 第二层：实际注入路径（ensure_release_env 是 run() 启动路径的 release env
+        // 注入函数）。先清掉外部可能残留的 env，确保断言的是注入函数自身的行为。
         std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
         std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
         super::ensure_release_env();
@@ -1166,5 +1223,6 @@ mod release_env_defaults_guard {
             std::env::var_os("PINVOU3_MAX_OUTPUT_TOKENS").is_none(),
             "ensure_release_env 不得重新注入 PINVOU3_MAX_OUTPUT_TOKENS（品悟上限仅经 prefs/route 携带）"
         );
+        // 退出时 EnvSnapshot::drop 按快照完整还原（含 PATH / UI env / 常量表变量）。
     }
 }

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -101,7 +101,10 @@ const RELEASE_ENV_DEFAULTS: &[(&str, &str)] = &[
     ("DEEPSEEK_REASONING_EFFORT", "off"),
     ("DEEPSEEK_ALLOW_INSECURE_HTTP", "1"),
     ("DEEPSEEK_FORCE_HTTP1", "1"),
-    ("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576"),
+    // 不再注入 DEEPSEEK_MAX_OUTPUT_TOKENS：它会把所有模型（含云端）的输出上限
+    // 钉死在 24576。底座对 ≥500K 窗口模型默认 64K（API_MAX_OUTPUT_TOKENS），
+    // 云端模型应落到底座兜底；本地 vLLM 的 24K 预算由 route_limits_for_model
+    // 的 is_local_vllm 分支显式携带，不依赖该 env。
     // 与 CodeWhale 的 stream_chunk_timeout 默认值保持一致。
     ("DEEPSEEK_STREAM_IDLE_TIMEOUT_SECS", "300"),
     // SSE 首响应头超时(open timeout):底座只认 env,默认 45s 是为云端调的。

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -1131,8 +1131,15 @@ mod release_env_defaults_guard {
     /// 所有模型（含云端）输出上限钉死 24576——正是本 PR 移除的根因。此守卫在
     /// CHANGES_REQUESTED 后新增：clean env 云端落底座 64K 兜底的前提，就是
     /// release 安装包启动路径（.deb 双击等）不再注入该变量。
+    ///
+    /// 两层检查（评审修正 2026-08-11）：
+    /// 1. 常量表本身不含这两个 key（防常量里重新出现）；
+    /// 2. 走**实际注入路径** `ensure_release_env`（boot/release 唯一 env 注入函数，
+    ///    无写盘副作用）后断言进程 env 仍无这两个 key——即使未来有人在注入函数里
+    ///    绕过常量表直接 set_var，这里也能抓到。
     #[test]
     fn release_env_defaults_must_not_pin_global_output_cap() {
+        // 第一层：常量表
         assert!(
             !super::RELEASE_ENV_DEFAULTS
                 .iter()
@@ -1144,6 +1151,20 @@ mod release_env_defaults_guard {
                 .iter()
                 .any(|(k, _)| *k == "PINVOU3_MAX_OUTPUT_TOKENS"),
             "RELEASE_ENV_DEFAULTS 不得包含 PINVOU3_MAX_OUTPUT_TOKENS（品悟侧上限仅经 prefs/route 携带）"
+        );
+
+        // 第二层：实际注入路径（ensure_release_env 是 boot/release 唯一 env 注入函数）。
+        // 先清掉外部可能残留的 env，确保断言的是注入函数自身的行为。
+        std::env::remove_var("DEEPSEEK_MAX_OUTPUT_TOKENS");
+        std::env::remove_var("PINVOU3_MAX_OUTPUT_TOKENS");
+        super::ensure_release_env();
+        assert!(
+            std::env::var_os("DEEPSEEK_MAX_OUTPUT_TOKENS").is_none(),
+            "ensure_release_env 不得重新注入 DEEPSEEK_MAX_OUTPUT_TOKENS（会重新钉死云端）"
+        );
+        assert!(
+            std::env::var_os("PINVOU3_MAX_OUTPUT_TOKENS").is_none(),
+            "ensure_release_env 不得重新注入 PINVOU3_MAX_OUTPUT_TOKENS（品悟上限仅经 prefs/route 携带）"
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -1123,3 +1123,27 @@ mod web_template_seed {
         assert!(crate::platform::paths::web_template_dir().ends_with("web-template"));
     }
 }
+
+#[cfg(test)]
+mod release_env_defaults_guard {
+    /// PR #210 守卫：release/boot 不得重新注入 DEEPSEEK_MAX_OUTPUT_TOKENS。
+    /// 该 env 会被底座 effective_max_output_tokens() 优先读取，一旦回归会重新把
+    /// 所有模型（含云端）输出上限钉死 24576——正是本 PR 移除的根因。此守卫在
+    /// CHANGES_REQUESTED 后新增：clean env 云端落底座 64K 兜底的前提，就是
+    /// release 安装包启动路径（.deb 双击等）不再注入该变量。
+    #[test]
+    fn release_env_defaults_must_not_pin_global_output_cap() {
+        assert!(
+            !super::RELEASE_ENV_DEFAULTS
+                .iter()
+                .any(|(k, _)| *k == "DEEPSEEK_MAX_OUTPUT_TOKENS"),
+            "RELEASE_ENV_DEFAULTS 不得包含 DEEPSEEK_MAX_OUTPUT_TOKENS（PR #210 移除全局注入）"
+        );
+        assert!(
+            !super::RELEASE_ENV_DEFAULTS
+                .iter()
+                .any(|(k, _)| *k == "PINVOU3_MAX_OUTPUT_TOKENS"),
+            "RELEASE_ENV_DEFAULTS 不得包含 PINVOU3_MAX_OUTPUT_TOKENS（品悟侧上限仅经 prefs/route 携带）"
+        );
+    }
+}

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -1150,17 +1150,22 @@ mod release_env_defaults_guard {
     /// 进程 env 全量快照：ensure_release_env 会 set RELEASE_ENV_DEFAULTS、重写 PATH、
     /// Linux 上还会 set GDK_BACKEND 等 UI env——只有全量快照才能完整还原，且不随
     /// 各常量表增删漂移。
-    struct EnvSnapshot(std::collections::HashMap<String, Option<String>>);
+    ///
+    /// 第四轮评审修正（2026-08-12）：此前用 `String` + `std::env::vars()`——`vars()`
+    /// 对任何非 UTF-8 的合法环境变量值（POSIX 允许任意字节）会直接 panic，且 Drop 中
+    /// 的二次枚举同样 panic；测试断言失败展开 panic 期间再 panic 会中止整个测试进程。
+    /// 现改用 `OsString` + `vars_os()`，非 UTF-8 环境变量也能完整快照/还原。
+    struct EnvSnapshot(std::collections::HashMap<std::ffi::OsString, Option<std::ffi::OsString>>);
 
     impl EnvSnapshot {
         fn take() -> Self {
             let mut map = std::collections::HashMap::new();
-            for (k, v) in std::env::vars() {
+            for (k, v) in std::env::vars_os() {
                 map.insert(k, Some(v));
             }
             // 显式记录"当前不存在"的 key，还原时统一按快照恢复原状（set / remove）。
             for key in ["DEEPSEEK_MAX_OUTPUT_TOKENS", "PINVOU3_MAX_OUTPUT_TOKENS"] {
-                map.entry(key.to_string()).or_insert(None);
+                map.entry(std::ffi::OsString::from(key)).or_insert(None);
             }
             Self(map)
         }
@@ -1176,8 +1181,8 @@ mod release_env_defaults_guard {
             }
             // ensure_release_env 可能 set 了快照中原本不存在的 key（PATH 分支、Linux
             // UI env 等）——全部移除，回到快照状态，杜绝后续测试的顺序依赖。
-            let keep: std::collections::HashSet<&String> = self.0.keys().collect();
-            let stale: Vec<String> = std::env::vars()
+            let keep: std::collections::HashSet<&std::ffi::OsString> = self.0.keys().collect();
+            let stale: Vec<std::ffi::OsString> = std::env::vars_os()
                 .map(|(k, _)| k)
                 .filter(|k| !keep.contains(k))
                 .collect();

--- a/pinvou3-app/src-tauri/tests/l1_dialog_harness.rs
+++ b/pinvou3-app/src-tauri/tests/l1_dialog_harness.rs
@@ -594,6 +594,8 @@ fn ensure_runtime_env() {
     // 允许开发者通过 DEEPSEEK_BASE_URL 接入非 loopback 的本地网络 vLLM。
     set_var_if_unset("DEEPSEEK_ALLOW_INSECURE_HTTP", "1");
     set_var_if_unset("DEEPSEEK_FORCE_HTTP1", "1");
+    // L1 是本地 vLLM headless 测试：24576 与 route_limits_for_model 的 is_local_vllm
+    // 分支显式携带的 24K 预算一致（正式 App 已不再全局注入该 env，此处仅测本地预算）。
     set_var_if_unset("DEEPSEEK_MAX_OUTPUT_TOKENS", "24576");
     // 与正式 App 和底座默认值保持一致，避免 L1 仍用旧 90s 配置，
     // 把慢速本地模型的正常长生成误判为运行时回归。


### PR DESCRIPTION
## 背景

问题 5：品悟通过 `DEEPSEEK_MAX_OUTPUT_TOKENS=24576` 全局 env（lib.rs 注入 + boot 时 `wire_max_output_tokens_env` 双保险）把**所有模型（含云端）**的请求输出上限钉死在 24576，远低于模型实际能力（如 deepseek-v4-pro 384K、glm-5.2 131072）。

## 决策（已确认）

底座对 ≥500K 窗口模型默认输出上限为 64K（`API_MAX_OUTPUT_TOKENS=65536`，route_budget.rs），即底座锁死 64K。按用户决策：**遵守底座，仅放开 24576**，不做模板模型官方最大值对齐。

## 变更

- `lib.rs`：移除 `DEEPSEEK_MAX_OUTPUT_TOKENS=24576` 注入
- `bridge.rs`：删除 `wire_max_output_tokens_env` helper 及 boot 调用、删除其专属测试
- 本地 vLLM 的 24K 预算不受影响：`route_limits_for_model` 的 `is_local_vllm` 分支仍显式写入 `RouteLimits.output_tokens=24576`，底座 `min(requested_cap, route_cap)` 后仍为 24576（防 SSE timeout 既有约束不变）
- 云端模型 `output_tokens=None` → 底座 `requested_cap.min(provider_capability.max_output)` = min(64K, 模型能力) = 64K 兜底
- forkguard 测试更新：验证 route_limits 显式携带 24576，不再依赖生产 env

## 验证

- `cargo test --lib`：964 passed / 1 环境性抖动（connector_skill_cache，单跑通过，与改动无关）
- forkguard_compaction_128k_scenarios：通过（本地 vLLM 仍 24576）

## 已知限制

- 底座锁死 64K 上限（≥500K 窗口模型），云端实际输出不会超过 64K；要追模型官方最大（如 384K）需改底座 requested_cap 逻辑（CodeWhale fork 边界，上游优先）。
- Anthropic Messages API 的 max_tokens 必填：底座 64K 对该 provider 是否会被钳制为 64000 由底座 adapter 处理，不在本 PR 范围。