### PR TITLE
fix(codex): 未挂载知识库时按钮不再显示「移除全部」

### DIFF
--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -201,7 +201,12 @@ function CodexComposerConfigSelect({
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
   const selected = choices.find(choice => String(choice.value) === String(value));
-  const selectedLabel = selected && (selected.name || selected.value) || value || unsetLabel;
+  // value 为空串 = "未选中"：优先显示 unsetLabel 占位，避免 choices 里
+  // 充当"卸载动作"的空值选项（value:''）把按钮主文本劫持成动作文案。
+  // 已选中（value 非空）才查 choices 显示对应项名称。
+  const selectedLabel = String(value) === ''
+    ? (unsetLabel || '')
+    : ((selected && (selected.name || selected.value)) || value || unsetLabel);
   const pick = (choiceValue) => {
     setOpen(false);
     if (String(choiceValue) !== String(value)) onChange(choiceValue);
@@ -1355,8 +1360,11 @@ export function CodexAcpView({
   const nativeMountedId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.mountedId : null)
     : (nativeDraftControls.mountedId ?? null);
+  // 空值选项仅在有挂载时作为「移除全部」卸载动作出现；未挂载时不渲染，
+  // 按钮主文本走 unsetLabel（t.kbMount = "知识库"），避免空挂载态误显示「移除全部」。
+  const nativeMounted = nativeMountedId != null;
   const nativeKbChoices = [
-    { value: '', name: t.kbMountRemove },
+    ...(nativeMounted ? [{ value: '', name: t.kbMountRemove }] : []),
     ...nativeKbCollections.map(collection => ({
       value: String(collection.id),
       name: collection.name,
@@ -2943,6 +2951,7 @@ export function CodexAcpView({
                         id="native-kb"
                         testId="native-kb"
                         label={t.kbMount}
+                        unsetLabel={t.kbMount}
                         value={nativeMountedId == null ? '' : String(nativeMountedId)}
                         choices={nativeKbChoices}
                         onChange={value => (


### PR DESCRIPTION
## 背景

问题 4：代码页面（原生车道）底部「知识库」按钮在未挂载任何知识库时显示「移除全部」。这不是正在挂载的知识库，是空挂载态的文案 bug。

## 根因

`nativeKbChoices` 把空值选项写死为 `{ value: '', name: t.kbMountRemove }`（CodexAcpView.jsx:1275）；未挂载时 `nativeMountedId == null` → select value 为 `''`（:2805），`CodexComposerConfigSelect` 的 `selectedLabel` 解析（:200）恒命中 `''` 选项，`unsetLabel` 兜底不可达 → 按钮主文本显示「移除全部」。对照 ChatView 侧 `ComposerKbSelector`（composer-controls.jsx:137）空态正确显示「知识库」，「移除全部」只在已挂载时出现在下拉内。

## 变更

1. `CodexComposerConfigSelect`：value 为空串时优先显示 `unsetLabel` 占位，避免 choices 里充当卸载动作的空值选项劫持按钮文案（对 native-model/native-mode 兄弟下拉无影响——它们 value 非空时仍走原分支）。
2. `nativeKbChoices`：`''` 选项仅在有挂载时作为「移除全部」卸载动作出现，未挂载时不渲染。
3. native-kb 调用处传 `unsetLabel={t.kbMount}`。

## 验证

- `npm run lint:ui` ✅
- codex_acp_platform_contract / runtime_notice / timeline / code_native_lane：全部通过

## 已知限制

- 会话切换的归属保护窗口（`nativeControlsSessionRef.current !== activeId` 时 mountedId 为 null）可能短暂显示「知识库」占位后刷新为挂载态，属正常异步刷新，非本次范围。