### PR TITLE
fix(monitor): TPS/TTFT 无数据时显示「—」而非 0

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -58,7 +58,7 @@
     "test:attachment-drop": "node tests/attachment_drop_logic.test.mjs && node tests/attachment_drop_bridge.test.mjs && node tests/attachment_bubble_logic.test.mjs",
     "test:voice-input": "node tests/voice_input_error_logic.test.js",
     "test:voice-asr-cancel": "node tests/voice_asr_cancel_logic.test.js",
-    "test:bridge-protocol": "node tests/bridge_domain_protocol.test.mjs && node tests/web_bridge_domain_contract.test.mjs",
+    "test:bridge-protocol": "node tests/bridge_domain_protocol.test.mjs && node tests/web_bridge_domain_contract.test.mjs && node tests/monitor_bridge_format.test.mjs",
     "test:detached-window": "node tests/detached_window_lifecycle.test.mjs",
     "test:web-access-contract": "node tests/web_access_contract.test.mjs",
     "test:web-access-desktop-proxy": "node tests/web_access_desktop_proxy.test.mjs",

--- a/pinvou3-app/src/features/monitor/MonitorView.jsx
+++ b/pinvou3-app/src/features/monitor/MonitorView.jsx
@@ -244,7 +244,7 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
       <div className="bg-white/58 dark:bg-[#2C2C2E] rounded-3xl p-5 border border-black/[0.055] dark:border-white/[0.055] shadow-[0_10px_28px_rgba(15,23,42,0.06)] dark:shadow-[0_20px_48px_rgba(0,0,0,0.48),0_7px_18px_rgba(0,0,0,0.36)] flex flex-col justify-between transition-all duration-300 hover:-translate-y-0.5 hover:bg-white/85 hover:shadow-[0_14px_36px_rgba(15,23,42,0.09)] dark:hover:!bg-[#3A3A3C] dark:hover:shadow-[0_16px_38px_rgba(0,0,0,0.34)]">
         <div>
           <span className="text-[13px] font-bold tracking-[0.02em] text-black/58 dark:text-white/62">{label}</span>
-          <div className="text-[32px] font-bold tracking-[-0.03em] mt-1">{value}<span className="text-[14px] text-black/40 dark:text-white/40 ml-1">{unit}</span></div>
+          <div className="text-[32px] font-bold tracking-[-0.03em] mt-1">{value}{unit && String(value) !== '—' && <span className="text-[14px] text-black/40 dark:text-white/40 ml-1">{unit}</span>}</div>
           <div className="text-[12px] leading-snug font-medium text-black/45 dark:text-white/45 mt-1.5">{hint}</div>
         </div>
         <MonitorSparkline color={color} data={data} />

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -238,7 +238,7 @@
         vllmKv: kvShown != null ? kvShown.toFixed(1) + "%" : "0%",
         vllmKvHasData: kvShown != null,
         vllmTtft: sadj && sadj.ttft_count > 0
-          ? (sadj.ttft_sum_s / sadj.ttft_count).toFixed(2) + " s" : "0 s",
+          ? (sadj.ttft_sum_s / sadj.ttft_count).toFixed(2) + " s" : "—",
         vllmTps: sadj && sadj.tps_time_s > 0
           ? (sadj.tps_tokens / sadj.tps_time_s).toFixed(1) + " tok/s" : "—",
         vllmTokTotal: sadj

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -240,7 +240,7 @@
         vllmTtft: sadj && sadj.ttft_count > 0
           ? (sadj.ttft_sum_s / sadj.ttft_count).toFixed(2) + " s" : "0 s",
         vllmTps: sadj && sadj.tps_time_s > 0
-          ? (sadj.tps_tokens / sadj.tps_time_s).toFixed(1) + " tok/s" : "0 tok/s",
+          ? (sadj.tps_tokens / sadj.tps_time_s).toFixed(1) + " tok/s" : "—",
         vllmTokTotal: sadj
           ? fmtTok(sadj.gen) + " / " + fmtTok(sadj.prompt) : "—",
         vllmStatsCleared: !!(sadj && sadj.cleared),

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -5802,9 +5802,9 @@
         vllmKv: kvShown != null ? kvShown.toFixed(1) + "%" : "0%",
         vllmKvHasData: kvShown != null,
         vllmTtft: sadj && sadj.ttft_count > 0
-          ? (sadj.ttft_sum_s / sadj.ttft_count).toFixed(2) + " s" : "0 s",
+          ? (sadj.ttft_sum_s / sadj.ttft_count).toFixed(2) + " s" : "—",
         vllmTps: sadj && sadj.tps_time_s > 0
-          ? (sadj.tps_tokens / sadj.tps_time_s).toFixed(1) + " tok/s" : "0 tok/s",
+          ? (sadj.tps_tokens / sadj.tps_time_s).toFixed(1) + " tok/s" : "—",
         vllmTokTotal: sadj
           ? fmtTok(sadj.gen) + " / " + fmtTok(sadj.prompt) : "—",
         vllmStatsCleared: !!(sadj && sadj.cleared),

--- a/pinvou3-app/tests/monitor_bridge_format.test.mjs
+++ b/pinvou3-app/tests/monitor_bridge_format.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '..');
+const read = (...parts) => fs.readFileSync(path.join(root, ...parts), 'utf8');
+
+// 两份 bridge(tauri 桌面 / web)的 TTFT/TPS 无数据回退必须统一为「—」,
+// 与 MonitorView.jsx 的 MonitorMetricCard(值为 — 时不渲染 unit)配套。
+// 防止某一侧单独回退成字面 "0 s"/"0 tok/s" 造成桌面/网页显示漂移。
+const bridges = {
+  tauri: read('src', 'platform', 'tauri', 'bridge', 'monitor.js'),
+  web: read('src', 'platform', 'web', 'bridge.js'),
+};
+
+const TTFT_FALLBACK_PATTERN =
+  /vllmTtft: sadj && sadj\.ttft_count > 0\s*\?\s*\(sadj\.ttft_sum_s \/ sadj\.ttft_count\)\.toFixed\(2\) \+ " s" : "—"/;
+const TPS_FALLBACK_PATTERN =
+  /vllmTps: sadj && sadj\.tps_time_s > 0\s*\?\s*\(sadj\.tps_tokens \/ sadj\.tps_time_s\)\.toFixed\(1\) \+ " tok\/s" : "—"/;
+
+for (const [name, source] of Object.entries(bridges)) {
+  assert.match(
+    source,
+    TTFT_FALLBACK_PATTERN,
+    `${name} bridge TTFT 无数据必须回退为 —`,
+  );
+  assert.match(
+    source,
+    TPS_FALLBACK_PATTERN,
+    `${name} bridge TPS 无数据必须回退为 —`,
+  );
+  assert.doesNotMatch(
+    source,
+    /vllmTtft:[\s\S]*?toFixed\(2\) \+ " s" : "0 s"/,
+    `${name} bridge TTFT 无数据不得回退为字面 "0 s"`,
+  );
+  assert.doesNotMatch(
+    source,
+    /vllmTps:[\s\S]*?toFixed\(1\) \+ " tok\/s" : "0 tok\/s"/,
+    `${name} bridge TPS 无数据不得回退为字面 "0 tok/s"`,
+  );
+}
+
+console.log('monitor bridge 无数据 TTFT/TPS fallback 在 tauri/web 两份 bridge 中一致为 —');


### PR DESCRIPTION
## 背景

问题 2：运行状态面板的 TPS/TTFT 在云端模型下全部显示 0。调查结论：Rust 侧 self_perf 打点对本地/云端一致（无后端分支），但 `monitor/mod.rs` 只在本轮满足「TurnStarted + 收到首个 MessageDelta + 无工具调用」三条件时计数；云端 agentic 模型几乎每轮都有工具调用 → 工具轮整轮跳过（有意设计，mod.rs:150-152），计数保持 0。前端把缺失渲染成字面 `"0 s"/"0 tok/s"`，缺失与真 0 不可区分。

## 变更

- `tauri/bridge/monitor.js` + `web/bridge.js`：`ttft_count==0` / `tps_time_s==0` 时渲染为 `"—"`（与 `vllmKv`/`vllmTokTotal` 的缺失惯例一致）
- `MonitorView.jsx`：`MonitorMetricCard` 在值为 `"—"` 时不渲染 unit，避免显示 `"—s"`；`readNum` 对 `"—"` 返回 null，历史曲线不写入 0 点

## 验证

- `npm run lint:ui` ✅
- `bridge_domain_protocol` ✅

## 说明

本 PR 只修「缺失显示为 0」的直接 bug 面。工具轮是否要单独口径统计 TTFT/TPS（只计 prefill 段）、以及首轮是否计入的口径矛盾（mod.rs 单测 vs engine.rs #[ignore] 真机测试）属产品语义决策，另议。