### PR TITLE
fix(chat): 上下文占用显示准确性（真实窗口分母 + 跳过累加值）

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -2697,6 +2697,7 @@ fn spawn_event_forwarder(
                         "session_id": session_id,
                         "input_tokens": usage.input_tokens,
                         "output_tokens": usage.output_tokens,
+                        "context_window": bridge.usage_context_window(),
                     });
                     let _ = app.emit("chat:usage", payload.clone());
                     crate::features::remote_control::forward_app_event(&app, "chat:usage", payload);

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -934,6 +934,13 @@ impl Pinvou3Bridge {
         limits.has_known_limit().then_some(limits)
     }
 
+    /// 当前 active route 的上下文窗口（供 chat:usage 事件携带给前端做
+    /// token 进度条分母）。与 effective_context_window 同源（SavedModel 声明
+    /// vs probe 取小），云端模型不再停留在前端 32K 假分母。
+    pub fn usage_context_window(&self) -> u32 {
+        self.effective_context_window(&self.model())
+    }
+
     /// 底座 emergency 线用的 context window。SavedModel 声明与 probe(vLLM
     /// `/v1/models` 的 `max_model_len`)取较小值；都没有时才按模型名 hint/128K。
     ///

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1930,12 +1930,12 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                 </>
               )}
             </div>
-            {ctxTokens && ctxTokens.input > 0 && (
+            {ctxTokens && ctxTokens.max > 0 && (
               <div className={`mt-1.5 px-5 text-[11px] font-mono ${
                 ctxPct >= 0.9 ? 'text-[#C5221F] dark:text-[#F28B82]'
                 : ctxPct >= 0.75 ? 'text-[#B06000] dark:text-[#F9AB00]'
                 : 'text-[#9AA0A6] dark:text-[#5F6368]'}`}>
-                {t.ctxUsage} {fmtCtxTok(ctxTokens.input)} / {fmtCtxTok(ctxTokens.max)} · {Math.round(ctxPct * 100)}%
+                {t.ctxUsage} {ctxTokens.input > 0 ? fmtCtxTok(ctxTokens.input) : '—'} / {fmtCtxTok(ctxTokens.max)} · {Math.round(ctxPct * 100)}%
               </div>
             )}
             <div className="flex items-center justify-center mt-3">

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -842,7 +842,10 @@
     var sid = e.payload && e.payload.session_id;
     if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加值≠占用，保留上个准确值
     var input = Number(e.payload && e.payload.input_tokens || 0);
-    if (input > 0) {
+    var windowTok = Number(e.payload && e.payload.context_window) || 0;
+    if (windowTok > 0) state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+    // 累加值超过窗口说明仍有多请求（内部重试等无事件轮），跳过避免显示超上限
+    if (input > 0 && input <= state.tokens.max) {
       state.tokens = { input: input, max: state.tokens.max };
       notify();
     }

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -840,10 +840,15 @@
 
   listen("chat:usage", function (e) { onSessionEvent(e, function () {
     var sid = e.payload && e.payload.session_id;
-    if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加值≠占用，保留上个准确值
-    var input = Number(e.payload && e.payload.input_tokens || 0);
+    // 真实窗口是模型能力常量，不随轮内请求数变化，必须先于 dirty guard 消费：
+    // 工具轮（最常见的 Agent 场景）只跳过不可信的累计 input，分母仍要更新。
     var windowTok = Number(e.payload && e.payload.context_window) || 0;
-    if (windowTok > 0) state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+    if (windowTok > 0 && windowTok !== state.tokens.max) {
+      state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+      notify(); // 窗口变化也要通知 UI（即使本轮 input 不可信）
+    }
+    if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加 input 不可信，保留上个准确值
+    var input = Number(e.payload && e.payload.input_tokens || 0);
     // 累加值超过窗口说明仍有多请求（内部重试等无事件轮），跳过避免显示超上限
     if (input > 0 && input <= state.tokens.max) {
       state.tokens = { input: input, max: state.tokens.max };

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -5308,8 +5308,11 @@
     var sid = e.payload && e.payload.session_id;
     if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加值≠占用，保留上个准确值
     var input = Number(e.payload && e.payload.input_tokens || 0);
-    if (input > 0) {
-      state.tokens = { input: input, max: maxModelLen };
+    var windowTok = Number(e.payload && e.payload.context_window) || 0;
+    if (windowTok > 0) state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+    // 累加值超过窗口说明仍有多请求（内部重试等无事件轮），跳过避免显示超上限
+    if (input > 0 && input <= state.tokens.max) {
+      state.tokens = { input: input, max: state.tokens.max };
       notify();
     }
   }); });

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -5306,10 +5306,15 @@
 
   listen("chat:usage", function (e) { onSessionEvent(e, function () {
     var sid = e.payload && e.payload.session_id;
-    if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加值≠占用，保留上个准确值
-    var input = Number(e.payload && e.payload.input_tokens || 0);
+    // 真实窗口是模型能力常量，不随轮内请求数变化，必须先于 dirty guard 消费：
+    // 工具轮（最常见的 Agent 场景）只跳过不可信的累计 input，分母仍要更新。
     var windowTok = Number(e.payload && e.payload.context_window) || 0;
-    if (windowTok > 0) state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+    if (windowTok > 0 && windowTok !== state.tokens.max) {
+      state.tokens.max = windowTok; // 云端真实窗口，替代 32K 假分母
+      notify(); // 窗口变化也要通知 UI（即使本轮 input 不可信）
+    }
+    if (sid && turnUsageDirty[sid]) return; // 本轮多请求，累加 input 不可信，保留上个准确值
+    var input = Number(e.payload && e.payload.input_tokens || 0);
     // 累加值超过窗口说明仍有多请求（内部重试等无事件轮），跳过避免显示超上限
     if (input > 0 && input <= state.tokens.max) {
       state.tokens = { input: input, max: state.tokens.max };

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -83,7 +83,7 @@ const expectedProtocolHashes = {
   multiAgent: 'b123eece32980d80787ab9cd7315f3566b0943ab366a2358a1ff0cb247b65491',
   orchestration: 'e5e333aca4d1fb7e8ed32f879d3b310c01cd0845d0e5cdc2b5ed1e95aee3ea31',
   artifacts: '9de646442d1192440abd14046e75ec402afc2c8bea1a8a88ff9667aab5e6ac4c',
-  chat: 'b9776406d996b5d1c28f66a4b98fd2dfe4b532ec9ae96635ae9afa6e41df190a',
+  chat: '02c475b1c538d711f65becf2b4fed45522c5322b246c8865c99c8417e88becbb',
   dependencies: '257468e4f9e2e9270de6ef75f685d5eafcd000226d44cfb81a1b04c0e7615707',
   interaction: 'dc75ecf05e5b015833c08ffa4e3de4319f657de5ce300b68f873e966236a4898',
   knowledge: '3ae1fb7f8b4909601edb91ec1b2df83d37a3a6cc302911517c5913b557b716ca',

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -83,7 +83,7 @@ const expectedProtocolHashes = {
   multiAgent: 'b123eece32980d80787ab9cd7315f3566b0943ab366a2358a1ff0cb247b65491',
   orchestration: 'e5e333aca4d1fb7e8ed32f879d3b310c01cd0845d0e5cdc2b5ed1e95aee3ea31',
   artifacts: '9de646442d1192440abd14046e75ec402afc2c8bea1a8a88ff9667aab5e6ac4c',
-  chat: '1debe7cf0bf31dbef5660b46414d6ca37514deb5a91f93ab516fd0a41d5119fd',
+  chat: 'b9776406d996b5d1c28f66a4b98fd2dfe4b532ec9ae96635ae9afa6e41df190a',
   dependencies: '257468e4f9e2e9270de6ef75f685d5eafcd000226d44cfb81a1b04c0e7615707',
   interaction: 'dc75ecf05e5b015833c08ffa4e3de4319f657de5ce300b68f873e966236a4898',
   knowledge: '3ae1fb7f8b4909601edb91ec1b2df83d37a3a6cc302911517c5913b557b716ca',

--- a/pinvou3-app/tests/chat_usage_context_window.test.mjs
+++ b/pinvou3-app/tests/chat_usage_context_window.test.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// chat:usage 的 context_window 消费时序回归：dirty 工具轮（turnUsageDirty=true）
+// 只跳过不可信的累计 input_tokens，仍必须消费真实窗口分母（PR #213 核心目标）。
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = (...parts) => readFileSync(path.join(root, ...parts), 'utf8');
+
+// ── tauri 端行为测试：dirty 工具轮仍更新 context window、但不更新 input ──
+const source = read('src', 'platform', 'tauri', 'bridge', 'chat-events.js');
+const windowObject = { __PINVOU_TAURI_BRIDGE_FEATURES__: {} };
+vm.runInContext(source, vm.createContext({
+  window: windowObject,
+  console,
+  Date,
+  String,
+}), { filename: 'chat-events.js' });
+
+const listeners = new Map();
+let notifyCount = 0;
+const state = {
+  activeSessionId: 'session-1',
+  chatItems: [],
+  messages: [],
+  tokens: { input: 0, max: 32768 }, // 云端无 vLLM probe 时的假分母起点
+  thinking: { active: false },
+};
+const context = {
+  state,
+  listen(name, handler) { listeners.set(name, handler); },
+  notify() { notifyCount += 1; },
+  invoke: async () => null,
+  turnUsageDirty: {},
+  sessionStates: {},
+  renderMarkdown(text) { return `<p>${text}</p>`; },
+  bt() { return ''; },
+  onSessionEvent(_event, callback) { callback(); },
+  runSyncOnSession(_sessionId, callback) { callback(); },
+  addChatItem(item) {
+    item.id = ++context.itemIdSeq;
+    state.chatItems.push(item);
+  },
+  addSystemItem(text, meta = {}) {
+    context.addChatItem({ type: 'system', text, ...meta });
+  },
+  timeStr() { return '12:00'; },
+  flushPendingTextBlock() {
+    if (!context.pendingAssistantText) return;
+    context.pendingAssistantBlocks.push({ type: 'text', text: context.pendingAssistantText });
+    context.pendingAssistantText = '';
+  },
+  currentStreamId: 1,
+  currentStreamText: '',
+  pendingAssistantText: '',
+  pendingAssistantBlocks: [],
+  itemIdSeq: 1,
+};
+windowObject.__PINVOU_TAURI_BRIDGE_FEATURES__['chat-events'](context);
+
+const emitUsage = payload => listeners.get('chat:usage')({
+  event: 'chat:usage',
+  payload: { session_id: 'session-1', ...payload },
+});
+
+// 场景 1：dirty 工具轮（tool_start 已置 dirty）——分母必须更新，input 保留。
+// 这是最常见 Agent 场景：PR #213 修复前此处提前 return，真实窗口永不消费。
+context.turnUsageDirty['session-1'] = true;
+emitUsage({ input_tokens: 45000, context_window: 131072 });
+assert.equal(state.tokens.max, 131072, 'dirty 工具轮仍必须消费真实窗口，替代 32K 假分母');
+assert.equal(state.tokens.input, 0, 'dirty 工具轮不得更新累计 input（本轮累加值不可信）');
+assert.ok(notifyCount >= 1, '窗口变化时必须通知 UI 刷新分母');
+
+// 场景 2：同一窗口再次到达——不重复 notify，但 input 仍跳过（仍是 dirty 轮）。
+const notifyBefore = notifyCount;
+emitUsage({ input_tokens: 45001, context_window: 131072 });
+assert.equal(state.tokens.max, 131072);
+assert.equal(state.tokens.input, 0, 'dirty 轮 input 保持冻结');
+assert.equal(notifyCount, notifyBefore, '窗口未变化不重复通知');
+
+// 场景 3：干净轮（新一轮开始，dirty 已重置）——input 恢复更新。
+context.turnUsageDirty['session-1'] = false;
+emitUsage({ input_tokens: 2048, context_window: 131072 });
+assert.equal(state.tokens.max, 131072);
+assert.equal(state.tokens.input, 2048, '干净轮 input 正常更新');
+assert.ok(notifyCount > notifyBefore, 'input 更新触发通知');
+
+// 场景 4：超窗累加值（内部重试等无事件轮）——跳过显示超上限数字。
+context.turnUsageDirty['session-1'] = false;
+const inputBefore = state.tokens.input;
+emitUsage({ input_tokens: 200000, context_window: 131072 });
+assert.equal(state.tokens.input, inputBefore, '超过窗口的累加值不得显示（保留上次准确值）');
+assert.equal(state.tokens.max, 131072, '超窗轮仍保留真实分母');
+
+// 场景 5：无 context_window 的旧远端（降级）——保留旧 max，不破坏。
+const maxBefore = state.tokens.max;
+emitUsage({ input_tokens: 100 }); // 无 context_window 字段
+assert.equal(state.tokens.max, maxBefore, '旧端不带 context_window 时保留旧值');
+assert.equal(state.tokens.input, 100);
+
+// ── tauri/web 双端源码断言：窗口消费必须先于 dirty guard ──
+const tauriSection = source.slice(source.indexOf('listen("chat:usage"'), source.indexOf('listen("chat:compaction"'));
+const webSource = read('src', 'platform', 'web', 'bridge.js');
+const webSection = webSource.slice(webSource.indexOf('listen("chat:usage"'), webSource.indexOf('listen("chat:compaction"'));
+
+for (const [label, section] of [['tauri', tauriSection], ['web', webSection]]) {
+  const dirtyGuard = section.indexOf('turnUsageDirty[sid]) return');
+  const windowRead = section.indexOf('e.payload.context_window');
+  assert.ok(dirtyGuard !== -1 && windowRead !== -1, `${label}: chat:usage handler 片段完整`);
+  assert.ok(windowRead < dirtyGuard, `${label}: context_window 消费必须先于 dirty guard（否则工具轮永不更新分母）`);
+  assert.ok(section.indexOf('windowTok !== state.tokens.max') !== -1, `${label}: 窗口变化才更新分母`);
+  assert.ok(section.indexOf('windowTok > 0') !== -1, `${label}: 窗口 0 守卫保留`);
+}
+
+console.log('chat_usage_context_window.test.mjs: OK');


### PR DESCRIPTION
## 背景

问题 1 + 问题 3（同一链路：usage → tokens → 显示）。

**问题 1**：上下文长度数字远超模型上限。根因：`chat:usage.input_tokens` 是底座按 turn 内**所有 API 请求累加**的计费口径（`Turn::add_usage` 逐请求求和），前端直接当「当前上下文占用」显示；多请求轮（工具调用/内部重试/SSE 重连）会透出 N×完整上下文的累加值。且 `tokens.max` 默认 32768，云端模型无 vLLM probe 不更新，假分母进一步放大观感。

**问题 3**：上下文长度时显时不显。根因：显示条件 `input > 0`，会话 buffer 重建 / durable 重载 / 切走再切回（ChatView 卸载重挂）时 tokens.input 归 0，显示行消失，直到下一次干净轮 usage 才恢复。

## 变更

1. **Rust**：`Pinvou3Bridge::usage_context_window()`（与 `effective_context_window` 同源：SavedModel 声明 vs probe 取小）；`chat:usage` payload 增加 `context_window` 字段。
2. **前端 tauri/web**：usage handler 用 `context_window` 更新 `tokens.max`（云端真实窗口，替代 32K 假分母）；新增 `input > max` 跳过——累加值超过窗口说明仍有多请求（内部重试等无事件轮），保留上次准确值，不再显示超上限数字。
3. **ChatView**：显示条件 `max > 0` 即显示（input 未知显示 `—`），切会话/重载后不再丢失。

## 验证

- `cargo test --lib`：965 passed / 1 并行环境抖动（code_native_workspace_info 与 connector_skill_cache 单跑均通过，与改动无关）
- `npm run lint:ui` ✅
- chat_turn_error_isolation / code_native_lane / model_reasoning_render：通过

## 已知限制

- 多请求轮的准确「单请求占用」底座未暴露（只有 turn 累加值），本 PR 用「超窗跳过 + 保留上次值」保守处理；若要精确占用需底座另发最后请求的 prompt tokens（CodeWhale 上游优先，未在本 PR 动底座）。