### PR TITLE
fix(codex): 代码模式底栏控件统一为工作/设计样式并补充语音输入

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -2060,6 +2060,7 @@ function workspaceDisplayName(path) {
                 onSwitchHomeMode={handleSwitchHomeMode}
                 bs={bs}
                 onGotoModelSettings={() => openSettingsSection('model')}
+                onGotoSettings={() => openSettingsSection('general')}
                 onGotoTools={() => navigateFromScheduledRun('toolStore')}
               />
             )}

--- a/pinvou3-app/src/features/chat/composer-controls.jsx
+++ b/pinvou3-app/src/features/chat/composer-controls.jsx
@@ -204,6 +204,9 @@ const ComposerModeChip = ({ t, bs, compact, mode: modeProp, busy: busyProp, onSw
   const busy = busyProp !== undefined ? busyProp : (bs && bs.busy);
   async function switchTo(target) {
     setOpen(false);
+    // 点击已激活模式：无状态变更，早退避免冗余刷新（代码车道 onSwitch 路径
+    // 会触发一次 refreshNativeControls 3 次 invoke；ChatView bridge 路径同样受益）。
+    if ((target === 'plan' && isPlan) || (target === 'yolo' && !isPlan)) return;
     if (onSwitch) { onSwitch(target, { isPlan, busy }); return; }
     if (!bridge.available) return;
     if (target === 'plan' && !isPlan) {

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
 import {
-  AlertTriangle, Brain, Check, CheckCircle2, ChevronDown, FileText, FolderOpen, Paperclip, Plus, Send,
+  AlertTriangle, Brain, Check, CheckCircle2, ChevronDown, FileText, FolderOpen, Mic, Paperclip, Plus, Send,
   RefreshCw, Sparkles, StopCircle, Terminal, User, Wrench,
 } from '../../components/icons.jsx';
 import { AcpAgentLogo } from './AcpAgentLogo.jsx';
@@ -16,7 +16,6 @@ import {
   runtimeOperationFor,
 } from './runtimeNoticeState.js';
 import { ComposerPopover } from '../../components/ComposerPopover.jsx';
-import { can } from '../../shared/platform.js';
 import {
   appendAcpEvent,
   commandExecutionDetails,
@@ -46,8 +45,14 @@ import {
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 import { assistantResponseAvailable, assistantResponseText } from '../conversation/message-clipboard.js';
 import {
+  ComposerModelSelector,
   ComposerToolMenu,
 } from '../settings/SettingsView.jsx';
+import {
+  COMPOSER_ICON_BUTTON_CLASS,
+  ComposerKbSelector,
+  ComposerModeChip,
+} from '../chat/composer-controls.jsx';
 import { visibleUserModels } from '../../shared/model-options.js';
 import { selectorMainLabel } from '../settings/model-catalog.js';
 import { isNearConversationBottom } from '../conversation/conversation-model.js';
@@ -55,6 +60,7 @@ import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
 import { PlanLayer, cardBoxCls, cardBtnCls } from '../tools/tool-renderers.jsx';
 import { AttachmentChips } from '../attachments/AttachmentChips.jsx';
 import { HomeModeSwitcher } from '../conversation/HomeModeSwitcher.jsx';
+import { bridge } from '../../hooks/useBridge.js';
 import {
   invokeTauri,
   listenTauri,
@@ -1285,17 +1291,8 @@ export function CodexAcpView({
   }, [sessions]);
 
   // 原生车道才加载知识库集合与 embedding 安装态；embedding 明确未装时选择器禁用。
-  useEffect(() => {
-    if (!isNativeAgent) return undefined;
-    let alive = true;
-    invoke('kb_collection_list')
-      .then(list => { if (alive) setNativeKbCollections(Array.isArray(list) ? list : []); })
-      .catch(() => { if (alive) setNativeKbCollections([]); });
-    invoke('kb_model_status')
-      .then(status => { if (alive) setNativeKbStatus(status || { installed: true }); })
-      .catch(() => { if (alive) setNativeKbStatus({ installed: true }); });
-    return () => { alive = false; };
-  }, [isNativeAgent]);
+  // 集合列表与安装态由 ComposerKbSelector 内部经 bridge.knowledge（kb_collection_list /
+  // kb_model_status，全局只读、不带会话）自行加载，代码页不再重复拉取。
   function getNativeLane(sessionId) {
     let lane = nativeLanesRef.current.get(sessionId);
     if (!lane) {
@@ -1333,17 +1330,9 @@ export function CodexAcpView({
   // 待确认的 yolo 切换请求（{ draft, chipBusy }）；非 null 时渲染确认卡。
   const [pendingYoloSwitch, setPendingYoloSwitch] = useState(null);
   const [yoloConfirmBusy, setYoloConfirmBusy] = useState(false);
-  // 知识库选择器的集合列表与 embedding 安装态（全局只读查询，不带会话）。
-  const [nativeKbCollections, setNativeKbCollections] = useState([]);
-  const [nativeKbStatus, setNativeKbStatus] = useState(null); // null=未知；新后端区分已安装与运行时已就绪
-  const nativeKbSetup = (bs && bs.kbModelSetup) || {};
-  const nativeKbMissing = nativeKbStatus && nativeKbStatus.installed === false;
-  const nativeKbReadyKnown = nativeKbStatus && typeof nativeKbStatus.ready === 'boolean';
-  const nativeKbNotReady = !nativeKbMissing && (
-    nativeKbSetup.startupLoading === true
-    || (nativeKbReadyKnown && nativeKbStatus.ready === false && nativeKbSetup.startupReady !== true)
-  );
-  const nativeKbBlocked = nativeKbMissing || nativeKbNotReady;
+  // 知识库集合列表与 embedding 安装态由 ComposerKbSelector 内部经 bridge.knowledge
+  // （kb_collection_list / kb_model_status，全局只读、不带会话）自行加载，代码页
+  // 不再重复拉取（PR #214 统一底栏控件时移除 nativeKb* 本地变量）。
   const nativeProjection = useMemo(
     () => (isNativeAgent ? projectNativeLane(activeNativeLane, activeId) : null),
     // nativeLaneTick 是 lane 内容变化的版本号（lane 本体是可变对象，靠 tick 触发重投影）。
@@ -1372,20 +1361,9 @@ export function CodexAcpView({
   const nativeSessionModelId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.modelId : null)
     : (nativeDraftControls.modelId || null);
-  const nativeModelValue = nativeSessionModelId || (bs && bs.activeModelId) || '';
-  const nativeManageModelsAction = can('modelManagement') && onGotoModelSettings
-    ? { label: t.manageModels, onClick: onGotoModelSettings }
-    : undefined;
   const nativeMountedId = activeId
     ? (nativeControlsSessionRef.current === activeId ? nativeControls.mountedId : null)
     : (nativeDraftControls.mountedId ?? null);
-  const nativeKbChoices = [
-    { value: '', name: t.kbMountRemove },
-    ...nativeKbCollections.map(collection => ({
-      value: String(collection.id),
-      name: collection.name,
-    })),
-  ];
   const activeAgentName = activeSession?.agent_name
     || agents.find(agent => agent.agent_id === activeAgentId)?.agent_name
     || (activeAgentId === 'pinvou' ? '品悟' : activeAgentId === 'claude' ? 'Claude Code' : activeAgentId === 'kimi' ? 'Kimi' : 'Codex');
@@ -1877,6 +1855,40 @@ export function CodexAcpView({
       ...current,
       [attachmentKey]: (current[attachmentKey] || []).filter(path => path !== relativePath),
     }));
+  }
+
+  // ── 语音输入（与 ChatView 同款：bridge.voice 一次录音 → 本地 ASR → 写回 draft）。
+  // 代码车道不物化聊天会话，语音状态仍由 bridge 全局管理（bs.voiceInput），写回走代码页 draft。
+  const nativeVoiceInput = (bs && bs.voiceInput) || { status: 'idle' };
+  const nativeVoiceActive = nativeVoiceInput.status === 'requesting_permission'
+    || nativeVoiceInput.status === 'recording'
+    || nativeVoiceInput.status === 'transcribing';
+  const nativeVoiceRecording = nativeVoiceInput.status === 'recording';
+  const nativeVoiceBusy = nativeVoiceInput.status === 'transcribing';
+  const nativeVoiceDisabled = !bridge.available || nativeVoiceBusy;
+  const nativeVoiceLabel = nativeVoiceInput.status === 'recording'
+    ? t.voiceStop
+    : nativeVoiceInput.status === 'failed'
+      ? t.voiceRetry
+      : nativeVoiceInput.status === 'requesting_permission'
+        ? t.voiceCancel
+        : nativeVoiceInput.status === 'transcribing'
+          ? t.voiceTranscribing
+          : t.voiceStart;
+  function handleNativeVoiceClick() {
+    if (!bridge.available) return;
+    if (nativeVoiceInput.status === 'requesting_permission') {
+      bridge.voice.cancelVoiceInput();
+      return;
+    }
+    if (nativeVoiceBusy) return;
+    bridge.voice.startVoiceInput(draft, (text) => setDraft(prev => bridge.voice.appendVoiceText(prev, text)));
+  }
+  function handleNativeVoiceCancel() {
+    if (bridge.available) bridge.voice.cancelVoiceInput();
+  }
+  function handleNativeVoiceClose() {
+    if (bridge.available) bridge.voice.clearVoiceInput();
   }
 
   function handlePaste(event) {
@@ -2811,6 +2823,32 @@ export function CodexAcpView({
                 className="mb-2"
                 formatError={value => String(value || '')}
               />
+              {nativeVoiceInput.status !== 'idle' && nativeVoiceInput.message && (
+                <div className={`flex items-center justify-between gap-2 mb-2 px-3 py-2 rounded-2xl text-[12px] ${
+                  nativeVoiceInput.status === 'failed'
+                    ? (theme === 'dark' ? 'bg-[#3A1F1F] text-[#F28B82]' : 'bg-[#FCE8E6] text-[#C5221F]')
+                    : (theme === 'dark' ? 'bg-[#1E2B3A] text-[#A8C7FA]' : 'bg-[#E8F0FE] text-[#174EA6]')
+                }`}>
+                  <span className="min-w-0 truncate">
+                    {nativeVoiceInput.status === 'requesting_permission' ? t.voiceRequesting
+                      : nativeVoiceInput.status === 'recording' ? t.voiceRecording
+                      : nativeVoiceInput.status === 'transcribing' ? t.voiceTranscribing
+                      : nativeVoiceInput.status === 'completed' ? t.voiceCompleted
+                      : nativeVoiceInput.message}
+                  </span>
+                  <div className="flex items-center gap-1 shrink-0">
+                    {nativeVoiceInput.status === 'failed' && (
+                      <button onClick={handleNativeVoiceClick} className={`px-2 py-1 rounded-full ${theme === 'dark' ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}>{t.voiceRetry}</button>
+                    )}
+                    {nativeVoiceActive && (
+                      <button onClick={handleNativeVoiceCancel} className={`px-2 py-1 rounded-full ${theme === 'dark' ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}>{t.voiceCancel}</button>
+                    )}
+                    {!nativeVoiceActive && (
+                      <button onClick={handleNativeVoiceClose} title={t.voiceClose} className={`w-6 h-6 rounded-full flex items-center justify-center ${theme === 'dark' ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}>×</button>
+                    )}
+                  </div>
+                </div>
+              )}
               {workspaceReferences.length > 0 && (
                 <div className="mb-2 flex flex-wrap items-center gap-1.5">
                   {workspaceReferences.map(path => (
@@ -2915,48 +2953,54 @@ export function CodexAcpView({
                   <button
                     type="button"
                     onClick={() => pickAttachments().catch(showError)}
-                    className="w-7 h-7 rounded-lg flex items-center justify-center hover:bg-black/[0.05] dark:hover:bg-white/[0.07]"
+                    className={COMPOSER_ICON_BUTTON_CLASS}
                     title={codexCopy.addAttachment}
                     aria-label={codexCopy.addAttachment}
                   >
-                    <Paperclip size={16} />
+                    <Paperclip size={18} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleNativeVoiceClick}
+                    disabled={nativeVoiceDisabled}
+                    aria-label={nativeVoiceLabel}
+                    title={nativeVoiceLabel}
+                    className={`${
+                      nativeVoiceRecording
+                        ? 'w-9 h-9 shrink-0 rounded-full flex items-center justify-center transition-colors bg-[#C5221F] text-white hover:bg-[#A50E0E] border border-transparent'
+                        : nativeVoiceActive
+                          ? `${COMPOSER_ICON_BUTTON_CLASS} text-[#174EA6] dark:text-[#A8C7FA]`
+                          : COMPOSER_ICON_BUTTON_CLASS
+                    } ${nativeVoiceDisabled ? 'opacity-70 cursor-wait' : ''}`}>
+                    <Mic size={18} />
                   </button>
                   <button type="button" onClick={() => setCommandOpen(value => !value)}
                     disabled={!availableCommands.length}
                     className="h-7 px-2 rounded-lg text-[11px] font-mono hover:bg-black/[0.05] dark:hover:bg-white/[0.07] disabled:opacity-40"
                     title={availableCommands.length ? codexCopy.commandsAvailable : codexCopy.commandsAfterSession}>/</button>
                   {isNativeAgent && (
-                    // 原生（品悟）车道的底栏控件：与 ACP 配置组同一套
-                    // CodexComposerConfigSelect 视觉语言；行为（直调 per-session 命令、
-                    // 草稿暂存、busy 禁用、归属保护）不变。Plan 说明：原生车道已接
-                    // plan_snapshot/plan_ready，切 Plan 后方案以审批卡呈现（批准调 accept_plan）。
+                    // 原生（品悟）车道的底栏控件：与工作/设计页共用同一套共享 composer
+                    // 控件（ComposerModeChip / ComposerModelSelector / ComposerKbSelector，
+                    // 显式会话态驱动 props 绕开 bridge 聊天 active 绑定）；行为（直调
+                    // per-session 命令、草稿暂存、busy 禁用、归属保护）不变。Plan 说明：
+                    // 原生车道已接 plan_snapshot/plan_ready，切 Plan 后方案以审批卡呈现。
                     <div data-testid="native-composer-controls" className="flex min-w-0 flex-wrap items-center gap-2">
-                      <CodexComposerConfigSelect
-                        id="native-mode"
-                        testId="native-mode"
-                        label={codexCopy.permissionMode}
-                        value={nativeModeValue}
-                        choices={[
-                          { value: 'yolo', name: t.modeYolo },
-                          { value: 'plan', name: t.modePlan },
-                        ]}
-                        onChange={target => switchNativeMode(String(target), {
-                          isPlan: nativeModeValue === 'plan',
-                          busy,
-                        })}
-                        title={`${t.modeSwitchTitle} · ${nativeModeValue === 'plan' ? t.modePlan : t.modeYolo}`}
+                      <ComposerModeChip
+                        t={t}
+                        bs={bs}
+                        mode={nativeModeValue}
+                        busy={busy || working}
+                        onSwitch={switchNativeMode}
                       />
                       {nativeModelChoices.length > 0 && (
-                        <CodexComposerConfigSelect
-                          id="native-model"
-                          testId="native-model"
-                          label={codexCopy.model}
-                          value={nativeModelValue}
-                          choices={nativeModelChoices}
-                          onChange={modelId => switchNativeModel(activeId, String(modelId))}
-                          disabled={busy || working}
-                          title={busy || working ? t.modelSwitchBusy : undefined}
-                          footerAction={nativeManageModelsAction}
+                        <ComposerModelSelector
+                          t={t}
+                          bs={bs}
+                          onGotoSettings={onGotoModelSettings}
+                          sessionId={activeId}
+                          sessionModelId={nativeSessionModelId}
+                          busy={busy || working}
+                          onSwitchModel={(sessionId, modelId) => switchNativeModel(sessionId, String(modelId))}
                         />
                       )}
                       <ComposerToolMenu
@@ -2968,17 +3012,12 @@ export function CodexAcpView({
                         triggerTestId="native-tools"
                         scope="code"
                       />
-                      <CodexComposerConfigSelect
-                        id="native-kb"
-                        testId="native-kb"
-                        label={t.kbMount}
-                        value={nativeMountedId == null ? '' : String(nativeMountedId)}
-                        choices={nativeKbChoices}
-                        onChange={value => (
-                          String(value) === '' ? unmountNativeKb() : mountNativeKb(Number(value))
-                        )}
-                        disabled={nativeKbBlocked}
-                        title={nativeKbBlocked ? (nativeKbMissing ? t.kbMountNoModel : t.kbMountNotReady) : t.kbMountTitle}
+                      <ComposerKbSelector
+                        t={t}
+                        bs={bs}
+                        mountedId={nativeMountedId}
+                        onMount={mountNativeKb}
+                        onUnmount={unmountNativeKb}
                       />
                       {activeId && nativeTokensInput > 0 && (
                         // 用量 chip 兼手动压缩入口（compact_now 的后端注释语义即"用户点 token

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
+import { can } from '../../shared/platform.js';
 import {
   AlertTriangle, Brain, Check, CheckCircle2, ChevronDown, FileText, FolderOpen, Mic, Paperclip, Plus, Send,
   RefreshCw, Sparkles, StopCircle, Terminal, User, Wrench,
@@ -1179,6 +1180,7 @@ export function CodexAcpView({
   bs = null,
   onGotoTools,
   onGotoModelSettings,
+  onGotoSettings,
   fixedSession = false,
 }) {
   const codexCopy = t.uiCodex;
@@ -1866,6 +1868,7 @@ export function CodexAcpView({
   const nativeVoiceRecording = nativeVoiceInput.status === 'recording';
   const nativeVoiceBusy = nativeVoiceInput.status === 'transcribing';
   const nativeVoiceDisabled = !bridge.available || nativeVoiceBusy;
+  const nativeVoiceCanInstallAsr = can('localModelSetup') && can('dependencyInstall');
   const nativeVoiceLabel = nativeVoiceInput.status === 'recording'
     ? t.voiceStop
     : nativeVoiceInput.status === 'failed'
@@ -1890,6 +1893,24 @@ export function CodexAcpView({
   function handleNativeVoiceClose() {
     if (bridge.available) bridge.voice.clearVoiceInput();
   }
+
+  // 离开代码页（切模式/视图，组件卸载）时可靠取消进行中的语音输入：
+  // bridge.voice 的写回守卫只绑定聊天侧 activeSessionId，代码页不物化聊天会话，
+  // 若不取消，转写结果可能写回已卸载组件（草稿态 null→null 时守卫还会放行并
+  // 显示「已完成」，但文本已丢失）。卸载前取消让「录音中切走」变成显式取消。
+  const nativeVoiceInputRef = useRef(nativeVoiceInput);
+  nativeVoiceInputRef.current = nativeVoiceInput;
+  useEffect(() => {
+    return () => {
+      const voice = nativeVoiceInputRef.current;
+      if (voice && (voice.status === 'requesting_permission'
+        || voice.status === 'recording'
+        || voice.status === 'transcribing')
+        && bridge.available) {
+        bridge.voice.cancelVoiceInput();
+      }
+    };
+  }, []);
 
   function handlePaste(event) {
     const items = Array.from(event.clipboardData && event.clipboardData.items || []);
@@ -2837,6 +2858,10 @@ export function CodexAcpView({
                       : nativeVoiceInput.message}
                   </span>
                   <div className="flex items-center gap-1 shrink-0">
+                    {nativeVoiceInput.status === 'failed' && nativeVoiceInput.category === 'recognition_failed'
+                      && nativeVoiceCanInstallAsr && onGotoSettings && (
+                      <button onClick={onGotoSettings} className={`px-2 py-1 rounded-full font-medium ${theme === 'dark' ? 'bg-white/10 hover:bg-white/20' : 'bg-black/5 hover:bg-black/10'}`}>{t.voiceGotoDeps}</button>
+                    )}
                     {nativeVoiceInput.status === 'failed' && (
                       <button onClick={handleNativeVoiceClick} className={`px-2 py-1 rounded-full ${theme === 'dark' ? 'hover:bg-white/10' : 'hover:bg-black/5'}`}>{t.voiceRetry}</button>
                     )}

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -2961,6 +2961,7 @@ export function CodexAcpView({
                   </button>
                   <button
                     type="button"
+                    data-testid="codex-voice-input"
                     onClick={handleNativeVoiceClick}
                     disabled={nativeVoiceDisabled}
                     aria-label={nativeVoiceLabel}

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -551,11 +551,16 @@ try {
     && codexView.includes('<ComposerToolMenu')
     && codexView.includes('triggerTestId="native-tools"')
     && codexView.includes('scope="code"')
-    && codexView.includes('mountedId={nativeMountedId}'),
-  'the native lane must mount the shared composer controls (work/design style) behind the native-agent gate');
-  assert.ok(codexView.includes('function CodexComposerConfigSelect')
+    && codexView.includes('mountedId={nativeMountedId}')
+    && codexView.includes('data-testid="codex-voice-input"'),
+  'the native lane must mount the shared composer controls (work/design style) plus the voice input button behind the native-agent gate');
+  // plain（非 native）车道仍走自绘 CodexComposerConfigSelect 配置组，不随 native 车道
+  // 迁移到共享组件；共享 config select 保留 ACP testid 契约。
+  assert.ok(codexView.includes('data-testid="codex-composer-configs"')
+    && codexView.includes('{composerControlsVisible && !isNativeAgent && (')
+    && codexView.includes('function CodexComposerConfigSelect')
     && codexView.includes('data-testid={testId || `codex-config-${id}`}'),
-  'the shared config select must keep its ACP testid contract while allowing native overrides');
+  'the plain lane must keep its self-drawn config select group while the shared config select keeps the ACP testid contract');
   assert.ok(codexView.includes("invoke('get_session_model_id'")
     && codexView.includes("invoke('set_session_model'")
     && codexView.includes("invoke('session_mount_collection'")

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -538,25 +538,21 @@ try {
   assert.ok(baseStyles.includes('.codex-markdown ol { list-style:decimal outside; }'),
     'Codex ordered lists must retain numbering after Tailwind preflight');
 
-  // 原生（品悟）车道底栏四控件契约：仅 isNativeAgent 渲染、与 ACP 配置组同一套
-  // CodexComposerConfigSelect 视觉、直调 per-session 命令、绝不复用 bridge 聊天
-  // active 绑定方法。
+  // 原生（品悟）车道底栏控件契约：仅 isNativeAgent 渲染、与工作/设计页共用同一套
+  // 共享 composer 控件（ComposerModeChip / ComposerModelSelector / ComposerKbSelector，
+  // 显式会话态驱动 props 绕开 bridge 聊天 active 绑定）、直调 per-session 命令、
+  // 并带与 ChatView 同款的语音输入按钮（bridge.voice 写回 draft）。
   const composerControls = readFileSync(path.join(root, 'src', 'features', 'chat', 'composer-controls.jsx'), 'utf8');
   assert.ok(codexView.includes('data-testid="native-composer-controls"')
     && codexView.includes('{isNativeAgent && (')
-    && codexView.includes('testId="native-mode"')
-    && codexView.includes('testId="native-model"')
-    && codexView.includes('testId="native-kb"')
-    && codexView.includes('triggerVariant="pill"')
+    && codexView.includes('<ComposerModeChip')
+    && codexView.includes('<ComposerModelSelector')
+    && codexView.includes('<ComposerKbSelector')
+    && codexView.includes('<ComposerToolMenu')
     && codexView.includes('triggerTestId="native-tools"')
-    && codexView.includes('label={codexCopy.model}')
-    && codexView.includes('label={codexCopy.permissionMode}')
-    && codexView.includes('label={t.kbMount}'),
-  'the native lane must mount the four composer controls as ACP-style config pills behind the native-agent gate');
-  assert.ok(!codexView.includes('<ComposerModeChip')
-    && !codexView.includes('<ComposerModelSelector')
-    && !codexView.includes('<ComposerKbSelector'),
-  'the code lane must not fall back to chat-style icon triggers for composer controls');
+    && codexView.includes('scope="code"')
+    && codexView.includes('mountedId={nativeMountedId}'),
+  'the native lane must mount the shared composer controls (work/design style) behind the native-agent gate');
   assert.ok(codexView.includes('function CodexComposerConfigSelect')
     && codexView.includes('data-testid={testId || `codex-config-${id}`}'),
   'the shared config select must keep its ACP testid contract while allowing native overrides');

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -554,6 +554,19 @@ try {
     && codexView.includes('mountedId={nativeMountedId}')
     && codexView.includes('data-testid="codex-voice-input"'),
   'the native lane must mount the shared composer controls (work/design style) plus the voice input button behind the native-agent gate');
+  // 语音输入生命周期契约：bridge.voice 的写回守卫只绑定聊天侧 activeSessionId，
+  // 代码页卸载（切模式/视图）前必须取消进行中的录音/转写，否则识别结果可能写回
+  // 已卸载组件（草稿态 null→null 时守卫放行并显示「已完成」但文本丢失）。
+  assert.ok(codexView.includes('nativeVoiceInputRef = useRef(nativeVoiceInput)')
+    && codexView.includes('bridge.voice.cancelVoiceInput()')
+    && codexView.includes("voice.status === 'requesting_permission'"),
+  'the code page must cancel an in-flight voice input before unmount so results cannot be written back to a detached composer');
+  // 语音失败提示条须带 ChatView 同款「去依赖体检」入口（recognition_failed + 本地
+  // ASR 可安装 + onGotoSettings 时渲染 voiceGotoDeps 按钮）。
+  assert.ok(codexView.includes("can('localModelSetup') && can('dependencyInstall')")
+    && codexView.includes('nativeVoiceInput.category === \'recognition_failed\'')
+    && codexView.includes('t.voiceGotoDeps'),
+  'the code page voice notice must offer the dependency-check shortcut on recognition failure like ChatView');
   // plain（非 native）车道仍走自绘 CodexComposerConfigSelect 配置组，不随 native 车道
   // 迁移到共享组件；共享 config select 保留 ACP testid 契约。
   assert.ok(codexView.includes('data-testid="codex-composer-configs"')
@@ -593,6 +606,10 @@ try {
     && composerControls.includes('if (onUnmount) { onUnmount(); return; }')
     && composerControls.includes('if (onSwitch) { onSwitch(target, { isPlan, busy }); return; }'),
   'extracted controls must support explicit session-driven props while keeping the bridge fallback');
+  // 等值守卫：点击已激活模式必须早退，避免代码车道 onSwitch 路径每次点击都触发
+  // 冗余 refreshNativeControls（3 次 invoke）；ChatView bridge 路径同样受益。
+  assert.ok(composerControls.includes("(target === 'plan' && isPlan) || (target === 'yolo' && !isPlan)"),
+  'ComposerModeChip must early-return when the clicked mode equals the active mode');
 
   console.log('codex_acp_timeline: ok');
 } finally {


### PR DESCRIPTION
## 背景

品悟代码模式（native 车道）输入框底栏控件此前自绘 ACP-style pill（`CodexComposerConfigSelect`），与工作/设计模式已有的共享控件样式漂移，且**缺少语音输入按钮**。本次将功能相同的控件统一为工作/设计已有样式，并补齐语音输入。

## 变更

- **附件按钮**：由小方钮改为 `COMPOSER_ICON_BUTTON_CLASS` 圆形，与工作/设计一致
- **模式切换**：`CodexComposerConfigSelect` → 共享组件 `ComposerModeChip`（显式会话态驱动 `mode`/`onSwitch`/`busy`）
- **模型选择**：→ 共享组件 `ComposerModelSelector`（显式会话态驱动 `sessionId`/`sessionModelId`/`busy`/`onSwitchModel`，保留思考深度切换与管理模型入口）
- **知识库**：→ 共享组件 `ComposerKbSelector`（显式会话态驱动 `mountedId`/`onMount`/`onUnmount`；集合列表/安装态改由其内部经 `bridge.knowledge` 全局只读查询加载，移除代码页重复拉取）
- **新增语音输入按钮**（Mic）：复用 `bridge.voice` 一次录音 → 本地 ASR → 写回代码页 draft，含录音/识别/失败状态提示条，交互与 ChatView 同款
- **main.jsx**：为代码页补传 `onGotoModelSettings`，保留模型选择器「管理模型」入口
- **契约测试**：`codex_acp_timeline` 同步更新为「native 车道必须挂载共享 composer 控件并带语音按钮」

> 共享组件（`ComposerModeChip`/`ComposerModelSelector`/`ComposerKbSelector`）均支持显式会话态驱动 props，绕开 bridge 聊天 active 绑定，per-session 命令直调与归属保护行为不变。

## 实际验证

- `npm run lint:ui` 通过
- `npm run test:codex-acp` 全绿（含更新后的契约断言）
- `test:voice-input`、`test:composer-tools`、`test:model-reasoning` 通过
- `python3 scripts/architecture-guard.py` 通过
- 浏览器 UI 冒烟测试（ui-smoke/kb-smoke）因本机无 chromium 跳过，非失败

## 已知风险

- 未跑真实 UI 冒烟（缺 chromium），建议开发环境启动后目测代码页底栏布局与语音输入
- 语音状态由 bridge 全局管理（`bs.voiceInput`），与工作/设计共享同一状态，跨模式切换时状态延续，与 ChatView 行为一致