### PR TITLE
fix(chat): 修复权威会话同步误报

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -703,3 +703,61 @@ pub(super) fn list_workspace_files_for_session(
     Ok(out)
 }
 use super::prelude::*;
+
+#[cfg(test)]
+mod desktop_saved_session_contract_tests {
+    use super::*;
+    use crate::features::sessions::transcript_revision;
+
+    /// Desktop `load_session` must expose `transcript_revision` at the top
+    /// level (snake_case, flatten with the rest of `SavedSession`), otherwise
+    /// the bridge reconcile falls into the every-turn-misreport path.
+    #[test]
+    fn desktop_load_session_response_contract() {
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-desktop-session-contract-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let previous = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &root);
+        let store = crate::features::sessions::SessionStore::boot_with_scheduled_root(
+            root.join("scheduled"),
+        )
+        .expect("session store");
+        let session = store
+            .create_new("model".to_string(), None, root.clone())
+            .expect("create session");
+        let revision = transcript_revision(&session.messages).expect("transcript revision");
+
+        let response = DesktopSavedSession {
+            session,
+            transcript_revision: revision.clone(),
+        };
+        let value = serde_json::to_value(&response).expect("serialize DesktopSavedSession");
+
+        // 顶层必须带 snake_case 的 transcript_revision(WebSavedSession 同契约)。
+        assert_eq!(
+            value.get("transcript_revision").and_then(|v| v.as_str()),
+            Some(revision.as_str()),
+            "load_session 响应必须携带 transcript_revision 字段"
+        );
+        // SavedSession 其余字段通过 flatten 保留在顶层,不得嵌套丢失。
+        assert!(
+            value.get("messages").is_some(),
+            "flatten 后 messages 必须仍在顶层"
+        );
+        assert!(
+            value.get("metadata").is_some(),
+            "flatten 后 metadata 必须仍在顶层"
+        );
+        match previous {
+            Some(value) => std::env::set_var("PINVOU3_HOME", value),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -364,6 +364,17 @@ pub async fn create_session(
     Ok(metadata)
 }
 
+/// Desktop `load_session` response: same shape as `SavedSession` plus the
+/// authoritative transcript revision, mirroring the Web download path
+/// (`WebSavedSession`). The frontend reconciles remote turns by this
+/// committed revision instead of presentation-derived message equality.
+#[derive(Debug, Serialize)]
+pub struct DesktopSavedSession {
+    #[serde(flatten)]
+    session: SavedSession,
+    transcript_revision: String,
+}
+
 /// 加载指定 session 的完整对话（含 messages）。
 /// 前端切换历史时调用 → 用返回的 messages 重渲染对话区。
 #[tauri::command]
@@ -371,7 +382,7 @@ pub async fn load_session(
     id: String,
     set_active: Option<bool>,
     store: State<'_, SessionStore>,
-) -> Result<SavedSession, String> {
+) -> Result<DesktopSavedSession, String> {
     let session = store
         .load(&id)
         .map_err(|e| format!("load_session({id}): {e:?}"))?;
@@ -381,7 +392,12 @@ pub async fn load_session(
     // 多 session 并发:切换不再 SyncSession 替换全局引擎(那是旧单引擎模型)。该 session
     // 有自己独立的 engine(已起则持有自己的上下文、还在跑就继续跑;未起则下次 chat 时
     // lazy spawn 并注水这里返回的 messages)。本命令只切 active 指针 + 返回 messages 给前端渲染。
-    Ok(session)
+    let revision = crate::features::sessions::transcript_revision(&session.messages)
+        .map_err(|e| format!("load_session({id}) revision: {e:?}"))?;
+    Ok(DesktopSavedSession {
+        session,
+        transcript_revision: revision,
+    })
 }
 
 /// 删除 session（含 artifacts 目录）。按 SessionKind 分发：定时运行会话联动

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1112,12 +1112,15 @@
           var saved = await invoke("load_session", { id: sid, setActive: false });
           if (!saved || !Array.isArray(saved.messages)) continue;
           var savedRevision = String(saved.transcript_revision || saved.transcriptRevision || "");
-          if (expectedCommittedRevision) {
+          // 仅当快照确实携带 revision 时才用严格相等作为权威屏障;旧后端/旧契约
+          // 不含该字段时降级到消息数与 assistant 身份校验,避免「期望非空但快照
+          // 无字段」导致对账必然失败(每轮误报)。
+          if (expectedCommittedRevision && savedRevision) {
             if (savedRevision !== expectedCommittedRevision) continue;
           } else {
             if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
           }
-          if (!expectedCommittedRevision && expectedAssistantKey) {
+          if ((!expectedCommittedRevision || !savedRevision) && expectedAssistantKey) {
             var hasExpectedAssistant = saved.messages.some(function (message) {
               return message && message.role === "assistant" &&
                 hydratedMessageKey(message, isScheduledRunSession(sid)) === expectedAssistantKey;

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -995,7 +995,7 @@
     }
   }
   // 事件监听器统一入口:按 payload.session_id 路由同步逻辑;后台变更后补一次 notify 刷新列表。
-  function markRemoteTurn(sid, buf) {
+  function markRemoteTurn(sid, buf, preserveCommittedRevision) {
     if (!sid || !buf || buf.localTurnOwned) return;
     if (!buf.remoteTurnActive) {
       var meta = state.sessions.find(function (session) { return session.id === sid; });
@@ -1005,6 +1005,7 @@
         : Number(meta && meta.message_count);
       if (!Number.isFinite(buf.remoteBaselineMessageCount)) buf.remoteBaselineMessageCount = null;
       buf.remoteExpectedAssistantKey = "";
+      if (!preserveCommittedRevision) buf.remoteCommittedRevision = "";
       buf.remoteTerminalSeen = false;
     }
     buf.remoteTurnActive = true;
@@ -1088,17 +1089,35 @@
     var expectedAssistantKey = buf.remoteTerminalSeen
       ? String(buf.remoteExpectedAssistantKey || "")
       : "";
+    // A committed transcript revision is the backend's canonical identity for
+    // this turn. Prefer it over presentation-derived message equality: native
+    // tools may normalize blocks between streamed events and durable storage
+    // without changing the committed conversation.
+    var expectedCommittedRevision = buf.remoteTerminalSeen
+      ? String(buf.remoteCommittedRevision || "")
+      : "";
     var minimumTerminalMessageCount = expectedAssistantKey && Array.isArray(buf.messages)
       ? buf.messages.length
       : 0;
     var sync = (async function () {
       for (var attempt = 0; attempt < 6; attempt++) {
         if (attempt) await new Promise(function (resolve) { setTimeout(resolve, 250); });
+        // A reconnect/replay can deliver the commit marker just after done.
+        // Adopt it on a later attempt instead of finishing on the weaker
+        // presentation-key fallback captured at function entry.
+        if (!expectedCommittedRevision && buf.remoteTerminalSeen) {
+          expectedCommittedRevision = String(buf.remoteCommittedRevision || "");
+        }
         try {
           var saved = await invoke("load_session", { id: sid, setActive: false });
           if (!saved || !Array.isArray(saved.messages)) continue;
-          if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
-          if (expectedAssistantKey) {
+          var savedRevision = String(saved.transcript_revision || saved.transcriptRevision || "");
+          if (expectedCommittedRevision) {
+            if (savedRevision !== expectedCommittedRevision) continue;
+          } else {
+            if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
+          }
+          if (!expectedCommittedRevision && expectedAssistantKey) {
             var hasExpectedAssistant = saved.messages.some(function (message) {
               return message && message.role === "assistant" &&
                 hydratedMessageKey(message, isScheduledRunSession(sid)) === expectedAssistantKey;
@@ -1178,6 +1197,7 @@
           buf.remoteBaselineMessageCount = null;
           buf.remoteBaselineTrusted = false;
           buf.remoteExpectedAssistantKey = "";
+          buf.remoteCommittedRevision = "";
           buf.deferredRemoteUserEvent = null;
           buf.busy = false;
           if (sid === state.activeSessionId) saveWorkingSetTo(buf);

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1102,10 +1102,12 @@
     var sync = (async function () {
       for (var attempt = 0; attempt < 6; attempt++) {
         if (attempt) await new Promise(function (resolve) { setTimeout(resolve, 250); });
-        // A reconnect/replay can deliver the commit marker just after done.
-        // Adopt it on a later attempt instead of finishing on the weaker
-        // presentation-key fallback captured at function entry.
-        if (!expectedCommittedRevision && buf.remoteTerminalSeen) {
+        // A reconnect/replay can deliver the commit marker just after done,
+        // and a newer turn's commit can land while this retry window is open.
+        // Re-read the live revision every attempt so a bumped expected value
+        // converges instead of comparing a stale one (which would report a
+        // false unsynced warning and block queued sends until the next event).
+        if (buf.remoteTerminalSeen) {
           expectedCommittedRevision = String(buf.remoteCommittedRevision || "");
         }
         try {

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -337,7 +337,10 @@
     var committedBuffer = getBuffer(sid);
     if (!committedBuffer) return;
     var revision = String(payload.transcript_revision || payload.transcriptRevision || "");
-    if (revision) committedBuffer.sessionRevision = revision;
+    if (revision) {
+      committedBuffer.sessionRevision = revision;
+      committedBuffer.remoteCommittedRevision = revision;
+    }
     if (committedBuffer.remoteTerminalSeen && !isBusyFor(sid)) {
       reconcileRemoteTurn(sid).then(function (ready) {
         if (ready) flushQueued(sid);
@@ -713,7 +716,12 @@
     });
     var doneBuffer = sid ? getBuffer(sid) : null;
     var requiresAuthorityReconcile = !isScheduledRunSession(sid);
-    if (requiresAuthorityReconcile && doneBuffer && !doneBuffer.localTurnOwned) markRemoteTurn(sid, doneBuffer);
+    if (requiresAuthorityReconcile && doneBuffer && !doneBuffer.localTurnOwned) {
+      // transcript_committed is emitted before chat:done. A client that joins
+      // at the terminal tail may not have seen an earlier turn event, so keep
+      // the already received revision while initializing remote-turn state.
+      markRemoteTurn(sid, doneBuffer, true);
+    }
     if (!requiresAuthorityReconcile) markScheduledInitialTurnTerminal(sid);
     runSyncOnSession(sid, function () {
       var error = e.payload && e.payload.error;

--- a/pinvou3-app/src/platform/tauri/bridge/chat.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat.js
@@ -222,6 +222,7 @@
       turnOwnerBuffer.localTurnOwned = true;
       turnOwnerBuffer.remoteTurnActive = false;
       turnOwnerBuffer.remoteTerminalSeen = false;
+      turnOwnerBuffer.remoteCommittedRevision = "";
     }
     runSyncOnSession(sid, function () {
       state.chatItems = state.chatItems.filter(function (item) { return !item.turnErrorNotice; });

--- a/pinvou3-app/src/platform/tauri/bridge/interaction.js
+++ b/pinvou3-app/src/platform/tauri/bridge/interaction.js
@@ -330,6 +330,10 @@
     if (state.busy || !state.activeSessionId) return;
     newText = (newText || "").trim();
     if (!newText) return;
+    // 编辑=新一轮:清掉上一轮可能残留的 committed revision,避免失败对账
+    // 状态下跨回合串用(与 web bridge 的 editLastTurn 对齐)。
+    var editBuffer = getBuffer(state.activeSessionId);
+    if (editBuffer) editBuffer.remoteCommittedRevision = "";
     // 删除末尾最近的 user 及之后所有，push 新 user，重渲染
     var cut = -1;
     for (var i = state.messages.length - 1; i >= 0; i--) {

--- a/pinvou3-app/src/platform/tauri/bridge/interaction.js
+++ b/pinvou3-app/src/platform/tauri/bridge/interaction.js
@@ -131,6 +131,7 @@
       planBuffer.localTurnOwned = true;
       planBuffer.remoteTurnActive = false;
       planBuffer.remoteTerminalSeen = false;
+      planBuffer.remoteCommittedRevision = "";
     }
     if (itemId) patchItemByIdFor(sid, itemId, { cardState: "approved", statusLabel: bt("approved"), resolved: true });
     var echoEntry = null;

--- a/pinvou3-app/src/platform/tauri/bridge/interaction.js
+++ b/pinvou3-app/src/platform/tauri/bridge/interaction.js
@@ -330,10 +330,25 @@
     if (state.busy || !state.activeSessionId) return;
     newText = (newText || "").trim();
     if (!newText) return;
-    // 编辑=新一轮:清掉上一轮可能残留的 committed revision,避免失败对账
+    var sid = state.activeSessionId;
+    var editBuffer = getBuffer(sid);
+    // 编辑前先收敛远端对账(与 web bridge 的 editLastTurn 对齐):失败对账
+    // 状态下编辑会被陈旧 committed 事件重武装旧 revision,污染新一轮。
+    if (editBuffer && editBuffer.remoteTurnActive && !(await reconcileRemoteTurn(sid))) {
+      addSystemItem(bt("remoteTurnSyncing"));
+      notify();
+      return;
+    }
+    // await 期间可能切会话或开始新回合,二次确认(与 web bridge 对齐)。
+    if (state.activeSessionId !== sid || state.busy) return;
+    // 编辑=新一轮:接管本地回合并清零 remote 对账状态,避免失败对账
     // 状态下跨回合串用(与 web bridge 的 editLastTurn 对齐)。
-    var editBuffer = getBuffer(state.activeSessionId);
-    if (editBuffer) editBuffer.remoteCommittedRevision = "";
+    if (editBuffer) {
+      editBuffer.localTurnOwned = true;
+      editBuffer.remoteTurnActive = false;
+      editBuffer.remoteTerminalSeen = false;
+      editBuffer.remoteCommittedRevision = "";
+    }
     // 删除末尾最近的 user 及之后所有，push 新 user，重渲染
     var cut = -1;
     for (var i = state.messages.length - 1; i >= 0; i--) {

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -58,6 +58,7 @@
       remoteBaselineMessageCount: null,
       remoteBaselineTrusted: false,
       remoteExpectedAssistantKey: "",
+      remoteCommittedRevision: "",
       sessionRevision: "",
       planSnapshot: { plan: null, todos: null },
       modeState: { mode: "yolo" },
@@ -337,6 +338,7 @@
       buf.remoteBaselineMessageCount = null;
       buf.remoteBaselineTrusted = false;
       buf.remoteExpectedAssistantKey = "";
+      buf.remoteCommittedRevision = "";
       buf.deferredRemoteUserEvent = null;
     }
     buf.stream = {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1335,12 +1335,15 @@
           var saved = await loadSessionForClient(sid, false);
           if (!saved || !Array.isArray(saved.messages)) continue;
           var savedRevision = String(saved.transcript_revision || saved.transcriptRevision || "");
-          if (expectedCommittedRevision) {
+          // 仅当快照确实携带 revision 时才用严格相等作为权威屏障;旧后端/旧契约
+          // 不含该字段时降级到消息数与 assistant 身份校验,避免「期望非空但快照
+          // 无字段」导致对账必然失败(每轮误报)。
+          if (expectedCommittedRevision && savedRevision) {
             if (savedRevision !== expectedCommittedRevision) continue;
           } else {
             if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
           }
-          if (!expectedCommittedRevision && expectedAssistantKey) {
+          if ((!expectedCommittedRevision || !savedRevision) && expectedAssistantKey) {
             var hasExpectedAssistant = saved.messages.some(function (message) {
               return message && message.role === "assistant" &&
                 hydratedMessageKey(message, isScheduledRunSession(sid)) === expectedAssistantKey;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -804,6 +804,7 @@
       remoteBaselineMessageCount: null,
       remoteBaselineTrusted: false,
       remoteExpectedAssistantKey: "",
+      remoteCommittedRevision: "",
       sessionRevision: "",
       planSnapshot: { plan: null, todos: null },
       modeState: { mode: "yolo" },
@@ -1081,6 +1082,7 @@
       buf.remoteBaselineMessageCount = null;
       buf.remoteBaselineTrusted = false;
       buf.remoteExpectedAssistantKey = "";
+      buf.remoteCommittedRevision = "";
       buf.deferredRemoteUserEvent = null;
     }
     buf.stream = {
@@ -1222,7 +1224,7 @@
     }
   }
   // 事件监听器统一入口:按 payload.session_id 路由同步逻辑;后台变更后补一次 notify 刷新列表。
-  function markRemoteTurn(sid, buf) {
+  function markRemoteTurn(sid, buf, preserveCommittedRevision) {
     if (!sid || !buf || buf.localTurnOwned) return;
     if (!buf.remoteTurnActive) {
       var meta = state.sessions.find(function (session) { return session.id === sid; });
@@ -1232,6 +1234,7 @@
         : Number(meta && meta.message_count);
       if (!Number.isFinite(buf.remoteBaselineMessageCount)) buf.remoteBaselineMessageCount = null;
       buf.remoteExpectedAssistantKey = "";
+      if (!preserveCommittedRevision) buf.remoteCommittedRevision = "";
       buf.remoteTerminalSeen = false;
     }
     buf.remoteTurnActive = true;
@@ -1304,10 +1307,17 @@
     if (authoritativeTranscriptSyncs[sid]) return authoritativeTranscriptSyncs[sid];
     // chat:done 与远端 load_session 分属两条异步通道。尤其是 WebUI 刚创建的
     // Session，第一份可读快照可能仍停在本轮 user，若立即拿它重建展示层，会把
-    // 已完整显示的流式 assistant 气泡一闪覆盖掉。以终态前的本地工作集作为
-    // authority barrier：消息数不能倒退，且最后一条 assistant 必须已进入快照。
+    // 已完整显示的流式 assistant 气泡一闪覆盖掉。优先用后端已提交 revision
+    // 建立 authority barrier；旧桌面端未提供 revision 时，才回退到消息数与
+    // 最后一条 assistant 的展示身份校验。
     var expectedAssistantKey = buf.remoteTerminalSeen
       ? String(buf.remoteExpectedAssistantKey || "")
+      : "";
+    // The committed revision identifies the canonical terminal transcript.
+    // Streamed/native-tool blocks may be normalized before persistence, so a
+    // presentation-derived message key is only a fallback for older desktops.
+    var expectedCommittedRevision = buf.remoteTerminalSeen
+      ? String(buf.remoteCommittedRevision || "")
       : "";
     var minimumTerminalMessageCount = expectedAssistantKey && Array.isArray(buf.messages)
       ? buf.messages.length
@@ -1315,11 +1325,22 @@
     var sync = (async function () {
       for (var attempt = 0; attempt < 6; attempt++) {
         if (attempt) await new Promise(function (resolve) { setTimeout(resolve, 250); });
+        // Relay replay may deliver the commit marker immediately after done.
+        // Pick it up during retry rather than staying on the weaker fallback
+        // captured when reconciliation first started.
+        if (!expectedCommittedRevision && buf.remoteTerminalSeen) {
+          expectedCommittedRevision = String(buf.remoteCommittedRevision || "");
+        }
         try {
           var saved = await loadSessionForClient(sid, false);
           if (!saved || !Array.isArray(saved.messages)) continue;
-          if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
-          if (expectedAssistantKey) {
+          var savedRevision = String(saved.transcript_revision || saved.transcriptRevision || "");
+          if (expectedCommittedRevision) {
+            if (savedRevision !== expectedCommittedRevision) continue;
+          } else {
+            if (minimumTerminalMessageCount && saved.messages.length < minimumTerminalMessageCount) continue;
+          }
+          if (!expectedCommittedRevision && expectedAssistantKey) {
             var hasExpectedAssistant = saved.messages.some(function (message) {
               return message && message.role === "assistant" &&
                 hydratedMessageKey(message, isScheduledRunSession(sid)) === expectedAssistantKey;
@@ -1406,6 +1427,7 @@
           buf.remoteBaselineMessageCount = null;
           buf.remoteBaselineTrusted = false;
           buf.remoteExpectedAssistantKey = "";
+          buf.remoteCommittedRevision = "";
           buf.deferredRemoteUserEvent = null;
           buf.busy = false;
           if (sid === state.activeSessionId) saveWorkingSetTo(buf);
@@ -3845,6 +3867,7 @@
       turnOwnerBuffer.localTurnOwned = true;
       turnOwnerBuffer.remoteTurnActive = false;
       turnOwnerBuffer.remoteTerminalSeen = false;
+      turnOwnerBuffer.remoteCommittedRevision = "";
     }
     runSyncOnSession(sid, function () {
       state.chatItems = state.chatItems.filter(function (item) { return !item.turnErrorNotice; });
@@ -4086,6 +4109,7 @@
     buffer.localTurnOwned = true;
     buffer.remoteTurnActive = false;
     buffer.remoteTerminalSeen = false;
+    buffer.remoteCommittedRevision = "";
     buffer.busy = true;
     buffer.thinking = {
       active: true,
@@ -4634,7 +4658,10 @@
     var committedBuffer = getBuffer(sid);
     if (!committedBuffer) return;
     var revision = String(payload.transcript_revision || payload.transcriptRevision || "");
-    if (revision) committedBuffer.sessionRevision = revision;
+    if (revision) {
+      committedBuffer.sessionRevision = revision;
+      committedBuffer.remoteCommittedRevision = revision;
+    }
     if (committedBuffer.remoteTerminalSeen && !isBusyFor(sid)) {
       reconcileRemoteTurn(sid).then(function (ready) {
         if (ready) flushQueued(sid);
@@ -5104,7 +5131,11 @@
       return;
     }
     var doneBuffer = sid ? getBuffer(sid) : null;
-    if (doneBuffer && !doneBuffer.localTurnOwned) markRemoteTurn(sid, doneBuffer);
+    if (doneBuffer && !doneBuffer.localTurnOwned) {
+      // transcript_committed precedes chat:done. Preserve its revision when a
+      // reconnecting client first materializes the turn at the terminal tail.
+      markRemoteTurn(sid, doneBuffer, true);
+    }
     if (isScheduledRunSession(sid)) markScheduledInitialTurnTerminal(sid);
     runSyncOnSession(sid, function () {
       if (isScheduledRunSession(sid)) markScheduledInitialTurnTerminal(sid);
@@ -6517,6 +6548,7 @@
       planBuffer.localTurnOwned = true;
       planBuffer.remoteTurnActive = false;
       planBuffer.remoteTerminalSeen = false;
+      planBuffer.remoteCommittedRevision = "";
     }
     if (itemId) patchItemByIdFor(sid, itemId, { cardState: "approved", statusLabel: bt("approved"), resolved: true });
     var echoEntry = null;
@@ -6690,6 +6722,7 @@
       editBuffer.localTurnOwned = true;
       editBuffer.remoteTurnActive = false;
       editBuffer.remoteTerminalSeen = false;
+      editBuffer.remoteCommittedRevision = "";
     }
     // 删除末尾最近的 user 及之后所有，push 新 user，重渲染
     var cut = -1;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1325,10 +1325,12 @@
     var sync = (async function () {
       for (var attempt = 0; attempt < 6; attempt++) {
         if (attempt) await new Promise(function (resolve) { setTimeout(resolve, 250); });
-        // Relay replay may deliver the commit marker immediately after done.
-        // Pick it up during retry rather than staying on the weaker fallback
-        // captured when reconciliation first started.
-        if (!expectedCommittedRevision && buf.remoteTerminalSeen) {
+        // Relay replay may deliver the commit marker immediately after done,
+        // and a newer turn's commit can land while this retry window is open.
+        // Re-read the live revision every attempt so a bumped expected value
+        // converges instead of comparing a stale one (which would report a
+        // false unsynced warning and block queued sends until the next event).
+        if (buf.remoteTerminalSeen) {
           expectedCommittedRevision = String(buf.remoteCommittedRevision || "");
         }
         try {

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -83,7 +83,7 @@ const expectedProtocolHashes = {
   multiAgent: 'b123eece32980d80787ab9cd7315f3566b0943ab366a2358a1ff0cb247b65491',
   orchestration: 'e5e333aca4d1fb7e8ed32f879d3b310c01cd0845d0e5cdc2b5ed1e95aee3ea31',
   artifacts: '9de646442d1192440abd14046e75ec402afc2c8bea1a8a88ff9667aab5e6ac4c',
-  chat: '2522b350f92fb6c6a8655066138f759d66fd5ac61a74be04afae1ef92cb1eeef',
+  chat: '2fa5debc3613bbd8ec3c580857e3f94d9561759aef940eb9dbca77646e6c95c8',
   dependencies: '257468e4f9e2e9270de6ef75f685d5eafcd000226d44cfb81a1b04c0e7615707',
   interaction: 'dc75ecf05e5b015833c08ffa4e3de4319f657de5ce300b68f873e966236a4898',
   knowledge: '3ae1fb7f8b4909601edb91ec1b2df83d37a3a6cc302911517c5913b557b716ca',

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -1896,6 +1896,128 @@ async function completedTurnFallsBackWhenSnapshotLacksRevision() {
   );
 }
 
+async function completedTurnAdoptsRevisionBumpDuringRetry() {
+  var harness = createBridgeHarness(null, {
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-revision-bump-during-retry";
+  var durable = {
+    metadata: { id: sessionId, title: "Revision bump", message_count: 0 },
+    messages: [],
+    artifacts: [],
+    transcript_revision: "revision-before-turn",
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "stream presentation" });
+
+  // 回合 1 提交 revision-after-turn 并完成;但此刻持久化快照仍停在
+  // revision-before-turn(模拟落盘延迟),reconcile 第一次尝试必然失败。
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-after-turn",
+  });
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  await tick();
+
+  // 在回合 1 的 reconcile 重试窗口内,回合 2 已提交并落盘:快照推进到
+  // revision-2,committed 事件也到达。每 attempt 重读 live revision 的修复
+  // 应收敛;若只在期望为空时重读(旧实现),6 次重试会一直拿 revision-after-turn
+  // 比较 revision-2 → 全部失败 → 误报「权威记录暂未同步」。
+  durable = {
+    metadata: { id: sessionId, title: "Revision bump", message_count: 4 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "canonical answer 1" }] },
+      { role: "user", content: [{ type: "text", text: "followup" }] },
+      { role: "assistant", content: [{ type: "text", text: "canonical answer 2" }] },
+    ],
+    artifacts: [],
+    transcript_revision: "revision-2",
+  };
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-2",
+  });
+  for (var bumpTick = 0; bumpTick < 12; bumpTick++) await tick();
+
+  var state = bridge.state.get("chat");
+  assert.ok(
+    state.chatItems.some(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("canonical answer 2");
+    }),
+    "a revision bump during the retry window must be adopted by the running reconcile"
+  );
+  assert.ok(
+    !state.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("权威记录暂未同步");
+    }),
+    "a revision bump during retry must not produce a false unsynced warning"
+  );
+}
+
+async function editLastTurnBlockedWhileAuthorityReconcilePending() {
+  var harness = createBridgeHarness(null, {
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-edit-blocked-unsynced";
+  var durable = {
+    metadata: { id: sessionId, title: "Edit blocked", message_count: 0 },
+    messages: [],
+    artifacts: [],
+    transcript_revision: "revision-before-turn",
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "stream answer" });
+
+  // 快照 revision 与 committed 不匹配:权威对账必然失败,remoteTurnActive
+  // 保持 true。此时编辑应被拦截(remoteTurnSyncing),而不是清掉 revision
+  // 继续编辑——否则陈旧 committed 事件会在编辑中重武装旧 revision。
+  durable = {
+    metadata: { id: sessionId, title: "Edit blocked", message_count: 2 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "persisted answer" }] },
+    ],
+    artifacts: [],
+    transcript_revision: "revision-stale",
+  };
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-committed-this-turn",
+  });
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  // 负向路径耗尽 6 次重试:setImmediate 加速的轮次等待对账终态。
+  for (var mismatchTick = 0; mismatchTick < 20; mismatchTick++) await tick();
+
+  var editCallsBefore = harness.calls.filter(function (call) { return call.cmd === "edit_last_turn"; }).length;
+  await bridge.interaction.editLastTurn("edited question");
+  var editCallsAfter = harness.calls.filter(function (call) { return call.cmd === "edit_last_turn"; }).length;
+  assert.strictEqual(
+    editCallsAfter, editCallsBefore,
+    "editing must be blocked while the authority reconcile is still pending"
+  );
+
+  var blockedState = bridge.state.get("chat");
+  assert.ok(
+    blockedState.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("该会话仍在同步另一端完成的回合");
+    }),
+    "a blocked edit must surface the sync-pending notice"
+  );
+}
+
 async function remoteAcceptPlanConvergesAcrossClients() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
@@ -4019,6 +4141,8 @@ Promise.resolve()
   .then(completedTurnKeepsWarningWhenRevisionMismatches)
   .then(completedTurnAdoptsLateCommittedRevision)
   .then(completedTurnFallsBackWhenSnapshotLacksRevision)
+  .then(completedTurnAdoptsRevisionBumpDuringRetry)
+  .then(editLastTurnBlockedWhileAuthorityReconcilePending)
   .then(remoteAcceptPlanConvergesAcrossClients)
   .then(activePlanSurvivesUnrelatedTerminalHydrate)
   .then(activePlanHydrateMigratesTicketWithoutDuplicate)

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -1743,6 +1743,159 @@ async function completedTurnUsesCommittedRevisionAsAuthority() {
   });
 }
 
+async function completedTurnKeepsWarningWhenRevisionMismatches() {
+  var harness = createBridgeHarness(null, {
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-revision-mismatch-warning";
+  var durable = {
+    metadata: { id: sessionId, title: "Revision mismatch", message_count: 0 },
+    messages: [],
+    artifacts: [],
+    transcript_revision: "revision-stale",
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "stream presentation" });
+
+  // 后端提交的 revision 与快照携带的 revision 不一致:持久化快照不属于本轮,
+  // 必须保留同步警告,不得假装收敛。
+  durable = {
+    metadata: { id: sessionId, title: "Revision mismatch", message_count: 2 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "canonical persisted answer" }] },
+    ],
+    artifacts: [],
+    transcript_revision: "revision-different-turn",
+  };
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-committed-this-turn",
+  });
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  // 负向路径会耗尽 6 次重试:用 setImmediate 加速的轮次等待对账终态。
+  for (var mismatchTick = 0; mismatchTick < 20; mismatchTick++) await tick();
+
+  var state = bridge.state.get("chat");
+  assert.ok(
+    state.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("权威记录暂未同步");
+    }),
+    "a mismatched committed revision must keep the unsynced warning"
+  );
+}
+
+async function completedTurnAdoptsLateCommittedRevision() {
+  var harness = createBridgeHarness(null, {
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-late-committed-revision";
+  var durable = {
+    metadata: { id: sessionId, title: "Late committed", message_count: 0 },
+    messages: [],
+    artifacts: [],
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "stream presentation" });
+
+  // Relay replay 可能在 chat:done 之后才送达 commit marker:对账重试窗口内
+  // 应拾取迟到的 revision 并收敛,而不是停留在较弱的展示身份回退上。
+  durable = {
+    metadata: { id: sessionId, title: "Late committed", message_count: 2 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "canonical persisted answer" }] },
+    ],
+    artifacts: [],
+    transcript_revision: "revision-after-done",
+  };
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  await tick();
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-after-done",
+  });
+  for (var i = 0; i < 8; i++) await tick();
+
+  var state = bridge.state.get("chat");
+  assert.ok(
+    state.chatItems.some(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("canonical persisted answer");
+    }),
+    "a commit marker delivered after done must be adopted during retry"
+  );
+  assert.ok(
+    !state.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("权威记录暂未同步");
+    }),
+    "adopting the late committed revision must not warn"
+  );
+}
+
+async function completedTurnFallsBackWhenSnapshotLacksRevision() {
+  var harness = createBridgeHarness(null, {
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-snapshot-no-revision";
+  var durable = {
+    metadata: { id: sessionId, title: "No revision", message_count: 0 },
+    messages: [],
+    artifacts: [],
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", { session_id: sessionId, text: "final answer" });
+
+  // 旧契约/旧后端快照不含 transcript_revision 字段:即使已收到 committed 事件,
+  // 也不能因「期望非空但快照无字段」而必然失败,应回退到消息身份校验。
+  durable = {
+    metadata: { id: sessionId, title: "No revision", message_count: 2 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "final answer" }] },
+    ],
+    artifacts: [],
+  };
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-committed-this-turn",
+  });
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  await tick();
+  await tick();
+
+  var state = bridge.state.get("chat");
+  assert.ok(
+    state.chatItems.some(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("final answer");
+    }),
+    "a snapshot without a revision field must fall back to identity reconciliation"
+  );
+  assert.ok(
+    !state.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("权威记录暂未同步");
+    }),
+    "the fallback path must not produce a false unsynced warning"
+  );
+}
+
 async function remoteAcceptPlanConvergesAcrossClients() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
@@ -3863,6 +4016,9 @@ Promise.resolve()
   .then(interruptedTurnWithoutUserItemDropsPartial)
   .then(completedTurnWaitsForAssistantInAuthoritySnapshot)
   .then(completedTurnUsesCommittedRevisionAsAuthority)
+  .then(completedTurnKeepsWarningWhenRevisionMismatches)
+  .then(completedTurnAdoptsLateCommittedRevision)
+  .then(completedTurnFallsBackWhenSnapshotLacksRevision)
   .then(remoteAcceptPlanConvergesAcrossClients)
   .then(activePlanSurvivesUnrelatedTerminalHydrate)
   .then(activePlanHydrateMigratesTicketWithoutDuplicate)

--- a/pinvou3-app/tests/scheduled_tasks_unit.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.js
@@ -1676,6 +1676,73 @@ async function completedTurnWaitsForAssistantInAuthoritySnapshot() {
   );
 }
 
+async function completedTurnUsesCommittedRevisionAsAuthority() {
+  var harness = createBridgeHarness(null, {
+    // A broken implementation exhausts all fallback retries. Keep that path
+    // deterministic and fast instead of adding more than a second to the test.
+    setTimeout: function (callback) { return setImmediate(callback); },
+  });
+  var bridge = harness.bridge;
+  var sessionId = "chat-committed-revision-authority";
+  var durable = {
+    metadata: { id: sessionId, title: "Revision authority", message_count: 0 },
+    messages: [],
+    artifacts: [],
+    transcript_revision: "revision-before-turn",
+  };
+  harness.handlers.load_session = function () {
+    return JSON.parse(JSON.stringify(durable));
+  };
+
+  await bridge.sessions.switchToSession(sessionId);
+  await bridge.chat.sendMessage("question");
+  await harness.emit("chat:delta", {
+    session_id: sessionId,
+    text: "stream presentation",
+  });
+
+  // Native/provider tools may normalize the terminal assistant block before
+  // persistence. The committed revision, rather than byte-identical streamed
+  // presentation, proves which durable snapshot belongs to this turn.
+  durable = {
+    metadata: { id: sessionId, title: "Revision authority", message_count: 2 },
+    messages: [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+      { role: "assistant", content: [{ type: "text", text: "canonical persisted answer" }] },
+    ],
+    artifacts: [],
+    transcript_revision: "revision-after-turn",
+  };
+  await harness.emit("chat:transcript_committed", {
+    session_id: sessionId,
+    transcript_revision: "revision-after-turn",
+  });
+  await harness.emit("chat:done", { session_id: sessionId, status: "Completed" });
+  await tick();
+  await tick();
+
+  var state = bridge.state.get("chat");
+  assert.ok(
+    state.chatItems.some(function (item) {
+      return item.type === "assistant" && String(item.html || "").includes("canonical persisted answer");
+    }),
+    "the committed revision must allow canonical hydration when streamed presentation differs"
+  );
+  assert.ok(
+    !state.chatItems.some(function (item) {
+      return item.type === "system" && String(item.text || "").includes("权威记录暂未同步");
+    }),
+    "a matching committed revision must not produce a false unsynced warning"
+  );
+
+  [tauriBridge, webBridge].forEach(function (source) {
+    assert.ok(source.includes('remoteCommittedRevision = revision'),
+      "desktop and Web bridges must both retain the committed turn revision");
+    assert.ok(source.includes('savedRevision !== expectedCommittedRevision'),
+      "desktop and Web bridges must both reconcile by committed revision");
+  });
+}
+
 async function remoteAcceptPlanConvergesAcrossClients() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
@@ -3795,6 +3862,7 @@ Promise.resolve()
   .then(remoteInterruptedTurnKeepsItsDisplayPosition)
   .then(interruptedTurnWithoutUserItemDropsPartial)
   .then(completedTurnWaitsForAssistantInAuthoritySnapshot)
+  .then(completedTurnUsesCommittedRevisionAsAuthority)
   .then(remoteAcceptPlanConvergesAcrossClients)
   .then(activePlanSurvivesUnrelatedTerminalHydrate)
   .then(activePlanHydrateMigratesTicketWithoutDuplicate)


### PR DESCRIPTION
## Summary

修复对话已经成功落盘时，桌面端或 Web 远程控制仍可能误报“权威记录暂未同步”的问题。

Closes #215

## Background

后端在发送 `chat:done` 前已经持久化会话并发布 `transcript_revision`，但前端原先只使用流式展示消息的数量和结构身份核对持久化快照。工具调用经过传输、重放或持久化规范化后，即使语义和落盘内容正确，也可能因结构差异无法通过校验并产生误报。

## Changes

- 桌面端与 Web 端按回合记录后端已提交的 transcript revision。
- 权威快照优先以 revision 完全匹配为准；旧桌面端未提供 revision 时保留原有消息身份回退校验。
- 覆盖终态尾部接入和 commit marker 稍晚到达的重连时序。
- 每轮开始和对账成功后清理 revision 状态，避免跨回合串用。
- 增加流式展示内容与持久化内容结构不同但 revision 一致时的回归测试，并更新桥接协议指纹。

## Verification

- `npm --prefix pinvou3-app test`：通过
- `npm --prefix pinvou3-app run lint:ui`：通过
- `npm --prefix pinvou3-app run build:ui`：通过
- `npm --prefix pinvou3-app run build:web`：通过
- `npm --prefix pinvou3-app run test:bridge-protocol`：通过
- `npm --prefix pinvou3-app run test:web-access-contract`：通过
- `python3 scripts/architecture-guard.py`：通过
- `git diff --check`：通过

## Impact and notes

- 影响范围仅限桌面端和 Web 端的普通聊天终态对账，不修改会话文件格式、公开 API、依赖、配置或 CodeWhale。
- revision 匹配后以后端持久化内容为准，极少数情况下可能看到完成后的展示格式被规范化，这是权威收敛的预期行为。
- 真实断线、读取失败或 revision 不匹配时仍保留同步警告。
- 未使用真实模型和人为断网环境做手工端到端复现；确定性回归测试覆盖了导致误报的消息结构差异及旧协议回退路径。

## Submission checklist

- [x] I based this PR on the latest `main`.
- [x] Every commit includes a matching `Signed-off-by` trailer (`git commit -s`).
- [x] I removed credentials, private data, internal URLs, and sensitive logs.
- [x] I updated tests and documentation where behavior changed; no standalone user documentation change is required.
- [x] The `CodeWhale` gitlink and fork behavior are unchanged, so fork inventory updates are not applicable.
