### PR TITLE
fix(codex): skill 双 scope 治理 follow-up 补漏（#202 审计修复）

### DIFF
--- a/docs/code-native-agent.md
+++ b/docs/code-native-agent.md
@@ -210,8 +210,8 @@ bridge 的 chat 状态机绑定单一 activeSession，代码页与主聊天并�
 - 前端工具菜单按会话类型传 `scope`（普通 = `plain` / 代码 = `code`），读写各自
   scope；`shape_disallowed_tools` 经 `SessionPolicy` 策略化（§3.6）：code 会话
   按 `policy.connector_scope()` 取 code scope 禁用集替换 plain scope 的（非连接器
-  禁用如 `kb_search` 保留），并按 `policy.extra_hidden_tools()` 继续隐藏
-  `present_artifact` 与 `load_skill`。
+  禁用如 `kb_search` 保留），并按 `policy.extra_hidden_tools()` 恒隐藏
+  `present_artifact`；`load_skill` 按该会话组合目录是否为空动态决定（§8.6）。
 
 ### 8.4 远程端过滤原生代码会话事件
 

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -78,7 +78,7 @@
     档案算：常量 − 档案 tools.include）。不变式：`tool_search` 的 gate **恒查常量、
     不可注入**（`forkguard_tool_search_always_gated` 守护，防模型用搜索复活被藏工具）；
     `request_user_input` 硬豁免不受注入影响
-    （`forkguard_request_user_input_exempt_from_injected_hidden`）；注入集生效由
+    （`forkguard_hidden_tools_cannot_expand_compile_time_blocklist`）；注入集生效由
     `forkguard_hidden_tools_injectable` 守护。hidden 变化仅 respawn 生效（无热刷
     通道），与 `disallowed_tools` 的热刷语义不同。
   - 内部 `<system-reminder>` 不参与 Working Set 路径提取。

--- a/pinvou3-app/src-tauri/src/app/commands/connectors.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/connectors.rs
@@ -86,12 +86,22 @@ pub async fn get_disabled_skills(scope: Option<String>) -> Result<Vec<String>, S
 #[tauri::command]
 pub async fn set_project_skills_enabled(
     enabled: bool,
+    app: AppHandle,
     pool: State<'_, EnginePool>,
 ) -> Result<(), String> {
     crate::features::marketplace::skill_scope::set_project_skills_enabled(enabled);
     // 开关影响 code 会话组合目录：重写在线会话 + 热刷 load_skill 隐藏判定。
     pool.refresh_live_sessions_skills().await;
     pool.refresh_disallowed_tools().await;
+    // 广播工具变更：项目级 skills 开关影响 code 会话组合目录，其它窗口/实例
+    // 需借此事件刷新开关状态（与 set_disabled_skills 对齐）。
+    let payload = serde_json::json!({});
+    let _ = app.emit("remote_control:tools_changed", payload.clone());
+    crate::features::remote_control::forward_app_event(
+        &app,
+        "remote_control:tools_changed",
+        payload,
+    );
     Ok(())
 }
 

--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -154,6 +154,7 @@ fn marketplace_oauth_login_coordinator() -> &'static MarketplaceOAuthLoginCoordi
 pub async fn install_marketplace_tool(
     tool_id: String,
     config: Option<std::collections::HashMap<String, String>>,
+    pool: tauri::State<'_, crate::features::assistant::engine_pool::EnginePool>,
 ) -> Result<(), String> {
     let user_config = config.unwrap_or_default();
     let install_tool_id = tool_id.clone();
@@ -194,14 +195,23 @@ pub async fn install_marketplace_tool(
                     .install(&sid)
             {
                 eprintln!("[marketplace] 配套技能 '{sid}' 安装失败: {e}");
+                continue;
             }
+            // 新装的 companion 技能默认加入 code 禁用集（外部能力显式开启，
+            // 与独立技能安装 install_marketplace_skill_sync 同语义）。
+            crate::features::marketplace::skill_scope::sync_code_scope_after_skill_install(&sid);
         }
         // 代码会话的 code scope 已初始化时,新装的连接器默认仍关闭(显式开启)。
         crate::features::marketplace::sync_code_scope_after_install(&tool_id);
-        Ok(())
+        Ok::<(), String>(())
     })
     .await
-    .map_err(|e| format!("任务执行失败: {e}"))?
+    .map_err(|e| format!("任务执行失败: {e}"))??;
+    // 联动安装的 companion 技能影响两个 scope 的启用集：重写在线会话组合目录
+    // （下一轮 prompt 即生效，与 uninstall_marketplace_tool 对称，skill 双 scope
+    // 治理事件驱动时机 §2.3.2）。
+    pool.refresh_live_sessions_skills().await;
+    Ok(())
 }
 
 pub(super) fn marketplace_oauth_error_result(

--- a/pinvou3-app/src-tauri/src/features/marketplace/skill_scope.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/skill_scope.rs
@@ -68,8 +68,15 @@ fn load_disabled_skills_file() -> DisabledSkillsFile {
         }
     };
     if let Ok(legacy) = serde_json::from_str::<Vec<String>>(&content) {
+        // 与对象格式读路径一致：剥除 `skill:` 前缀（旧前端 bug 窗口期误写入的
+        // 带前缀 id），否则 `model_skill_names` 按裸 id 映射不到目录名，
+        // 该技能当次启动漏禁（下次读取自愈）。
+        let plain = legacy
+            .into_iter()
+            .map(|id| id.strip_prefix("skill:").map(str::to_string).unwrap_or(id))
+            .collect();
         let file = DisabledSkillsFile {
-            plain: legacy,
+            plain,
             code: Vec::new(),
             code_initialized: false,
             project_skills_enabled: false,
@@ -332,6 +339,31 @@ mod tests {
             assert!(
                 content.contains("\"plain\""),
                 "迁移后应为对象格式: {content}"
+            );
+        });
+    }
+
+    #[test]
+    fn migrates_legacy_bare_array_strips_skill_prefix() {
+        with_temp_home(|| {
+            std::fs::create_dir_all(paths::pinvou3_home()).unwrap();
+            // 旧前端 bug 窗口期误写入的带 `skill:` 前缀条目：迁移时必须归一为裸 id，
+            // 否则按裸 id 匹配的 model_skill_names/组合目录物化会漏禁该技能。
+            std::fs::write(
+                disabled_skills_path(),
+                r#"["skill:visualizer","government-writing"]"#,
+            )
+            .unwrap();
+            assert_eq!(
+                load_disabled_skills_for(ConnectorScope::Plain),
+                vec!["visualizer".to_string(), "government-writing".to_string()],
+                "裸数组迁移应剥除 skill: 前缀"
+            );
+            // 落盘后的对象格式同样无前缀
+            let content = std::fs::read_to_string(disabled_skills_path()).unwrap();
+            assert!(
+                !content.contains("skill:visualizer"),
+                "迁移落盘不应残留前缀: {content}"
             );
         });
     }


### PR DESCRIPTION
## Summary

PR #202（skill 双 scope 治理）审计后的 follow-up 修复：补上三处接线/迁移缺陷与两处文档订正。基于最新 main（PR #202 已合入，merge commit 076fe209）。

## Changes

1. **install_marketplace_tool 漏接组合目录重写（行为回归，核心修复）**
   - 安装 MCP 会联动安装其 companion skills，但原命令末尾未重写在线会话组合目录，运行中会话下一轮 prompt 看不到新装的 companion 技能（旧机制每轮扫 bundle/skills 立即可见，此为回归）。
   - 补 pool 参数 + 命令末尾 refresh_live_sessions_skills()，与 uninstall_marketplace_tool 对称；companion 技能安装成功时同步进 code 禁用集（sync_code_scope_after_skill_install，与独立技能安装同语义）。
2. **裸数组迁移漏剥 skill: 前缀**
   - 旧格式 disabled_skills.json 裸数组含带前缀 id（旧前端 bug 窗口期误写入形态）时，迁移后按裸 id 匹配会漏禁该技能一次（对象格式读路径已归一）。迁移分支复用同一归一逻辑，新增单测覆盖。
3. **set_project_skills_enabled 补 tools_changed 事件广播**
   - 项目级 skills 开关影响 code 会话组合目录，其它窗口/实例需借此事件刷新开关状态（对齐 set_disabled_skills）。
4. **文档订正**
   - docs/code-native-agent.md §8.3 残留过时句（load_skill 已改按组合目录空否动态判定，§3.4/§8.6 已同步）。
   - docs/fork-modifications.md 测试名错配（forkguard_request_user_input_exempt_from_injected_hidden → 实际存在的 forkguard_hidden_tools_cannot_expand_compile_time_blocklist）。

## Verification

- cargo check --tests / cargo clippy --tests / cargo fmt --check：通过（零新增 warning）
- 单测：skill_scope 8 个（含新增迁移前缀用例）、skill_materialization 9 个、marketplace 48 个、commands 112 个——全过
- ./scripts/fork-guard.sh --fast：指纹层全过
- python3 scripts/architecture-guard.py：通过

## Notes

- 审计时发现的健壮性建议（materialize 失败阻断 spawn、rewrite 失败静默、迁移写路径不加锁、remove+rename 原子性残余窗口）未在本 PR 代码中改动，属可接受的既有设计取舍，留待后续评估。
- 未涉及 fork 侧改动（CodeWhale submodule gitlink 不变），fork-modifications.md 仅订正测试名引用。

## Submission checklist

- [x] I based this PR on the latest main.
- [x] Every commit includes a matching Signed-off-by trailer (git commit -s).
- [x] I removed sensitive data and internal URLs from code and logs.
- [x] I updated tests and documentation where behavior changed.
