### PR TITLE
fix(codex): 修复后台会话提问无提示与切回显示已提交无法选择

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,3 @@ pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/node/
 pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/acp/
 pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/manifest.json
 pinvou3-app/src-tauri/resources/platforms/linux/.codex-bridge-build.*/
-
-# CodeWhale 工作流运行时数据（本地工具产物，不提交）
-.codewhale/

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/node/
 pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/acp/
 pinvou3-app/src-tauri/resources/platforms/linux/codex-bridge/manifest.json
 pinvou3-app/src-tauri/resources/platforms/linux/.codex-bridge-build.*/
+
+# CodeWhale 工作流运行时数据（本地工具产物，不提交）
+.codewhale/

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -162,6 +162,9 @@ function workspaceDisplayName(path) {
         }
       });
       const [codexBusyBySession, setCodexBusyBySession] = useState({});
+      // 代码会话等待用户输入（request_user_input 挂起）的会话集合：侧边栏用
+      // 「等待你的选择」橙色点提示，与 running 灰点区分——后台会话提问不再无感知。
+      const [codexWaitingInputBySession, setCodexWaitingInputBySession] = useState({});
       // 全局事件监听器按 id 判断是否为代码会话（监听器注册一次，不能闭包旧列表）。
       const codexSessionIdsRef = useRef(new Set());
       // 进入设置前的页面（openSettingsSection 记录），关闭设置时原路返回。
@@ -230,6 +233,29 @@ function workspaceDisplayName(path) {
             const sessionId = message && message.payload && message.payload.session_id;
             if (!sessionId || !codexSessionIdsRef.current.has(sessionId)) return;
             setCodexBusyBySession(current => ({ ...current, [sessionId]: eventName === 'chat:turn_started' }));
+            if (eventName === 'chat:done') {
+              setCodexWaitingInputBySession(current => ({ ...current, [sessionId]: false }));
+            }
+            refreshCodexSessions().catch(() => {});
+          }).then(unlisten => {
+            if (disposed) unlisten();
+            else unlisteners.push(unlisten);
+          }).catch(() => {});
+        });
+        // 后台会话提问（request_user_input 挂起）时点亮「等待你的选择」提示，
+        // 收口（提交/取消/超时→tool_end）后熄灭；turn 结束由上面 chat:done 兜底。
+        ['chat:user_input_required', 'chat:tool_end'].forEach(eventName => {
+          tauriEvents.listen(eventName, (message) => {
+            if (disposed) return;
+            const p = message && message.payload || {};
+            const sessionId = p.session_id;
+            if (!sessionId || !codexSessionIdsRef.current.has(sessionId)) return;
+            if (eventName === 'chat:user_input_required') {
+              setCodexWaitingInputBySession(current => ({ ...current, [sessionId]: true }));
+              setCodexBusyBySession(current => ({ ...current, [sessionId]: true }));
+            } else if (p.name === 'request_user_input') {
+              setCodexWaitingInputBySession(current => ({ ...current, [sessionId]: false }));
+            }
             refreshCodexSessions().catch(() => {});
           }).then(unlisten => {
             if (disposed) unlisten();
@@ -689,6 +715,7 @@ function workspaceDisplayName(path) {
         pinned: !!session.pinned,
         pinnedAt: session.pinned_at || '',
         working: !!codexBusyBySession[session.id],
+        waitingInput: !!codexWaitingInputBySession[session.id],
         taskKind: 'codex',
         leadingIcon: <AcpAgentLogo agentId={session.agent_id} className="h-[18px] w-[18px]" title={session.agent_name || t.acpAgent} />,
         testId: 'codex-sidebar-item',

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -255,8 +255,10 @@ function workspaceDisplayName(path) {
               setCodexBusyBySession(current => ({ ...current, [sessionId]: true }));
             } else if (p.name === 'request_user_input') {
               setCodexWaitingInputBySession(current => ({ ...current, [sessionId]: false }));
+              // 只有提问收口才刷新会话列表；普通工具 tool_end 不动列表，避免
+              // 工具密集 turn 下每个 chat:tool_end 都触发一次 IPC + 重渲染。
+              refreshCodexSessions().catch(() => {});
             }
-            refreshCodexSessions().catch(() => {});
           }).then(unlisten => {
             if (disposed) unlisten();
             else unlisteners.push(unlisten);

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -315,7 +315,8 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
               <span className="block truncate text-[12px] leading-4 text-[#8A8F94] dark:text-[#9AA0A6]">{chat.subtitle}</span>
             )}
           </span>
-          {chat.working && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-current opacity-70 animate-pulse" title={t.riGenerating}></span>}
+          {/* 等待选择时模型不在生成：橙点替代灰点，避免两个徽标叠加 */}
+          {chat.working && !chat.waitingInput && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-current opacity-70 animate-pulse" title={t.riGenerating}></span>}
           {chat.waitingInput && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-[#F9AB00] opacity-90 animate-pulse" title={t.riAwaitingInput}></span>}
           {chat.skill && <span className="text-[11px] shrink-0 opacity-70 mr-1" title={chat.skill}>🧭</span>}
           {chat.unread && (

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -316,6 +316,7 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
             )}
           </span>
           {chat.working && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-current opacity-70 animate-pulse" title={t.riGenerating}></span>}
+          {chat.waitingInput && <span className="shrink-0 mr-1 inline-block w-2 h-2 rounded-full bg-[#F9AB00] opacity-90 animate-pulse" title={t.riAwaitingInput}></span>}
           {chat.skill && <span className="text-[11px] shrink-0 opacity-70 mr-1" title={chat.skill}>🧭</span>}
           {chat.unread && (
             <span data-testid="scheduled-run-sidebar-unread" aria-label={t.uiScheduled.unread}

--- a/pinvou3-app/src/features/codex/code-native-lane.js
+++ b/pinvou3-app/src/features/codex/code-native-lane.js
@@ -303,7 +303,10 @@ export function applyNativeChatEvent(lane, name, payload) {
       lane.thinking = lane.busy
         ? { active: true, startedAt: lane.thinking?.startedAt || Date.now(), phase: 'thinking', toolName: null }
         : null;
-      if (meta && meta.name === 'request_user_input') {
+      // remount 恢复的 active 卡（pending → chat:user_input_required）没有经过
+      // tool_start，toolMeta 缺失；后端 tool_end payload 自带 name，用它兜底判断，
+      // 避免超时/收口时落入普通工具分支导致卡片不收口。
+      if ((meta?.name || p.name) === 'request_user_input') {
         const card = [...lane.items].reverse().find(item => (
           item && item.type === 'user_input' && item.toolCallId === p.id && !item.resolved
         ));

--- a/pinvou3-app/src/features/codex/code-native-lane.js
+++ b/pinvou3-app/src/features/codex/code-native-lane.js
@@ -337,7 +337,18 @@ export function applyNativeChatEvent(lane, name, payload) {
     case 'chat:user_input_required': {
       const questions = Array.isArray(p.questions) ? p.questions : [];
       if (!p.id || !questions.length) return false;
-      if (lane.items.some(item => item && item.type === 'user_input' && item.toolCallId === p.id)) return false;
+      const existing = lane.items.find(item => (
+        item && item.type === 'user_input' && item.toolCallId === p.id
+      ));
+      if (existing) {
+        // 同 id 卡片已存在：未解决 → 无需重复；已 resolved（历史快照误标为
+        // submitted 的进行中提问）→ 重置为 active，让用户仍能选择。
+        if (!existing.resolved) return false;
+        existing.resolved = false;
+        existing.cardState = 'active';
+        existing.questions = questions;
+        return true;
+      }
       lane.items.push({
         id: nextId(lane),
         type: 'user_input',
@@ -554,13 +565,18 @@ export function hydrateNativeLane(lane, saved, timelineEvents = []) {
           const questions = (block.input && block.input.questions) || [];
           if (Array.isArray(questions) && questions.length) {
             const result = resultById[block.id];
+            // 磁盘快照可能落在 turn 进行中（底座 add_session_message 每次落盘）：
+            // 此时 tool_use 还没有对应 tool_result。若按历史恢复，result 缺失会
+            // 落入 submitted 误标，且挡住 get_pending_user_inputs 恢复的 active 卡
+            // （幂等去重按 toolCallId 命中）。此处跳过，交给 pending 恢复为可交互卡。
+            if (!result) continue;
             lane.items.push({
               id: nextId(lane),
               type: 'user_input',
               toolCallId: block.id,
               questions,
               resolved: true,
-              cardState: result && result.is_error ? 'cancelled' : 'submitted',
+              cardState: result.is_error ? 'cancelled' : 'submitted',
               time: '',
             });
           }

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1627,10 +1627,14 @@
             var qs = (b.input && b.input.questions) || [];
             if (Array.isArray(qs) && qs.length) {
               var res = resultById[b.id];
+              // 快照可能落在 turn 进行中（底座每次落盘）：tool_use 尚无对应
+              // tool_result，不能按历史恢复为 submitted。跳过，等
+              // chat:user_input_required 事件渲染可交互的 active 卡。
+              if (!res) continue;
               addChatItem({
                 type: "user_input", toolCallId: b.id, questions: qs,
-                resolved: true, cardState: (res && res.is_error) ? "cancelled" : "submitted",
-                restoredAnswers: res ? parseUserAnswers(res.content, qs) : null, time: "",
+                resolved: true, cardState: res.is_error ? "cancelled" : "submitted",
+                restoredAnswers: parseUserAnswers(res.content, qs), time: "",
               });
             }
             continue;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -3365,10 +3365,14 @@
             var qs = (b.input && b.input.questions) || [];
             if (Array.isArray(qs) && qs.length) {
               var res = resultById[b.id];
+              // 快照可能落在 turn 进行中（底座每次落盘）：tool_use 尚无对应
+              // tool_result，不能按历史恢复为 submitted。跳过，等
+              // chat:user_input_required 事件渲染可交互的 active 卡。
+              if (!res) continue;
               addChatItem({
                 type: "user_input", toolCallId: b.id, questions: qs,
-                resolved: true, cardState: (res && res.is_error) ? "cancelled" : "submitted",
-                restoredAnswers: res ? parseUserAnswers(res.content, qs) : null, time: "",
+                resolved: true, cardState: res.is_error ? "cancelled" : "submitted",
+                restoredAnswers: parseUserAnswers(res.content, qs), time: "",
               });
             }
             continue;

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -642,7 +642,7 @@ const dict = {
         cpDescLabel: '简介',
         cpEquipBubbleNote: '完整能力档案已注入,AI 将以该专家的方法论承接后续任务。',
         cpTargetMarkTitle: '加持目标 · 在卡牌池选的专家会注入到这个对话',
-        riGenerating: '正在生成中', riDelQ: '删除?', riDelConfirm: '确认删除', riRename: '重命名', riPin: '置顶', riUnpin: '取消置顶',
+        riGenerating: '正在生成中', riDelQ: '删除?', riDelConfirm: '确认删除', riRename: '重命名', riPin: '置顶', riUnpin: '取消置顶', riAwaitingInput: '等待你的选择',
         // —— 聊天链路/全局 chrome ——
         appTitle: 'PINVOU 智能助手（内测版）', winMin: '最小化', winMax: '最大化', winClose: '关闭',
         sidebarCollapse: '收起侧边栏', sidebarExpand: '展开侧边栏',
@@ -993,7 +993,7 @@ const dict = {
         cpDescLabel: 'Description',
         cpEquipBubbleNote: "Full capability profile injected — the AI will handle following tasks with this expert's methodology.",
         cpTargetMarkTitle: 'Equip target · experts picked in the card pool are injected into this chat',
-        riGenerating: 'Generating…', riDelQ: 'Delete?', riDelConfirm: 'Confirm delete', riRename: 'Rename', riPin: 'Pin', riUnpin: 'Unpin',
+        riGenerating: 'Generating…', riDelQ: 'Delete?', riDelConfirm: 'Confirm delete', riRename: 'Rename', riPin: 'Pin', riUnpin: 'Unpin', riAwaitingInput: 'Awaiting your input',
         // —— Chat & global chrome ——
         appTitle: 'PINVOU AI Assistant', winMin: 'Minimize', winMax: 'Maximize', winClose: 'Close',
         sidebarCollapse: 'Collapse sidebar', sidebarExpand: 'Expand sidebar',
@@ -1343,7 +1343,7 @@ const dict = {
         cpDescLabel: '説明',
         cpEquipBubbleNote: '能力プロファイルを注入しました。AI はこのエキスパートの方法論でタスクを担当します。',
         cpTargetMarkTitle: '装備先 · カードプールで選んだエキスパートがこの会話に注入されます',
-        riGenerating: '生成中…', riDelQ: '削除?', riDelConfirm: '削除を確認', riRename: '名前を変更', riPin: 'ピン留め', riUnpin: 'ピン留め解除',
+        riGenerating: '生成中…', riDelQ: '削除?', riDelConfirm: '削除を確認', riRename: '名前を変更', riPin: 'ピン留め', riUnpin: 'ピン留め解除', riAwaitingInput: 'あなたの入力を待っています',
         // —— チャット/グローバル chrome ——
         appTitle: 'PINVOU アシスタント', winMin: '最小化', winMax: '最大化', winClose: '閉じる',
         sidebarCollapse: 'サイドバーを折りたたむ', sidebarExpand: 'サイドバーを展開',

--- a/pinvou3-app/tests/code_native_lane.test.mjs
+++ b/pinvou3-app/tests/code_native_lane.test.mjs
@@ -174,6 +174,37 @@ try {
   assert.equal(pendingCard.resolved, false);
   assert.equal(pendingCard.cardState, 'active');
 
+  // ── remount 恢复的 active 卡超时/收口：tool_end 用 payload.name 兜底 ──
+  // 恢复路径（pending → chat:user_input_required）没经过 tool_start，toolMeta
+  // 缺失；tool_end 处理器若只看 toolMeta 会落入普通工具分支、卡片不收口。
+  // 回归：300s 超时（success=false）后卡片进入 cancelled 终态。
+  applyNativeChatEvent(lane4b, 'chat:tool_end', {
+    session_id: 's4b',
+    id: 'c9',
+    name: 'request_user_input',
+    success: false,
+    output: '',
+  });
+  assert.equal(pendingCard.resolved, true, 'toolMeta 缺失时靠 payload.name 识别 request_user_input 收口');
+  assert.equal(pendingCard.cardState, 'cancelled', '超时收口为 cancelled 终态');
+  // 正常提交（success=true）同理进入 submitted 终态。
+  const lane4c = createNativeLane();
+  applyNativeChatEvent(lane4c, 'chat:user_input_required', {
+    session_id: 's4c',
+    id: 'c10',
+    questions: [{ id: 'q', header: 'H', question: '选？', options: [{ label: 'A' }] }],
+  });
+  const pendingCard2 = lane4c.items.find(item => item.type === 'user_input');
+  applyNativeChatEvent(lane4c, 'chat:tool_end', {
+    session_id: 's4c',
+    id: 'c10',
+    name: 'request_user_input',
+    success: true,
+    output: 'A',
+  });
+  assert.equal(pendingCard2.resolved, true);
+  assert.equal(pendingCard2.cardState, 'submitted', '提交收口为 submitted 终态');
+
   // ── 远端用户消息（遥控端发送）：去重本地乐观气泡 ────────────────
   const lane5 = createNativeLane();
   appendLocalUserMessage(lane5, '本地一句\n📎 a.png');

--- a/pinvou3-app/tests/code_native_lane.test.mjs
+++ b/pinvou3-app/tests/code_native_lane.test.mjs
@@ -85,6 +85,11 @@ try {
   applyNativeChatEvent(lane2, 'chat:tool_end', { session_id: 's2', id: 'call-9', success: true, output: '' });
   assert.equal(card.resolved, true);
   assert.equal(card.cardState, 'submitted');
+  // 已收口（resolved）的卡片再收到同 id 事件（历史快照误标后 pending 恢复）→
+  // 重置为 active，让用户仍能选择（对应「切回显示已提交无法选择」的修复）。
+  applyNativeChatEvent(lane2, 'chat:user_input_required', { session_id: 's2', id: 'call-9', questions: [{ id: 'q1' }] });
+  assert.equal(card.resolved, false, '误标/历史快照卡片被 pending 恢复重置为 active');
+  assert.equal(card.cardState, 'active');
 
   // ── 发送失败回滚 ────────────────────────────────────────────────
   const lane3 = createNativeLane();
@@ -142,6 +147,32 @@ try {
   assert.equal(lane4.busy, true);
   hydrateNativeLane(lane4, { messages: [] }, []);
   assert.equal(lane4.busy, true, '已有 live turn 时 hydration 不得清 busy');
+
+  // ── hydration：request_user_input 的 tool_use 无 tool_result ──────
+  // 快照可能落在 turn 进行中（底座 add_session_message 每次落盘）：此时
+  // tool_use 尚无对应 tool_result，不能按历史恢复为 submitted（会误标并挡住
+  // pending 恢复的 active 卡）——应跳过，由 chat:user_input_required 恢复。
+  const lane4b = createNativeLane();
+  hydrateNativeLane(lane4b, {
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: '继续跑' }] },
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'c9', name: 'request_user_input', input: { questions: [{ id: 'q', header: 'H' }] } }],
+      },
+    ],
+  }, []);
+  assert.equal(lane4b.items.some(item => item.type === 'user_input'), false, '无 tool_result 的挂起提问不按历史恢复');
+  // 随后 pending 恢复（get_pending_user_inputs → chat:user_input_required）出 active 卡。
+  applyNativeChatEvent(lane4b, 'chat:user_input_required', {
+    session_id: 's4b',
+    id: 'c9',
+    questions: [{ id: 'q', header: 'H', question: '选？', options: [{ label: 'A' }] }],
+  });
+  const pendingCard = lane4b.items.find(item => item.type === 'user_input');
+  assert.equal(!!pendingCard, true);
+  assert.equal(pendingCard.resolved, false);
+  assert.equal(pendingCard.cardState, 'active');
 
   // ── 远端用户消息（遥控端发送）：去重本地乐观气泡 ────────────────
   const lane5 = createNativeLane();


### PR DESCRIPTION
## 背景

同时运行多个代码会话时，后台会话需要向用户提问（`request_user_input`）存在两个问题：

1. **无任何提示**：侧边栏 busy 徽标只监听 `chat:turn_started`/`chat:done`，后台会话提问时用户完全无感知，直到 300s 超时被底座自动收口；
2. **切回显示"已提交"无法选择**：底座 `add_session_message` 每次加消息都发射 `SessionUpdated` 并落盘（turn 进行中也落盘），磁盘快照可能包含**没有对应 `tool_result` 的 `request_user_input` tool_use**。切回会话时 `hydrateNativeLane` / `rerenderFromMessages` 按 `result && result.is_error ? 'cancelled' : 'submitted'` 恢复，result 缺失落入 `submitted`（resolved），且 `get_pending_user_inputs` 恢复 active 卡时被按 toolCallId 的幂等去重命中这张假卡而跳过 → 用户看到"✓ 已提交"且无法再选择。

## 变更

- **`code-native-lane.js`**：hydration 时无 `tool_result` 的 `request_user_input` 不再恢复为 resolved 卡（跳过，交给 pending 恢复）；`chat:user_input_required` 幂等去重改为只跳过**未解决**的同 id 卡片，命中误标卡时重置为 active。
- **`tauri/web bridge.js`**：`rerenderFromMessages` 同样跳过无 result 的 `request_user_input`（主聊天 remount 的同源问题一并修复）。
- **`main.jsx` + `NavigationComponents.jsx` + `i18n.js`**：侧边栏新增"等待你的选择"橙色提示（监听 `chat:user_input_required` 点亮，`chat:tool_end`(request_user_input)/`chat:done` 熄灭），三语文案。
- **`tests/code_native_lane.test.mjs`**：新增两场景——无 tool_result 的挂起提问不按历史恢复 + pending 恢复重置 active；收口卡片再收同 id 事件重置 active。

## 验证

- `tests/code_native_lane.test.mjs` 全过（含新断言）
- `deepseek_conversation_timeline` / `codex_acp_timeline` / `bridge_domain_protocol` / `i18n_no_zh_literals` 全过
- eslint（6 个改动 JS 文件）通过；`architecture-guard.py` 通过

## 已知风险

- 底座 300s 超时机制未改动（超出本 PR 范围）；提示机制让用户能及时切回处理提问，超时风险大幅降低。
- 等待提示仅在侧边栏会话条目上（与现有 busy 徽标同一位置），代码页内无会话列表。