### PR TITLE
fix(ui): 会话操作收敛到更多菜单并补全打开文件夹文案

### DIFF
--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -334,7 +334,7 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
             </div>
           ) : (
             <>
-              {/* 默认: 显示日期(辨识每条会话什么时候发生);hover/active 时换成编辑/删除按钮。
+              {/* 默认: 显示日期(辨识每条会话什么时候发生);hover/active 时换成置顶/更多按钮,重命名/收纳/删除在更多菜单里。
                   窄屏无 hover：按钮组常显、日期让位，保证触屏可达。 */}
               {chat.date && (
                 <span className="text-[11px] shrink-0 opacity-60 whitespace-nowrap group-hover:hidden max-sm:hidden text-[#5F6368] dark:text-[#9AA0A6]">
@@ -346,12 +346,7 @@ const NavItem = ({ icon, label, active, unread = false, theme, isSidebarOpen = t
                   className="w-6 h-6 rounded-full flex items-center justify-center transition-colors text-[#5F6368] hover:bg-[#D3D7DB] dark:text-[#C4C7C5] dark:hover:bg-[#444746]">
                   {chat.pinned ? <PinOffIcon size={13} /> : <PinIcon size={13} />}
                 </button>
-                <button title={t.riRename} onClick={(e) => { e.stopPropagation(); setVal(chat.title); setEditing(true); }}
-                  className="w-6 h-6 rounded-full flex items-center justify-center text-[#5F6368] hover:bg-[#D3D7DB] dark:text-[#C4C7C5] dark:hover:bg-[#444746]"><Edit2 size={13} /></button>
-                <button title={t.archiveSession} onClick={(e) => { e.stopPropagation(); onArchive && onArchive(chat.id); }}
-                  className="w-6 h-6 rounded-full flex items-center justify-center text-[#5F6368] hover:bg-[#D3D7DB] dark:text-[#C4C7C5] dark:hover:bg-[#444746]"><Archive size={13} /></button>
-                <button title={t.cpDelete} onClick={(e) => { e.stopPropagation(); setConfirming(true); }}
-                  className="w-6 h-6 rounded-full flex items-center justify-center text-[#5F6368] hover:text-[#C5221F] hover:bg-[#FAD2CF] dark:text-[#C4C7C5] dark:hover:text-[#F28B82] dark:hover:bg-[#5c2b29]"><Trash2 size={13} /></button>
+
                 <div className="relative">
                   <button title={t.riMore} onClick={toggleMenu}
                     className="w-6 h-6 rounded-full flex items-center justify-center text-[#5F6368] hover:bg-[#D3D7DB] dark:text-[#C4C7C5] dark:hover:bg-[#444746]"><MoreHorizontal size={14} /></button>

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -642,7 +642,7 @@ const dict = {
         cpDescLabel: '简介',
         cpEquipBubbleNote: '完整能力档案已注入,AI 将以该专家的方法论承接后续任务。',
         cpTargetMarkTitle: '加持目标 · 在卡牌池选的专家会注入到这个对话',
-        riGenerating: '正在生成中', riDelQ: '删除?', riDelConfirm: '确认删除', riRename: '重命名', riPin: '置顶', riUnpin: '取消置顶', riAwaitingInput: '等待你的选择',
+        riGenerating: '正在生成中', riDelQ: '删除?', riDelConfirm: '确认删除', riRename: '重命名', riPin: '置顶', riUnpin: '取消置顶', riOpenFolder: '打开文件夹', riAwaitingInput: '等待你的选择',
         // —— 聊天链路/全局 chrome ——
         appTitle: 'PINVOU 智能助手（内测版）', winMin: '最小化', winMax: '最大化', winClose: '关闭',
         sidebarCollapse: '收起侧边栏', sidebarExpand: '展开侧边栏',
@@ -993,7 +993,7 @@ const dict = {
         cpDescLabel: 'Description',
         cpEquipBubbleNote: "Full capability profile injected — the AI will handle following tasks with this expert's methodology.",
         cpTargetMarkTitle: 'Equip target · experts picked in the card pool are injected into this chat',
-        riGenerating: 'Generating…', riDelQ: 'Delete?', riDelConfirm: 'Confirm delete', riRename: 'Rename', riPin: 'Pin', riUnpin: 'Unpin', riAwaitingInput: 'Awaiting your input',
+        riGenerating: 'Generating…', riDelQ: 'Delete?', riDelConfirm: 'Confirm delete', riRename: 'Rename', riPin: 'Pin', riUnpin: 'Unpin', riOpenFolder: 'Open folder', riAwaitingInput: 'Awaiting your input',
         // —— Chat & global chrome ——
         appTitle: 'PINVOU AI Assistant', winMin: 'Minimize', winMax: 'Maximize', winClose: 'Close',
         sidebarCollapse: 'Collapse sidebar', sidebarExpand: 'Expand sidebar',
@@ -1343,7 +1343,7 @@ const dict = {
         cpDescLabel: '説明',
         cpEquipBubbleNote: '能力プロファイルを注入しました。AI はこのエキスパートの方法論でタスクを担当します。',
         cpTargetMarkTitle: '装備先 · カードプールで選んだエキスパートがこの会話に注入されます',
-        riGenerating: '生成中…', riDelQ: '削除?', riDelConfirm: '削除を確認', riRename: '名前を変更', riPin: 'ピン留め', riUnpin: 'ピン留め解除', riAwaitingInput: 'あなたの入力を待っています',
+        riGenerating: '生成中…', riDelQ: '削除?', riDelConfirm: '削除を確認', riRename: '名前を変更', riPin: 'ピン留め', riUnpin: 'ピン留め解除', riOpenFolder: 'フォルダを開く', riAwaitingInput: 'あなたの入力を待っています',
         // —— チャット/グローバル chrome ——
         appTitle: 'PINVOU アシスタント', winMin: '最小化', winMax: '最大化', winClose: '閉じる',
         sidebarCollapse: 'サイドバーを折りたたむ', sidebarExpand: 'サイドバーを展開',


### PR DESCRIPTION
## 背景

左侧会话项存在两个 UI 问题：

1. hover 按钮组与「更多」（⋮）菜单重复暴露 **重命名 / 收纳 / 删除** 三个操作，同一操作两处入口；
2. 「更多」菜单中「打开文件夹」选项只有文件夹图标、右侧无文字——`riOpenFolder` 文案在三语词典中均缺失。

## 变更

- `pinvou3-app/src/components/layout/NavigationComponents.jsx`：会话项 hover 按钮组收敛为只保留 **置顶 / 更多** 两个入口，重命名、收纳、删除统一从「更多」菜单进入（菜单中本就有完整项）；同步更新过时注释。
- `pinvou3-app/src/shared/i18n.js`：三语补充 `riOpenFolder`（打开文件夹 / Open folder / フォルダを開く）。

## 验证

- `node --check` 通过 `i18n.js` 语法；确认三语 `riOpenFolder` 就位、三个操作仅存于菜单。
- 分支基于最新 `origin/main`（cherry-pick，无 merge 提交），PR 差异仅含上述 2 个文件。
- eslint / 构建未运行：本地 `node_modules` 未安装，依赖缺失。

## 已知风险

- 无功能行为变化，仅入口位置与文案补齐。