### PR TITLE
fix(monitor): 上下文长度按十进制进位显示

### DIFF
--- a/pinvou3-app/src/features/monitor/MonitorView.jsx
+++ b/pinvou3-app/src/features/monitor/MonitorView.jsx
@@ -479,7 +479,7 @@ const ClearStatsHold = ({ theme, t, onClear }) => {
       const modelIcon = monitorModelIcon(vllmModel);
       const tokenPair = monitorTokenPair(clearOverride ? clearOverride.tokTotal : vllmTokTotal);
       const ctxNum = typeof vllmMaxLen === 'number' ? vllmMaxLen : parseFloat(String(vllmMaxLen || '').replace(/[^\d.]/g, ''));
-      const ctxValue = Number.isFinite(ctxNum) ? Math.round(ctxNum / 1024) : String(vllmMaxLen || '—');
+      const ctxValue = Number.isFinite(ctxNum) ? Math.round(ctxNum / 1000) : String(vllmMaxLen || '—');
       const ctxUnit = Number.isFinite(ctxNum) ? 'K' : '';
       const queueText = String(vllmQueue || '—').replace(/\s+/g, '');
       const ttftText = String(clearOverride ? clearOverride.ttft : vllmTtft).replace(/\s*s$/i, '');


### PR DESCRIPTION
## 背景

「运行状态」页的上下文长度卡片按二进制进位换算（1M=1024K），而聊天页 footer 的上下文显示已按十进制进位（1e6/1e3）。两处口径不一致。

## 变更

- `pinvou3-app/src/features/monitor/MonitorView.jsx`：上下文长度换算由 `÷1024` 改为 `÷1000`（1M=1000K 十进制进位）。

换算示例（原始 token → 显示值）：32768 → 33K（原 32K），131072 → 131K（原 128K），1000000 → 1000K。

## 实际验证

- 对该文件运行 ESLint 通过（exit 0）。
- 已排查全链路：bridge 层与 Rust 侧只下发原始 `max_model_len` token 数，显示换算仅此一处。

## 已知风险

- 无；纯显示换算口径调整，不改变数据本身。