### PR TITLE
fix(voice): support numeric-only speech transcripts

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1044,6 +1044,7 @@ jobs:
 
       - name: Windows Codex Runtime 原生打包冒烟
         run: |
+          npm --prefix pinvou3-app run test:windows-runtime-manifest
           npm --prefix pinvou3-app run test:windows-runtime
           npm --prefix pinvou3-app run test:codex-acp-windows-runtime
 

--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -32,6 +32,7 @@
     "runtime:windows:init:onnx": "powershell -NoProfile -ExecutionPolicy Bypass -File src-tauri/packaging/windows/runtime/scripts/init-submodule.ps1 -OnnxOnly",
     "runtime:windows:cache-key": "powershell -NoProfile -ExecutionPolicy Bypass -File src-tauri/packaging/windows/runtime/scripts/init-submodule.ps1 -CacheKeyOnly",
     "test:windows-runtime": "node tests/windows_runtime_packaging_contract.test.js",
+    "test:windows-runtime-manifest": "powershell -NoProfile -ExecutionPolicy Bypass -File src-tauri/packaging/windows/runtime/scripts/test-runtime-manifest-contract.ps1",
     "build:nsis": "node scripts/tauri/build.js build --bundles nsis",
     "test:tauri-layout": "node tests/tauri_platform_layout.test.js",
     "test:tauri-effective-config": "node tests/tauri_effective_config.test.js",

--- a/pinvou3-app/src-tauri/config/platforms/windows/runtime/x86_64.lock.json
+++ b/pinvou3-app/src-tauri/config/platforms/windows/runtime/x86_64.lock.json
@@ -5,11 +5,11 @@
     "type": "git-submodule",
     "path": "private-runtimes/windows",
     "url": "https://github.com/Pinvou/pinvou3-windows-runtime.git",
-    "commit": "5b77961dea402a1580ab9e79edb2a6346e519f4c"
+    "commit": "dcde8f01dc009c4acecfbe3bc64dff39de22d341"
   },
   "manifest": {
     "path": "windows-runtime.manifest.json",
-    "sha256": "0d14c4b67fd6dc1e0e5c3d4dc07c50a0e7a5072722b082edbeaef6a22b6cdc14"
+    "sha256": "9e6221b6b7f20f3f3e8b01e42520dab17e3f0d14c4e890dc828064bd4fb2b792"
   },
   "vcRedist": {
     "minimumVersion": "14.51.36247.0"

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
@@ -15,6 +15,7 @@ Windows 大型运行时存放在独立的公开仓库，不直接提交到主仓
 npm run runtime:windows:init
 npm run runtime:windows:validate
 npm run runtime:windows:stage
+npm run test:windows-runtime-manifest
 ```
 
 Windows 桌面开发先执行一次 `npm run runtime:windows:init:onnx`。该命令初始化固定版本的 runtime checkout，
@@ -26,7 +27,7 @@ ONNX Runtime 组件到 `target/windows-runtime/<commit>-<manifest-sha>-onnx-dev/
 脚本会检查受 LFS 管理的实际文件，只有仍存在 pointer 时才按路径执行 `git lfs pull`，并输出
 `pinvou3-windows-runtime-<commit>` 形式的 Jenkins 缓存键。
 
-校验内容包括 submodule commit、gitlink、origin URL、工作树状态、manifest SHA-256、文件大小与 SHA-256，以及受管理 ZIP 解压后的逐文件清单。
+Validation covers the submodule commit, gitlink, origin URL, worktree status, manifest SHA-256, file sizes and SHA-256 hashes, and the per-file inventory extracted from managed ZIP archives. The resolver supports schemas 1 and 2. In schema 2, `stagedFiles` describes the lifecycle snapshot after payload files have been copied and components expanded, but before derived files are generated or payload files are removed. Validation rejects both missing and extra files.
 
 每次构建都会按 runtime manifest 复核源文件的大小和 SHA-256。staging 内的 `.verified-lock` 绑定 runtime commit、manifest
 SHA-256、lock 文件 SHA-256 和目标平台，`.verified-stage.json` 则记录全部展开文件的路径、大小和 SHA-256；任一暂存产物变化

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/README.md
@@ -27,7 +27,7 @@ ONNX Runtime 组件到 `target/windows-runtime/<commit>-<manifest-sha>-onnx-dev/
 脚本会检查受 LFS 管理的实际文件，只有仍存在 pointer 时才按路径执行 `git lfs pull`，并输出
 `pinvou3-windows-runtime-<commit>` 形式的 Jenkins 缓存键。
 
-Validation covers the submodule commit, gitlink, origin URL, worktree status, manifest SHA-256, file sizes and SHA-256 hashes, and the per-file inventory extracted from managed ZIP archives. The resolver supports schemas 1 and 2. In schema 2, `stagedFiles` describes the lifecycle snapshot after payload files have been copied and components expanded, but before derived files are generated or payload files are removed. Validation rejects both missing and extra files.
+校验内容包括 submodule commit、gitlink、origin URL、工作树状态、manifest SHA-256、文件大小与 SHA-256，以及受管理 ZIP 解压后的逐文件清单。解析器支持 schema 1 与 schema 2：schema 2 的 `stagedFiles` 记录生命周期快照，取自 payload 复制、各组件解压、按需分发的 ASR 主模型移除之后，派生文件生成与 payload 清理之前；校验会同时拒绝缺失与多余的暂存文件。
 
 每次构建都会按 runtime manifest 复核源文件的大小和 SHA-256。staging 内的 `.verified-lock` 绑定 runtime commit、manifest
 SHA-256、lock 文件 SHA-256 和目标平台，`.verified-stage.json` 则记录全部展开文件的路径、大小和 SHA-256；任一暂存产物变化

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/resolve-runtime.ps1
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/resolve-runtime.ps1
@@ -9,6 +9,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+. (Join-Path $PSScriptRoot "runtime-manifest-contract.ps1")
 
 $tauriRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..\..")).Path
 $appRoot = (Resolve-Path (Join-Path $tauriRoot "..")).Path
@@ -163,9 +164,11 @@ function Read-CompatibleRuntimeManifest {
   param([string]$ManifestPath)
 
   $manifest = Get-Content -LiteralPath $ManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
-  if ([int]$manifest.schemaVersion -ne 1 -or [string]$manifest.target -ne [string]$lock.target) {
+  $schemaVersion = [int]$manifest.schemaVersion
+  if ($schemaVersion -notin @(1, 2) -or [string]$manifest.target -ne [string]$lock.target) {
     throw "Windows runtime submodule manifest schema or target is incompatible."
   }
+  Assert-WindowsRuntimeStagedFilesDeclared -Manifest $manifest
   return $manifest
 }
 
@@ -553,6 +556,10 @@ function Stage-Submodule {
       Expand-FlattenedRuntime -ZipPath (Find-ComponentArchive -PayloadRoot $payloadRoot -Pattern "onnxruntime-win-x64-*-runtime.zip" -Label "ONNX Runtime") -Destination (Join-Path $expandedRoot "onnxruntime") -RequiredFile "onnxruntime.dll" -OnnxOnly
       $expandedRoot = $stageContext.ExpandedRoot
       Write-Host ("Expanded all Windows runtime components: {0}" -f $expandedRoot)
+
+      # Schema 2 stagedFiles is the exact lifecycle snapshot after payload copy
+      # and component expansion, before derived files or payload cleanup.
+      Assert-WindowsRuntimeStagedFilesExact -Manifest $Manifest -StageRoot $stageContext.TemporaryRoot
 
       # Resolver 只把 VC++ 组件放入通用 staging；是否供 NSIS 使用由 installer adapter 决定。
       Write-Host "Preparing descriptor-owned VC++ runtime component."

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/runtime-manifest-contract.ps1
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/runtime-manifest-contract.ps1
@@ -1,0 +1,105 @@
+$ErrorActionPreference = "Stop"
+
+function Get-CanonicalWindowsRuntimeManifestPath {
+  param([string]$Path)
+
+  if (
+    [string]::IsNullOrWhiteSpace($Path) -or
+    $Path.StartsWith('/') -or
+    $Path.StartsWith('\') -or
+    $Path -match '^[A-Za-z]:' -or
+    $Path.Contains('\')
+  ) {
+    throw "Windows runtime manifest path must be a canonical relative path: $Path"
+  }
+
+  $segments = @($Path.Split('/'))
+  foreach ($segment in $segments) {
+    if (
+      [string]::IsNullOrEmpty($segment) -or
+      $segment -eq '.' -or
+      $segment -eq '..' -or
+      $segment -ne $segment.Trim() -or
+      $segment.EndsWith('.') -or
+      $segment.Contains(':')
+    ) {
+      throw "Windows runtime manifest path contains a non-canonical segment: $Path"
+    }
+  }
+
+  return $Path.Normalize([System.Text.NormalizationForm]::FormC)
+}
+
+function Get-WindowsRuntimeRelativePath {
+  param([string]$Root, [string]$Path)
+
+  $rootFull = [System.IO.Path]::GetFullPath($Root).TrimEnd([char[]]@('\', '/')) + '\'
+  $pathFull = [System.IO.Path]::GetFullPath($Path)
+  if (-not $pathFull.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Windows runtime staged file is outside the selected lifecycle root: $Path"
+  }
+  return Get-CanonicalWindowsRuntimeManifestPath -Path $pathFull.Substring($rootFull.Length).Replace('\', '/')
+}
+
+function Assert-WindowsRuntimeStagedFilesDeclared {
+  param($Manifest)
+
+  if ([int]$Manifest.schemaVersion -lt 2) {
+    return
+  }
+  if ($null -eq $Manifest.stagedFiles -or @($Manifest.stagedFiles).Count -eq 0) {
+    throw "Windows runtime manifest schema 2 must contain stagedFiles."
+  }
+}
+
+function Assert-WindowsRuntimeStagedFilesExact {
+  param($Manifest, [string]$StageRoot)
+
+  if ([int]$Manifest.schemaVersion -lt 2) {
+    return
+  }
+  Assert-WindowsRuntimeStagedFilesDeclared -Manifest $Manifest
+  if (-not (Test-Path -LiteralPath $StageRoot -PathType Container)) {
+    throw "Windows runtime stagedFiles lifecycle root is missing: $StageRoot"
+  }
+
+  $entries = @($Manifest.stagedFiles)
+
+  $expected = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($entry in $entries) {
+    $canonicalPath = Get-CanonicalWindowsRuntimeManifestPath -Path ([string]$entry.path)
+    if ($expected.ContainsKey($canonicalPath)) {
+      throw "Windows runtime stagedFiles contains a duplicate canonical path: $canonicalPath"
+    }
+    $expected.Add($canonicalPath, $entry)
+  }
+
+  $actual = [System.Collections.Generic.Dictionary[string, System.IO.FileInfo]]::new([System.StringComparer]::OrdinalIgnoreCase)
+  foreach ($file in Get-ChildItem -LiteralPath $StageRoot -File -Recurse -Force) {
+    $canonicalPath = Get-WindowsRuntimeRelativePath -Root $StageRoot -Path $file.FullName
+    if ($actual.ContainsKey($canonicalPath)) {
+      throw "Windows runtime lifecycle contains a duplicate canonical file path: $canonicalPath"
+    }
+    $actual.Add($canonicalPath, $file)
+  }
+
+  foreach ($canonicalPath in $expected.Keys) {
+    if (-not $actual.ContainsKey($canonicalPath)) {
+      throw "Windows runtime staged file is missing: $canonicalPath"
+    }
+  }
+  foreach ($canonicalPath in $actual.Keys) {
+    if (-not $expected.ContainsKey($canonicalPath)) {
+      throw "Windows runtime lifecycle contains an extra file: $canonicalPath"
+    }
+  }
+
+  foreach ($canonicalPath in $expected.Keys) {
+    $entry = $expected[$canonicalPath]
+    $file = $actual[$canonicalPath]
+    $sha256 = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ([long]$file.Length -ne [long]$entry.bytes -or $sha256 -ne [string]$entry.sha256) {
+      throw "Windows runtime staged file failed verification: $canonicalPath"
+    }
+  }
+}

--- a/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/test-runtime-manifest-contract.ps1
+++ b/pinvou3-app/src-tauri/packaging/windows/runtime/scripts/test-runtime-manifest-contract.ps1
@@ -1,0 +1,151 @@
+$ErrorActionPreference = "Stop"
+
+. (Join-Path $PSScriptRoot "runtime-manifest-contract.ps1")
+
+function Write-FixtureFile {
+  param([string]$Root, [string]$RelativePath, [string]$Content)
+  $path = Join-Path $Root $RelativePath.Replace('/', '\')
+  New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+  [System.IO.File]::WriteAllText($path, $Content, [System.Text.Encoding]::UTF8)
+  return $path
+}
+
+function New-FixtureEntry {
+  param([string]$Root, [string]$RelativePath)
+  $path = Join-Path $Root $RelativePath.Replace('/', '\')
+  return [pscustomobject]@{
+    path = $RelativePath
+    bytes = [long](Get-Item -LiteralPath $path).Length
+    sha256 = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+  }
+}
+
+function Assert-Throws {
+  param([string]$Name, [string]$MessagePattern = "", [scriptblock]$Action)
+  $thrown = $false
+  try {
+    & $Action
+  } catch {
+    $thrown = $true
+    if (-not [string]::IsNullOrEmpty($MessagePattern) -and $_.Exception.Message -notmatch $MessagePattern) {
+      throw "Fixture '$Name' failed for an unexpected reason: $($_.Exception.Message)"
+    }
+  }
+  if (-not $thrown) {
+    throw "Expected fixture '$Name' to fail."
+  }
+}
+
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("pinvou-runtime-manifest-fixture-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+try {
+  $schema1Root = Join-Path $fixtureRoot "schema1"
+  Write-FixtureFile -Root $schema1Root -RelativePath "unmanaged/legacy.txt" -Content "legacy" | Out-Null
+  Assert-WindowsRuntimeStagedFilesExact `
+    -Manifest ([pscustomobject]@{ schemaVersion = 1 }) `
+    -StageRoot $schema1Root
+
+  $schema2Root = Join-Path $fixtureRoot "schema2"
+  Write-FixtureFile -Root $schema2Root -RelativePath "payload/archive.zip" -Content "archive" | Out-Null
+  Write-FixtureFile -Root $schema2Root -RelativePath "expanded/asr/pinvou-asr.exe" -Content "wrapper" | Out-Null
+  $schema2Entries = @(
+    New-FixtureEntry -Root $schema2Root -RelativePath "payload/archive.zip"
+    New-FixtureEntry -Root $schema2Root -RelativePath "expanded/asr/pinvou-asr.exe"
+  )
+  $schema2Manifest = [pscustomobject]@{ schemaVersion = 2; stagedFiles = $schema2Entries }
+  Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+
+  Assert-Throws -Name "schema2 missing stagedFiles property" -MessagePattern "must contain stagedFiles" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest ([pscustomobject]@{ schemaVersion = 2 }) `
+      -StageRoot $schema2Root
+  }
+  Assert-Throws -Name "schema2 empty stagedFiles" -MessagePattern "must contain stagedFiles" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest ([pscustomobject]@{ schemaVersion = 2; stagedFiles = @() }) `
+      -StageRoot $schema2Root
+  }
+  Assert-Throws -Name "schema2 missing lifecycle root" -MessagePattern "lifecycle root is missing" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest $schema2Manifest `
+      -StageRoot (Join-Path $fixtureRoot "missing-stage-root")
+  }
+
+  Write-FixtureFile -Root $schema2Root -RelativePath "payload/archive.zip" -Content "archive-tampered" | Out-Null
+  Assert-Throws -Name "schema2 byte mismatch" -MessagePattern "failed verification" -Action {
+    Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+  }
+  Write-FixtureFile -Root $schema2Root -RelativePath "payload/archive.zip" -Content "Archive" | Out-Null
+  Assert-Throws -Name "schema2 sha256 mismatch" -MessagePattern "failed verification" -Action {
+    Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+  }
+  Write-FixtureFile -Root $schema2Root -RelativePath "payload/archive.zip" -Content "archive" | Out-Null
+  Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+
+  $missingEntry = [pscustomobject]@{
+    path = "expanded/asr/missing.exe"
+    bytes = 1
+    sha256 = ("0" * 64)
+  }
+  Assert-Throws -Name "schema2 missing" -MessagePattern "staged file is missing" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest ([pscustomobject]@{ schemaVersion = 2; stagedFiles = @($schema2Entries + $missingEntry) }) `
+      -StageRoot $schema2Root
+  }
+
+  $extraPath = Write-FixtureFile -Root $schema2Root -RelativePath "expanded/asr/extra.dll" -Content "extra"
+  Assert-Throws -Name "schema2 extra" -MessagePattern "lifecycle contains an extra file" -Action {
+    Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+  }
+  [System.IO.File]::Delete($extraPath)
+
+  $caseDuplicate = [pscustomobject]@{
+    path = "Payload/ARCHIVE.zip"
+    bytes = [long]$schema2Entries[0].bytes
+    sha256 = [string]$schema2Entries[0].sha256
+  }
+  Assert-Throws -Name "schema2 case duplicate" -MessagePattern "duplicate canonical path" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest ([pscustomobject]@{ schemaVersion = 2; stagedFiles = @($schema2Entries + $caseDuplicate) }) `
+      -StageRoot $schema2Root
+  }
+
+  $composed = "expanded/caf$([char]0x00E9).txt"
+  $decomposed = "expanded/cafe$([char]0x0301).txt"
+  $unicodeDuplicateEntries = @(
+    [pscustomobject]@{ path = $composed; bytes = 1; sha256 = ("0" * 64) }
+    [pscustomobject]@{ path = $decomposed; bytes = 1; sha256 = ("0" * 64) }
+  )
+  Assert-Throws -Name "schema2 normalized duplicate" -MessagePattern "duplicate canonical path" -Action {
+    Assert-WindowsRuntimeStagedFilesExact `
+      -Manifest ([pscustomobject]@{ schemaVersion = 2; stagedFiles = $unicodeDuplicateEntries }) `
+      -StageRoot $schema2Root
+  }
+
+  foreach ($invalidPath in @(
+    "/absolute.txt",
+    "C:/absolute.txt",
+    "payload//archive.zip",
+    "payload/./archive.zip",
+    "payload/../archive.zip",
+    "payload\archive.zip"
+  )) {
+    Assert-Throws -Name "schema2 non-canonical path $invalidPath" -MessagePattern "canonical" -Action {
+      Assert-WindowsRuntimeStagedFilesExact `
+        -Manifest ([pscustomobject]@{
+          schemaVersion = 2
+          stagedFiles = @([pscustomobject]@{ path = $invalidPath; bytes = 1; sha256 = ("0" * 64) })
+        }) `
+        -StageRoot $schema2Root
+    }
+  }
+
+  [System.IO.Directory]::Delete((Join-Path $schema2Root "payload"), $true)
+  Assert-Throws -Name "schema2 after payload cleanup" -MessagePattern "staged file is missing" -Action {
+    Assert-WindowsRuntimeStagedFilesExact -Manifest $schema2Manifest -StageRoot $schema2Root
+  }
+} finally {
+  Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Windows runtime manifest lifecycle fixture: ok"

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1092,6 +1092,16 @@ fn parses_local_asr_numeric_only_output() {
         parse_local_asr_text("1\n00:00:03,000 --> 00:00:04,000\n", ""),
         None
     );
+    assert_eq!(
+        parse_local_asr_text("hello world\n", "4\n"),
+        Some("hello world".to_string()),
+        "a lone numeric stderr line must not shadow a plain stdout result"
+    );
+    assert_eq!(
+        parse_local_asr_text("", "4\n"),
+        Some("4".to_string()),
+        "numeric-only speech on a clean stderr stream remains valid"
+    );
     assert!(
         parse_local_asr_text("...\n", "[INFO] loading\n").is_none(),
         "punctuation and log output must not become a transcript"

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1057,6 +1057,45 @@ fn agentic_guide_mentions_collection_and_kb_search() {
 fn parses_local_asr_plain_text_output() {
     let text = parse_local_asr_text("hello from voice\n", "").expect("plain text");
     assert_eq!(text, "hello from voice");
+    assert_eq!(
+        parse_local_asr_text("[0-.5] Hello\n[.5-1] .\n[1-1.5] World\n", ""),
+        Some("Hello. World".to_string())
+    );
+}
+
+#[test]
+fn parses_local_asr_numeric_only_output() {
+    let text = parse_local_asr_text("123\n", "").expect("numeric transcript");
+    assert_eq!(text, "123");
+    assert_eq!(
+        parse_local_asr_text("123\n100%\n", "100/100%\n12:34:56\n"),
+        Some("123".to_string())
+    );
+    assert_eq!(parse_local_asr_text("100%\n", ""), None);
+    assert_eq!(
+        parse_local_asr_text("１２３\n", ""),
+        Some("１２３".to_string())
+    );
+    assert_eq!(
+        parse_local_asr_text(r#"{"text":"123"}"#, ""),
+        Some("123".to_string())
+    );
+    assert_eq!(parse_local_asr_text("", "100/100%\n100\n12:34:56\n"), None);
+    assert_eq!(
+        parse_local_asr_text(
+            "{\"timestamp\":0,\"text\":\"hello\"}\n{\"timestamp\":1,\"text\":\"world\"}\n",
+            ""
+        ),
+        Some("hello world".to_string())
+    );
+    assert_eq!(
+        parse_local_asr_text("1\n00:00:03,000 --> 00:00:04,000\n", ""),
+        None
+    );
+    assert!(
+        parse_local_asr_text("...\n", "[INFO] loading\n").is_none(),
+        "punctuation and log output must not become a transcript"
+    );
 }
 
 #[test]

--- a/pinvou3-app/src-tauri/src/app/commands/voice.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/voice.rs
@@ -122,62 +122,7 @@ fn compact_process_output(stdout: &str, stderr: &str) -> String {
 }
 
 pub(super) fn parse_local_asr_text(stdout: &str, stderr: &str) -> Option<String> {
-    let combined = format!("{stdout}\n{stderr}");
-    let result_prefixes = [
-        "result:",
-        "asr result:",
-        "recognition result:",
-        "text:",
-        "output:",
-    ];
-
-    for line in combined.lines().rev() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let lower = line.to_ascii_lowercase();
-        for prefix in result_prefixes {
-            if lower.starts_with(prefix) {
-                let text = line[prefix.len()..].trim();
-                if !text.is_empty() {
-                    return Some(text.to_string());
-                }
-            }
-        }
-        if (line.starts_with("['") && line.ends_with("']"))
-            || (line.starts_with("[\"") && line.ends_with("\"]"))
-        {
-            let text = line
-                .trim_start_matches('[')
-                .trim_end_matches(']')
-                .trim_matches('\'')
-                .trim_matches('"')
-                .trim();
-            if !text.is_empty() {
-                return Some(text.to_string());
-            }
-        }
-        if lower.contains("error")
-            || lower.contains("warning")
-            || lower.contains("paddlespeech")
-            || lower.contains("sensevoice")
-            || lower.contains("funasr")
-            || lower.contains("gguf")
-            || lower.contains("python")
-            || lower.contains("download")
-            || lower.starts_with('[')
-        {
-            continue;
-        }
-        if line
-            .chars()
-            .any(|ch| ch.is_alphabetic() || ('\u{4e00}'..='\u{9fff}').contains(&ch))
-        {
-            return Some(line.to_string());
-        }
-    }
-    None
+    crate::features::voice::parse_asr_transcript(stdout, stderr)
 }
 
 fn run_local_asr_cli(wav_path: &std::path::Path) -> Result<LocalAsrOutput, VoiceCommandError> {

--- a/pinvou3-app/src-tauri/src/features/voice/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/mod.rs
@@ -1,9 +1,11 @@
 pub(crate) mod microphone_permission;
 mod platform;
+mod transcript;
 pub(crate) mod voice_asr;
 
 pub(crate) use platform::{
     asr_dependency_packages, asr_missing_message, asr_tool_exists, asr_tool_path,
     engine_binary_name, native_recognition_source, recognize_native,
 };
+pub(crate) use transcript::parse_asr_transcript;
 pub(crate) use voice_asr::set_bundled_engine_dir;

--- a/pinvou3-app/src-tauri/src/features/voice/transcript.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/transcript.rs
@@ -10,8 +10,12 @@ pub(crate) fn parse_asr_transcript(stdout: &str, stderr: &str) -> Option<String>
         // command variables may emit their final plain-text result on stderr.
         // The bundled runtime uses an explicit/timed stdout protocol, so keep
         // those higher-confidence forms ahead of this compatibility fallback.
-        .or_else(|| parse_plain_fallback(stderr, true))
-        .or_else(|| parse_plain_fallback(stdout, false))
+        // A lone number on stderr is weaker evidence than a plain stdout line
+        // (counters and exit codes land there too), so it is only trusted
+        // after stdout had the chance to provide a plain result.
+        .or_else(|| parse_plain_fallback(stderr, true, Some(false)))
+        .or_else(|| parse_plain_fallback(stdout, false, None))
+        .or_else(|| parse_plain_fallback(stderr, true, Some(true)))
 }
 
 fn parse_explicit_asr_result(stream: &str) -> Option<String> {
@@ -68,7 +72,14 @@ fn parse_timed_fallback(stream: &str) -> Option<String> {
     None
 }
 
-fn parse_plain_fallback(stream: &str, reject_numeric_progress: bool) -> Option<String> {
+/// `numeric_candidate` steers bare-number results: `None` keeps every
+/// candidate, `Some(true)` keeps only numbers, `Some(false)` defers numbers
+/// to a later stdout fallback instead of returning them from this pass.
+fn parse_plain_fallback(
+    stream: &str,
+    reject_numeric_progress: bool,
+    numeric_candidate: Option<bool>,
+) -> Option<String> {
     let lines = stream
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -79,9 +90,23 @@ fn parse_plain_fallback(stream: &str, reject_numeric_progress: bool) -> Option<S
     let has_subtitle_timing = lines.iter().any(|line| looks_like_subtitle_timing(line));
     for line in lines.iter().rev().copied() {
         if let Some(text) = parse_plain_transcript_line(line) {
-            if (has_subtitle_timing || (reject_numeric_progress && has_progress_context))
-                && looks_like_number(&text)
-            {
+            let numeric = looks_like_number(&text);
+            let progress_shaped =
+                has_subtitle_timing || (reject_numeric_progress && has_progress_context);
+            if numeric && numeric_candidate == Some(false) {
+                if progress_shaped {
+                    // Classified as progress output, not a deferred result.
+                    continue;
+                }
+                // Defer to the stdout fallback instead of masking it with a
+                // bare number; the numeric-only retry restores it when stdout
+                // has no plain result to offer.
+                return None;
+            }
+            if numeric_candidate == Some(true) && !numeric {
+                continue;
+            }
+            if progress_shaped && numeric {
                 continue;
             }
             return Some(text);
@@ -464,6 +489,16 @@ mod tests {
             parse_asr_transcript("final spoken sentence here\n", "Using 4 threads\n"),
             Some("final spoken sentence here".to_string()),
             "stderr diagnostics must not mask a usable stdout fallback"
+        );
+        assert_eq!(
+            parse_asr_transcript("hello world\n", "4\n"),
+            Some("hello world".to_string()),
+            "a lone numeric stderr line must not shadow a plain stdout result"
+        );
+        assert_eq!(
+            parse_asr_transcript("", "4\n"),
+            Some("4".to_string()),
+            "numeric-only speech on a clean stderr stream remains valid"
         );
         assert_eq!(parse_asr_transcript("", "[0-.5] timed stderr text\n"), None);
     }

--- a/pinvou3-app/src-tauri/src/features/voice/transcript.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/transcript.rs
@@ -1,0 +1,661 @@
+fn has_usable_asr_text(text: &str) -> bool {
+    text.chars().any(|ch| ch.is_alphanumeric())
+}
+
+pub(crate) fn parse_asr_transcript(stdout: &str, stderr: &str) -> Option<String> {
+    parse_explicit_asr_result(stdout)
+        .or_else(|| parse_explicit_asr_result(stderr))
+        .or_else(|| parse_timed_fallback(stdout))
+        // Custom engines configured through PINVOU3_ASR_CMD and the legacy
+        // command variables may emit their final plain-text result on stderr.
+        // The bundled runtime uses an explicit/timed stdout protocol, so keep
+        // those higher-confidence forms ahead of this compatibility fallback.
+        .or_else(|| parse_plain_fallback(stderr, true))
+        .or_else(|| parse_plain_fallback(stdout, false))
+}
+
+fn parse_explicit_asr_result(stream: &str) -> Option<String> {
+    let mut later_fallback_result = false;
+    let mut later_json_segment = false;
+    let mut json_segments = Vec::new();
+    for line in stream
+        .lines()
+        .rev()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        if let Some(segment) = parse_timestamped_json_transcript_line(line) {
+            if !later_fallback_result {
+                json_segments.push(segment);
+                later_json_segment = true;
+            }
+            continue;
+        }
+        if let Some(result) = parse_protocol_line(line) {
+            // A later transcript-like line is the final result. Do not let an
+            // earlier JSON log object with a generic `text` field mask it.
+            if !later_fallback_result && !later_json_segment {
+                return Some(result);
+            }
+            continue;
+        }
+        if parse_plain_transcript_line(line).is_some()
+            || parse_timed_transcript_line(line)
+                .is_some_and(|segment| has_usable_asr_text(&segment.text))
+        {
+            later_fallback_result = true;
+        }
+    }
+    json_segments.reverse();
+    let transcript = join_transcript_segments(&json_segments);
+    has_usable_asr_text(&transcript).then_some(transcript)
+}
+
+fn parse_timed_fallback(stream: &str) -> Option<String> {
+    let lines = stream
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+
+    let timed_segments = lines
+        .iter()
+        .filter_map(|line| parse_timed_transcript_line(line))
+        .collect::<Vec<_>>();
+    let timed_segments = join_transcript_segments(&timed_segments);
+    if has_usable_asr_text(&timed_segments) {
+        return Some(timed_segments);
+    }
+    None
+}
+
+fn parse_plain_fallback(stream: &str, reject_numeric_progress: bool) -> Option<String> {
+    let lines = stream
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    let has_progress_context = lines
+        .iter()
+        .any(|line| looks_like_plain_status(&clean_asr_text(line)));
+    let has_subtitle_timing = lines.iter().any(|line| looks_like_subtitle_timing(line));
+    for line in lines.iter().rev().copied() {
+        if let Some(text) = parse_plain_transcript_line(line) {
+            if (has_subtitle_timing || (reject_numeric_progress && has_progress_context))
+                && looks_like_number(&text)
+            {
+                continue;
+            }
+            return Some(text);
+        }
+    }
+    None
+}
+
+fn parse_plain_transcript_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    let structured_json = serde_json::from_str::<serde_json::Value>(line)
+        .is_ok_and(|value| value.is_object() || value.is_array());
+    if line.is_empty() || protocol_payload(line).is_some() || structured_json {
+        return None;
+    }
+    let text = clean_asr_text(line);
+    (!text.is_empty()
+        && !looks_like_log_line(line)
+        && !looks_like_plain_status(&text)
+        && has_usable_asr_text(&text))
+    .then_some(text)
+}
+
+struct TranscriptSegment {
+    text: String,
+    has_leading_whitespace: bool,
+    has_trailing_whitespace: bool,
+}
+
+fn transcript_segment(raw_text: &str) -> Option<TranscriptSegment> {
+    let cleaned = strip_asr_control_markers(raw_text);
+    let text = cleaned.trim().to_string();
+    (!text.is_empty()).then(|| TranscriptSegment {
+        text,
+        has_leading_whitespace: cleaned.starts_with(char::is_whitespace),
+        has_trailing_whitespace: cleaned.ends_with(char::is_whitespace),
+    })
+}
+
+fn parse_timed_transcript_line(line: &str) -> Option<TranscriptSegment> {
+    let line = line.trim_start();
+    let rest = line.strip_prefix('[')?;
+    let end = rest.find(']')?;
+    let range = &rest[..end];
+    let (start, finish) = range.split_once("-->").or_else(|| range.split_once('-'))?;
+    if !looks_like_time_value(start.trim()) || !looks_like_time_value(finish.trim()) {
+        return None;
+    }
+    let raw_text = rest[end + 1..]
+        .strip_prefix(char::is_whitespace)
+        .unwrap_or(&rest[end + 1..]);
+    // A valid timestamp is the SenseVoice protocol credential. Values such as
+    // `12:30`, `50%`, or `3/4` are legitimate recognized speech inside a timed
+    // segment; progress filtering is only safe for unstructured loose output.
+    transcript_segment(raw_text)
+}
+
+fn join_transcript_segments(segments: &[TranscriptSegment]) -> String {
+    let mut transcript = String::new();
+    let mut previous_had_trailing_whitespace = false;
+    for segment in segments {
+        let needs_word_separator = needs_segment_separator(&transcript, &segment.text);
+        if !transcript.is_empty()
+            && (previous_had_trailing_whitespace
+                || segment.has_leading_whitespace
+                || needs_word_separator)
+        {
+            transcript.push(' ');
+        }
+        transcript.push_str(&segment.text);
+        previous_had_trailing_whitespace = segment.has_trailing_whitespace;
+    }
+    transcript
+}
+
+fn needs_segment_separator(transcript: &str, next_segment: &str) -> bool {
+    let Some(next) = next_segment.chars().next() else {
+        return false;
+    };
+    if !is_latin_word_char(next) {
+        return false;
+    }
+
+    let mut preceding = transcript.chars().rev();
+    let Some(mut previous) = preceding.next() else {
+        return false;
+    };
+    while matches!(previous, '"' | ')' | ']' | '}') {
+        let Some(before_closer) = preceding.next() else {
+            return false;
+        };
+        previous = before_closer;
+    }
+    if previous.is_numeric() && next.is_numeric() {
+        return false;
+    }
+    is_latin_word_char(previous) || matches!(previous, ',' | '.' | '!' | '?' | ':' | ';')
+}
+
+fn is_latin_word_char(ch: char) -> bool {
+    if ch.is_ascii_alphanumeric() {
+        return true;
+    }
+    ch.is_alphabetic()
+        && (('\u{00C0}'..='\u{024F}').contains(&ch)
+            || ('\u{1E00}'..='\u{1EFF}').contains(&ch)
+            || ('\u{2C60}'..='\u{2C7F}').contains(&ch)
+            || ('\u{A720}'..='\u{A7FF}').contains(&ch)
+            || ('\u{AB30}'..='\u{AB6F}').contains(&ch))
+}
+
+fn parse_protocol_line(line: &str) -> Option<String> {
+    if let Some(payload) = protocol_payload(line) {
+        return explicit_result_text(payload);
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(line) {
+        if let Some(object) = value.as_object() {
+            if ["level", "severity", "logger"]
+                .iter()
+                .any(|key| object.contains_key(*key))
+                || object
+                    .get("timestamp")
+                    .is_some_and(serde_json::Value::is_string)
+            {
+                return None;
+            }
+            for key in ["text", "result", "sentence", "transcript"] {
+                if let Some(text) = object.get(key).and_then(serde_json::Value::as_str) {
+                    if let Some(text) = explicit_result_text(text) {
+                        return Some(text);
+                    }
+                }
+            }
+            return None;
+        }
+    }
+
+    if (line.starts_with("['") && line.ends_with("']"))
+        || (line.starts_with("[\"") && line.ends_with("\"]"))
+    {
+        let text = line
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .trim_matches('\'')
+            .trim_matches('"')
+            .trim();
+        return explicit_result_text(text);
+    }
+    None
+}
+
+fn parse_timestamped_json_transcript_line(line: &str) -> Option<TranscriptSegment> {
+    let value = serde_json::from_str::<serde_json::Value>(line).ok()?;
+    let object = value.as_object()?;
+    if ["level", "severity", "logger"]
+        .iter()
+        .any(|key| object.contains_key(*key))
+        || !object
+            .get("timestamp")
+            .is_some_and(serde_json::Value::is_number)
+    {
+        return None;
+    }
+    ["text", "result", "sentence", "transcript"]
+        .iter()
+        .find_map(|key| object.get(*key).and_then(serde_json::Value::as_str))
+        .and_then(transcript_segment)
+}
+
+fn protocol_payload(line: &str) -> Option<&str> {
+    const RESULT_PREFIXES: [&str; 7] = [
+        "result:",
+        "asr result:",
+        "recognition result:",
+        "transcription:",
+        "transcript:",
+        "text:",
+        "output:",
+    ];
+
+    let lower = line.to_ascii_lowercase();
+    for prefix in RESULT_PREFIXES {
+        if lower.starts_with(prefix) {
+            return Some(line[prefix.len()..].trim());
+        }
+    }
+    None
+}
+
+fn explicit_result_text(text: &str) -> Option<String> {
+    let text = clean_asr_text(text);
+    (!text.is_empty() && has_usable_asr_text(&text)).then_some(text)
+}
+
+fn looks_like_log_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("error")
+        || lower.contains("warning")
+        || lower.contains("paddlespeech")
+        || lower.contains("sensevoice")
+        || lower.contains("funasr")
+        || lower.contains("gguf")
+        || lower.contains("python")
+        || lower.contains("download")
+        || lower == "done"
+        || lower.starts_with("done in ")
+        || (lower.starts_with("using ") && lower.contains("thread"))
+        || lower.starts_with('[')
+}
+
+fn looks_like_plain_status(line: &str) -> bool {
+    let trimmed = line.trim().trim_matches(['[', ']', '(', ')']);
+    let lower = trimmed.to_ascii_lowercase();
+    if [
+        "progress:",
+        "progress ",
+        "loading:",
+        "loading ",
+        "processed:",
+        "processed ",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+    {
+        return true;
+    }
+
+    if looks_like_subtitle_timing(trimmed) {
+        return true;
+    }
+
+    if let Some(value) = trimmed
+        .strip_suffix('%')
+        .or_else(|| trimmed.strip_suffix('％'))
+    {
+        if looks_like_number(value.trim()) {
+            return true;
+        }
+    }
+
+    for separator in ['/', '／'] {
+        if let Some((current, total)) = trimmed.split_once(separator) {
+            let total = total
+                .trim()
+                .strip_suffix('%')
+                .or_else(|| total.trim().strip_suffix('％'))
+                .unwrap_or(total.trim());
+            if looks_like_number(current.trim()) && looks_like_number(total) {
+                return true;
+            }
+        }
+    }
+    if let Some((current, total)) = lower.split_once(" of ") {
+        if looks_like_number(current.trim()) && looks_like_number(total.trim()) {
+            return true;
+        }
+    }
+
+    looks_like_clock_value(trimmed)
+}
+
+fn looks_like_subtitle_timing(line: &str) -> bool {
+    line.split_once("-->").is_some_and(|(start, finish)| {
+        looks_like_clock_value(start.trim()) && looks_like_clock_value(finish.trim())
+    })
+}
+
+fn looks_like_number(value: &str) -> bool {
+    let mut saw_digit = false;
+    for ch in value.chars() {
+        if ch.is_numeric() {
+            saw_digit = true;
+        } else if !matches!(ch, '.' | '．' | ',') {
+            return false;
+        }
+    }
+    saw_digit
+}
+
+fn looks_like_clock_value(value: &str) -> bool {
+    let parts = value.split([':', '：']).collect::<Vec<_>>();
+    (parts.len() == 2 || parts.len() == 3)
+        && parts
+            .iter()
+            .all(|part| !part.trim().is_empty() && looks_like_number(part.trim()))
+}
+
+fn looks_like_time_value(value: &str) -> bool {
+    looks_like_number(value) || looks_like_clock_value(value)
+}
+
+fn clean_asr_text(text: &str) -> String {
+    strip_asr_control_markers(text).trim().to_string()
+}
+
+fn strip_asr_control_markers(text: &str) -> String {
+    let mut out = String::new();
+    let mut rest = text;
+    loop {
+        let Some(start) = rest.find("<|") else {
+            out.push_str(rest);
+            break;
+        };
+        out.push_str(&rest[..start]);
+        let after_start = &rest[start + 2..];
+        let Some(end) = after_start.find("|>") else {
+            // A truncated control marker is metadata, not recognized speech.
+            // Discard the unterminated marker and its tail instead of leaking
+            // `<|...` into the user transcript.
+            break;
+        };
+        rest = &after_start[end + 2..];
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_numeric_only_transcripts_without_accepting_punctuation_noise() {
+        assert!(has_usable_asr_text("123"));
+        assert!(has_usable_asr_text("１２３"));
+        assert!(has_usable_asr_text("你好"));
+        assert!(!has_usable_asr_text("...，。!?"));
+        assert!(!has_usable_asr_text(" \t\r\n"));
+    }
+
+    #[test]
+    fn stdout_plain_text_wins_over_stderr_progress_noise() {
+        assert_eq!(
+            parse_asr_transcript("123\n100%\n", "100/100%\n12:34:56\n"),
+            Some("123".to_string())
+        );
+        assert_eq!(parse_asr_transcript("100%\n", ""), None);
+    }
+
+    #[test]
+    fn stderr_explicit_result_wins_over_stdout_fallback_text() {
+        assert_eq!(
+            parse_asr_transcript("Done\n", "result: 123\n"),
+            Some("123".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("Using 4 threads\n", r#"{"text":"final transcript"}"#),
+            Some("final transcript".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] preliminary transcript\n", r#"{"result":"final"}"#),
+            Some("final".to_string()),
+            "stdout timestamp fallback must not mask an explicit stderr result"
+        );
+    }
+
+    #[test]
+    fn stderr_plain_fallback_preserves_custom_engine_compatibility() {
+        assert_eq!(parse_asr_transcript("", "100/100%\n12:34:56\n"), None);
+        assert_eq!(
+            parse_asr_transcript("", "100\n"),
+            Some("100".to_string()),
+            "numeric-only speech remains valid for custom stderr engines"
+        );
+        assert_eq!(
+            parse_asr_transcript("", "100/100%\n100\n12:34:56\n"),
+            None,
+            "a bare number among progress-shaped stderr lines is progress output"
+        );
+        assert_eq!(
+            parse_asr_transcript("", "ordinary stderr text\n"),
+            Some("ordinary stderr text".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("noise banner text\n", "final spoken sentence here\n"),
+            Some("final spoken sentence here".to_string()),
+            "legacy custom engines may emit their final plain result on stderr"
+        );
+        assert_eq!(
+            parse_asr_transcript("final spoken sentence here\n", "Using 4 threads\n"),
+            Some("final spoken sentence here".to_string()),
+            "stderr diagnostics must not mask a usable stdout fallback"
+        );
+        assert_eq!(parse_asr_transcript("", "[0-.5] timed stderr text\n"), None);
+    }
+
+    #[test]
+    fn structured_logs_and_non_string_json_do_not_mask_the_final_result() {
+        assert_eq!(
+            parse_asr_transcript("{\"text\":\"loading vocab\"}\n你好世界\n", ""),
+            Some("你好世界".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript(
+                "{\"level\":\"info\",\"text\":\"done in 1.2s\"}\nfinal result\n",
+                ""
+            ),
+            Some("final result".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript(
+                "final stdout result\n",
+                "{\"level\":\"info\",\"text\":\"loading model\"}\n"
+            ),
+            Some("final stdout result".to_string()),
+            "a JSON log on stderr must not mask a plain stdout result"
+        );
+        assert_eq!(parse_asr_transcript("{\"text\":123}\n", ""), None);
+        assert_eq!(
+            parse_asr_transcript("{\"text\":123}\n", "result: fallback\n"),
+            Some("fallback".to_string())
+        );
+        assert_eq!(parse_asr_transcript("result: ...\n", ""), None);
+    }
+
+    #[test]
+    fn joins_numeric_timestamp_jsonl_segments_without_accepting_json_logs() {
+        assert_eq!(
+            parse_asr_transcript(
+                "{\"timestamp\":0,\"text\":\"hello\"}\n{\"timestamp\":1,\"text\":\"world\"}\n",
+                ""
+            ),
+            Some("hello world".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript(
+                "{\"timestamp\":0,\"level\":\"info\",\"text\":\"loading\"}\n",
+                ""
+            ),
+            None
+        );
+        assert_eq!(
+            parse_asr_transcript(
+                "{\"timestamp\":\"2026-08-25T00:00:00Z\",\"text\":\"loading\"}\n",
+                ""
+            ),
+            None
+        );
+        assert_eq!(
+            parse_asr_transcript("{\"timestamp\":null,\"text\":\"final result\"}\n", ""),
+            Some("final result".to_string()),
+            "only string timestamps are diagnostic metadata by themselves"
+        );
+    }
+
+    #[test]
+    fn subtitle_timing_and_plain_progress_phrases_are_not_transcripts() {
+        assert_eq!(
+            parse_asr_transcript("1\n00:00:03,000 --> 00:00:04,000\n", ""),
+            None
+        );
+        assert_eq!(parse_asr_transcript("3 of 4\n", ""), None);
+    }
+
+    #[test]
+    fn accepts_unicode_digits_and_structured_numeric_strings() {
+        assert_eq!(
+            parse_asr_transcript("１２３\n", ""),
+            Some("１２３".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript(r#"{"text":"123"}"#, ""),
+            Some("123".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("", "result: 123\n"),
+            Some("123".to_string()),
+            "stderr explicit protocol results remain highest-confidence output"
+        );
+        assert_eq!(
+            parse_asr_transcript("result: 50%\n", ""),
+            Some("50%".to_string()),
+            "an explicit protocol credential makes percentage speech unambiguous"
+        );
+        assert_eq!(
+            parse_asr_transcript("[0.00-0.50] <|zh|><|NEUTRAL|>１２\n[0.50-1.00] ３\n", ""),
+            Some("１２３".to_string()),
+            "SenseVoice timestamped segments are its explicit backend protocol"
+        );
+    }
+
+    #[test]
+    fn joins_timed_segments_without_corrupting_word_boundaries() {
+        assert_eq!(
+            parse_asr_transcript("[0-.5] hello there\n[.5-1] wide world\n", ""),
+            Some("hello there wide world".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 你好\n[.5-1] ，\n[1-1.5] 世界\n[1.5-2] ！\n", ""),
+            Some("你好，世界！".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 你好 \n[.5-1] 世界\n", ""),
+            Some("你好 世界".to_string()),
+            "explicit backend whitespace is retained at a CJK segment boundary"
+        );
+        assert_eq!(
+            parse_asr_transcript(
+                "[0-.5] 中文\n[.5-1] Rust\n[1-1.5] 123\n[1.5-2] ，\n[2-2.5] 版本\n",
+                ""
+            ),
+            Some("中文Rust 123，版本".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] １２\n[.5-1] ３\n", ""),
+            Some("１２３".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 12\n[.5-1] 34\n", ""),
+            Some("1234".to_string()),
+            "ASCII and full-width digits use the same segment-boundary rule"
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 现在是\n[.5-1] 12:30\n", ""),
+            Some("现在是12:30".to_string()),
+            "clock text inside the timed protocol is recognized speech, not progress"
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 完成度\n[.5-1] 50%\n", ""),
+            Some("完成度50%".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] hello,\n[.5-1] world\n", ""),
+            Some("hello, world".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] Hello\n[.5-1] .\n[1-1.5] World\n", ""),
+            Some("Hello. World".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] (Hello\n[.5-1] )\n[1-1.5] World\n", ""),
+            Some("(Hello) World".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] \"Hello\n[.5-1] .\n[1-1.5] \"\n[1.5-2] World\n", ""),
+            Some("\"Hello.\" World".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] can\n[.5-1] 't\n", ""),
+            Some("can't".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] state-\n[.5-1] of-the-art\n", ""),
+            Some("state-of-the-art".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 你好\n[.5-1] 。\n[1-1.5] 世界\n", ""),
+            Some("你好。世界".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] 你好，\n[.5-1] world\n", ""),
+            Some("你好，world".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] ,\n[.5-1] !\n", ""),
+            None,
+            "a timestamp protocol does not make punctuation-only output usable"
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] timed result\nplain footer\n", ""),
+            Some("timed result".to_string()),
+            "a mixed stream keeps the higher-confidence timed protocol"
+        );
+    }
+
+    #[test]
+    fn control_markers_never_leak_into_transcripts() {
+        assert_eq!(
+            parse_asr_transcript("<|zh|><|NEUTRAL|>你好 <|en\n", ""),
+            Some("你好".to_string())
+        );
+        assert_eq!(
+            parse_asr_transcript("[0-.5] <|zh|><|NEUTRAL|>你好 <|en\n", ""),
+            Some("你好".to_string())
+        );
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/voice_asr.rs
@@ -414,43 +414,9 @@ pub fn transcribe(wav: &Path) -> Result<String, String> {
     Ok(text)
 }
 
-/// 剥 `[start-end]` 时间戳前缀，拼接多段，再去掉 `<|zh|><|NEUTRAL|>` 等控制标记。
+/// Parse engine output through the shared voice transcript protocol handler.
 fn clean_engine_output(stdout: &str) -> String {
-    let mut parts = Vec::new();
-    for line in stdout.lines() {
-        let line = line.trim();
-        // 形如 "[1.22-1.86] 文字"
-        if let Some(rest) = line.strip_prefix('[') {
-            if let Some(idx) = rest.find(']') {
-                let text = rest[idx + 1..].trim();
-                if !text.is_empty() {
-                    parts.push(text.to_string());
-                }
-            }
-        }
-    }
-    strip_control_markers(&parts.join(""))
-}
-
-/// 去掉所有 `<|...|>` 控制标记（SenseVoice 偶发泄漏的语言/情感/事件标记）。
-fn strip_control_markers(s: &str) -> String {
-    let mut out = String::new();
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '<' && chars.peek() == Some(&'|') {
-            chars.next(); // 吃掉 '|'
-                          // 跳到 "|>"
-            while let Some(n) = chars.next() {
-                if n == '|' && chars.peek() == Some(&'>') {
-                    chars.next();
-                    break;
-                }
-            }
-        } else {
-            out.push(c);
-        }
-    }
-    out.trim().to_string()
+    super::parse_asr_transcript(stdout, "").unwrap_or_default()
 }
 
 /// 前端查询本地语音识别各组件就绪状态。

--- a/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
+++ b/pinvou3-app/tests/windows_runtime_packaging_contract.test.js
@@ -44,6 +44,14 @@ const runtimeScript = readApp(
   "scripts",
   "resolve-runtime.ps1",
 );
+const runtimeManifestContract = readApp(
+  "src-tauri",
+  "packaging",
+  "windows",
+  "runtime",
+  "scripts",
+  "runtime-manifest-contract.ps1",
+);
 const onnxRuntimeScript = readApp(
   "src-tauri",
   "packaging",
@@ -115,6 +123,7 @@ for (const contract of [
   "manifest SHA-256",
   "Test-LfsPointer",
   "Test-ManagedArchiveExpansion",
+  "Assert-WindowsRuntimeStagedFilesExact",
   "System.IO.Compression.ZipFile",
   "Write-Utf8WithoutBom",
   "Test-StageInventory",
@@ -126,6 +135,27 @@ for (const contract of [
   assert.ok(runtimeScript.includes(contract), `runtime staging must retain ${contract}`);
 }
 assert.match(runtimeScript, /Get-Sha256 -Path \$sourcePath/u);
+assert.match(runtimeScript, /schemaVersion -notin @\(1, 2\)/u);
+assert.match(runtimeManifestContract, /Manifest\.stagedFiles/u);
+assert.match(runtimeScript, /runtime-manifest-contract\.ps1/u);
+assert.match(runtimeScript, /Assert-WindowsRuntimeStagedFilesDeclared -Manifest \$manifest/u);
+assert.match(runtimeManifestContract, /Get-CanonicalWindowsRuntimeManifestPath/u);
+assert.match(runtimeManifestContract, /\$null -eq \$Manifest\.stagedFiles/u);
+assert.match(runtimeManifestContract, /Dictionary\[string, object\]/u);
+assert.match(runtimeManifestContract, /Windows runtime lifecycle contains an extra file/u);
+assert.match(runtimeManifestContract, /Windows runtime staged file failed verification/u);
+const stagedFilesCheck = runtimeScript.indexOf("Assert-WindowsRuntimeStagedFilesExact");
+const derivedVcStage = runtimeScript.indexOf("Preparing descriptor-owned VC++ runtime component");
+const payloadCleanup = runtimeScript.indexOf("Remove-Item -LiteralPath $stageContext.PayloadRoot");
+const verifiedStageWrite = runtimeScript.indexOf(
+  'Write-Utf8WithoutBom -Path (Join-Path $stageContext.TemporaryRoot ".verified-stage.json")',
+);
+assert.ok(stagedFilesCheck >= 0 && stagedFilesCheck < derivedVcStage);
+assert.ok(stagedFilesCheck < payloadCleanup);
+assert.ok(
+  verifiedStageWrite >= 0 && stagedFilesCheck < verifiedStageWrite,
+  "runtime verification must finish before the verified-stage marker is written",
+);
 assert.match(runtimeScript, /vcRedist\.minimumVersion/u);
 assert.match(runtimeScript, /System\.Diagnostics\.FileVersionInfo/u);
 assert.match(runtimeScript, /\$vcActualVersion -lt \$vcMinimumVersion/u);


### PR DESCRIPTION
## Background

Numeric-only and Unicode-digit speech could be rejected as empty output. This PR fixes that failure and hardens ASR output parsing across multiple protocols, stdout/stderr compatibility, and segmented transcript assembly. The PR was originally stacked on #314; it is now based directly on `main`.

## Changes

- Improve ASR result parsing:
  - Accept ASCII and Unicode digits and other usable alphanumeric content while rejecting punctuation-only and invalid structured results.
  - Resolve output in this order: explicit stdout protocol, explicit stderr protocol, timed stdout, plain stderr (non-numeric), plain stdout, then numeric-only stderr.
  - Keep a lone numeric result from a clean custom-engine stderr stream, but reject it when the same stderr stream also contains progress-shaped output.
  - Join numeric-timestamp JSONL transcript segments while continuing to filter JSON log objects, including string-timestamp logs.
  - Reject bare SRT timing rows and plain progress phrases such as `3 of 4`.
  - Preserve valid speech such as `12:30`, `50%`, and `3/4` inside explicit or timed protocols.
  - Apply consistent segment-boundary behavior and prevent truncated control markers from leaking into transcripts.
  - Reuse the shared transcript parser from the Linux ASR path instead of maintaining a divergent parser.
- Tighten the Windows runtime schema 2 contract:
  - Reject missing, null, or empty `stagedFiles`.
  - Compare canonical manifest paths bidirectionally with staged files and reject extra or missing files and byte/hash mismatches.
  - Require validation to finish before writing `.verified-stage.json`; schema 1 remains compatible.
- Update the runtime gitlink and x86_64 lock/manifest SHA, and extend CI, PowerShell fixture, and Node packaging contract coverage.
- Publish the referenced runtime revision through [Pinvou/pinvou3-windows-runtime#1](https://github.com/Pinvou/pinvou3-windows-runtime/pull/1), so it is reachable from that repository's `main` ref.
- Reorganize the branch into two focused, DCO-signed voice/runtime commits with policy-compliant subjects.
- Review round 3: defer numeric-only stderr fallback candidates to the plain stdout fallback before restoring them (with regression tests), and restore the Chinese runtime README validation paragraph with exact stagedFiles snapshot timing.

## Validation

- Standalone transcript Rust tests: 10/10 passed.
- PowerShell manifest lifecycle fixture: passed.
- Windows runtime packaging Node contract: passed.
- `python scripts/architecture-guard.py`: passed.
- Focused `rustfmt --check`: passed.
- Commit-message range validation: passed.
- `git diff --check`: passed.
- The rewritten tree was verified byte-for-byte equivalent to the prior reviewed head plus the review fixes.
- A full crate `cargo test` attempt reached the 10-minute local limit while compiling dependencies; it is not claimed as passed locally. The standalone test binary compiles the production parser source directly with its real `serde_json` dependency.

## Risks

- Loose plain-text fallback still uses heuristics: standalone clock, percentage, fraction, and progress phrases without a protocol credential are rejected as status noise, while the same content is preserved by explicit and timed protocols.
- To support arbitrary custom ASR commands, an unknown ordinary stderr line can still be accepted ahead of a real plain stdout result. Explicit and timed protocol results always take precedence.
- Strict schema 2 validation now fails on manifest omissions, extra staged files, or content mismatches that previously went undetected. Schema 1 behavior is unchanged.
