### PR TITLE
fix(ui): 阻止 macOS 触摸板滚动把整个界面拖出空白

### DIFF
--- a/pinvou3-app/src/styles/base.css
+++ b/pinvou3-app/src/styles/base.css
@@ -10,14 +10,23 @@
     input[type="password"]::-ms-clear {
       display: none;
     }
-    /* 移动 Web 的应用自身负责滚动。禁止 iOS Safari 聚焦输入框时再平移整份文档。 */
+    /* 应用自身负责滚动：各视图自带滚动容器，文档本身不可滚动。
+       macOS 触摸板滑动到滚动边界继续划时会产生 rubber-band，把整个
+       WebView 内容（除原生红绿灯）拖出空白；overscroll-behavior 阻断
+       滚动链传播到 document。桌面与 Web 通用，移动紧凑视口在此基础上
+       额外钉死宽高并固定 body（见下方 compact-web-viewport 规则）。 */
+    html,
+    html body,
+    html #root {
+      overflow: hidden;
+      overscroll-behavior: none;
+    }
+    /* 移动 Web 的紧凑视口：宽度/高度钉死视口，禁止 iOS Safari 聚焦输入框时再平移整份文档。 */
     html.compact-web-viewport,
     html.compact-web-viewport body,
     html.compact-web-viewport #root {
       width: 100%;
       height: 100%;
-      overflow: hidden;
-      overscroll-behavior: none;
     }
     html.compact-web-viewport body {
       position: fixed;


### PR DESCRIPTION
## 背景

macOS 下品悟主界面（除左上角原生红绿灯）可响应上下滑动手势，滑动时整个 WebView 内容上下移动并露出空白。根因：`html/body/#root` 的文档级滚动锁定（`overflow: hidden; overscroll-behavior: none`）此前只挂在 `html.compact-web-viewport`（移动 Web 紧凑视口）下，桌面端没有任何锁定。触摸板滑动到滚动边界继续划时，滚动链传播到 document 产生 rubber-band，整个界面被拖动。

## 变更

`pinvou3-app/src/styles/base.css`：
- 将 `overflow: hidden; overscroll-behavior: none` 提升为全局规则（`html` / `body` / `#root`），阻断滚动链传播到 document；
- 移动紧凑视口规则保留其宽高钉死与 body 固定，行为与原来一致。

各视图（Chat/Settings/Knowledge/Workflow/Personas 等）均为自带 `overflow-y-auto` 滚动容器；桌宠（`html.pet-window` 已有 `overflow: hidden !important`）、阅读器、撕离窗口内部均自管滚动，不受文档级锁定影响。

## 验证

- CSS 括号平衡检查通过；
- `npm run build:ui`（vite build）构建成功，无报错；
- macOS 触摸板滚动效果需真机确认（本环境无法复现手势）。

## 已知风险

无。改动仅 1 个 CSS 文件（+12/-3）。