### PR TITLE
fix(monitor): Windows GPU 卡片误显示 CPU 型号

### DIFF
--- a/pinvou3-app/src-tauri/src/features/monitor/platform/windows_gpu.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/platform/windows_gpu.rs
@@ -7,7 +7,12 @@ use super::super::GpuSnapshot;
 pub fn gpu_snapshot() -> Option<GpuSnapshot> {
     let script = r#"
 $cpuName = (Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty Name)
-$gpuName = (Get-CimInstance Win32_VideoController | Where-Object { $_.Name -notmatch 'Microsoft Basic Display|Remote Display|Virtual|VMware|VirtualBox|QXL|Indirect' } | Select-Object -First 1 -ExpandProperty Name)
+# 优先选真实 PCI 物理适配器（PNPDeviceID 以 PCI\ 开头）——IDD 虚拟/远程显示驱动
+# （OrayIddDriver、GameViewer 等）是 ROOT\ 枚举，名称黑名单覆盖不全，只能靠 PNPDeviceID 区分；
+# 若无 PCI 显卡（纯 headless / 虚拟机），回退到名称黑名单过滤。
+$gpu = Get-CimInstance Win32_VideoController | Where-Object { $_.PNPDeviceID -like 'PCI\*' -and $_.Name -notmatch 'Microsoft Basic Display|Remote Display|Virtual|VMware|VirtualBox|QXL|Indirect' } | Select-Object -First 1
+if (-not $gpu) { $gpu = Get-CimInstance Win32_VideoController | Where-Object { $_.Name -notmatch 'Microsoft Basic Display|Remote Display|Virtual|VMware|VirtualBox|QXL|Indirect' } | Select-Object -First 1 }
+$gpuName = if ($gpu) { $gpu.Name } else { $null }
 $cpu = $null
 try { $cpu = (Get-Counter '\Processor Information(_Total)\% Processor Utility').CounterSamples[0].CookedValue } catch {}
 $gpu = $null
@@ -48,17 +53,15 @@ try {
 /// 解析 PowerShell 输出的 JSON 并构造 GPU 快照。
 /// 独立成纯函数便于在任何平台做单元测试（PowerShell 脚本本身只能在 Windows 跑）。
 fn parse_gpu_json(value: &Value) -> Option<GpuSnapshot> {
-    let cpu_name = value
-        .get("cpuName")
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim();
     let gpu_name = value
         .get("gpuName")
         .and_then(Value::as_str)
         .unwrap_or("")
         .trim();
-    if cpu_name.is_empty() && gpu_name.is_empty() {
+    // 没有真实 GPU（探测不到任何显示适配器）时返回 None，交给前端已有的
+    // `snap.cpu` fallback（"本机处理器"卡片）接管；不能用 CPU 名构造 GPU 快照，
+    // 否则前端因 `snap.gpu` 非空而置 gpuAvailable=true，仍把 CPU 显示在 GPU 卡片上。
+    if gpu_name.is_empty() {
         return None;
     }
     let cpu_pct = value
@@ -80,12 +83,9 @@ fn parse_gpu_json(value: &Value) -> Option<GpuSnapshot> {
         .map(|number| number.round().clamp(0.0, 120.0) as u32);
 
     Some(GpuSnapshot {
-        // GPU 名称优先；仅当探测不到任何真实 GPU（如纯 headless/无显示适配器）时才退回 CPU 名。
-        name: if gpu_name.is_empty() {
-            cpu_name.to_string()
-        } else {
-            gpu_name.to_string()
-        },
+        // GPU 名称必须来自真实显示适配器；探测不到时外层已返回 None，
+        // 不再退回 CPU 名（避免前端把 CPU 当 GPU 渲染）。
+        name: gpu_name.to_string(),
         vram_used_mib: 0,
         vram_total_mib: 0,
         utilization_pct: gpu_pct,
@@ -128,10 +128,10 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_cpu_name_when_no_gpu_found() {
-        let snapshot = parse_gpu_json(&sample("AMD Ryzen 9 7950X", ""))
-            .expect("snapshot should parse with cpu fallback");
-        assert_eq!(snapshot.name, "AMD Ryzen 9 7950X");
+    fn returns_none_when_no_gpu_name() {
+        // 没有真实 GPU 时绝不能退回 CPU 名：前端因 snap.gpu 非空置 gpuAvailable=true，
+        // 会把 CPU 型号继续显示在 GPU 卡片上。应返回 None，让已有 snap.cpu fallback 接管。
+        assert!(parse_gpu_json(&sample("AMD Ryzen 9 7950X", "")).is_none());
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/monitor/platform/windows_gpu.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/platform/windows_gpu.rs
@@ -7,7 +7,7 @@ use super::super::GpuSnapshot;
 pub fn gpu_snapshot() -> Option<GpuSnapshot> {
     let script = r#"
 $cpuName = (Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty Name)
-$gpuName = (Get-CimInstance Win32_VideoController | Where-Object { $_.Name -match 'Intel|Arc|Graphics|GPU' } | Select-Object -First 1 -ExpandProperty Name)
+$gpuName = (Get-CimInstance Win32_VideoController | Where-Object { $_.Name -notmatch 'Microsoft Basic Display|Remote Display|Virtual|VMware|VirtualBox|QXL|Indirect' } | Select-Object -First 1 -ExpandProperty Name)
 $cpu = $null
 try { $cpu = (Get-Counter '\Processor Information(_Total)\% Processor Utility').CounterSamples[0].CookedValue } catch {}
 $gpu = $null
@@ -42,6 +42,12 @@ try {
         return None;
     }
     let value: Value = serde_json::from_slice(&output.stdout).ok()?;
+    parse_gpu_json(&value)
+}
+
+/// 解析 PowerShell 输出的 JSON 并构造 GPU 快照。
+/// 独立成纯函数便于在任何平台做单元测试（PowerShell 脚本本身只能在 Windows 跑）。
+fn parse_gpu_json(value: &Value) -> Option<GpuSnapshot> {
     let cpu_name = value
         .get("cpuName")
         .and_then(Value::as_str)
@@ -74,10 +80,11 @@ try {
         .map(|number| number.round().clamp(0.0, 120.0) as u32);
 
     Some(GpuSnapshot {
-        name: if cpu_name.is_empty() {
-            gpu_name.to_string()
-        } else {
+        // GPU 名称优先；仅当探测不到任何真实 GPU（如纯 headless/无显示适配器）时才退回 CPU 名。
+        name: if gpu_name.is_empty() {
             cpu_name.to_string()
+        } else {
+            gpu_name.to_string()
         },
         vram_used_mib: 0,
         vram_total_mib: 0,
@@ -87,4 +94,55 @@ try {
         temperature_c,
         power_w: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample(cpu: &str, gpu: &str) -> Value {
+        json!({
+            "cpuName": cpu,
+            "gpuName": gpu,
+            "cpuPct": 12.0,
+            "gpuPct": 34.0,
+            "sharedBytes": 123456789.0,
+            "tempC": 45.0,
+        })
+    }
+
+    #[test]
+    fn gpu_name_takes_priority_over_cpu_name() {
+        // 回归测试：GPU 卡片必须显示 GPU 型号，而不是 CPU 型号。
+        let snapshot = parse_gpu_json(&sample(
+            "Intel(R) Core(TM) i7-12700K",
+            "NVIDIA GeForce RTX 4070",
+        ))
+        .expect("snapshot should parse");
+        assert_eq!(snapshot.name, "NVIDIA GeForce RTX 4070");
+        assert_eq!(snapshot.utilization_pct, 34);
+        assert_eq!(snapshot.processor_utilization_pct, Some(12));
+        assert_eq!(snapshot.shared_memory_used_mib, Some(118)); // 123456789 B / 1024^2 ≈ 117.7 → round = 118
+        assert_eq!(snapshot.temperature_c, Some(45));
+    }
+
+    #[test]
+    fn falls_back_to_cpu_name_when_no_gpu_found() {
+        let snapshot = parse_gpu_json(&sample("AMD Ryzen 9 7950X", ""))
+            .expect("snapshot should parse with cpu fallback");
+        assert_eq!(snapshot.name, "AMD Ryzen 9 7950X");
+    }
+
+    #[test]
+    fn uses_gpu_name_when_cpu_name_missing() {
+        let snapshot = parse_gpu_json(&sample("", "Intel(R) UHD Graphics 770"))
+            .expect("snapshot should parse with gpu name");
+        assert_eq!(snapshot.name, "Intel(R) UHD Graphics 770");
+    }
+
+    #[test]
+    fn returns_none_when_both_names_missing() {
+        assert!(parse_gpu_json(&sample("", "")).is_none());
+    }
 }


### PR DESCRIPTION
## 背景

Windows 平台监控页「图形处理器 (GPU)」卡片显示的是 CPU 型号（如 "Intel(R) Core(TM) i7-12700K"），用户反馈确认属实。

## 根因

`pinvou3-app/src-tauri/src/features/monitor/platform/windows_gpu.rs` 中 `GpuSnapshot.name` 的优先级**写反了**：只要 PowerShell 取到 CPU 名（`Win32_Processor` 几乎必返），GPU 快照名称字段就是 CPU 型号，前端直接将该字段渲染为 GPU 卡片设备名。

附带问题：GPU 名过滤 `Where-Object { $_.Name -match 'Intel|Arc|Graphics|GPU' }` 会排除 NVIDIA / AMD 独显（名称不含这些关键词），仅 Intel 核显能通过。

## 变更

- **名称来源改为真实显示适配器**：GPU 名优先来自 `Win32_VideoController` 探测结果；探测不到任何真实 GPU 时 `parse_gpu_json` 返回 `None`，不再用 CPU 名构造 `GpuSnapshot`（否则前端因 `snap.gpu` 非空而置 `gpuAvailable=true`，仍把 CPU 显示在 GPU 卡片上），交由已有 `snap.cpu` fallback（"本机处理器"卡片）接管；
- **物理 GPU 优先识别**：先按 `PNPDeviceID -like 'PCI\*'` 选真实 PCI 物理适配器——第三方 IDD 虚拟/远程显示驱动（OrayIddDriver、GameViewer 等）是 `ROOT\` 枚举，名称黑名单覆盖不全，只能靠 PNPDeviceID 区分；无 PCI 显卡（纯 headless / 虚拟机）时回退名称黑名单过滤（排除 `Microsoft Basic Display`、`Remote`、`VMware`、`VirtualBox`、`QXL`、`Indirect`），NVIDIA / AMD / Intel 真卡均可被选中；
- 抽出纯函数 `parse_gpu_json` 并补充 4 个单元测试（GPU 优先、无 GPU 返回 None、GPU-only、双空返回 None），锁定行为防止回归。

## 验证

- 单元测试 4/4 通过（在 macOS 上用临时工程直接编译真实 `windows_gpu.rs` 并运行测试，stub 掉 Windows 专属进程调用）；
- `python3 scripts/architecture-guard.py` 通过；
- Windows 交叉编译（`cargo check --target x86_64-pc-windows-msvc`）因本机缺 Windows SDK C 头文件（`ring` 编译失败）无法完成，与本次改动无关。

## 评审与复核

- 协作者 zhuowp 实机复核：物理 GPU 按 `PNPDeviceID=PCI\*` 优先选择，在 CIM 顺序 `OrayIddDriver → Intel UHD 630 → GameViewer` 的 Windows 真机上正确选中 `Intel(R) UHD Graphics 630`；`gpuName` 为空时 `parse_gpu_json` 返回 `None`，不再用 CPU 名构造 GPU 快照。复核通过（APPROVED）。

## 已知风险

- PowerShell 脚本的实际行为已由协作者在 Windows 真机确认，其余机器形态（纯 headless、虚拟机）建议在 Windows CI 上最终确认；
- 多 GPU 机器（核显 + 独显）仍取枚举第一条，属既有行为，未扩大改动范围。
