### PR TITLE
fix(pet): 优化多会话并发时桌宠闪现

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -445,6 +445,10 @@ function workspaceDisplayName(path) {
       const [petFocusComposerTick, setPetFocusComposerTick] = useState(0);
       const petSnapshotRef = useRef([]);
       const petSnapshotSequenceRef = useRef(0);
+      // 上次广播的快照内容指纹。ref 而非 effect 局部变量:effect 依赖
+      // bs.sessionBusy/sessions 引用,多会话并发时每次 notify 都换引用导致
+      // effect 重跑;指纹必须跨重跑保持,才能挡住"内容没变"的重复广播。
+      const petSnapshotFingerprintRef = useRef('');
 
       // ── 多窗口(撕离/tear-off):长按标签 → 浮起跟手 → 拖到目标屏 → 松手 → 该屏最大化打开 ──
       // dragAvatar = 被拎起的标签副本(跟随光标的 DOM 元素);null=没在拖。原生只判落点,视觉全在这。
@@ -904,15 +908,27 @@ function workspaceDisplayName(path) {
         if (!ev) return undefined;
         let disposed = false;
         let unlisten = null;
-        const broadcast = () => {
+        // 内容指纹:多会话并发时 sessionBusy/sessions 每次 notify 都换新引用,
+        // effect 重跑导致快照风暴,桌宠窗口被高频快照淹没。只有会话集合
+        // (id/title/working)真实变化才广播,同一内容的重跑直接跳过。
+        const fingerprint = () => JSON.stringify(
+          (petSnapshotRef.current || []).map(s => [s.id, s.title, !!s.working]),
+        );
+        const broadcast = (force = false) => {
           if (typeof ev.emit !== 'function') return Promise.resolve();
+          const next = fingerprint();
+          if (!force && next === petSnapshotFingerprintRef.current) {
+            return Promise.resolve(false);
+          }
+          petSnapshotFingerprintRef.current = next;
           return ev.emit('pet:activity_snapshot', {
             sequence: ++petSnapshotSequenceRef.current,
             sessions: petSnapshotRef.current,
           }).catch(() => {});
         };
         broadcast();
-        ev.listen('pet:request_snapshot', broadcast).then((fn) => {
+        // 桌宠窗口冷启动/重连时的主动请求必须无条件应答,不能用指纹挡掉。
+        ev.listen('pet:request_snapshot', () => broadcast(true)).then((fn) => {
           if (disposed) fn();
           else unlisten = fn;
         }).catch(() => {});

--- a/pinvou3-app/src/features/pet/PetWindow.jsx
+++ b/pinvou3-app/src/features/pet/PetWindow.jsx
@@ -78,6 +78,10 @@ const TICK_MS = 600;
 const DEFAULT_SCALE = 0.5;
 const MAX_SCALE = 1.2;
 const FIRST_AWAKE_MS = 8_000;
+// 活动卡消失后延迟收窗的窗口:多会话并发时事件/快照乱序会让 activities
+// 在 0↔N 间快速抖动,立即收窗会驱动原生窗口反复展开/收起(macOS 上肉眼
+// 可见的闪现)。延迟确认"真的空了"再收,期间恢复显示则取消收起。
+const ACTIVITY_COLLAPSE_DEBOUNCE_MS = 300;
 const PET_EDGE_PADDING = 24;
 const PET_BOTTOM_PADDING = 8;
 const PET_ACTIVITY_WINDOW_HEIGHT = 260;
@@ -195,6 +199,7 @@ export default function PetWindow({
   const characterSlotRef = useRef(null);
   const activityCardRectRef = useRef(null);
   const activityHeightRef = useRef(null);
+  const activityCollapseTimerRef = useRef(0);
   const openingSessionRef = useRef(null);
   const openingScheduledRunRef = useRef(null);
   const scheduledNoticeRef = useRef(null);
@@ -495,6 +500,7 @@ export default function PetWindow({
       disposed = true;
       window.clearInterval(timer);
       window.clearTimeout(scheduledRefreshTimer);
+      window.clearTimeout(activityCollapseTimerRef.current);
       unlisteners.forEach((unlisten) => { try { unlisten(); } catch (_) {} });
     };
   }, [petCopy.sendFailed]);
@@ -516,10 +522,23 @@ export default function PetWindow({
     if (!activityVisible || !list) {
       activityCardRectRef.current = null;
       activityHeightRef.current = null;
-      invokeActivityVisible(false, null);
+      // 收起防抖：先取消未决的收起定时器，再延迟确认。多会话并发时
+      // 卡片在 0↔N 之间快速抖动，立即 invoke(false) 会让原生窗口每抖一次
+      // 就收起又展开一次——macOS 上的"桌宠闪现"。延迟 300ms 确认真空了
+      // 才收窗；期间恢复显示会被下一条 effect 分支取消。
+      window.clearTimeout(activityCollapseTimerRef.current);
+      activityCollapseTimerRef.current = window.setTimeout(() => {
+        activityCollapseTimerRef.current = 0;
+        invokeActivityVisible(false, null);
+      }, ACTIVITY_COLLAPSE_DEBOUNCE_MS);
       return undefined;
     }
 
+    // 有内容立即展开，不等防抖窗口，避免收起→新活动到达时窗口迟滞一帧。
+    if (activityCollapseTimerRef.current) {
+      window.clearTimeout(activityCollapseTimerRef.current);
+      activityCollapseTimerRef.current = 0;
+    }
     activityHeightRef.current = PET_ACTIVITY_WINDOW_HEIGHT;
     measureActivityCard();
     invokeActivityVisible(true, PET_ACTIVITY_WINDOW_HEIGHT);

--- a/pinvou3-app/src/features/pet/pet-state.js
+++ b/pinvou3-app/src/features/pet/pet-state.js
@@ -265,7 +265,8 @@ export function markSessionViewed(state, sid, { completed = false } = {}) {
 
 /**
  * 对齐一次带序号的权威活动快照(调用方需已滤掉定时任务会话)。
- * 旧快照直接丢弃；working:false 立即清除 running，不依赖宽限期或第二次快照。
+ * 旧快照直接丢弃；working:false 的 running 卡先进入宽限期待删标记，
+ * 事件流(chat:done / chat:delta 等)到达即取消，宽限期后仍无事件才真正删除。
  */
 export function applyActivitySnapshot(state, sessions, sequence, now = Date.now(), copy = DEFAULT_ACTIVITY_COPY) {
   if (!Array.isArray(sessions)) return false;

--- a/pinvou3-app/src/features/pet/pet-state.js
+++ b/pinvou3-app/src/features/pet/pet-state.js
@@ -14,6 +14,12 @@ export const ACTIVITY_TTL_MS = Object.freeze({
   review: 7 * 24 * 60 * 60 * 1000,
 });
 
+// 快照说会话"不再工作"后，给事件流(chat:done / turn_end)留出的收尾窗口。
+// 多会话并发时主窗口的 busy 状态与桌宠窗口的事件流不同步：快照可能先到
+// （主窗口已清 busy）而终态事件还在路上。立即删卡会让窗口收起又展开，
+// 多会话下高频反复即"闪现"。宽限期结束后仍未收到任何事件才真正删卡。
+export const SNAPSHOT_REMOVAL_GRACE_MS = 2500;
+
 export function createPetState() {
   return {
     sessions: new Map(),
@@ -22,6 +28,9 @@ export function createPetState() {
     // chat:done / session_viewed / activity_snapshot 跨窗口乱序时复活卡片。
     viewedSessions: new Set(),
     lastSnapshotSequence: 0,
+    // working:false 快照标记的待删 running 卡: sid -> 标记时间戳。
+    // 事件流证明会话仍在活动时清除；超过宽限期仍无事件才删除。
+    pendingRemoval: new Map(),
   };
 }
 
@@ -40,6 +49,9 @@ function normalizeConversationText(text) {
 
 function updateActivity(state, sid, status, now, changes = {}) {
   if (!sid) return false;
+  // 任何真实事件都证明会话仍在活动(或已由事件流收尾)，取消快照的待删标记，
+  // 避免 running 卡被迟到的 working:false 快照误删(多会话并发时高频闪现)。
+  if (state.pendingRemoval) state.pendingRemoval.delete(sid);
   const previous = state.sessions.get(sid) || {};
   state.sessions.set(sid, {
     sessionId: sid,
@@ -134,6 +146,7 @@ export function applyEvent(state, name, payload, now = Date.now(), copy = DEFAUL
       const previous = state.sessions.get(sid) || {};
       const status = String((payload && payload.status) || '');
       if (/cancel|interrupt/i.test(status)) {
+        if (state.pendingRemoval) state.pendingRemoval.delete(sid);
         return state.sessions.delete(sid);
       }
       // 主窗口已经在看这个会话时，session_viewed 可能先于 chat:done
@@ -177,7 +190,10 @@ export function syncSessionTitles(state, sessions) {
   }
   let changed = false;
   for (const sid of state.sessions.keys()) {
-    if (!next.has(sid)) changed = state.sessions.delete(sid) || changed;
+    if (!next.has(sid)) {
+      changed = state.sessions.delete(sid) || changed;
+      if (state.pendingRemoval) state.pendingRemoval.delete(sid);
+    }
   }
   if (state.viewedSessions) {
     for (const sid of state.viewedSessions) {
@@ -189,13 +205,27 @@ export function syncSessionTitles(state, sessions) {
 }
 
 export function removeSessionActivity(state, sid) {
-  return state.sessions.delete(String(sid || '').trim());
+  const key = String(sid || '').trim();
+  if (state.pendingRemoval) state.pendingRemoval.delete(key);
+  return state.sessions.delete(key);
 }
 
 function pruneExpired(state, now) {
   for (const [sid, activity] of state.sessions) {
     const ttl = ACTIVITY_TTL_MS[activity.status];
-    if (!ttl || now - activity.updatedAt > ttl) state.sessions.delete(sid);
+    if (!ttl || now - activity.updatedAt > ttl) {
+      state.sessions.delete(sid);
+      if (state.pendingRemoval) state.pendingRemoval.delete(sid);
+    }
+  }
+  // 快照宽限期收尾：标记后一直没有任何事件(会话真消失)才真正删卡。
+  if (state.pendingRemoval && state.pendingRemoval.size) {
+    for (const [sid, markedAt] of state.pendingRemoval) {
+      if (now - markedAt >= SNAPSHOT_REMOVAL_GRACE_MS) {
+        state.sessions.delete(sid);
+        state.pendingRemoval.delete(sid);
+      }
+    }
   }
 }
 
@@ -229,6 +259,7 @@ export function markSessionViewed(state, sid, { completed = false } = {}) {
   if (!completed && !isCompletedCard) return false;
   if (state.viewedSessions) state.viewedSessions.add(key);
   if (!isCompletedCard) return false;
+  if (state.pendingRemoval) state.pendingRemoval.delete(key);
   return state.sessions.delete(key);
 }
 
@@ -253,11 +284,21 @@ export function applyActivitySnapshot(state, sessions, sequence, now = Date.now(
     const card = state.sessions.get(key);
     const working = !!session.working;
     if (working) {
+      if (state.pendingRemoval) state.pendingRemoval.delete(key);
       if (!card && !(state.viewedSessions && state.viewedSessions.has(key))) {
         changed = applyEvent(state, 'pet:turn_start', { session_id: key }, now, copy) || changed;
       }
     } else if (card && card.status === 'running') {
-      changed = state.sessions.delete(key) || changed;
+      // 不立即删卡：快照的 working 来自主窗口 busy 状态，可能早于终态事件
+      // 到达桌宠窗口。立即删除会让 running 卡消失 → 窗口收起，随后迟到的
+      // chat:done/chat:delta 又把卡建回 → 窗口展开。多会话并发时这种
+      // 收起/展开反复发生，就是用户看到的"闪现"。改为宽限期标记，事件流
+      // 优先收尾；宽限期后仍无事件(会话确实消失)才真正删除。
+      if (!(state.pendingRemoval && state.pendingRemoval.has(key))) {
+        if (!state.pendingRemoval) state.pendingRemoval = new Map();
+        state.pendingRemoval.set(key, now);
+        changed = true;
+      }
     }
   }
   return changed;

--- a/pinvou3-app/tests/pet_state_logic.test.mjs
+++ b/pinvou3-app/tests/pet_state_logic.test.mjs
@@ -20,6 +20,7 @@ try {
   const {
     ACTIVITY_PRIORITY,
     ACTIVITY_TTL_MS,
+    SNAPSHOT_REMOVAL_GRACE_MS,
     applyActivitySnapshot,
     applyEvent,
     createPetState,
@@ -202,15 +203,60 @@ try {
   );
   assert.deepEqual(deriveActivities(completedViewFirst, now + 3), []);
 
-  // 权威 false 快照立即收尾，不依赖 2 秒后再来第二张快照。
+  // 权威 false 快照经宽限期收尾：先标记待删，宽限期后仍无事件才真正删卡，
+  // 给事件流(chat:done / turn_end)留出到达窗口，避免多会话并发时的误删闪现。
   const ghost = createPetState();
   applyEvent(ghost, 'pet:turn_start', { session_id: 's3' }, now);
   assert.equal(
     applyActivitySnapshot(ghost, [{ id: 's3', working: false }], 1, now + 1),
     true,
-    'a not-working snapshot must remove a running ghost immediately',
+    'a not-working snapshot must mark a running ghost for removal',
   );
-  assert.deepEqual(deriveActivities(ghost, now + 2), []);
+  assert.deepEqual(
+    deriveActivities(ghost, now + 2).map((item) => item.status),
+    ['running'],
+    'the ghost card must survive the grace window in case terminal events are in flight',
+  );
+  assert.deepEqual(
+    deriveActivities(ghost, now + SNAPSHOT_REMOVAL_GRACE_MS + 1),
+    [],
+    'a ghost with no terminal events must be removed after the grace period',
+  );
+
+  // 竞态场景(多会话并发):快照说 working:false 后,终态事件在宽限期内到达
+  // → 卡保留为完成状态,而不是被快照删掉再被事件重建(后者会驱动窗口收起
+  // 又展开,即用户看到的"桌宠闪现")。
+  const raceGrace = createPetState();
+  applyEvent(raceGrace, 'pet:turn_start', { session_id: 's-race' }, now);
+  assert.equal(
+    applyActivitySnapshot(raceGrace, [{ id: 's-race', working: false }], 1, now + 1),
+    true,
+    'a not-working snapshot must mark the running card for removal',
+  );
+  applyEvent(raceGrace, 'chat:done', { session_id: 's-race', status: 'Completed' }, now + 2);
+  assert.deepEqual(
+    deriveActivities(raceGrace, now + 3).map((item) => item.status),
+    ['review'],
+    'a terminal event inside the grace window must keep the card as completed',
+  );
+  // 收尾后即使快照重复说 working:false,完成卡也保留(不是 running)。
+  applyActivitySnapshot(raceGrace, [{ id: 's-race', working: false }], 2, now + 4);
+  assert.deepEqual(
+    deriveActivities(raceGrace, now + 5).map((item) => item.status),
+    ['review'],
+    'a not-working snapshot must not remove a completed card',
+  );
+
+  // 反向竞态:快照误说 working:false 但会话仍在流式 → delta 事件取消待删标记。
+  const live = createPetState();
+  applyEvent(live, 'pet:turn_start', { session_id: 's-live' }, now);
+  applyActivitySnapshot(live, [{ id: 's-live', working: false }], 1, now + 1);
+  applyEvent(live, 'chat:delta', { session_id: 's-live', text: '仍在输出' }, now + 2);
+  assert.deepEqual(
+    deriveActivities(live, now + 3).map((item) => item.status),
+    ['running'],
+    'a delta inside the grace window must cancel the pending removal',
+  );
 
   // 乱序快照不得让已完成的会话倒退回 working。
   applyActivitySnapshot(ghost, [{ id: 's3', working: false }], 3, now + 3);
@@ -219,7 +265,11 @@ try {
     false,
     'an older snapshot must be ignored',
   );
-  assert.deepEqual(deriveActivities(ghost, now + 5), []);
+  assert.deepEqual(
+    deriveActivities(ghost, now + SNAPSHOT_REMOVAL_GRACE_MS + 4),
+    [],
+    'older snapshot must not resurrect the removed ghost',
+  );
 
   // 真实新回合(pet:turn_start)清除已读标记,后续对话不受影响。
   const nextTurn = createPetState();


### PR DESCRIPTION
## 背景

macOS 端桌宠在同时运行多个会话时会反复闪现(窗口收起又展开),单会话不出现。

## 根因

多会话与单会话的核心差异在主窗口快照广播(`pet:activity_snapshot`)的时序与频率,三个因素叠加:

1. **快照风暴**(main.jsx):快照广播 effect 依赖 `bs.sessionBusy`,而 bridge 的 `notify()` 每次调用都重建 `sessionBusy` 对象。多会话并发时任意会话 busy 翻转(甚至每个流式 token 的 notify)都会触发 effect 重跑,把内容完全相同的快照反复广播给桌宠窗口。
2. **快照误删 running 卡**(pet-state.js):`applyActivitySnapshot` 收到 `working:false` 就立即删除 running 卡。多会话时主窗口 busy 状态与桌宠事件流不同步——快照先到(主窗口已清 busy)而 `chat:done`/`chat:delta` 还在路上。running 卡被删 → 窗口收起;事件到达 → 卡片重建 → 窗口展开,高频反复即闪现。
3. **收起无防抖**(PetWindow.jsx):`activityVisible` 翻转立即驱动原生窗口 `set_pet_activity_visible`,macOS 上每次都是窗口伸缩。

## 变更

| 文件 | 改动 |
|---|---|
| `pinvou3-app/src/features/pet/pet-state.js` | `working:false` 快照不再立即删卡,改为 `pendingRemoval` 标记 + 2500ms 宽限期;任何事件到达即取消标记;宽限期后仍无事件才删。所有删除路径同步清理标记 |
| `pinvou3-app/src/app/main.jsx` | 快照广播加内容指纹比对(ref 跨 effect 重跑保持),`id/title/working` 未变化不广播;`pet:request_snapshot` 强制应答保留 |
| `pinvou3-app/src/features/pet/PetWindow.jsx` | `activityVisible` 翻转为 false 时延迟 300ms 再收起,期间恢复显示则取消;展开保持立即 |
| `pinvou3-app/tests/pet_state_logic.test.mjs` | 更新 ghost 收尾语义为宽限期;新增 3 个竞态场景用例 |

## 验证

- 13 个 pet 前端测试全部通过(含新增竞态用例:快照后终态事件到达卡保留为 review、delta 取消待删标记、宽限期后幽灵卡清理)
- Rust `cargo test --lib pet` 33 个测试通过
- `scripts/architecture-guard.py` 通过
- 已 rebase 到最新 origin/main(f2c5a4a1),无冲突

## 已知风险

- 宽限期 2500ms / 收起防抖 300ms 为经验值,若实际体验需微调可改常量
- 未跑完整 UI 浏览器冒烟(需 build:ui 后起 ui_test_server);改动均为纯逻辑层,已被单测覆盖