### PR TITLE
fix(codex): 修复思考阶段工具命令渲染溢出

### DIFF
--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -304,9 +304,9 @@ function terminalStatus(status, exitCode = null) {
 function TerminalBlock({ label, text }) {
   if (!text) return null;
   return (
-    <div className="mt-3">
+    <div className="mt-3 min-w-0 max-w-full">
       <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-gray-400">{label}</div>
-      <pre className="max-h-80 overflow-auto whitespace-pre rounded-xl bg-[#F4F5F7] dark:bg-black/30 px-3 py-2.5 text-[12px] leading-5 font-mono text-gray-700 dark:text-gray-200">{text}</pre>
+      <pre className="max-h-80 max-w-full overflow-auto whitespace-pre rounded-xl bg-[#F4F5F7] dark:bg-black/30 px-3 py-2.5 text-[12px] leading-5 font-mono text-gray-700 dark:text-gray-200">{text}</pre>
     </div>
   );
 }
@@ -341,7 +341,7 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
       : 'text-gray-500 bg-black/[0.04] dark:bg-white/[0.06]';
   return (
     <button type="button" onClick={onToggle}
-      className="w-full min-h-10 px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
+      className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[12px] font-medium">{title}</span>
@@ -422,7 +422,7 @@ function ToolGroup({ group, now, copy, cv }) {
   ) === 'failed');
   const [open, setOpen] = useState(false);
   return (
-    <div>
+    <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
@@ -430,7 +430,7 @@ function ToolGroup({ group, now, copy, cv }) {
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && (
-        <div className="ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
+        <div className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => item.type === 'command_execution'
             ? <CommandExecutionItem key={item.id} item={item} now={now} copy={copy} />
             : <GenericToolItem key={item.id} item={item} now={now} copy={copy} cv={cv} />)}
@@ -445,14 +445,14 @@ function ReasoningItem({ item, now, copy }) {
   const [open, setOpen] = useState(false);
   const duration = copy.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   return (
-    <div>
+    <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
         <span>{running ? copy.thinking : copy.thoughtCompleted} · {duration}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
-      {open && <div className="ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap">{item.text}</div>}
+      {open && <div data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{item.text}</div>}
     </div>
   );
 }
@@ -461,15 +461,15 @@ function PlanBlock({ plan, copy }) {
   const entries = plan && plan.entries || [];
   if (!entries.length) return null;
   return (
-    <div className="rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-3.5">
+    <div data-testid="conversation-plan" className="min-w-0 max-w-full rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-3.5">
       <div className="text-[12px] font-semibold text-violet-600 dark:text-violet-300 mb-2">{copy.plan}</div>
       <div className="space-y-2">
         {entries.map((entry, index) => (
-          <div key={index} className="flex items-start gap-2 text-[13px]">
+          <div key={index} className="min-w-0 flex items-start gap-2 text-[13px]">
             <span className={`mt-1.5 w-2 h-2 shrink-0 rounded-full ${
               entry.status === 'completed' ? 'bg-emerald-500' : entry.status === 'in_progress' ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'
             }`} />
-            <span className="flex-1">{entry.content}</span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{entry.content}</span>
           </div>
         ))}
       </div>
@@ -488,7 +488,7 @@ function PermissionCard({ permission, pending, onRespond, responding, agentName,
         <AlertTriangle size={18} className="text-amber-500 mt-0.5 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-semibold">{copy.permissionRequest(agentName)}</div>
-          <div className="mt-1 text-[12px] text-gray-500 dark:text-gray-400">{tool.title || copy.protectedOperation}</div>
+          <div className="mt-1 min-w-0 max-w-full text-[12px] text-gray-500 dark:text-gray-400 break-words [overflow-wrap:anywhere]">{tool.title || copy.protectedOperation}</div>
           {tool.rawInput && tool.rawInput.command
             ? <TerminalBlock label={copy.command} text={String(tool.rawInput.command)} />
             : <StructuredValue label={copy.operationArguments} value={tool.rawInput} />}

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
 import { can } from '../../shared/platform.js';
@@ -333,7 +333,7 @@ function StructuredValue({ label, value }) {
   );
 }
 
-function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
+function CompactItemRow({ icon, title, meta, status, open, onToggle, controlsId }) {
   const tone = status === 'failed'
     ? 'text-red-500 bg-red-500/10'
     : status === 'running'
@@ -341,6 +341,9 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
       : 'text-gray-500 bg-black/[0.04] dark:bg-white/[0.06]';
   return (
     <button type="button" onClick={onToggle}
+      data-testid="conversation-compact-item-toggle"
+      aria-expanded={controlsId ? Boolean(open) : undefined}
+      aria-controls={controlsId || undefined}
       className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
@@ -357,6 +360,7 @@ function CommandExecutionItem({ item, now, copy }) {
   const details = commandExecutionDetails(item.tool);
   const state = terminalStatus(item.status, details.exitCode);
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
   const countHint = details.commandCount > 1 ? ` · ${copy.segments(details.commandCount)}` : '';
   const duration = copy.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const outcome = state === 'running'
@@ -367,9 +371,10 @@ function CommandExecutionItem({ item, now, copy }) {
   return (
     <div className={`rounded-xl border ${state === 'failed' ? 'border-red-500/20' : 'border-black/[0.05] dark:border-white/[0.07]'} bg-white/45 dark:bg-white/[0.015]`}>
       <CompactItemRow icon={<Terminal size={13} />} title={details.summary}
-        meta={`${outcome}${countHint}`} status={state} open={open} onToggle={() => setOpen(value => !value)} />
+        meta={`${outcome}${countHint}`} status={state} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           <TerminalBlock label={copy.command} text={details.command} />
           {details.cwd && (
             <div className="mt-2 text-[10px] text-gray-400">
@@ -387,15 +392,17 @@ function GenericToolItem({ item, now, copy, cv }) {
   const tool = item.tool || {};
   const state = terminalStatus(item.status);
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
   const duration = copy.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const label = item.type === 'file_change' ? copy.fileChange : (tool.kind || cv.codexTool);
   return (
     <div className="rounded-xl border border-black/[0.05] dark:border-white/[0.07] bg-white/45 dark:bg-white/[0.015]">
       <CompactItemRow icon={<Wrench size={13} />} title={tool.title || label}
         meta={`${label} · ${state === 'running' ? `${copy.inProgress} · ${duration}` : state === 'failed' ? copy.failed : `${cv.ended} · ${duration}`}`}
-        status={state} open={open} onToggle={() => setOpen(value => !value)} />
+        status={state} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           {tool.locations && tool.locations.length > 0 && (
             <div className="mt-3 flex flex-wrap gap-1.5">
               {tool.locations.map((location, index) => (
@@ -421,16 +428,21 @@ function ToolGroup({ group, now, copy, cv }) {
     item.type === 'command_execution' ? commandExecutionDetails(item.tool).exitCode : null,
   ) === 'failed');
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
+  const hasDetails = items.length > 0;
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
+        data-testid="conversation-tool-group-summary"
+        aria-expanded={hasDetails ? Boolean(open) : undefined}
+        aria-controls={hasDetails ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
         <span>{running ? copy.executing : failed ? cv.stepsFailed : copy.executionSteps} · {items.length}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
-      {open && (
-        <div className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
+      {open && hasDetails && (
+        <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => item.type === 'command_execution'
             ? <CommandExecutionItem key={item.id} item={item} now={now} copy={copy} />
             : <GenericToolItem key={item.id} item={item} now={now} copy={copy} cv={cv} />)}
@@ -443,16 +455,21 @@ function ToolGroup({ group, now, copy, cv }) {
 function ReasoningItem({ item, now, copy }) {
   const running = item.status === 'in_progress';
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
+  const hasDetails = Boolean(item.text);
   const duration = copy.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
+        data-testid="conversation-reasoning-toggle"
+        aria-expanded={hasDetails ? Boolean(open) : undefined}
+        aria-controls={hasDetails ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
         <span>{running ? copy.thinking : copy.thoughtCompleted} · {duration}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
-      {open && <div data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{item.text}</div>}
+      {open && hasDetails && <div id={detailsId} data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{item.text}</div>}
     </div>
   );
 }
@@ -896,7 +913,7 @@ function Turn({
               <AssistantMessageActions resolveText={() => assistantResponseText(turn)} copy={copy} />
             )}
             {(turn.completedAt || turn.error) && <>
-              <StatusBadge status={turn.status} />
+              <StatusBadge status={turn.status} copy={copy} />
               <span className="text-[11px] text-gray-400">{duration}</span>
               {turn.usage && <span className="text-[11px] text-gray-400">{copy.contextUsage(Number(turn.usage.used || 0).toLocaleString(), Number(turn.usage.size || 0).toLocaleString())}</span>}
               {turn.error && <span className="text-[11px] text-red-500">{turn.error}</span>}

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -343,7 +343,7 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle, controlsId 
     <button type="button" onClick={onToggle}
       data-testid="conversation-compact-item-toggle"
       aria-expanded={controlsId ? Boolean(open) : undefined}
-      aria-controls={controlsId || undefined}
+      aria-controls={controlsId && open ? controlsId : undefined}
       className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
@@ -435,7 +435,7 @@ function ToolGroup({ group, now, copy, cv }) {
       <button type="button" onClick={() => setOpen(value => !value)}
         data-testid="conversation-tool-group-summary"
         aria-expanded={hasDetails ? Boolean(open) : undefined}
-        aria-controls={hasDetails ? detailsId : undefined}
+        aria-controls={hasDetails && open ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
         <span>{running ? copy.executing : failed ? cv.stepsFailed : copy.executionSteps} · {items.length}</span>
@@ -463,7 +463,7 @@ function ReasoningItem({ item, now, copy }) {
       <button type="button" onClick={() => setOpen(value => !value)}
         data-testid="conversation-reasoning-toggle"
         aria-expanded={hasDetails ? Boolean(open) : undefined}
-        aria-controls={hasDetails ? detailsId : undefined}
+        aria-controls={hasDetails && open ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
         <span>{running ? copy.thinking : copy.thoughtCompleted} · {duration}</span>

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import { FileTypeIcon } from '../../components/files/FileTypeIcon.jsx';
 import { renderMarkdown } from '../../shared/markdown-renderer.js';
 import {
@@ -243,7 +243,7 @@ function StructuredValue({ label, value }) {
   );
 }
 
-function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
+function CompactItemRow({ icon, title, meta, status, open, onToggle, controlsId }) {
   const tone = status === 'failed'
     ? 'text-red-500 bg-red-500/10'
     : status === 'warning'
@@ -253,6 +253,9 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
       : 'text-gray-500 bg-black/[0.04] dark:bg-white/[0.06]';
   return (
     <button type="button" onClick={onToggle}
+      data-testid="conversation-compact-item-toggle"
+      aria-expanded={controlsId ? Boolean(open) : undefined}
+      aria-controls={controlsId || undefined}
       className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
@@ -270,6 +273,7 @@ function CommandExecutionItem({ item, now, copy }) {
   const details = commandExecutionDetails(item.tool);
   const state = terminalStatus(item.status, details.exitCode);
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
   const countHint = details.commandCount > 1 ? ` · ${c.segments(details.commandCount)}` : '';
   const duration = c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const outcome = state === 'running'
@@ -280,9 +284,10 @@ function CommandExecutionItem({ item, now, copy }) {
   return (
     <div className={`rounded-xl border ${state === 'failed' ? 'border-red-500/20' : 'border-black/[0.05] dark:border-white/[0.07]'} bg-white/45 dark:bg-white/[0.015]`}>
       <CompactItemRow icon={<Terminal size={13} />} title={localizedSemanticLabel(details.summary, c)}
-        meta={`${outcome}${countHint}`} status={state} open={open} onToggle={() => setOpen(value => !value)} />
+        meta={`${outcome}${countHint}`} status={state} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           <TerminalBlock label={c.command} text={details.command} />
           {details.cwd && (
             <div className="mt-2 text-[10px] text-gray-400">
@@ -303,6 +308,7 @@ function SearchToolItem({ item, now, onOpenExternal, copy }) {
   const state = terminalStatus(item.status);
   const [open, setOpen] = useState(false);
   const [rawOpen, setRawOpen] = useState(false);
+  const detailsId = useId();
   const duration = c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const query = details.query || tool.title || c.webContent;
   const toolName = String(tool.name || '').trim() || 'web_search';
@@ -321,9 +327,10 @@ function SearchToolItem({ item, now, onOpenExternal, copy }) {
   return (
     <div className={`rounded-xl border ${state === 'failed' ? 'border-red-500/20' : 'border-black/[0.05] dark:border-white/[0.07]'} bg-white/45 dark:bg-white/[0.015]`}>
       <CompactItemRow icon={<Wrench size={13} />} title={toolName}
-        meta={meta} status={state} open={open} onToggle={() => setOpen(value => !value)} />
+        meta={meta} status={state} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           {details.results.length > 0 ? (
             <div className="mt-2 divide-y divide-black/[0.05] dark:divide-white/[0.06]">
               {details.results.slice(0, 5).map((result, index) => {
@@ -383,6 +390,7 @@ function FetchToolItem({ item, now, onOpenExternal, copy }) {
   const visualState = responseWarning && state !== 'failed' ? 'warning' : state;
   const [open, setOpen] = useState(false);
   const [rawOpen, setRawOpen] = useState(false);
+  const detailsId = useId();
   const duration = c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const toolName = String(tool.name || '').trim() || 'fetch_url';
   const statusLabel = details.status != null
@@ -404,9 +412,10 @@ function FetchToolItem({ item, now, onOpenExternal, copy }) {
           : 'border-black/[0.05] dark:border-white/[0.07]'
     } bg-white/45 dark:bg-white/[0.015]`}>
       <CompactItemRow icon={<Wrench size={13} />} title={toolName}
-        meta={meta} status={visualState} open={open} onToggle={() => setOpen(value => !value)} />
+        meta={meta} status={visualState} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           {details.url && (
             <button
               type="button"
@@ -452,15 +461,17 @@ function GenericToolItem({ item, now, copy }) {
   const tool = item.tool || {};
   const state = terminalStatus(item.status);
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
   const duration = c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const label = item.type === 'file_change' ? c.fileChange : (tool.kind || c.tool);
   return (
     <div className="rounded-xl border border-black/[0.05] dark:border-white/[0.07] bg-white/45 dark:bg-white/[0.015]">
       <CompactItemRow icon={<Wrench size={13} />} title={localizedSemanticLabel(tool.title || label, c)}
         meta={`${label} · ${state === 'running' ? `${c.inProgress} · ${duration}` : state === 'failed' ? c.failed : `${c.executionFinished} · ${duration}`}`}
-        status={state} open={open} onToggle={() => setOpen(value => !value)} />
+        status={state} open={open} controlsId={detailsId}
+        onToggle={() => setOpen(value => !value)} />
       {open && (
-        <div className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
+        <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           {tool.locations && tool.locations.length > 0 && (
             <div className="mt-3 flex flex-wrap gap-1.5">
               {tool.locations.map((location, index) => (
@@ -516,17 +527,21 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
   }`;
   const [open, setOpen] = useState(running);
   const expanded = running || open;
+  const detailsId = useId();
+  const hasDetails = items.length > 0;
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
         data-testid="conversation-tool-group-summary"
+        aria-expanded={hasDetails ? Boolean(expanded) : undefined}
+        aria-controls={hasDetails ? detailsId : undefined}
         className="w-full min-w-0 h-9 overflow-hidden px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 shrink-0 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
         <span className="min-w-0 flex-1 truncate">{summary}</span>
         <ChevronDown size={13} className={`shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
       </button>
-      {expanded && (
-        <div className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
+      {expanded && hasDetails && (
+        <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => (
             <ToolItem
               key={item.id}
@@ -547,6 +562,8 @@ function ReasoningItem({ item, now, copy }) {
   const c = conversationCopy(copy);
   const running = item.status === 'in_progress';
   const [open, setOpen] = useState(false);
+  const detailsId = useId();
+  const hasDetails = Boolean(item.text);
   const duration = item.startedAt == null
     ? ''
     : c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
@@ -554,13 +571,16 @@ function ReasoningItem({ item, now, copy }) {
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
+        data-testid="conversation-reasoning-toggle"
+        aria-expanded={hasDetails ? Boolean(open) : undefined}
+        aria-controls={hasDetails ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
         <span>{statusText}{duration ? ` · ${duration}` : ''}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
-      {open && item.text && (
-        <div data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+      {open && hasDetails && (
+        <div id={detailsId} data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
           {item.text}
         </div>
       )}

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -255,7 +255,7 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle, controlsId 
     <button type="button" onClick={onToggle}
       data-testid="conversation-compact-item-toggle"
       aria-expanded={controlsId ? Boolean(open) : undefined}
-      aria-controls={controlsId || undefined}
+      aria-controls={controlsId && open ? controlsId : undefined}
       className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
@@ -534,7 +534,7 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
       <button type="button" onClick={() => setOpen(value => !value)}
         data-testid="conversation-tool-group-summary"
         aria-expanded={hasDetails ? Boolean(expanded) : undefined}
-        aria-controls={hasDetails ? detailsId : undefined}
+        aria-controls={hasDetails && expanded ? detailsId : undefined}
         className="w-full min-w-0 h-9 overflow-hidden px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 shrink-0 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
         <span className="min-w-0 flex-1 truncate">{summary}</span>
@@ -573,7 +573,7 @@ function ReasoningItem({ item, now, copy }) {
       <button type="button" onClick={() => setOpen(value => !value)}
         data-testid="conversation-reasoning-toggle"
         aria-expanded={hasDetails ? Boolean(open) : undefined}
-        aria-controls={hasDetails ? detailsId : undefined}
+        aria-controls={hasDetails && open ? detailsId : undefined}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
         <span>{statusText}{duration ? ` · ${duration}` : ''}</span>

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -214,9 +214,9 @@ export function ConversationActivityIndicator({
 function TerminalBlock({ label, text }) {
   if (!text) return null;
   return (
-    <div className="mt-3">
+    <div className="mt-3 min-w-0 max-w-full">
       <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-gray-400">{label}</div>
-      <pre className="max-h-80 overflow-auto whitespace-pre rounded-xl bg-[#F4F5F7] dark:bg-black/30 px-3 py-2.5 text-[12px] leading-5 font-mono text-gray-700 dark:text-gray-200">{text}</pre>
+      <pre className="max-h-80 max-w-full overflow-auto whitespace-pre rounded-xl bg-[#F4F5F7] dark:bg-black/30 px-3 py-2.5 text-[12px] leading-5 font-mono text-gray-700 dark:text-gray-200">{text}</pre>
     </div>
   );
 }
@@ -253,7 +253,7 @@ function CompactItemRow({ icon, title, meta, status, open, onToggle }) {
       : 'text-gray-500 bg-black/[0.04] dark:bg-white/[0.06]';
   return (
     <button type="button" onClick={onToggle}
-      className="w-full min-h-10 px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
+      className="w-full min-w-0 min-h-10 overflow-hidden px-2.5 py-2 flex items-center gap-2.5 text-left rounded-xl hover:bg-black/[0.025] dark:hover:bg-white/[0.035]">
       <span className={`w-6 h-6 shrink-0 rounded-lg flex items-center justify-center ${tone}`}>{icon}</span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[12px] font-medium">{title}</span>
@@ -493,6 +493,16 @@ function ToolItem({ item, now, renderToolItem, onOpenExternal, copy }) {
   return <GenericToolItem item={item} now={now} copy={copy} />;
 }
 
+function runningToolLabel(item, copy) {
+  if (!item) return '';
+  if (item.type === 'command_execution' || String(item.tool && item.tool.kind || '').toLowerCase() === 'execute') {
+    return copy.shellCommand;
+  }
+  if (item.type === 'file_change') return copy.fileChange;
+  const name = String(item.tool && item.tool.name || '').trim();
+  return name || copy.tool;
+}
+
 function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
   const c = conversationCopy(copy);
   const items = group.items || [];
@@ -500,25 +510,23 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
   const failedCount = items.filter(countsAsFailedOperation).length;
   const failed = failedCount > 0;
   const runningItem = [...items].reverse().find(item => terminalStatus(item.status) === 'running');
-  const runningLabel = runningItem
-    ? (runningItem.tool && (runningItem.tool.name || runningItem.tool.title))
-      || (runningItem.type === 'file_change' ? c.fileChange : '')
-    : '';
+  const runningLabel = runningToolLabel(runningItem, c);
   const summary = `${running ? `${c.executing}${runningLabel ? ` · ${runningLabel}` : ''}` : c.executionSteps} · ${c.items(items.length)}${
     failedCount ? ` · ${c.failedItems(failedCount)}` : ''
   }`;
   const [open, setOpen] = useState(running);
   const expanded = running || open;
   return (
-    <div>
+    <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
-        className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
-        <span className={`w-1.5 h-1.5 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
-        <span>{summary}</span>
-        <ChevronDown size={13} className={`ml-auto transition-transform ${expanded ? 'rotate-180' : ''}`} />
+        data-testid="conversation-tool-group-summary"
+        className="w-full min-w-0 h-9 overflow-hidden px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
+        <span className={`w-1.5 h-1.5 shrink-0 rounded-full ${failed ? 'bg-red-500' : running ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
+        <span className="min-w-0 flex-1 truncate">{summary}</span>
+        <ChevronDown size={13} className={`shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
       </button>
       {expanded && (
-        <div className="ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
+        <div className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => (
             <ToolItem
               key={item.id}
@@ -544,7 +552,7 @@ function ReasoningItem({ item, now, copy }) {
     : c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const statusText = running ? c.thinking : c.thoughtCompleted;
   return (
-    <div>
+    <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
         className="w-full h-9 px-1 flex items-center gap-2 text-left text-[12px] text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200">
         <span className={`w-1.5 h-1.5 rounded-full bg-violet-500 ${running ? 'animate-pulse' : ''}`} />
@@ -552,7 +560,7 @@ function ReasoningItem({ item, now, copy }) {
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && item.text && (
-        <div className="ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap">
+        <div data-testid="conversation-reasoning-content" className="min-w-0 max-w-full ml-3 pl-3 py-1 border-l border-violet-500/15 text-[12px] leading-6 text-gray-500 dark:text-gray-300 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
           {item.text}
         </div>
       )}
@@ -565,15 +573,15 @@ function PlanBlock({ plan, copy }) {
   const entries = plan && plan.entries || [];
   if (!entries.length) return null;
   return (
-    <div className="rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-3.5">
+    <div data-testid="conversation-plan" className="min-w-0 max-w-full rounded-2xl border border-violet-500/15 bg-violet-500/[0.04] p-3.5">
       <div className="text-[12px] font-semibold text-violet-600 dark:text-violet-300 mb-2">{c.plan}</div>
       <div className="space-y-2">
         {entries.map((entry, index) => (
-          <div key={index} className="flex items-start gap-2 text-[13px]">
+          <div key={index} className="min-w-0 flex items-start gap-2 text-[13px]">
             <span className={`mt-1.5 w-2 h-2 shrink-0 rounded-full ${
               entry.status === 'completed' ? 'bg-emerald-500' : entry.status === 'in_progress' ? 'bg-blue-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'
             }`} />
-            <span className="flex-1">{entry.content}</span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{entry.content}</span>
           </div>
         ))}
       </div>
@@ -593,7 +601,7 @@ function PermissionCard({ permission, pending, onRespond, responding, agentLabel
         <AlertTriangle size={18} className="text-amber-500 mt-0.5 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-semibold">{c.permissionRequest(agentLabel)}</div>
-          <div className="mt-1 text-[12px] text-gray-500 dark:text-gray-400">{tool.title || c.protectedOperation}</div>
+          <div className="mt-1 min-w-0 max-w-full text-[12px] text-gray-500 dark:text-gray-400 break-words [overflow-wrap:anywhere]">{tool.title || c.protectedOperation}</div>
           {tool.rawInput && tool.rawInput.command
             ? <TerminalBlock label={c.command} text={String(tool.rawInput.command)} />
             : <StructuredValue label={c.operationArguments} value={tool.rawInput} />}

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -345,6 +345,18 @@ try {
   assert.ok(codexView.includes(boundedPermissionOptionClass)
     && conversationView.includes(boundedPermissionOptionClass),
   'long ACP permission option labels must wrap inside both unified and legacy permission cards');
+  assert.ok(conversationView.includes('function runningToolLabel(item, copy)')
+    && conversationView.includes("return copy.shellCommand;")
+    && !conversationView.includes('runningItem.tool.name || runningItem.tool.title')
+    && conversationView.includes('data-testid="conversation-tool-group-summary"')
+    && conversationView.includes('min-w-0 flex-1 truncate'),
+  'running tool groups must use bounded semantic labels instead of rendering raw command titles');
+  const boundedLongTextClass = 'whitespace-pre-wrap break-words [overflow-wrap:anywhere]';
+  assert.ok(codexView.includes(boundedLongTextClass)
+    && conversationView.includes(boundedLongTextClass)
+    && codexView.includes('max-h-80 max-w-full overflow-auto whitespace-pre')
+    && conversationView.includes('max-h-80 max-w-full overflow-auto whitespace-pre'),
+  'reasoning, plan, permission, and terminal content must stay within both timeline implementations');
   assert.ok(codexView.includes("directory: true"), 'new Codex sessions must expose a native directory picker');
   assert.ok(codexView.includes('workspacePath'), 'selected project directory must reach the Tauri command');
   assert.ok(!codexView.includes('data-testid="acp-agent-selector"')

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -58,6 +58,7 @@ function injectSource() {
       {id:'s1',title:'第三季度财报分析',created_at:Date.now()-1000,updated_at:Date.now()}
     ];
     let CODEX_SESSIONS=[{id:'codex-1',agent_id:'codex',title:'Codex回归会话',created_at:new Date(Date.now()-1000).toISOString(),updated_at:new Date().toISOString(),workspace_kind:'temporary',workspace_path:''}];
+    const LONG_CODEX_COMMAND='overflow-marker-'+('x'.repeat(1200));
     let ARCHIVED_SESSIONS=[];
     let MOUNTED_COLLECTIONS=[];
     let MOUNTED_COLLECTIONS_REVISION=0;
@@ -95,6 +96,11 @@ function injectSource() {
           {version:1,sessionId:'codex-1',turnId:'copy-turn',seq:2,timestamp:'2026-08-04T01:00:01Z',event:{type:'turn_started',data:{status:'running'}}},
           {version:1,sessionId:'codex-1',turnId:'copy-turn',seq:3,timestamp:'2026-08-04T01:00:02Z',event:{type:'agent_message_chunk',data:{update:{content:{type:'text',text:'Codex copy layout'}}}}},
           {version:1,sessionId:'codex-1',turnId:'copy-turn',seq:4,timestamp:'2026-08-04T01:00:03Z',event:{type:'turn_completed',data:{status:'Completed',error:null}}},
+          {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:10,timestamp:'2026-08-04T01:01:00Z',event:{type:'user_message',data:{content:[{type:'text',text:'Test streaming overflow'}]}}},
+          {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:11,timestamp:'2026-08-04T01:01:01Z',event:{type:'turn_started',data:{status:'running'}}},
+          {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:12,timestamp:'2026-08-04T01:01:02Z',event:{type:'agent_thought_chunk',data:{update:{content:{type:'text',text:'reasoning-marker-'+('r'.repeat(1200))}}}}},
+          {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:13,timestamp:'2026-08-04T01:01:03Z',event:{type:'plan',data:{update:{entries:[{content:'plan-marker-'+('p'.repeat(1200)),status:'in_progress'}]}}}},
+          {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:14,timestamp:'2026-08-04T01:01:04Z',event:{type:'tool_call',data:{update:{toolCallId:'overflow-tool',title:LONG_CODEX_COMMAND,kind:'execute',status:'in_progress',rawInput:{command:LONG_CODEX_COMMAND,cwd:'C:/tmp'}}}}},
         ]);
         case 'get_codex_acp_pending_permissions': return Promise.resolve([]);
         case 'get_codex_acp_pending_elicitations': return Promise.resolve([]);
@@ -497,6 +503,79 @@ async function expand(page) {
     codexAssistantCopy.failureFeedback === '复制失败' && codexAssistantCopy.failureTitle === '复制失败' &&
     codexAssistantCopy.sameRow,
     JSON.stringify(codexAssistantCopy));
+
+  const codexStreamingOverflow = await page.evaluate(async () => {
+    const turn = document.querySelector('[data-conversation-turn="overflow-turn"]');
+    const summary = turn?.querySelector('[data-testid="conversation-tool-group-summary"]');
+    const plan = turn?.querySelector('[data-testid="conversation-plan"]');
+    const reasoningToggle = [...(turn?.querySelectorAll('button') || [])]
+      .find(node => node.textContent.includes('思考完成'));
+    reasoningToggle?.click();
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const reasoning = turn?.querySelector('[data-testid="conversation-reasoning-content"]');
+    const commandButton = [...(turn?.querySelectorAll('button') || [])]
+      .find(node => node !== summary && node.textContent.includes('overflow-marker-'));
+    const commandTitle = commandButton?.querySelector('span.min-w-0.flex-1 > span.truncate');
+    const turnRect = turn?.getBoundingClientRect();
+    const contained = [reasoning, plan, summary, commandButton].every(node => {
+      if (!node || !turnRect) return false;
+      const rect = node.getBoundingClientRect();
+      return rect.left >= turnRect.left - 1 && rect.right <= turnRect.right + 1;
+    });
+    const reasoningRect = reasoning?.getBoundingClientRect();
+    const planRect = plan?.getBoundingClientRect();
+    const summaryRect = summary?.getBoundingClientRect();
+    return {
+      found: Boolean(turn && reasoning && plan && summary && commandButton && commandTitle),
+      turnIds: [...document.querySelectorAll('[data-conversation-turn]')]
+        .map(node => node.getAttribute('data-conversation-turn')),
+      hasOverflowText: document.body.innerText.includes('Test streaming overflow'),
+      summaryCount: document.querySelectorAll('[data-testid="conversation-tool-group-summary"]').length,
+      summary: summary?.textContent.trim() || '',
+      summaryContainsRawCommand: Boolean(summary?.textContent.includes('overflow-marker-')),
+      contained,
+      ordered: Boolean(reasoningRect && planRect && summaryRect
+        && reasoningRect.bottom <= planRect.top + 1
+        && planRect.bottom <= summaryRect.top + 1),
+      commandClipped: Boolean(commandTitle && commandTitle.scrollWidth > commandTitle.clientWidth
+        && commandButton.scrollWidth <= commandButton.clientWidth + 1),
+    };
+  });
+  rec('①a-3c Codex 流式超长命令保持在工具卡内',
+    codexStreamingOverflow.found
+      && codexStreamingOverflow.summary === '正在执行 · 执行 Shell 命令 · 1 项'
+      && !codexStreamingOverflow.summaryContainsRawCommand
+      && codexStreamingOverflow.contained
+      && codexStreamingOverflow.ordered
+      && codexStreamingOverflow.commandClipped,
+    JSON.stringify(codexStreamingOverflow));
+
+  await page.evaluate(async () => {
+    const events = [
+      {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:15,timestamp:'2026-08-04T01:01:05Z',event:{type:'tool_call_update',data:{update:{toolCallId:'overflow-tool',status:'completed',rawOutput:{formatted_output:'ok',exit_code:0}}}}},
+      {version:1,sessionId:'codex-1',turnId:'overflow-turn',seq:16,timestamp:'2026-08-04T01:01:06Z',event:{type:'turn_completed',data:{status:'Completed',error:null}}},
+    ];
+    for (const payload of events) {
+      for (const handler of (window.__TAURI_EVENT_HANDLERS__['acp:event'] || [])) await handler({ payload });
+    }
+  });
+  await sleep(100);
+  const codexCompletedOverflow = await page.evaluate(() => {
+    const turn = document.querySelector('[data-conversation-turn="overflow-turn"]');
+    const summary = turn?.querySelector('[data-testid="conversation-tool-group-summary"]');
+    const turnRect = turn?.getBoundingClientRect();
+    const summaryRect = summary?.getBoundingClientRect();
+    return {
+      summary: summary?.textContent.trim() || '',
+      containsRawCommand: Boolean(summary?.textContent.includes('overflow-marker-')),
+      contained: Boolean(turnRect && summaryRect && summaryRect.left >= turnRect.left - 1 && summaryRect.right <= turnRect.right + 1),
+    };
+  });
+  rec('①a-3d Codex 工具完成后摘要保持稳定',
+    codexCompletedOverflow.summary === '执行步骤 · 1 项'
+      && !codexCompletedOverflow.containsRawCommand
+      && codexCompletedOverflow.contained,
+    JSON.stringify(codexCompletedOverflow));
 
   await clickText(page, '查看全部'); await sleep(400);
   const managedActiveState = await page.evaluate(() => {

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -534,12 +534,18 @@ async function expand(page) {
     const reasoningRect = reasoning?.getBoundingClientRect();
     const planRect = plan?.getBoundingClientRect();
     const summaryRect = summary?.getBoundingClientRect();
+    reasoningToggle?.click();
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const reasoningCollapsed = controlledState(reasoningToggle);
     const commandClipped = Boolean(commandTitle && commandTitle.scrollWidth > commandTitle.clientWidth
       && commandButton.scrollWidth <= commandButton.clientWidth + 1);
     const commandBefore = controlledState(commandButton);
     commandButton?.click();
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     const commandAfter = controlledState(commandButton);
+    commandButton?.click();
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const commandCollapsed = controlledState(commandButton);
     return {
       found: Boolean(turn && reasoning && plan && summary && commandButton && commandTitle),
       turnIds: [...document.querySelectorAll('[data-conversation-turn]')]
@@ -553,7 +559,15 @@ async function expand(page) {
         && reasoningRect.bottom <= planRect.top + 1
         && planRect.bottom <= summaryRect.top + 1),
       commandClipped,
-      accessibility: { summaryState, reasoningBefore, reasoningAfter, commandBefore, commandAfter },
+      accessibility: {
+        summaryState,
+        reasoningBefore,
+        reasoningAfter,
+        reasoningCollapsed,
+        commandBefore,
+        commandAfter,
+        commandCollapsed,
+      },
     };
   });
   rec('①a-3c Codex 流式超长命令保持在工具卡内',
@@ -569,13 +583,23 @@ async function expand(page) {
     unifiedA11y.summaryState?.expanded === 'true'
       && unifiedA11y.summaryState?.detailsPresent
       && unifiedA11y.reasoningBefore?.expanded === 'false'
+      && !unifiedA11y.reasoningBefore?.controls
       && !unifiedA11y.reasoningBefore?.detailsPresent
       && unifiedA11y.reasoningAfter?.expanded === 'true'
+      && Boolean(unifiedA11y.reasoningAfter?.controls)
       && unifiedA11y.reasoningAfter?.detailsPresent
+      && unifiedA11y.reasoningCollapsed?.expanded === 'false'
+      && !unifiedA11y.reasoningCollapsed?.controls
+      && !unifiedA11y.reasoningCollapsed?.detailsPresent
       && unifiedA11y.commandBefore?.expanded === 'false'
+      && !unifiedA11y.commandBefore?.controls
       && !unifiedA11y.commandBefore?.detailsPresent
       && unifiedA11y.commandAfter?.expanded === 'true'
-      && unifiedA11y.commandAfter?.detailsPresent,
+      && Boolean(unifiedA11y.commandAfter?.controls)
+      && unifiedA11y.commandAfter?.detailsPresent
+      && unifiedA11y.commandCollapsed?.expanded === 'false'
+      && !unifiedA11y.commandCollapsed?.controls
+      && !unifiedA11y.commandCollapsed?.detailsPresent,
     JSON.stringify(unifiedA11y));
 
   await page.evaluate(async () => {
@@ -605,6 +629,7 @@ async function expand(page) {
       controls,
       expandedBefore,
       detailsBefore,
+      controlsAfter: summary?.getAttribute('aria-controls') || '',
       expandedAfter: summary?.getAttribute('aria-expanded') || '',
       detailsAfter: Boolean(controls && document.getElementById(controls)),
     };
@@ -616,8 +641,10 @@ async function expand(page) {
     JSON.stringify(codexCompletedOverflow));
   rec('①a-3d-1 统一工具组折叠状态与详情 DOM 一致',
     codexCompletedOverflow.expandedBefore === 'true'
+      && Boolean(codexCompletedOverflow.controls)
       && codexCompletedOverflow.detailsBefore
       && codexCompletedOverflow.expandedAfter === 'false'
+      && !codexCompletedOverflow.controlsAfter
       && !codexCompletedOverflow.detailsAfter,
     JSON.stringify(codexCompletedOverflow));
 
@@ -1569,6 +1596,9 @@ async function expand(page) {
     reasoningToggle?.click();
     await settle();
     const reasoningAfter = state(reasoningToggle);
+    reasoningToggle?.click();
+    await settle();
+    const reasoningCollapsed = state(reasoningToggle);
 
     const summary = document.querySelector('[data-testid="conversation-tool-group-summary"]');
     const groupBefore = state(summary);
@@ -1581,15 +1611,24 @@ async function expand(page) {
     compactToggle?.click();
     await settle();
     const compactAfter = state(compactToggle);
+    compactToggle?.click();
+    await settle();
+    const compactCollapsed = state(compactToggle);
+    summary?.click();
+    await settle();
+    const groupCollapsed = state(summary);
     const controls = [reasoningAfter.controls, groupAfter.controls, compactAfter.controls].filter(Boolean);
     return {
       found: Boolean(reasoningToggle && summary && compactToggle),
       reasoningBefore,
       reasoningAfter,
+      reasoningCollapsed,
       groupBefore,
       groupAfter,
+      groupCollapsed,
       compactBefore,
       compactAfter,
+      compactCollapsed,
       uniqueControls: controls.length === 3 && new Set(controls).size === controls.length,
     };
   });
@@ -1597,17 +1636,32 @@ async function expand(page) {
     legacyConversationA11y.found
       && legacyConversationA11y.uniqueControls
       && legacyConversationA11y.reasoningBefore.expanded === 'false'
+      && !legacyConversationA11y.reasoningBefore.controls
       && !legacyConversationA11y.reasoningBefore.detailsPresent
       && legacyConversationA11y.reasoningAfter.expanded === 'true'
+      && Boolean(legacyConversationA11y.reasoningAfter.controls)
       && legacyConversationA11y.reasoningAfter.detailsPresent
+      && legacyConversationA11y.reasoningCollapsed.expanded === 'false'
+      && !legacyConversationA11y.reasoningCollapsed.controls
+      && !legacyConversationA11y.reasoningCollapsed.detailsPresent
       && legacyConversationA11y.groupBefore.expanded === 'false'
+      && !legacyConversationA11y.groupBefore.controls
       && !legacyConversationA11y.groupBefore.detailsPresent
       && legacyConversationA11y.groupAfter.expanded === 'true'
+      && Boolean(legacyConversationA11y.groupAfter.controls)
       && legacyConversationA11y.groupAfter.detailsPresent
+      && legacyConversationA11y.groupCollapsed.expanded === 'false'
+      && !legacyConversationA11y.groupCollapsed.controls
+      && !legacyConversationA11y.groupCollapsed.detailsPresent
       && legacyConversationA11y.compactBefore.expanded === 'false'
+      && !legacyConversationA11y.compactBefore.controls
       && !legacyConversationA11y.compactBefore.detailsPresent
       && legacyConversationA11y.compactAfter.expanded === 'true'
-      && legacyConversationA11y.compactAfter.detailsPresent,
+      && Boolean(legacyConversationA11y.compactAfter.controls)
+      && legacyConversationA11y.compactAfter.detailsPresent
+      && legacyConversationA11y.compactCollapsed.expanded === 'false'
+      && !legacyConversationA11y.compactCollapsed.controls
+      && !legacyConversationA11y.compactCollapsed.detailsPresent,
     JSON.stringify(legacyConversationA11y));
 
   if (errs.length) console.log('⚠️ PAGEERRORS:', errs.slice(0, 3).join(' | '));

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -508,13 +508,22 @@ async function expand(page) {
     const turn = document.querySelector('[data-conversation-turn="overflow-turn"]');
     const summary = turn?.querySelector('[data-testid="conversation-tool-group-summary"]');
     const plan = turn?.querySelector('[data-testid="conversation-plan"]');
-    const reasoningToggle = [...(turn?.querySelectorAll('button') || [])]
-      .find(node => node.textContent.includes('思考完成'));
+    const controlledState = (toggle) => {
+      const controls = toggle?.getAttribute('aria-controls') || '';
+      return {
+        expanded: toggle?.getAttribute('aria-expanded') || '',
+        controls,
+        detailsPresent: Boolean(controls && document.getElementById(controls)),
+      };
+    };
+    const summaryState = controlledState(summary);
+    const reasoningToggle = turn?.querySelector('[data-testid="conversation-reasoning-toggle"]');
+    const reasoningBefore = controlledState(reasoningToggle);
     reasoningToggle?.click();
     await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const reasoningAfter = controlledState(reasoningToggle);
     const reasoning = turn?.querySelector('[data-testid="conversation-reasoning-content"]');
-    const commandButton = [...(turn?.querySelectorAll('button') || [])]
-      .find(node => node !== summary && node.textContent.includes('overflow-marker-'));
+    const commandButton = turn?.querySelector('[data-testid="conversation-compact-item-toggle"]');
     const commandTitle = commandButton?.querySelector('span.min-w-0.flex-1 > span.truncate');
     const turnRect = turn?.getBoundingClientRect();
     const contained = [reasoning, plan, summary, commandButton].every(node => {
@@ -525,6 +534,12 @@ async function expand(page) {
     const reasoningRect = reasoning?.getBoundingClientRect();
     const planRect = plan?.getBoundingClientRect();
     const summaryRect = summary?.getBoundingClientRect();
+    const commandClipped = Boolean(commandTitle && commandTitle.scrollWidth > commandTitle.clientWidth
+      && commandButton.scrollWidth <= commandButton.clientWidth + 1);
+    const commandBefore = controlledState(commandButton);
+    commandButton?.click();
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const commandAfter = controlledState(commandButton);
     return {
       found: Boolean(turn && reasoning && plan && summary && commandButton && commandTitle),
       turnIds: [...document.querySelectorAll('[data-conversation-turn]')]
@@ -537,8 +552,8 @@ async function expand(page) {
       ordered: Boolean(reasoningRect && planRect && summaryRect
         && reasoningRect.bottom <= planRect.top + 1
         && planRect.bottom <= summaryRect.top + 1),
-      commandClipped: Boolean(commandTitle && commandTitle.scrollWidth > commandTitle.clientWidth
-        && commandButton.scrollWidth <= commandButton.clientWidth + 1),
+      commandClipped,
+      accessibility: { summaryState, reasoningBefore, reasoningAfter, commandBefore, commandAfter },
     };
   });
   rec('①a-3c Codex 流式超长命令保持在工具卡内',
@@ -549,6 +564,19 @@ async function expand(page) {
       && codexStreamingOverflow.ordered
       && codexStreamingOverflow.commandClipped,
     JSON.stringify(codexStreamingOverflow));
+  const unifiedA11y = codexStreamingOverflow.accessibility || {};
+  rec('①a-3c-1 统一对话详情向辅助技术同步展开状态',
+    unifiedA11y.summaryState?.expanded === 'true'
+      && unifiedA11y.summaryState?.detailsPresent
+      && unifiedA11y.reasoningBefore?.expanded === 'false'
+      && !unifiedA11y.reasoningBefore?.detailsPresent
+      && unifiedA11y.reasoningAfter?.expanded === 'true'
+      && unifiedA11y.reasoningAfter?.detailsPresent
+      && unifiedA11y.commandBefore?.expanded === 'false'
+      && !unifiedA11y.commandBefore?.detailsPresent
+      && unifiedA11y.commandAfter?.expanded === 'true'
+      && unifiedA11y.commandAfter?.detailsPresent,
+    JSON.stringify(unifiedA11y));
 
   await page.evaluate(async () => {
     const events = [
@@ -560,21 +588,37 @@ async function expand(page) {
     }
   });
   await sleep(100);
-  const codexCompletedOverflow = await page.evaluate(() => {
+  const codexCompletedOverflow = await page.evaluate(async () => {
     const turn = document.querySelector('[data-conversation-turn="overflow-turn"]');
     const summary = turn?.querySelector('[data-testid="conversation-tool-group-summary"]');
     const turnRect = turn?.getBoundingClientRect();
     const summaryRect = summary?.getBoundingClientRect();
+    const controls = summary?.getAttribute('aria-controls') || '';
+    const expandedBefore = summary?.getAttribute('aria-expanded') || '';
+    const detailsBefore = Boolean(controls && document.getElementById(controls));
+    summary?.click();
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     return {
       summary: summary?.textContent.trim() || '',
       containsRawCommand: Boolean(summary?.textContent.includes('overflow-marker-')),
       contained: Boolean(turnRect && summaryRect && summaryRect.left >= turnRect.left - 1 && summaryRect.right <= turnRect.right + 1),
+      controls,
+      expandedBefore,
+      detailsBefore,
+      expandedAfter: summary?.getAttribute('aria-expanded') || '',
+      detailsAfter: Boolean(controls && document.getElementById(controls)),
     };
   });
   rec('①a-3d Codex 工具完成后摘要保持稳定',
     codexCompletedOverflow.summary === '执行步骤 · 1 项'
       && !codexCompletedOverflow.containsRawCommand
       && codexCompletedOverflow.contained,
+    JSON.stringify(codexCompletedOverflow));
+  rec('①a-3d-1 统一工具组折叠状态与详情 DOM 一致',
+    codexCompletedOverflow.expandedBefore === 'true'
+      && codexCompletedOverflow.detailsBefore
+      && codexCompletedOverflow.expandedAfter === 'false'
+      && !codexCompletedOverflow.detailsAfter,
     JSON.stringify(codexCompletedOverflow));
 
   await clickText(page, '查看全部'); await sleep(400);
@@ -1500,6 +1544,71 @@ async function expand(page) {
     return { auth: txt.includes('等待系统授权'), wait: txt.includes('等待模型加载就绪'), elapsed: txt.includes('已等待') };
   });
   rec('⑩ 点启用后等待系统授权+计时渲染', prog.auth && prog.wait && prog.elapsed, JSON.stringify(prog));
+
+  // 旧兼容渲染路径也必须暴露与详情 DOM 一致的展开状态。
+  await page.evaluate(() => localStorage.setItem('pinvou_conversation_ui_v2', 'false'));
+  await page.reload({ waitUntil: 'networkidle0' });
+  await page.waitForFunction(() => window.TauriBridge && document.body && document.body.innerText.includes('PINVOU'), { timeout: 20000 }).catch(() => {});
+  await sleep(1200);
+  await expand(page); await sleep(200);
+  await page.waitForSelector('[data-testid="codex-sidebar-item"]', { timeout: 10000 }).catch(() => {});
+  await page.evaluate(() => document.querySelector('[data-testid="codex-sidebar-item"]')?.click());
+  await sleep(500);
+  const legacyConversationA11y = await page.evaluate(async () => {
+    const state = (toggle) => {
+      const controls = toggle?.getAttribute('aria-controls') || '';
+      return {
+        expanded: toggle?.getAttribute('aria-expanded') || '',
+        controls,
+        detailsPresent: Boolean(controls && document.getElementById(controls)),
+      };
+    };
+    const settle = () => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    const reasoningToggle = document.querySelector('[data-testid="conversation-reasoning-toggle"]');
+    const reasoningBefore = state(reasoningToggle);
+    reasoningToggle?.click();
+    await settle();
+    const reasoningAfter = state(reasoningToggle);
+
+    const summary = document.querySelector('[data-testid="conversation-tool-group-summary"]');
+    const groupBefore = state(summary);
+    summary?.click();
+    await settle();
+    const groupAfter = state(summary);
+
+    const compactToggle = document.querySelector('[data-testid="conversation-compact-item-toggle"]');
+    const compactBefore = state(compactToggle);
+    compactToggle?.click();
+    await settle();
+    const compactAfter = state(compactToggle);
+    const controls = [reasoningAfter.controls, groupAfter.controls, compactAfter.controls].filter(Boolean);
+    return {
+      found: Boolean(reasoningToggle && summary && compactToggle),
+      reasoningBefore,
+      reasoningAfter,
+      groupBefore,
+      groupAfter,
+      compactBefore,
+      compactAfter,
+      uniqueControls: controls.length === 3 && new Set(controls).size === controls.length,
+    };
+  });
+  rec('⑩a 旧兼容对话详情向辅助技术同步展开状态',
+    legacyConversationA11y.found
+      && legacyConversationA11y.uniqueControls
+      && legacyConversationA11y.reasoningBefore.expanded === 'false'
+      && !legacyConversationA11y.reasoningBefore.detailsPresent
+      && legacyConversationA11y.reasoningAfter.expanded === 'true'
+      && legacyConversationA11y.reasoningAfter.detailsPresent
+      && legacyConversationA11y.groupBefore.expanded === 'false'
+      && !legacyConversationA11y.groupBefore.detailsPresent
+      && legacyConversationA11y.groupAfter.expanded === 'true'
+      && legacyConversationA11y.groupAfter.detailsPresent
+      && legacyConversationA11y.compactBefore.expanded === 'false'
+      && !legacyConversationA11y.compactBefore.detailsPresent
+      && legacyConversationA11y.compactAfter.expanded === 'true'
+      && legacyConversationA11y.compactAfter.detailsPresent,
+    JSON.stringify(legacyConversationA11y));
 
   if (errs.length) console.log('⚠️ PAGEERRORS:', errs.slice(0, 3).join(' | '));
   await browser.close();


### PR DESCRIPTION
## 背景

在 Code 模式中使用 Codex 时，工具执行阶段如果生成较长的 PowerShell 命令，命令文本会越过工具区域，覆盖上方的执行计划和下方的工具卡片。工具完成后摘要会恢复为普通的“执行步骤”，因此最终回复显示正常，异常只在流式处理期间出现。

## 根因

ACP 事件分类本身正确：长命令属于 `tool_call.title`，并未混入思考或计划事件。共享时间线在工具运行时使用 `tool.name || tool.title` 生成工具组摘要；命令执行事件通常没有 `name`，于是完整命令被直接放入摘要。该摘要所在的 Flex 子项同时缺少收缩、截断和溢出约束，长文本因此突破当前回合的布局边界。

## 变更

- 命令执行、文件变更和普通工具使用短语义标签作为运行中摘要，不再把原始命令放进工具组标题。
- 为工具组、命令卡、思考内容、执行计划、权限标题和终端内容补充宽度、换行、截断及滚动边界。
- 同步加固共享时间线与旧 ACP 兼容渲染路径。
- 增加超长命令的浏览器回归，覆盖执行中与执行完成两个状态，并验证思考、计划和工具区域不重叠。

## 验证

- `npm run build:ui`
- `npm run test:codex-acp`
- `npm run test:ui-smoke`（ALL 50 PASS）
- `npm run test:model-reasoning`
- `npm run test:multiagent-plan`（33/33）
- `npm run lint:ui`
- `npm run check:architecture`
- `git diff --check`

## 风险

本次只调整前端展示和测试，不改变 ACP 事件协议、工具执行逻辑或后端状态。完整命令仍保留在可展开的命令卡中。