### PR TITLE
fix(chat): 多智能体开关按会话隔离并防运行中对话覆盖

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -980,7 +980,12 @@
     touchSessionBuffer(sid, bg, isScheduledRunSession(sid));
     var realId = state.activeSessionId;
     var draftComposer = realId ? "" : (state.composerDraft || "");
-    saveWorkingSetTo(getBuffer(realId));
+    // 进入时就把【当前完整工作集】落进 restoreBuffer：realId 为 null（草稿态）
+    // 时也要保存——草稿态可能已含乐观的 modeState（如刚打开的多智能体开关）、
+    // 未发送文本，finally 里不能拿全新 freshBuffer 覆盖（否则开关状态被后台
+    // 会话事件冲掉，表现为"打开开关后被正在运行的对话覆盖成关"）。
+    var restoreBuffer = realId ? getBuffer(realId) : freshBuffer();
+    saveWorkingSetTo(restoreBuffer);
     loadWorkingSetFrom(bg);
     state.activeSessionId = sid;
     var prev = suppressNotify; suppressNotify = true;
@@ -989,11 +994,8 @@
       suppressNotify = prev;
       saveWorkingSetTo(bg);
       state.activeSessionId = realId;
-      // realId 为 null(草稿态)时 getBuffer(null)=null、loadWorkingSetFrom(null) 是 no-op,
-      // 会把刚处理的后台 session 工作集泄漏进草稿视图(activeSessionId=null 却带着它的 chatItems),
-      // 召唤检阅等依赖 activeSessionId 的操作随之错乱。草稿态须切回干净工作集，
-      // 但要保留用户正在输入的未发送文本。
-      var restoreBuffer = realId ? getBuffer(realId) : freshBuffer();
+      // 恢复的是进入时的同一工作集对象（草稿态下保留乐观 modeState /
+      // 未发送文本），不是全新 buffer。
       if (!realId) restoreBuffer.composerDraft = draftComposer;
       loadWorkingSetFrom(restoreBuffer);
     }

--- a/pinvou3-app/src/platform/tauri/bridge/interaction.js
+++ b/pinvou3-app/src/platform/tauri/bridge/interaction.js
@@ -50,15 +50,51 @@
   }
 
   // ── Mode state ───────────────────────────────────────────────────
+  // 会话级读取。必须防住的竞态：
+  // 1. await 挂起期间用户切走：响应返回后不能写当前 active 会话的显示（否则
+  //    上一个会话的开关/模式状态会串台到新会话，表现为"在一个对话打开开关，
+  //    所有对话都开"）。校验发起时的 sid 仍是 active，否则把结果定向写回
+  //    sid 自己的 buffer，不碰当前显示。
+  // 2. 多智能体开关翻转/模式切换的本地权威改写：乐观翻转已把新状态显示出来
+  //    （后端尚未落盘），或权威写回已完成，此时在途的 get_mode_state 只会
+  //    拿到旧值，把用户刚打开（或关闭）的开关覆盖回去。防法：per-session
+  //    epoch——每次本地权威改写 bump 对应会话的 revision，读取发起时捕获、
+  //    返回后校验，epoch 变了即丢弃陈旧读取，权威值由对应操作写回。
+  //    只看瞬时 in-flight 集合识别不了"toggle 已完成（集合已清空）、旧读取
+  //    才返回"的顺序（审计意见），epoch 一并覆盖在途与已完成两种顺序。
+  var modeStateEpochs = {};
+  function bumpModeStateEpoch(sid) {
+    if (!sid) return;
+    modeStateEpochs[sid] = (modeStateEpochs[sid] || 0) + 1;
+  }
   async function syncModeState() {
-    if (!state.activeSessionId) {
+    var sid = state.activeSessionId;
+    if (!sid) {
       state.modeState = { mode: "yolo", multiAgent: false };
       return;
     }
+    if (multiAgentToggleInFlight.has(sid)) return;
+    var epoch = modeStateEpochs[sid] || 0;
     try {
+      // invoke 形状保持 { sessionId: state.activeSessionId }（协议指纹按文本
+      // 计算）；发起瞬间 activeSessionId === sid，await 返回后按 sid 校验归属。
       var ms = await invoke("get_mode_state", { sessionId: state.activeSessionId });
+      // 响应返回后校验 epoch：期间任何本地权威改写（开关翻转、plan/模式切换）
+      // 都会使该读取成为陈旧值，丢弃——权威值由对应操作写回。此检查覆盖
+      // 两种返回顺序：改写仍在途（原 in-flight 闸场景）与改写已完成（旧读取
+      // 最后返回的顺序，in-flight 集合已清空、仅靠集合识别不了）。
+      if ((modeStateEpochs[sid] || 0) !== epoch) return;
+      if (state.activeSessionId !== sid) {
+        runSyncOnSession(sid, function () {
+          state.modeState = { mode: ms.mode || "yolo", multiAgent: !!ms.multi_agent };
+        });
+        return;
+      }
       state.modeState = { mode: ms.mode || "yolo", multiAgent: !!ms.multi_agent };
     } catch (e) {
+      // get 失败同样不得用默认值覆盖已发生的权威改写。
+      if ((modeStateEpochs[sid] || 0) !== epoch) return;
+      if (state.activeSessionId !== sid) return;
       state.modeState = { mode: "yolo", multiAgent: false };
     }
   }
@@ -150,6 +186,7 @@
         displayMessage: displayEcho,
       });
       if (planBuffer) planBuffer.deferredRemoteUserEvent = null;
+      bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
       runOnSession(sid, function () { applyModeFromState(st); });
     } catch (e) {
       var errorText = String(e && e.message ? e.message : e || "");
@@ -170,6 +207,7 @@
       if (concurrentTurn && planBuffer) markRemoteTurn(sid, planBuffer);
       try {
         var currentMode = await invoke("get_mode_state", { sessionId: sid });
+        bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
         runOnSession(sid, function () { applyModeFromState(currentMode); });
       } catch (_) {}
       addSystemItemFor(sid, bt("acceptPlanFailed") + e);
@@ -187,6 +225,7 @@
     notify();
     try {
       var st = await invoke("discard_plan", { sessionId: sid, planId: planTicket });
+      bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
       runOnSession(sid, function () { applyModeFromState(st); });
       patchItemByIdFor(sid, itemId, { planResolutionConfirmed: true });
     } catch (e) {
@@ -211,6 +250,7 @@
       if (planNotActive) {
         try {
           var currentMode = await invoke("get_mode_state", { sessionId: sid });
+          bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
           runOnSession(sid, function () { applyModeFromState(currentMode); });
         } catch (_) {}
       }
@@ -220,10 +260,15 @@
   }
   async function exitPlanToYolo() {
     if (!state.activeSessionId) return;
+    var sid = state.activeSessionId;
     try {
+      // invoke 形状保持原样（协议指纹按文本计算，不因捕获 sid 而改写）。
       var st = await invoke("exit_plan_to_yolo", { sessionId: state.activeSessionId });
-      applyModeFromState(st);
-    } catch (e) { addSystemItem(bt("exitPlanFailed") + e); }
+      bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
+      // 写回必须定向触发会话：await 期间用户可能已切走，直接写全局 modeState
+      // 会把 A 会话的模式串到 B 会话显示——syncModeState 串台的写入镜像面。
+      runOnSession(sid, function () { applyModeFromState(st); });
+    } catch (e) { addSystemItemFor(sid, bt("exitPlanFailed") + e); }
     notify();
   }
   // 灯泡 toggle：plan ↔ yolo
@@ -269,6 +314,10 @@
       // 等返回再翻拨杆会像"点了没反应"。先翻显示并 notify，成功后用后端
       // 权威状态复核；失败回滚显示并提示。in-flight 闸已挡并发重入。
       var previousMultiAgent = !!(state.modeState && state.modeState.multiAgent);
+      // 翻转即刻 bump 该会话 epoch：让在途的 get_mode_state 读取（syncModeState）
+      // 全部作废，无论其响应在 toggle 进行中还是完成后返回——陈旧读取一律
+      // 丢弃，权威值由下方 set_multi_agent_mode 返回后写回（审计意见）。
+      bumpModeStateEpoch(sid);
       state.modeState = {
         mode: (state.modeState && state.modeState.mode) || "yolo",
         multiAgent: !!enabled,

--- a/pinvou3-app/src/platform/tauri/bridge/interaction.js
+++ b/pinvou3-app/src/platform/tauri/bridge/interaction.js
@@ -260,15 +260,10 @@
   }
   async function exitPlanToYolo() {
     if (!state.activeSessionId) return;
-    var sid = state.activeSessionId;
     try {
-      // invoke 形状保持原样（协议指纹按文本计算，不因捕获 sid 而改写）。
       var st = await invoke("exit_plan_to_yolo", { sessionId: state.activeSessionId });
-      bumpModeStateEpoch(sid); // 权威 mode 写回前让在途读取作废
-      // 写回必须定向触发会话：await 期间用户可能已切走，直接写全局 modeState
-      // 会把 A 会话的模式串到 B 会话显示——syncModeState 串台的写入镜像面。
-      runOnSession(sid, function () { applyModeFromState(st); });
-    } catch (e) { addSystemItemFor(sid, bt("exitPlanFailed") + e); }
+      applyModeFromState(st);
+    } catch (e) { addSystemItem(bt("exitPlanFailed") + e); }
     notify();
   }
   // 灯泡 toggle：plan ↔ yolo

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6275,15 +6275,31 @@
   }
 
   // ── Mode state ───────────────────────────────────────────────────
+  // 会话级读取：await 挂起期间用户可能已切走，响应返回后必须校验发起时的
+  // sid 仍是 active，否则把结果定向写回 sid 自己的 buffer，不污染当前显示。
+  // 另加请求序号：同一会话内并发读取乱序返回时，旧响应不得覆盖新响应
+  // （A→B→A 快速切换时 #1 的慢响应覆盖 #3 的新值，审计；tauri 版 epoch 对齐）。
+  var modeSyncSeq = 0;
   async function syncModeState() {
-    if (!state.activeSessionId) {
+    var sid = state.activeSessionId;
+    if (!sid) {
       state.modeState = { mode: "yolo", multiAgent: false };
       return;
     }
+    var seq = ++modeSyncSeq;
     try {
       var ms = await invoke("get_mode_state", { sessionId: state.activeSessionId });
+      if (seq !== modeSyncSeq) return; // 已有更新的读取发起，本响应陈旧
+      if (state.activeSessionId !== sid) {
+        runSyncOnSession(sid, function () {
+          state.modeState = { mode: ms.mode || "yolo", multiAgent: !!ms.multi_agent };
+        });
+        return;
+      }
       state.modeState = { mode: ms.mode || "yolo", multiAgent: !!ms.multi_agent };
     } catch (e) {
+      if (seq !== modeSyncSeq) return;
+      if (state.activeSessionId !== sid) return;
       state.modeState = { mode: "yolo", multiAgent: false };
     }
   }

--- a/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
+++ b/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
@@ -1267,3 +1267,120 @@ test('详情清单未解析或终态无 transcript 时不发起读取', async ()
     assert.equal(reads, 0, `${testCase.name} 的详情读取次数必须为 0`);
   }
 });
+// ── modeState 竞态回归：陈旧读取不得覆盖权威改写（审计意见）────────
+// 装载 interaction 桥的 runtime 快照，用可控 invoke 精确编排异步返回顺序。
+// 场景：syncModeState 先发起 get_mode_state（将返回旧值），toggle 先落盘
+// （in-flight 清空）后旧读取才返回。只靠瞬时 in-flight 集合识别不了这种
+// 顺序——epoch 校验必须在场（审计 P1）。
+function loadInteractionRuntime() {
+  const root = {};
+  vm.runInNewContext(interactionBridgeSource, { window: root, globalThis: root });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__.interaction;
+  const state = {
+    activeSessionId: 'chat-a',
+    modeState: { mode: 'yolo', multiAgent: false },
+    pendingDraftMultiAgent: false,
+    chatItems: [],
+    messages: [],
+  };
+  const deferred = {};
+  const calls = [];
+  const runtime = {
+    state,
+    calls,
+    notifyCount: 0,
+    defer(name) {
+      deferred[name] = deferred[name] || {};
+      deferred[name].promise = new Promise((resolve, reject) => {
+        deferred[name].resolve = resolve;
+        deferred[name].reject = reject;
+      });
+      return deferred[name];
+    },
+  };
+  runtime.api = factory({
+    state,
+    notify() { runtime.notifyCount += 1; },
+    bt(key) { return key; },
+    addSystemItem() {},
+    addAuthoritySyncNotice() {},
+    addChatItem() {},
+    timeStr() { return ''; },
+    runSyncOnSession(sid, fn) {
+      // 记录跨会话定向调用：sid !== active 时 fn 必须落在 sid 的 buffer 上，
+      // 不能直接改当前显示。本 mock 简化执行 fn 但保留调用证据。
+      if (sid !== state.activeSessionId) calls.push('runSyncOnSession:' + sid);
+      fn();
+    },
+    getBuffer() { return null; },
+    flushAssistantMessageToHistory() {},
+    resetPendingAssistant() {},
+    rerenderFromMessages() {},
+    ensureSession: async () => (state.activeSessionId || 'chat-a'),
+    sendMessage: async () => {},
+    reconcileRemoteTurn: async () => true,
+    isBusyFor() { return false; },
+    markRemoteTurn() {},
+    turnUsageDirty: {},
+    invoke(name, args) {
+      calls.push(name);
+      if (deferred[name] && deferred[name].promise) return deferred[name].promise;
+      return Promise.resolve({ mode: 'yolo', multi_agent: false });
+    },
+  });
+  return runtime;
+}
+
+test('陈旧 get_mode_state 不得覆盖已完成 toggle：set 先落盘、旧读取后返回', async () => {
+  const rt = loadInteractionRuntime();
+  const get = rt.defer('get_mode_state');
+  const set = rt.defer('set_multi_agent_mode');
+  const syncP = rt.api.syncModeState();                    // t0: get 挂起（将返回旧值 false）
+  const toggleP = rt.api.setMultiAgentMode(true);          // t1: 乐观翻转 true，set 在途
+  set.resolve({ mode: 'yolo', multi_agent: true });        // t2: toggle 先落盘，finally 清空 in-flight
+  await toggleP;
+  get.resolve({ mode: 'yolo', multi_agent: false });       // t3: 旧 get 最后返回
+  await syncP;
+  assert.equal(rt.state.modeState.multiAgent, true,
+    'toggle 已完成的权威值 true 不得被旧读取 false 覆盖（审计 P1 顺序）');
+});
+
+test('get_mode_state 返回时 toggle 仍在途：旧读取丢弃，乐观态保持', async () => {
+  const rt = loadInteractionRuntime();
+  const get = rt.defer('get_mode_state');
+  const set = rt.defer('set_multi_agent_mode');
+  const syncP = rt.api.syncModeState();
+  const toggleP = rt.api.setMultiAgentMode(true);          // 乐观翻转 true，set 在途
+  get.resolve({ mode: 'yolo', multi_agent: false });       // get 先返回（toggle 尚未落盘）
+  await syncP;
+  assert.equal(rt.state.modeState.multiAgent, true,
+    '在途 toggle 期间的旧读取不得把乐观态覆盖回去');
+  set.resolve({ mode: 'yolo', multi_agent: true });
+  await toggleP;
+});
+
+test('get_mode_state 失败且期间发生 toggle：默认值不得覆盖权威改写', async () => {
+  const rt = loadInteractionRuntime();
+  const get = rt.defer('get_mode_state');
+  const set = rt.defer('set_multi_agent_mode');
+  const syncP = rt.api.syncModeState();
+  const toggleP = rt.api.setMultiAgentMode(true);
+  set.resolve({ mode: 'yolo', multi_agent: true });
+  await toggleP;
+  get.reject(new Error('backend down'));                   // get 失败（旧值本不可信）
+  await syncP;
+  assert.equal(rt.state.modeState.multiAgent, true,
+    'get 失败也不得用 yolo/false 默认值把已完成的切换砸掉');
+});
+
+test('无权威改写时 syncModeState 正常写回后端值（epoch 不变）', async () => {
+  const rt = loadInteractionRuntime();
+  const get = rt.defer('get_mode_state');
+  const syncP = rt.api.syncModeState();
+  get.resolve({ mode: 'plan', multi_agent: true });
+  await syncP;
+  // 逐字段断言（vm 上下文的对象原型与主上下文不同，deepEqual 不可用）
+  assert.equal(rt.state.modeState.mode, 'plan');
+  assert.equal(rt.state.modeState.multiAgent, true,
+    '没有发生过 toggle 的普通读取必须照常生效');
+});


### PR DESCRIPTION
## 背景

多智能体模式开关有两个 bug：

1. **开关对全局生效**：在一个对话里打开开关，切到其他对话也显示打开。
2. **打开开关被运行中的对话覆盖成关**：某对话正在运行时打开开关，容易被正在运行的对话状态冲回关闭。

后端（`set_multi_agent_mode` / `sessions/_multi_agent.json`）本就是按会话存储的，问题全在前端 bridge 的两条竞态路径。

## 根因

- `syncModeState()` 是无会话归属校验的 async 写入：切会话时发起 `get_mode_state`，await 挂起期间用户又切走，响应返回后**无条件写全局 `state.modeState`**，把上一个会话的开关/模式状态覆盖到当前会话显示 → bug 1。
- 开关乐观翻转后 `set_multi_agent_mode` 仍在 in-flight，任何 `syncModeState` 触发都会拉回**后端旧值**（尚未落盘）覆盖新状态 → bug 2 之一。
- tauri 版 `runSyncOnSession` 草稿态（无 active 会话）处理后台事件时，恢复用全新 `freshBuffer()` 覆盖，草稿里刚打开的开关状态被后台会话事件冲掉 → bug 2 之二（web 版已修复，tauri 版落后）。

## 变更

| 文件 | 改动 |
|---|---|
| `pinvou3-app/src/platform/tauri/bridge/interaction.js` | `syncModeState` 捕获 sid + **per-session epoch**：陈旧读取在「toggle 在途」与「toggle 已完成」两种返回顺序下均被作废，权威值由 `setMultiAgentMode` 写回；`acceptPlan`/`discardPlan`/`setMultiAgentMode` 权威改写前 bump epoch |
| `pinvou3-app/src/platform/web/bridge.js` | 对齐 tauri：syncModeState sid 归属 + 请求序号 |
| `pinvou3-app/src/platform/tauri/bridge.js` | `runSyncOnSession` 草稿态保留完整工作集（含乐观 modeState），不再以 freshBuffer 覆盖 |

## 实际验证

- `multiagent_plan_normalize` 38 个测试全绿（含 4 个 modeState epoch 竞态回归测试）
- `node --check` / eslint 通过；`invoke` 参数形状保持原样，`bridge_domain_protocol` 指纹无变化

## 范围说明（已拆分）

本 PR 原含的扩展修复（会话管理 / 记忆 / 专家卡 / 工作流 / 定时 / 设置 / 更新 / 远程控制 / interaction 域写入定向）已**有机拆分为独立 PR**，便于分开 review：

- #256 interaction 域 UI 写入定向（**依赖本 PR 的 epoch 基础设施**）
- #257 会话管理异步竞态
- #258 记忆面板与专家卡跨会话竞态
- #259 工作流 run 身份校验
- #260 定时/设置/更新/远程控制异步竞态

## 已知风险

- 建议手动验证：① A 对话打开开关 → 快速切到 B/C 看开关是否串台；② A 对话正在运行时在 B 打开开关，观察是否被覆盖成关。