### PR TITLE
fix(memory): 修复升级后记忆资料无法读取和保存

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,7 +15,7 @@ name: PR Check
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
 #   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
 #   欠账由清理 PR(#35 及后续)消化后逐个升 deny。
-# - windows-rust-test:只在 main push 且 rust 相关路径变更时跑，不作为 PR 或 Merge Queue 合入门禁。
+# - windows-rust-test:Rust 相关 Ready PR、Merge Queue 与 main push 跑 Windows 原生编译/单测；Draft 跳过。
 # - windows-codex-runtime-test:相关 PR 在 Windows 原生准备 Node + ACP Bridge，并核对安装包资源。
 # - required-gate:PR 阶段汇总所有适用检查，作为唯一 required check。
 # - merge_group:按 base/head 的真实组合 diff 运行适用门禁，保证验证对象就是
@@ -680,10 +680,9 @@ jobs:
   windows-rust-test:
     name: windows-rust-test
     needs: changes
-    # 跨平台构建不作为 PR 检测项；合入 main 后按路径做 Windows 原生验证:
-    # 仅 rust 相关改动才跑(docs-only 推送烧 32min Windows runner 零收益——其 cache
-    # shared-key 只被自身消费,不为 PR 提供暖 cache)。
-    if: ${{ !cancelled() && github.event_name == 'push' && needs.changes.outputs.rust_code == 'true' }}
+    # Windows 专属原语必须在原生 runner 执行；Draft 保持快速反馈，Ready PR、Merge Queue
+    # 与 main push 按 Rust 路径触发，docs-only 变更不消耗 Windows runner。
+    if: ${{ !cancelled() && needs.changes.outputs.rust_code == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)) }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 移除 sccache 后冷编译更长,放宽到 90min(aws-lc-sys NASM 预生成对象冷编译更久)。
@@ -750,6 +749,9 @@ jobs:
 
       - name: Windows Rust 单元测试链接检查
         run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
+
+      - name: Windows 原子替换状态机回归
+        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib platform::filesystem::tests::windows_ -- --test-threads=1
 
   windows-codex-runtime-test:
     name: windows-codex-runtime-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -752,11 +752,21 @@ jobs:
 
       - name: Windows 原子替换状态机回归
         run: |
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib platform::filesystem::tests::windows_ -- --test-threads=1
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_read_recovers_an_occupied_1177_layout_after_release -- --test-threads=1
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_writes_never_expose_partial_utf8_to_concurrent_readers -- --test-threads=1
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_public_read_ -- --test-threads=1
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib features::memory::tests::topic_migration_ -- --test-threads=1
+          set -euo pipefail
+          # 逐过滤器断言至少命中 1 个测试,避免测试改名后过滤器 0 匹配却 exit 0
+          # 导致的静默空跑。
+          for filter in \
+            'platform::filesystem::tests::windows_' \
+            'artifact_read_recovers_an_occupied_1177_layout_after_release' \
+            'artifact_writes_never_expose_partial_utf8_to_concurrent_readers' \
+            'artifact_public_read_' \
+            'features::memory::tests::topic_migration_'; do
+            cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib "$filter" -- --test-threads=1 2>&1 | tee /tmp/windows_regression.log
+            grep -qE 'running [1-9][0-9]* tests?' /tmp/windows_regression.log || {
+              echo "FAIL: 回归过滤器 '$filter' 匹配 0 个测试(疑似测试改名导致静默空跑)" >&2
+              exit 1
+            }
+          done
 
   windows-codex-runtime-test:
     name: windows-codex-runtime-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -755,6 +755,8 @@ jobs:
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib platform::filesystem::tests::windows_ -- --test-threads=1
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_read_recovers_an_occupied_1177_layout_after_release -- --test-threads=1
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_writes_never_expose_partial_utf8_to_concurrent_readers -- --test-threads=1
+          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_public_read_ -- --test-threads=1
+          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib features::memory::tests::topic_migration_ -- --test-threads=1
 
   windows-codex-runtime-test:
     name: windows-codex-runtime-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -751,7 +751,10 @@ jobs:
         run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
 
       - name: Windows 原子替换状态机回归
-        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib platform::filesystem::tests::windows_ -- --test-threads=1
+        run: |
+          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib platform::filesystem::tests::windows_ -- --test-threads=1
+          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_read_recovers_an_occupied_1177_layout_after_release -- --test-threads=1
+          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib artifact_writes_never_expose_partial_utf8_to_concurrent_readers -- --test-threads=1
 
   windows-codex-runtime-test:
     name: windows-codex-runtime-test

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -218,30 +218,37 @@ fn recover_interrupted_artifact_write(path: &std::path::Path) -> std::io::Result
     }
 
     if path.is_file() {
-        for (_, (tmp, backup)) in candidates {
-            if let Some(tmp) = tmp {
-                let _ = std::fs::remove_file(tmp);
-            }
-            if let Some(backup) = backup {
-                let _ = std::fs::remove_file(backup);
-            }
-        }
+        cleanup_artifact_recovery_candidates(candidates.values());
         return Ok(());
     }
 
-    for (token, (tmp, backup)) in candidates.into_iter().rev() {
+    let mut ordered = candidates
+        .iter()
+        .map(|(token, (tmp, backup))| {
+            (
+                artifact_recovery_sort_key(token, tmp.as_deref(), backup.as_deref()),
+                token.clone(),
+                tmp.clone(),
+                backup.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    ordered.sort_by_key(|(key, _, _, _)| *key);
+    for (_, token, tmp, backup) in ordered.into_iter().rev() {
         let replacement = tmp.unwrap_or_else(|| parent.join(format!("{tmp_prefix}{token}")));
         let backup = backup.unwrap_or_else(|| parent.join(format!("{bak_prefix}{token}")));
         match crate::platform::filesystem::recover_interrupted_replace(&replacement, path, &backup)
         {
-            Ok(crate::platform::filesystem::ReplaceState::Committed) => return Ok(()),
+            Ok(crate::platform::filesystem::ReplaceState::Committed) => {
+                cleanup_artifact_recovery_candidates(candidates.values());
+                return Ok(());
+            }
             Ok(_) => unreachable!("recovery success is always committed"),
             Err(error)
                 if error.state() == crate::platform::filesystem::ReplaceState::RolledBack
                     && path.is_file() =>
             {
-                let _ = std::fs::remove_file(replacement);
-                let _ = std::fs::remove_file(backup);
+                cleanup_artifact_recovery_candidates(candidates.values());
                 return Ok(());
             }
             Err(error)
@@ -253,6 +260,48 @@ fn recover_interrupted_artifact_write(path: &std::path::Path) -> std::io::Result
         }
     }
     Ok(())
+}
+
+fn artifact_recovery_sort_key(
+    token: &str,
+    tmp: Option<&std::path::Path>,
+    backup: Option<&std::path::Path>,
+) -> (bool, u128) {
+    let timestamp = token
+        .rsplit_once('-')
+        .and_then(|(_, nanos)| nanos.parse::<u128>().ok())
+        .or_else(|| {
+            [backup, tmp]
+                .into_iter()
+                .flatten()
+                .filter_map(|path| {
+                    std::fs::metadata(path)
+                        .and_then(|value| value.modified())
+                        .ok()
+                })
+                .filter_map(|modified| {
+                    modified
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .ok()
+                        .map(|duration| duration.as_nanos())
+                })
+                .max()
+        })
+        .unwrap_or_default();
+    (backup.is_some(), timestamp)
+}
+
+fn cleanup_artifact_recovery_candidates<'a>(
+    candidates: impl Iterator<Item = &'a (Option<std::path::PathBuf>, Option<std::path::PathBuf>)>,
+) {
+    for (tmp, backup) in candidates {
+        if let Some(tmp) = tmp {
+            let _ = std::fs::remove_file(tmp);
+        }
+        if let Some(backup) = backup {
+            let _ = std::fs::remove_file(backup);
+        }
+    }
 }
 
 /// 题目转安全文件名:去掉路径分隔/非法字符,截长,空了给兜底。

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -1,5 +1,11 @@
 use super::prelude::*;
 use crate::platform::path_policy::validate_user_path;
+use std::sync::OnceLock;
+
+fn artifact_lifecycle_lock() -> &'static parking_lot::Mutex<()> {
+    static LOCK: OnceLock<parking_lot::Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| parking_lot::Mutex::new(()))
+}
 
 /// 产物文件元数据。前端右栏 list 用。
 #[derive(Debug, Clone, Serialize)]
@@ -19,6 +25,9 @@ pub async fn read_artifact_text(path: String) -> Result<String, String> {
 
 pub(crate) fn read_artifact_text_impl(path: &str) -> Result<String, String> {
     let p = validate_user_path(path)?;
+    let _lifecycle = artifact_lifecycle_lock().lock();
+    recover_interrupted_artifact_write(&p)
+        .map_err(|e| format!("recover_artifact_text({}): {e}", p.display()))?;
     std::fs::read_to_string(&p).map_err(|e| format!("read_artifact_text({}): {e}", p.display()))
 }
 
@@ -32,6 +41,9 @@ pub async fn write_artifact_text(path: String, content: String) -> Result<(), St
 
 pub(crate) fn write_artifact_text_impl(path: &str, content: &str) -> Result<(), String> {
     let p = validate_user_path(path)?;
+    let _lifecycle = artifact_lifecycle_lock().lock();
+    recover_interrupted_artifact_write(&p)
+        .map_err(|e| format!("recover_artifact_text({}): {e}", p.display()))?;
     if !p.is_file() {
         return Err(format!("not a file: {}", p.display()));
     }
@@ -50,7 +62,8 @@ pub(crate) fn write_artifact_text_impl(path: &str, content: &str) -> Result<(), 
         return Err("markdown artifact is too large to save".into());
     }
 
-    atomic_write_utf8(&p, content).map_err(|e| format!("write_artifact_text({}): {e}", p.display()))
+    atomic_write_utf8_unlocked(&p, content)
+        .map_err(|e| format!("write_artifact_text({}): {e}", p.display()))
 }
 
 fn ensure_editable_artifact_path(path: &std::path::Path) -> Result<(), String> {
@@ -90,6 +103,30 @@ fn ensure_editable_artifact_path(path: &std::path::Path) -> Result<(), String> {
     Ok(())
 }
 pub(super) fn atomic_write_utf8(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+    let _lifecycle = artifact_lifecycle_lock().lock();
+    atomic_write_utf8_unlocked(path, content)
+}
+
+fn atomic_write_utf8_unlocked(path: &std::path::Path, content: &str) -> std::io::Result<()> {
+    atomic_write_utf8_unlocked_with(
+        path,
+        content,
+        crate::platform::filesystem::replace_file_atomically,
+    )
+}
+
+pub(super) fn atomic_write_utf8_unlocked_with<F>(
+    path: &std::path::Path,
+    content: &str,
+    replace: F,
+) -> std::io::Result<()>
+where
+    F: FnOnce(
+        &std::path::Path,
+        &std::path::Path,
+        &std::path::Path,
+    ) -> crate::platform::filesystem::ReplaceResult,
+{
     use std::io::Write;
 
     let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
@@ -97,24 +134,18 @@ pub(super) fn atomic_write_utf8(path: &std::path::Path, content: &str) -> std::i
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("artifact.md");
-    let tmp = parent.join(format!(
-        ".{file_name}.tmp-{}-{}",
+    let token = format!(
+        "{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos()
-    ));
-    let backup = parent.join(format!(
-        ".{file_name}.bak-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
+    );
+    let tmp = parent.join(format!(".{file_name}.tmp-{token}"));
+    let backup = parent.join(format!(".{file_name}.bak-{token}"));
 
-    let write_result = (|| -> std::io::Result<()> {
+    let stage_result = (|| -> std::io::Result<()> {
         let mut f = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -122,20 +153,106 @@ pub(super) fn atomic_write_utf8(path: &std::path::Path, content: &str) -> std::i
         f.write_all(content.as_bytes())?;
         f.sync_all()?;
         drop(f);
-
-        crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup)?;
-
-        if let Ok(dir) = std::fs::File::open(parent) {
-            let _ = dir.sync_all();
-        }
         Ok(())
     })();
-
-    if write_result.is_err() {
+    if let Err(error) = stage_result {
         let _ = std::fs::remove_file(&tmp);
-        let _ = std::fs::remove_file(&backup);
+        return Err(error);
     }
-    write_result
+
+    match replace(&tmp, path, &backup) {
+        Ok(crate::platform::filesystem::ReplaceState::Committed) => {
+            let _ = std::fs::remove_file(&backup);
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        }
+        Ok(state) => Err(std::io::Error::other(format!(
+            "unexpected successful replacement state: {state:?}"
+        ))),
+        Err(error) => {
+            if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
+                let _ = std::fs::remove_file(&tmp);
+                let _ = std::fs::remove_file(&backup);
+            }
+            Err(error.into_io_error())
+        }
+    }
+}
+
+fn recover_interrupted_artifact_write(path: &std::path::Path) -> std::io::Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+        return Ok(());
+    };
+    let tmp_prefix = format!(".{file_name}.tmp-");
+    let bak_prefix = format!(".{file_name}.bak-");
+    let mut candidates = std::collections::BTreeMap::<
+        String,
+        (Option<std::path::PathBuf>, Option<std::path::PathBuf>),
+    >::new();
+    if let Ok(entries) = std::fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            if !std::fs::symlink_metadata(&candidate)
+                .is_ok_and(|metadata| metadata.file_type().is_file())
+            {
+                continue;
+            }
+            let Some(name) = candidate
+                .file_name()
+                .and_then(|value| value.to_str())
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            if let Some(token) = name.strip_prefix(&tmp_prefix) {
+                candidates.entry(token.to_string()).or_default().0 = Some(candidate);
+            } else if let Some(token) = name.strip_prefix(&bak_prefix) {
+                candidates.entry(token.to_string()).or_default().1 = Some(candidate);
+            }
+        }
+    }
+
+    if path.is_file() {
+        for (_, (tmp, backup)) in candidates {
+            if let Some(tmp) = tmp {
+                let _ = std::fs::remove_file(tmp);
+            }
+            if let Some(backup) = backup {
+                let _ = std::fs::remove_file(backup);
+            }
+        }
+        return Ok(());
+    }
+
+    for (token, (tmp, backup)) in candidates.into_iter().rev() {
+        let replacement = tmp.unwrap_or_else(|| parent.join(format!("{tmp_prefix}{token}")));
+        let backup = backup.unwrap_or_else(|| parent.join(format!("{bak_prefix}{token}")));
+        match crate::platform::filesystem::recover_interrupted_replace(&replacement, path, &backup)
+        {
+            Ok(crate::platform::filesystem::ReplaceState::Committed) => return Ok(()),
+            Ok(_) => unreachable!("recovery success is always committed"),
+            Err(error)
+                if error.state() == crate::platform::filesystem::ReplaceState::RolledBack
+                    && path.is_file() =>
+            {
+                let _ = std::fs::remove_file(replacement);
+                let _ = std::fs::remove_file(backup);
+                return Ok(());
+            }
+            Err(error)
+                if error.state() == crate::platform::filesystem::ReplaceState::RecoveryRequired =>
+            {
+                return Err(error.into_io_error());
+            }
+            Err(error) => return Err(error.into_io_error()),
+        }
+    }
+    Ok(())
 }
 
 /// 题目转安全文件名:去掉路径分隔/非法字符,截长,空了给兜底。

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -175,6 +175,16 @@ where
             if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
                 let _ = std::fs::remove_file(&tmp);
                 let _ = std::fs::remove_file(&backup);
+            } else if error.state() == crate::platform::filesystem::ReplaceState::RecoveryRequired
+                && path.exists()
+            {
+                // A target that still exists (e.g. a directory occupying its
+                // path) is a permanent failure: recovery can never promote a
+                // candidate over it, so the staged tmp/backup are garbage. A
+                // truly missing target keeps its candidates for
+                // recover_interrupted_artifact_write.
+                let _ = std::fs::remove_file(&tmp);
+                let _ = std::fs::remove_file(&backup);
             }
             Err(error.into_io_error())
         }

--- a/pinvou3-app/src-tauri/src/app/commands/memory.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/memory.rs
@@ -589,8 +589,19 @@ pub async fn update_memory_preference(
     store: State<'_, SessionStore>,
     app: AppHandle,
 ) -> Result<MemoryWriteState<Option<crate::features::memory::PreferenceFile>>, String> {
-    let item = crate::features::memory::update_preference(&id, patch)
+    let mutation = crate::features::memory::update_preference(&id, patch)
         .map_err(|e| format!("update preference: {e}"))?;
+    let mut persistence_warnings = Vec::new();
+    let item = mutation.map(|mutation| {
+        if let Some(detail) = mutation.cleanup_warning {
+            persistence_warnings.push(memory_warning(
+                "memory_topic_cleanup_required",
+                "preferences",
+                detail,
+            ));
+        }
+        mutation.value
+    });
     if let (Some(sid), Some(item)) = (
         resolve_memory_session_id(session_id.clone(), &store),
         item.as_ref(),
@@ -606,11 +617,12 @@ pub async fn update_memory_preference(
             }],
         );
     }
-    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    let (runtime, mut warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    persistence_warnings.append(&mut warnings);
     Ok(MemoryWriteState {
         value: item,
         runtime,
-        warnings,
+        warnings: persistence_warnings,
     })
 }
 
@@ -622,8 +634,19 @@ pub async fn update_work_context_memory(
     store: State<'_, SessionStore>,
     app: AppHandle,
 ) -> Result<MemoryWriteState<Option<crate::features::memory::WorkContextFile>>, String> {
-    let item = crate::features::memory::update_work_context(&id, patch)
+    let mutation = crate::features::memory::update_work_context(&id, patch)
         .map_err(|e| format!("update work context: {e}"))?;
+    let mut persistence_warnings = Vec::new();
+    let item = mutation.map(|mutation| {
+        if let Some(detail) = mutation.cleanup_warning {
+            persistence_warnings.push(memory_warning(
+                "memory_topic_cleanup_required",
+                "work_context",
+                detail,
+            ));
+        }
+        mutation.value
+    });
     if let (Some(sid), Some(item)) = (
         resolve_memory_session_id(session_id.clone(), &store),
         item.as_ref(),
@@ -639,11 +662,12 @@ pub async fn update_work_context_memory(
             }],
         );
     }
-    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    let (runtime, mut warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    persistence_warnings.append(&mut warnings);
     Ok(MemoryWriteState {
         value: item,
         runtime,
-        warnings,
+        warnings: persistence_warnings,
     })
 }
 
@@ -823,5 +847,14 @@ mod tests {
         assert_eq!(value["code"], "runtime_refresh_failed");
         assert_eq!(value["source"], "runtime");
         assert!(value["detail"].as_str().unwrap().contains("occupied"));
+
+        let cleanup = serde_json::to_value(memory_warning(
+            "memory_topic_cleanup_required",
+            "preferences",
+            "old topic file is occupied",
+        ))
+        .unwrap();
+        assert_eq!(cleanup["code"], "memory_topic_cleanup_required");
+        assert_eq!(cleanup["source"], "preferences");
     }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/memory.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/memory.rs
@@ -5,6 +5,7 @@ use crate::features::assistant::engine_pool::user_display_message;
 pub struct MemoryProfileState {
     pub profile: crate::features::memory::MemoryProfile,
     pub runtime: Option<crate::features::memory::RuntimeMemorySnapshot>,
+    pub warnings: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -25,6 +26,7 @@ pub struct MemoryOverviewState {
     pub never: Vec<crate::features::memory::NeverMemoryItem>,
     pub runtime: Option<crate::features::memory::RuntimeMemorySnapshot>,
     pub snapshot_path: String,
+    pub warnings: Vec<String>,
 }
 
 fn resolve_memory_session_id(session_id: Option<String>, store: &SessionStore) -> Option<String> {
@@ -79,6 +81,39 @@ fn refresh_memory_runtime_for_command(
     }
 }
 
+fn refresh_memory_runtime_best_effort(
+    session_id: Option<String>,
+    store: &SessionStore,
+    app: &AppHandle,
+) -> (
+    Option<crate::features::memory::RuntimeMemorySnapshot>,
+    Vec<String>,
+) {
+    match refresh_memory_runtime_for_command(session_id, store, app) {
+        Ok(runtime) => (runtime, Vec::new()),
+        Err(warning) => {
+            eprintln!("[memory] {warning}");
+            (None, vec![warning])
+        }
+    }
+}
+
+fn keep_memory_source_or_default<T: Default>(
+    label: &str,
+    result: std::io::Result<T>,
+    warnings: &mut Vec<String>,
+) -> T {
+    match result {
+        Ok(value) => value,
+        Err(error) => {
+            let warning = format!("{label}: {error}");
+            eprintln!("[memory] {warning}");
+            warnings.push(warning);
+            T::default()
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn get_memory_profile(
     session_id: Option<String>,
@@ -86,14 +121,18 @@ pub async fn get_memory_profile(
 ) -> Result<MemoryProfileState, String> {
     let profile =
         crate::features::memory::load_profile().map_err(|e| format!("load profile: {e}"))?;
-    let runtime = match resolve_memory_session_id(session_id, &store) {
-        Some(sid) => Some(
-            crate::features::memory::runtime_snapshot(&sid)
-                .map_err(|e| format!("render runtime memory: {e}"))?,
-        ),
-        None => None,
+    let (runtime, warnings) = match resolve_memory_session_id(session_id, &store) {
+        Some(sid) => match crate::features::memory::runtime_snapshot(&sid) {
+            Ok(snapshot) => (Some(snapshot), Vec::new()),
+            Err(error) => (None, vec![format!("render runtime memory: {error}")]),
+        },
+        None => (None, Vec::new()),
     };
-    Ok(MemoryProfileState { profile, runtime })
+    Ok(MemoryProfileState {
+        profile,
+        runtime,
+        warnings,
+    })
 }
 
 #[tauri::command]
@@ -105,8 +144,12 @@ pub async fn update_memory_profile(
 ) -> Result<MemoryProfileState, String> {
     let profile = crate::features::memory::update_profile(patch)
         .map_err(|e| format!("update profile: {e}"))?;
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
-    Ok(MemoryProfileState { profile, runtime })
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    Ok(MemoryProfileState {
+        profile,
+        runtime,
+        warnings,
+    })
 }
 
 #[tauri::command]
@@ -117,8 +160,12 @@ pub async fn clear_memory_profile(
 ) -> Result<MemoryProfileState, String> {
     let profile =
         crate::features::memory::clear_profile().map_err(|e| format!("clear profile: {e}"))?;
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
-    Ok(MemoryProfileState { profile, runtime })
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
+    Ok(MemoryProfileState {
+        profile,
+        runtime,
+        warnings,
+    })
 }
 
 #[tauri::command]
@@ -128,28 +175,55 @@ pub async fn get_memory_overview(
 ) -> Result<MemoryOverviewState, String> {
     let profile =
         crate::features::memory::load_profile().map_err(|e| format!("load profile: {e}"))?;
-    let preferences = crate::features::memory::list_preferences()
-        .map_err(|e| format!("load preferences: {e}"))?;
-    let work_context = crate::features::memory::load_work_context()
-        .map_err(|e| format!("load work context: {e}"))?;
-    let current_focus = crate::features::memory::load_current_focus()
-        .map_err(|e| format!("load current focus: {e}"))?;
-    let recent_activity = crate::features::memory::load_recent_activity()
-        .map_err(|e| format!("load recent activity: {e}"))?;
-    let recent_work = crate::features::memory::load_recent_work()
-        .map_err(|e| format!("load recent work: {e}"))?;
-    let pending = crate::features::memory::load_pending_memory()
-        .map_err(|e| format!("load pending memory: {e}"))?;
-    let never = crate::features::memory::load_never_memory()
-        .map_err(|e| format!("load never memory: {e}"))?;
+    let mut warnings = Vec::new();
+    let preferences = keep_memory_source_or_default(
+        "load preferences",
+        crate::features::memory::list_preferences(),
+        &mut warnings,
+    );
+    let work_context = keep_memory_source_or_default(
+        "load work context",
+        crate::features::memory::load_work_context(),
+        &mut warnings,
+    );
+    let current_focus = keep_memory_source_or_default(
+        "load current focus",
+        crate::features::memory::load_current_focus(),
+        &mut warnings,
+    );
+    let recent_activity = keep_memory_source_or_default(
+        "load recent activity",
+        crate::features::memory::load_recent_activity(),
+        &mut warnings,
+    );
+    let recent_work = keep_memory_source_or_default(
+        "load recent work",
+        crate::features::memory::load_recent_work(),
+        &mut warnings,
+    );
+    let pending = keep_memory_source_or_default(
+        "load pending memory",
+        crate::features::memory::load_pending_memory(),
+        &mut warnings,
+    );
+    let never = keep_memory_source_or_default(
+        "load never memory",
+        crate::features::memory::load_never_memory(),
+        &mut warnings,
+    );
     let runtime = match resolve_memory_session_id(session_id, &store) {
-        Some(sid) => Some(
-            crate::features::memory::runtime_snapshot(&sid)
-                .map_err(|e| format!("render runtime memory: {e}"))?,
-        ),
+        Some(sid) => match crate::features::memory::runtime_snapshot(&sid) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                let warning = format!("render runtime memory: {error}");
+                eprintln!("[memory] {warning}");
+                warnings.push(warning);
+                None
+            }
+        },
         None => None,
     };
-    let snapshot_path = crate::features::memory::write_memory_snapshot_document(
+    let snapshot_path = match crate::features::memory::write_memory_snapshot_document(
         &profile,
         &preferences,
         &work_context,
@@ -159,10 +233,15 @@ pub async fn get_memory_overview(
         &pending,
         &never,
         runtime.as_ref(),
-    )
-    .map_err(|e| format!("write memory snapshot: {e}"))?
-    .display()
-    .to_string();
+    ) {
+        Ok(path) => path.display().to_string(),
+        Err(error) => {
+            let warning = format!("write memory snapshot: {error}");
+            eprintln!("[memory] {warning}");
+            warnings.push(warning);
+            String::new()
+        }
+    };
     Ok(MemoryOverviewState {
         profile,
         preferences,
@@ -174,6 +253,7 @@ pub async fn get_memory_overview(
         never,
         runtime,
         snapshot_path,
+        warnings,
     })
 }
 

--- a/pinvou3-app/src-tauri/src/app/commands/memory.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/memory.rs
@@ -159,6 +159,38 @@ fn load_memory_source<T: Default>(
     }
 }
 
+fn load_topic_memory_source<T: Default>(
+    source: &str,
+    result: std::io::Result<crate::features::memory::TopicRead<T>>,
+    warnings: &mut Vec<MemoryWarning>,
+    sources: &mut BTreeMap<String, MemorySourceStatus>,
+) -> T {
+    match result {
+        Ok(read) => {
+            let code = read
+                .cleanup_warning
+                .as_ref()
+                .map(|_| "memory_topic_cleanup_required".to_string());
+            if let Some(detail) = read.cleanup_warning {
+                warnings.push(memory_warning(
+                    "memory_topic_cleanup_required",
+                    source,
+                    detail,
+                ));
+            }
+            sources.insert(
+                source.to_string(),
+                MemorySourceStatus {
+                    available: true,
+                    code,
+                },
+            );
+            read.value
+        }
+        Err(error) => load_memory_source(source, Err(error), warnings, sources),
+    }
+}
+
 #[tauri::command]
 pub async fn get_memory_profile(
     session_id: Option<String>,
@@ -233,15 +265,15 @@ pub async fn get_memory_overview(
         &mut warnings,
         &mut sources,
     );
-    let preferences = load_memory_source(
+    let preferences = load_topic_memory_source(
         "preferences",
-        crate::features::memory::list_preferences(),
+        crate::features::memory::list_preferences_with_cleanup(),
         &mut warnings,
         &mut sources,
     );
-    let work_context = load_memory_source(
+    let work_context = load_topic_memory_source(
         "work_context",
-        crate::features::memory::load_work_context(),
+        crate::features::memory::load_work_context_with_cleanup(),
         &mut warnings,
         &mut sources,
     );
@@ -834,6 +866,25 @@ mod tests {
         );
         assert_eq!(warnings[0].code, "memory_source_unavailable");
         assert_eq!(warnings[0].source, "pending");
+
+        let pending: Vec<String> = load_topic_memory_source(
+            "preferences",
+            Ok(crate::features::memory::TopicRead {
+                value: vec!["new".to_string()],
+                cleanup_warning: Some("old topic file is occupied".to_string()),
+            }),
+            &mut warnings,
+            &mut sources,
+        );
+        assert_eq!(pending, ["new"]);
+        assert!(sources["preferences"].available);
+        assert_eq!(
+            sources["preferences"].code.as_deref(),
+            Some("memory_topic_cleanup_required")
+        );
+        assert!(warnings.iter().any(|warning| {
+            warning.code == "memory_topic_cleanup_required" && warning.source == "preferences"
+        }));
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/app/commands/memory.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/memory.rs
@@ -1,17 +1,32 @@
 use super::prelude::*;
 use crate::features::assistant::engine_pool::user_display_message;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MemoryWarning {
+    pub code: String,
+    pub source: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MemorySourceStatus {
+    pub available: bool,
+    pub code: Option<String>,
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MemoryProfileState {
     pub profile: crate::features::memory::MemoryProfile,
     pub runtime: Option<crate::features::memory::RuntimeMemorySnapshot>,
-    pub warnings: Vec<String>,
+    pub warnings: Vec<MemoryWarning>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct MemoryWriteState<T> {
     pub value: T,
     pub runtime: Option<crate::features::memory::RuntimeMemorySnapshot>,
+    pub warnings: Vec<MemoryWarning>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -26,7 +41,8 @@ pub struct MemoryOverviewState {
     pub never: Vec<crate::features::memory::NeverMemoryItem>,
     pub runtime: Option<crate::features::memory::RuntimeMemorySnapshot>,
     pub snapshot_path: String,
-    pub warnings: Vec<String>,
+    pub warnings: Vec<MemoryWarning>,
+    pub sources: BTreeMap<String, MemorySourceStatus>,
 }
 
 fn resolve_memory_session_id(session_id: Option<String>, store: &SessionStore) -> Option<String> {
@@ -87,28 +103,57 @@ fn refresh_memory_runtime_best_effort(
     app: &AppHandle,
 ) -> (
     Option<crate::features::memory::RuntimeMemorySnapshot>,
-    Vec<String>,
+    Vec<MemoryWarning>,
 ) {
     match refresh_memory_runtime_for_command(session_id, store, app) {
         Ok(runtime) => (runtime, Vec::new()),
-        Err(warning) => {
-            eprintln!("[memory] {warning}");
-            (None, vec![warning])
+        Err(detail) => {
+            eprintln!("[memory] {detail}");
+            (
+                None,
+                vec![memory_warning("runtime_refresh_failed", "runtime", detail)],
+            )
         }
     }
 }
 
-fn keep_memory_source_or_default<T: Default>(
-    label: &str,
+fn memory_warning(code: &str, source: &str, detail: impl Into<String>) -> MemoryWarning {
+    MemoryWarning {
+        code: code.to_string(),
+        source: source.to_string(),
+        detail: detail.into(),
+    }
+}
+
+fn load_memory_source<T: Default>(
+    source: &str,
     result: std::io::Result<T>,
-    warnings: &mut Vec<String>,
+    warnings: &mut Vec<MemoryWarning>,
+    sources: &mut BTreeMap<String, MemorySourceStatus>,
 ) -> T {
     match result {
-        Ok(value) => value,
+        Ok(value) => {
+            sources.insert(
+                source.to_string(),
+                MemorySourceStatus {
+                    available: true,
+                    code: None,
+                },
+            );
+            value
+        }
         Err(error) => {
-            let warning = format!("{label}: {error}");
-            eprintln!("[memory] {warning}");
-            warnings.push(warning);
+            let detail = format!("load {source}: {error}");
+            eprintln!("[memory] {detail}");
+            let code = "memory_source_unavailable";
+            warnings.push(memory_warning(code, source, detail));
+            sources.insert(
+                source.to_string(),
+                MemorySourceStatus {
+                    available: false,
+                    code: Some(code.to_string()),
+                },
+            );
             T::default()
         }
     }
@@ -124,7 +169,14 @@ pub async fn get_memory_profile(
     let (runtime, warnings) = match resolve_memory_session_id(session_id, &store) {
         Some(sid) => match crate::features::memory::runtime_snapshot(&sid) {
             Ok(snapshot) => (Some(snapshot), Vec::new()),
-            Err(error) => (None, vec![format!("render runtime memory: {error}")]),
+            Err(error) => (
+                None,
+                vec![memory_warning(
+                    "runtime_refresh_failed",
+                    "runtime",
+                    format!("render runtime memory: {error}"),
+                )],
+            ),
         },
         None => (None, Vec::new()),
     };
@@ -173,74 +225,143 @@ pub async fn get_memory_overview(
     session_id: Option<String>,
     store: State<'_, SessionStore>,
 ) -> Result<MemoryOverviewState, String> {
-    let profile =
-        crate::features::memory::load_profile().map_err(|e| format!("load profile: {e}"))?;
     let mut warnings = Vec::new();
-    let preferences = keep_memory_source_or_default(
-        "load preferences",
+    let mut sources = BTreeMap::new();
+    let profile = load_memory_source(
+        "profile",
+        crate::features::memory::load_profile(),
+        &mut warnings,
+        &mut sources,
+    );
+    let preferences = load_memory_source(
+        "preferences",
         crate::features::memory::list_preferences(),
         &mut warnings,
+        &mut sources,
     );
-    let work_context = keep_memory_source_or_default(
-        "load work context",
+    let work_context = load_memory_source(
+        "work_context",
         crate::features::memory::load_work_context(),
         &mut warnings,
+        &mut sources,
     );
-    let current_focus = keep_memory_source_or_default(
-        "load current focus",
+    let current_focus = load_memory_source(
+        "current_focus",
         crate::features::memory::load_current_focus(),
         &mut warnings,
+        &mut sources,
     );
-    let recent_activity = keep_memory_source_or_default(
-        "load recent activity",
+    let recent_activity = load_memory_source(
+        "recent_activity",
         crate::features::memory::load_recent_activity(),
         &mut warnings,
+        &mut sources,
     );
-    let recent_work = keep_memory_source_or_default(
-        "load recent work",
+    let recent_work = load_memory_source(
+        "recent_work",
         crate::features::memory::load_recent_work(),
         &mut warnings,
+        &mut sources,
     );
-    let pending = keep_memory_source_or_default(
-        "load pending memory",
+    let pending = load_memory_source(
+        "pending",
         crate::features::memory::load_pending_memory(),
         &mut warnings,
+        &mut sources,
     );
-    let never = keep_memory_source_or_default(
-        "load never memory",
+    let never = load_memory_source(
+        "never",
         crate::features::memory::load_never_memory(),
         &mut warnings,
+        &mut sources,
     );
+    let authoritative_sources_available = sources.values().all(|status| status.available);
     let runtime = match resolve_memory_session_id(session_id, &store) {
         Some(sid) => match crate::features::memory::runtime_snapshot(&sid) {
-            Ok(snapshot) => Some(snapshot),
+            Ok(snapshot) => {
+                sources.insert(
+                    "runtime".to_string(),
+                    MemorySourceStatus {
+                        available: true,
+                        code: None,
+                    },
+                );
+                Some(snapshot)
+            }
             Err(error) => {
-                let warning = format!("render runtime memory: {error}");
-                eprintln!("[memory] {warning}");
-                warnings.push(warning);
+                let detail = format!("render runtime memory: {error}");
+                eprintln!("[memory] {detail}");
+                warnings.push(memory_warning("runtime_refresh_failed", "runtime", detail));
+                sources.insert(
+                    "runtime".to_string(),
+                    MemorySourceStatus {
+                        available: false,
+                        code: Some("runtime_refresh_failed".to_string()),
+                    },
+                );
                 None
             }
         },
-        None => None,
-    };
-    let snapshot_path = match crate::features::memory::write_memory_snapshot_document(
-        &profile,
-        &preferences,
-        &work_context,
-        &current_focus,
-        &recent_activity,
-        &recent_work,
-        &pending,
-        &never,
-        runtime.as_ref(),
-    ) {
-        Ok(path) => path.display().to_string(),
-        Err(error) => {
-            let warning = format!("write memory snapshot: {error}");
-            eprintln!("[memory] {warning}");
-            warnings.push(warning);
-            String::new()
+        None => {
+            sources.insert(
+                "runtime".to_string(),
+                MemorySourceStatus {
+                    available: true,
+                    code: None,
+                },
+            );
+            None
         }
+    };
+    let snapshot_path = if authoritative_sources_available && sources["runtime"].available {
+        match crate::features::memory::write_memory_snapshot_document(
+            &profile,
+            &preferences,
+            &work_context,
+            &current_focus,
+            &recent_activity,
+            &recent_work,
+            &pending,
+            &never,
+            runtime.as_ref(),
+        ) {
+            Ok(path) => {
+                sources.insert(
+                    "snapshot".to_string(),
+                    MemorySourceStatus {
+                        available: true,
+                        code: None,
+                    },
+                );
+                path.display().to_string()
+            }
+            Err(error) => {
+                let detail = format!("write memory snapshot: {error}");
+                eprintln!("[memory] {detail}");
+                warnings.push(memory_warning(
+                    "snapshot_refresh_failed",
+                    "snapshot",
+                    detail,
+                ));
+                sources.insert(
+                    "snapshot".to_string(),
+                    MemorySourceStatus {
+                        available: false,
+                        code: Some("snapshot_refresh_failed".to_string()),
+                    },
+                );
+                String::new()
+            }
+        }
+    } else {
+        sources.insert(
+            "snapshot".to_string(),
+            MemorySourceStatus {
+                available: false,
+                code: Some("snapshot_refresh_deferred".to_string()),
+            },
+        );
+        String::new()
     };
     Ok(MemoryOverviewState {
         profile,
@@ -254,6 +375,7 @@ pub async fn get_memory_overview(
         runtime,
         snapshot_path,
         warnings,
+        sources,
     })
 }
 
@@ -284,10 +406,11 @@ pub async fn suggest_memory(
             }],
         );
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: item,
         runtime,
+        warnings,
     })
 }
 
@@ -306,10 +429,11 @@ pub async fn confirm_pending_memory(
     ) {
         emit_memory_write_events(&app, &sid, std::slice::from_ref(event));
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: event,
         runtime,
+        warnings,
     })
 }
 
@@ -328,10 +452,11 @@ pub async fn ignore_pending_memory(
     ) {
         emit_memory_write_events(&app, &sid, std::slice::from_ref(event));
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: event,
         runtime,
+        warnings,
     })
 }
 
@@ -351,10 +476,11 @@ pub async fn never_pending_memory(
     ) {
         emit_memory_write_events(&app, &sid, std::slice::from_ref(event));
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: event,
         runtime,
+        warnings,
     })
 }
 
@@ -385,10 +511,11 @@ pub async fn upsert_recent_work_memory(
             }],
         );
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: item,
         runtime,
+        warnings,
     })
 }
 
@@ -415,10 +542,11 @@ pub async fn archive_recent_work_memory(
             );
         }
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: changed,
         runtime,
+        warnings,
     })
 }
 
@@ -445,10 +573,11 @@ pub async fn delete_memory_preference(
             );
         }
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: changed,
         runtime,
+        warnings,
     })
 }
 
@@ -477,10 +606,11 @@ pub async fn update_memory_preference(
             }],
         );
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: item,
         runtime,
+        warnings,
     })
 }
 
@@ -509,10 +639,11 @@ pub async fn update_work_context_memory(
             }],
         );
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: item,
         runtime,
+        warnings,
     })
 }
 
@@ -539,10 +670,11 @@ pub async fn delete_work_context_memory(
             );
         }
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: changed,
         runtime,
+        warnings,
     })
 }
 
@@ -572,10 +704,11 @@ pub async fn update_timed_memory(
             }],
         );
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: item,
         runtime,
+        warnings,
     })
 }
 
@@ -603,10 +736,11 @@ pub async fn delete_timed_memory(
             );
         }
     }
-    let runtime = refresh_memory_runtime_for_command(session_id, &store, &app)?;
+    let (runtime, warnings) = refresh_memory_runtime_best_effort(session_id, &store, &app);
     Ok(MemoryWriteState {
         value: changed,
         runtime,
+        warnings,
     })
 }
 
@@ -643,4 +777,51 @@ pub async fn edit_last_turn(
     pool.edit_last_turn_reserved(&sid, full, display_message, reservation)
         .await
         .map_err(|e| format!("edit_last_turn: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overview_source_status_distinguishes_empty_from_unavailable() {
+        let mut warnings = Vec::new();
+        let mut sources = BTreeMap::new();
+        let empty: Vec<String> =
+            load_memory_source("preferences", Ok(Vec::new()), &mut warnings, &mut sources);
+        assert!(empty.is_empty());
+        assert!(warnings.is_empty());
+        assert!(sources["preferences"].available);
+
+        let unavailable: Vec<String> = load_memory_source(
+            "pending",
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "locked",
+            )),
+            &mut warnings,
+            &mut sources,
+        );
+        assert!(unavailable.is_empty());
+        assert!(!sources["pending"].available);
+        assert_eq!(
+            sources["pending"].code.as_deref(),
+            Some("memory_source_unavailable")
+        );
+        assert_eq!(warnings[0].code, "memory_source_unavailable");
+        assert_eq!(warnings[0].source, "pending");
+    }
+
+    #[test]
+    fn warnings_are_serialized_as_stable_codes() {
+        let warning = memory_warning(
+            "runtime_refresh_failed",
+            "runtime",
+            "runtime cache is occupied",
+        );
+        let value = serde_json::to_value(warning).unwrap();
+        assert_eq!(value["code"], "runtime_refresh_failed");
+        assert_eq!(value["source"], "runtime");
+        assert!(value["detail"].as_str().unwrap().contains("occupied"));
+    }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -926,7 +926,11 @@ fn artifact_writes_never_expose_partial_utf8_to_concurrent_readers() {
     let old_for_reader = old.clone();
     let new_for_reader = new.clone();
     let reader = std::thread::spawn(move || {
-        while reader_running.load(Ordering::Acquire) {
+        // Bound the loop so a writer panic cannot leave the reader spinning
+        // forever and hang the test runner.
+        let mut spins = 0;
+        while reader_running.load(Ordering::Acquire) && spins < 1_000_000 {
+            spins += 1;
             if let Ok(value) = std::fs::read_to_string(&reader_path) {
                 assert!(value == old_for_reader || value == new_for_reader);
             }

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -801,6 +801,54 @@ fn write_artifact_text_cleans_temp_file_on_error() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+#[test]
+fn artifact_public_read_prefers_newer_cross_pid_backup_group() {
+    let root =
+        std::env::temp_dir().join(format!("pinvou3-artifact-cross-pid-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let target = root.join("note.md");
+    let older_temp = root.join(".note.md.tmp-9001-100");
+    let newer_temp = root.join(".note.md.tmp-12-300");
+    let newer_backup = root.join(".note.md.bak-12-300");
+    std::fs::write(&older_temp, "uncommitted older temp").unwrap();
+    std::fs::write(&newer_temp, "uncommitted newer replacement").unwrap();
+    std::fs::write(&newer_backup, "authoritative backup").unwrap();
+
+    let restored = read_artifact_text_impl(target.to_str().unwrap()).unwrap();
+
+    assert_eq!(restored, "authoritative backup");
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), restored);
+    assert!(!older_temp.exists());
+    assert!(!newer_temp.exists());
+    assert!(!newer_backup.exists());
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
+fn artifact_public_read_uses_metadata_when_tokens_are_not_parseable() {
+    let root = std::env::temp_dir().join(format!(
+        "pinvou3-artifact-token-fallback-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let target = root.join("note.md");
+    let older_backup = root.join(".note.md.bak-invalid-old");
+    let newer_backup = root.join(".note.md.bak-invalid-new");
+    std::fs::write(&older_backup, "older authority").unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    std::fs::write(&newer_backup, "newer authority").unwrap();
+
+    assert_eq!(
+        read_artifact_text_impl(target.to_str().unwrap()).unwrap(),
+        "newer authority"
+    );
+    assert!(!older_backup.exists());
+    assert!(!newer_backup.exists());
+    let _ = std::fs::remove_dir_all(root);
+}
+
 #[cfg(windows)]
 #[test]
 fn artifact_read_recovers_an_occupied_1177_layout_after_release() {

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1,4 +1,5 @@
 // 本文件为命令层测试,借 platform::paths::tests::ENV_LOCK(std Mutex)串行化全局 env;跨 await 持有无竞争者,不会死锁。
+// architecture-guard: allow-target-cfg -- artifact 调用链回归需用 Windows 独占句柄模拟 ReplaceFileW 1177 布局
 #![allow(clippy::await_holding_lock)]
 
 use super::prelude::*;
@@ -798,6 +799,98 @@ fn write_artifact_text_cleans_temp_file_on_error() {
         "temp files left behind: {leftovers:?}"
     );
     let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[cfg(windows)]
+#[test]
+fn artifact_read_recovers_an_occupied_1177_layout_after_release() {
+    use std::cell::RefCell;
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    let _home = test_pinvou_home("pinvou3-artifact-1177-recovery");
+    let md = session_artifact_path("s1", "note.md");
+    std::fs::write(&md, "old").unwrap();
+    let occupied = RefCell::new(None);
+
+    let error = atomic_write_utf8_unlocked_with(&md, "new", |replacement, target, backup| {
+        crate::platform::filesystem::replace_file_atomically_with(
+            replacement,
+            target,
+            backup,
+            |target, _, backup| {
+                std::fs::rename(target, backup)?;
+                *occupied.borrow_mut() = Some(
+                    std::fs::OpenOptions::new()
+                        .read(true)
+                        .share_mode(0)
+                        .open(backup)?,
+                );
+                Err(std::io::Error::from_raw_os_error(1177))
+            },
+        )
+    })
+    .unwrap_err();
+
+    assert!(error.to_string().contains("RecoveryRequired"));
+    assert!(!md.exists());
+    let leftovers_while_occupied: Vec<_> = std::fs::read_dir(md.parent().unwrap())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.contains(".note.md.tmp-") || name.contains(".note.md.bak-")
+        })
+        .collect();
+    assert_eq!(leftovers_while_occupied.len(), 2);
+
+    drop(occupied.borrow_mut().take());
+    assert_eq!(
+        read_artifact_text_impl(md.to_str().unwrap()).unwrap(),
+        "old"
+    );
+    let leftovers_after_recovery: Vec<_> = std::fs::read_dir(md.parent().unwrap())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            name.contains(".note.md.tmp-") || name.contains(".note.md.bak-")
+        })
+        .collect();
+    assert!(leftovers_after_recovery.is_empty());
+}
+
+#[cfg(windows)]
+#[test]
+fn artifact_writes_never_expose_partial_utf8_to_concurrent_readers() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let _home = test_pinvou_home("pinvou3-artifact-concurrent-read");
+    let md = session_artifact_path("s1", "note.md");
+    let old = "a".repeat(32 * 1024);
+    let new = "b".repeat(32 * 1024);
+    std::fs::write(&md, &old).unwrap();
+    let running = Arc::new(AtomicBool::new(true));
+    let reader_running = Arc::clone(&running);
+    let reader_path = md.clone();
+    let old_for_reader = old.clone();
+    let new_for_reader = new.clone();
+    let reader = std::thread::spawn(move || {
+        while reader_running.load(Ordering::Acquire) {
+            if let Ok(value) = std::fs::read_to_string(&reader_path) {
+                assert!(value == old_for_reader || value == new_for_reader);
+            }
+        }
+    });
+
+    for index in 0..16 {
+        let content = if index % 2 == 0 { &new } else { &old };
+        write_artifact_text_impl(md.to_str().unwrap(), content).unwrap();
+    }
+    running.store(false, Ordering::Release);
+    reader.join().unwrap();
 }
 
 /// accept_plan 切 Yolo 后注入的执行指令必须裹住方案全文 + 带"立即执行"信号——

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -4,7 +4,7 @@
 //! only a prompt cache consumed through `InstructionSource::File`.
 // architecture-guard: allow-target-cfg -- 记忆持久化测试需用 Windows 独占句柄覆盖 ReplaceFileW 恢复路径
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::fs;
 use std::io::{self, Write as IoWrite};
@@ -391,11 +391,23 @@ pub struct TopicMutation<T> {
     pub cleanup_warning: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct TopicRead<T> {
+    pub value: T,
+    pub cleanup_warning: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TopicMigrationJournal {
     authority_file: String,
     authority_hash: String,
     stale_files: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+struct TopicReconciliation {
+    hidden_files: BTreeSet<PathBuf>,
+    cleanup_warning: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1246,23 +1258,39 @@ fn resolve_topic_authorities<T: Clone>(
 }
 
 pub fn load_work_context() -> io::Result<Vec<WorkContextFile>> {
+    load_work_context_with_cleanup().map(|result| result.value)
+}
+
+pub fn load_work_context_with_cleanup() -> io::Result<TopicRead<Vec<WorkContextFile>>> {
     let _lifecycle = file_lifecycle_lock().lock();
-    load_work_context_unlocked()
+    load_work_context_with_cleanup_unlocked()
 }
 
 fn load_work_context_unlocked() -> io::Result<Vec<WorkContextFile>> {
+    load_work_context_with_cleanup_unlocked().map(|result| result.value)
+}
+
+fn load_work_context_with_cleanup_unlocked() -> io::Result<TopicRead<Vec<WorkContextFile>>> {
     let dir = work_context_dir();
     recover_directory_json_files_unlocked::<WorkContextFile>(&dir)?;
-    reconcile_topic_migration_journals_unlocked::<WorkContextFile>(&dir)?;
+    let reconciliation = reconcile_topic_migration_journals_unlocked::<WorkContextFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok(TopicRead {
+                value: Vec::new(),
+                cleanup_warning: reconciliation.cleanup_warning,
+            });
+        }
         Err(err) => return Err(err),
     };
     let mut records = Vec::new();
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
+        if reconciliation.hidden_files.contains(&path) {
+            continue;
+        }
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
@@ -1275,7 +1303,10 @@ fn load_work_context_unlocked() -> io::Result<Vec<WorkContextFile>> {
             records.push((path, item));
         }
     }
-    resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)
+    Ok(TopicRead {
+        value: resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)?,
+        cleanup_warning: reconciliation.cleanup_warning,
+    })
 }
 
 fn upsert_work_context_unlocked(
@@ -1456,12 +1487,16 @@ fn write_topic_migration_journal_unlocked(
 
 fn reconcile_topic_migration_journals_unlocked<T: serde::de::DeserializeOwned>(
     dir: &Path,
-) -> io::Result<()> {
+) -> io::Result<TopicReconciliation> {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(TopicReconciliation::default());
+        }
         Err(error) => return Err(error),
     };
+    let mut hidden_files = BTreeSet::new();
+    let mut cleanup_failures = Vec::new();
     for entry in entries {
         let journal_path = entry?.path();
         let Some(name) = journal_path.file_name().and_then(|value| value.to_str()) else {
@@ -1493,34 +1528,28 @@ fn reconcile_topic_migration_journals_unlocked<T: serde::de::DeserializeOwned>(
             fs::remove_file(&journal_path)?;
             continue;
         }
+        let mut journal_cleanup_pending = false;
         for stale_name in &journal.stale_files {
             let stale = dir.join(stale_name);
             if stale == authority || !stale.exists() {
                 continue;
             }
-            fs::remove_file(&stale).map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!(
-                        "memory_topic_cleanup_required:{}:{}",
-                        stale.display(),
-                        error
-                    ),
-                )
-            })?;
+            if let Err(error) = fs::remove_file(&stale) {
+                journal_cleanup_pending = true;
+                hidden_files.insert(stale.clone());
+                cleanup_failures.push(format!("{}: {error}", stale.display()));
+            }
         }
-        fs::remove_file(&journal_path).map_err(|error| {
-            io::Error::new(
-                error.kind(),
-                format!(
-                    "memory_topic_cleanup_required:{}:{}",
-                    journal_path.display(),
-                    error
-                ),
-            )
-        })?;
+        if !journal_cleanup_pending {
+            if let Err(error) = fs::remove_file(&journal_path) {
+                cleanup_failures.push(format!("{}: {error}", journal_path.display()));
+            }
+        }
     }
-    Ok(())
+    Ok(TopicReconciliation {
+        hidden_files,
+        cleanup_warning: (!cleanup_failures.is_empty()).then(|| cleanup_failures.join("; ")),
+    })
 }
 
 fn is_plain_filename(value: &str) -> bool {
@@ -4015,6 +4044,10 @@ pub fn list_preferences() -> io::Result<Vec<PreferenceFile>> {
     load_preferences()
 }
 
+pub fn list_preferences_with_cleanup() -> io::Result<TopicRead<Vec<PreferenceFile>>> {
+    load_preferences_with_cleanup()
+}
+
 fn preference_stale_paths_unlocked(
     dir: &Path,
     new_path: &Path,
@@ -4147,23 +4180,39 @@ pub fn delete_preference(id: &str) -> io::Result<bool> {
 }
 
 fn load_preferences() -> io::Result<Vec<PreferenceFile>> {
+    load_preferences_with_cleanup().map(|result| result.value)
+}
+
+fn load_preferences_with_cleanup() -> io::Result<TopicRead<Vec<PreferenceFile>>> {
     let _lifecycle = file_lifecycle_lock().lock();
-    load_preferences_unlocked()
+    load_preferences_with_cleanup_unlocked()
 }
 
 fn load_preferences_unlocked() -> io::Result<Vec<PreferenceFile>> {
+    load_preferences_with_cleanup_unlocked().map(|result| result.value)
+}
+
+fn load_preferences_with_cleanup_unlocked() -> io::Result<TopicRead<Vec<PreferenceFile>>> {
     let dir = paths::user_memory_preferences_dir();
     recover_directory_json_files_unlocked::<PreferenceFile>(&dir)?;
-    reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&dir)?;
+    let reconciliation = reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            return Ok(TopicRead {
+                value: Vec::new(),
+                cleanup_warning: reconciliation.cleanup_warning,
+            });
+        }
         Err(err) => return Err(err),
     };
     let mut records = Vec::new();
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
+        if reconciliation.hidden_files.contains(&path) {
+            continue;
+        }
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
@@ -4188,7 +4237,10 @@ fn load_preferences_unlocked() -> io::Result<Vec<PreferenceFile>> {
     }
     let mut out = resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)?;
     out.sort_by(|a, b| a.id.cmp(&b.id).then_with(|| a.text.cmp(&b.text)));
-    Ok(out)
+    Ok(TopicRead {
+        value: out,
+        cleanup_warning: reconciliation.cleanup_warning,
+    })
 }
 
 fn looks_like_profile_preference_text(text: &str) -> bool {
@@ -4815,6 +4867,126 @@ mod tests {
         reader.join().unwrap();
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].text, "new value");
+        drop(home);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn topic_migration_preference_pending_cleanup_stays_available_and_hides_stale_id() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        let home = IsolatedPinvouHome::new("preference-pending-cleanup");
+        let dir = paths::user_memory_preferences_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let old_id = stable_id_with_prefix("pref", "answer_style");
+        let old_path = dir.join(format!("{old_id}.json"));
+        write_json_atomic(
+            &old_path,
+            &preference_fixture(&old_id, "answer_style", "old preference"),
+        )
+        .unwrap();
+        let occupied = fs::OpenOptions::new()
+            .read(true)
+            .share_mode(1)
+            .open(&old_path)
+            .unwrap();
+
+        let updated = update_preference(
+            &old_id,
+            MemoryTextPatch {
+                topic: Some("workflow_preference".to_string()),
+                text: Some("new preference".to_string()),
+                ttl_days: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert!(updated.cleanup_warning.is_some());
+        let new_id = updated.value.id.clone();
+
+        for _ in 0..2 {
+            let read = list_preferences_with_cleanup().unwrap();
+            assert!(read.cleanup_warning.is_some());
+            assert_eq!(read.value.len(), 1);
+            assert_eq!(read.value[0].id, new_id);
+            assert_ne!(read.value[0].id, old_id);
+        }
+        assert!(old_path.exists());
+
+        drop(occupied);
+        let read = list_preferences_with_cleanup().unwrap();
+        assert!(read.cleanup_warning.is_none());
+        assert_eq!(read.value.len(), 1);
+        assert_eq!(read.value[0].id, new_id);
+        assert!(!old_path.exists());
+        assert!(fs::read_dir(&dir).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".topic-migration-")
+        }));
+        drop(home);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn topic_migration_work_context_pending_cleanup_stays_available_and_hides_stale_id() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        let home = IsolatedPinvouHome::new("work-context-pending-cleanup");
+        let dir = work_context_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let old_id = stable_id_with_prefix("ctx", "role_domain");
+        let old_path = dir.join(format!("{old_id}.json"));
+        write_json_atomic(
+            &old_path,
+            &WorkContextFile {
+                id: old_id.clone(),
+                kind: "work_context".to_string(),
+                topic: "role_domain".to_string(),
+                text: "old context".to_string(),
+                source: "test".to_string(),
+                confidence: 1.0,
+                created_at: Utc::now().to_rfc3339(),
+                updated_at: Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+        let occupied = fs::OpenOptions::new()
+            .read(true)
+            .share_mode(1)
+            .open(&old_path)
+            .unwrap();
+
+        let updated = update_work_context(
+            &old_id,
+            MemoryTextPatch {
+                topic: Some("project_context".to_string()),
+                text: Some("new context".to_string()),
+                ttl_days: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert!(updated.cleanup_warning.is_some());
+        let new_id = updated.value.id.clone();
+
+        for _ in 0..2 {
+            let read = load_work_context_with_cleanup().unwrap();
+            assert!(read.cleanup_warning.is_some());
+            assert_eq!(read.value.len(), 1);
+            assert_eq!(read.value[0].id, new_id);
+            assert_ne!(read.value[0].id, old_id);
+        }
+        assert!(old_path.exists());
+
+        drop(occupied);
+        let read = load_work_context_with_cleanup().unwrap();
+        assert!(read.cleanup_warning.is_none());
+        assert_eq!(read.value.len(), 1);
+        assert_eq!(read.value[0].id, new_id);
+        assert!(!old_path.exists());
         drop(home);
     }
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -4427,7 +4427,15 @@ fn read_text_recovering_unlocked_with(
             io::ErrorKind::InvalidData,
             "authoritative memory file is invalid",
         ),
-        Err(error) => error,
+        Err(error) => {
+            // A transient read failure on an existing authoritative file (e.g.
+            // an antivirus scan lock on Windows) must not trigger recovery:
+            // promoting a stale backup would overwrite the still-valid target.
+            if error.kind() != io::ErrorKind::NotFound && path.is_file() {
+                return Err(error);
+            }
+            error
+        }
     };
     let Some(parent) = path.parent() else {
         return Err(current_error);
@@ -4672,6 +4680,37 @@ mod tests {
         assert!(restored.contains("\"revision\":7"));
         assert!(!backup.exists());
         assert!(!replacement.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transient_read_error_keeps_authoritative_target_untouched() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let root = recovery_test_root("transient-read-guard");
+        let target = root.join("profile.json");
+        let backup = target.with_extension("bak");
+        let authoritative = "{\"version\":1,\"revision\":9,\"identity\":{\"call_name\":\"权威\",\"assistant_alias\":\"品悟\"}}\n";
+        fs::write(&target, authoritative).unwrap();
+        fs::write(
+            &backup,
+            "{\"version\":1,\"revision\":1,\"identity\":{\"call_name\":\"旧值\",\"assistant_alias\":\"品悟\"}}\n",
+        )
+        .unwrap();
+
+        // Simulate a transient read failure (e.g. an antivirus lock on
+        // Windows): the authoritative file exists but cannot be read right now.
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = read_text_recovering(&target, |raw| {
+            serde_json::from_str::<MemoryProfile>(raw).is_ok()
+        });
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        assert!(result.is_err());
+        // The authoritative target must be preserved, never overwritten by a
+        // stale backup, and the backup stays as a candidate.
+        assert_eq!(fs::read_to_string(&target).unwrap(), authoritative);
+        assert!(backup.exists());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -1218,7 +1218,7 @@ fn resolve_topic_authorities<T: Clone>(
     records: Vec<(PathBuf, T)>,
     topic: impl Fn(&T) -> &str,
     id: impl Fn(&T) -> &str,
-) -> io::Result<Vec<T>> {
+) -> (Vec<T>, Vec<String>) {
     let mut grouped = BTreeMap::<String, Vec<(PathBuf, T)>>::new();
     for (path, item) in records {
         grouped
@@ -1227,6 +1227,7 @@ fn resolve_topic_authorities<T: Clone>(
             .push((path, item));
     }
     let mut authorities = Vec::new();
+    let mut cleanup_failures = Vec::new();
     for (_, mut group) in grouped {
         group.sort_by_key(|(path, item)| {
             let canonical = path.file_name().and_then(|value| value.to_str())
@@ -1240,21 +1241,19 @@ fn resolve_topic_authorities<T: Clone>(
             .pop()
             .expect("topic groups are constructed from at least one record");
         for (duplicate, _) in group {
-            fs::remove_file(&duplicate).map_err(|error| {
-                io::Error::new(
-                    error.kind(),
-                    format!(
-                        "memory_topic_cleanup_required:{}:{}",
-                        duplicate.display(),
-                        error
-                    ),
-                )
-            })?;
+            // A duplicate that cannot be removed right now (e.g. an open
+            // handle on Windows) must not fail the whole load: keep it on
+            // disk so the next read retries, and surface a cleanup warning
+            // instead of a hard error — mirroring the soft handling in
+            // reconcile_topic_migration_journals_unlocked.
+            if let Err(error) = fs::remove_file(&duplicate) {
+                cleanup_failures.push(format!("{}: {error}", duplicate.display()));
+            }
         }
         debug_assert!(authority_path.is_file());
         authorities.push(authority);
     }
-    Ok(authorities)
+    (authorities, cleanup_failures)
 }
 
 pub fn load_work_context() -> io::Result<Vec<WorkContextFile>> {
@@ -1303,9 +1302,16 @@ fn load_work_context_with_cleanup_unlocked() -> io::Result<TopicRead<Vec<WorkCon
             records.push((path, item));
         }
     }
+    let (value, authority_cleanup_failures) =
+        resolve_topic_authorities(records, |item| &item.topic, |item| &item.id);
+    let mut cleanup_parts = Vec::new();
+    if let Some(base) = reconciliation.cleanup_warning {
+        cleanup_parts.push(base);
+    }
+    cleanup_parts.extend(authority_cleanup_failures);
     Ok(TopicRead {
-        value: resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)?,
-        cleanup_warning: reconciliation.cleanup_warning,
+        value,
+        cleanup_warning: (!cleanup_parts.is_empty()).then(|| cleanup_parts.join("; ")),
     })
 }
 
@@ -1505,19 +1511,27 @@ fn reconcile_topic_migration_journals_unlocked<T: serde::de::DeserializeOwned>(
         if !name.starts_with(".topic-migration-") || !name.ends_with(".journal") {
             continue;
         }
-        let journal = fs::read_to_string(&journal_path).and_then(|raw| {
+        let journal = match fs::read_to_string(&journal_path).and_then(|raw| {
             serde_json::from_str::<TopicMigrationJournal>(&raw).map_err(invalid_data)
-        })?;
+        }) {
+            Ok(journal) => journal,
+            Err(_) => {
+                // An unparsable journal (truncated write or disk corruption)
+                // must not permanently block loading preferences / work
+                // context. Quarantine it so the next read stops tripping over
+                // it while keeping the bytes for diagnosis.
+                quarantine_unparsable_journal(&journal_path);
+                continue;
+            }
+        };
         if !is_plain_filename(&journal.authority_file)
             || journal
                 .stale_files
                 .iter()
                 .any(|name| !is_plain_filename(name))
         {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "invalid memory topic migration journal path",
-            ));
+            quarantine_unparsable_journal(&journal_path);
+            continue;
         }
         let authority = dir.join(&journal.authority_file);
         let authority_valid = fs::read_to_string(&authority).is_ok_and(|raw| {
@@ -1559,6 +1573,19 @@ fn is_plain_filename(value: &str) -> bool {
             Path::new(value).components().next(),
             Some(std::path::Component::Normal(_))
         )
+}
+
+fn quarantine_unparsable_journal(journal_path: &Path) {
+    let Some(name) = journal_path.file_name().and_then(|value| value.to_str()) else {
+        return;
+    };
+    let quarantined = journal_path.with_file_name(format!("{name}.corrupt-{}", std::process::id()));
+    if let Err(error) = fs::rename(journal_path, quarantined) {
+        // Rename can fail if the file is momentarily locked (e.g. Windows);
+        // the journal then stays in place and is skipped again on the next
+        // read without blocking the load.
+        let _ = error;
+    }
 }
 
 fn work_context_stale_paths_unlocked(
@@ -4235,11 +4262,17 @@ fn load_preferences_with_cleanup_unlocked() -> io::Result<TopicRead<Vec<Preferen
             records.push((path, pref));
         }
     }
-    let mut out = resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)?;
+    let (mut out, authority_cleanup_failures) =
+        resolve_topic_authorities(records, |item| &item.topic, |item| &item.id);
     out.sort_by(|a, b| a.id.cmp(&b.id).then_with(|| a.text.cmp(&b.text)));
+    let mut cleanup_parts = Vec::new();
+    if let Some(base) = reconciliation.cleanup_warning {
+        cleanup_parts.push(base);
+    }
+    cleanup_parts.extend(authority_cleanup_failures);
     Ok(TopicRead {
         value: out,
-        cleanup_warning: reconciliation.cleanup_warning,
+        cleanup_warning: (!cleanup_parts.is_empty()).then(|| cleanup_parts.join("; ")),
     })
 }
 
@@ -4391,6 +4424,17 @@ where
             if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
                 let _ = fs::remove_file(&tmp);
                 let _ = fs::remove_file(&backup);
+            } else if error.state() == crate::platform::filesystem::ReplaceState::RecoveryRequired
+                && path.exists()
+            {
+                // A target that still exists (e.g. a directory occupying its
+                // path) is a permanent failure: recovery can never promote a
+                // candidate over it, so the staged tmp/backup are garbage. A
+                // truly missing target keeps its candidates for
+                // read_text_recovering_unlocked_with — matching the artifact
+                // write path.
+                let _ = fs::remove_file(&tmp);
+                let _ = fs::remove_file(&backup);
             }
             Err(error.into_io_error())
         }
@@ -4431,7 +4475,16 @@ fn read_text_recovering_unlocked_with(
             // A transient read failure on an existing authoritative file (e.g.
             // an antivirus scan lock on Windows) must not trigger recovery:
             // promoting a stale backup would overwrite the still-valid target.
-            if error.kind() != io::ErrorKind::NotFound && path.is_file() {
+            // Deterministic errors (e.g. invalid UTF-8 → InvalidData) still
+            // fall through to recovery so a corrupted authoritative file can
+            // self-heal from a valid backup candidate.
+            let transient = matches!(
+                error.kind(),
+                io::ErrorKind::PermissionDenied
+                    | io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::Interrupted
+            );
+            if transient && path.is_file() {
                 return Err(error);
             }
             error
@@ -4532,6 +4585,15 @@ fn promote_recovery_candidate(candidate: &Path, target: &Path, bytes: &[u8]) -> 
             if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
                 let _ = fs::remove_file(replacement);
                 let _ = fs::remove_file(backup);
+            } else if error.state() == crate::platform::filesystem::ReplaceState::RecoveryRequired
+                && target.exists()
+            {
+                // A permanently blocked target (e.g. a directory occupying its
+                // path) can never accept a promoted candidate: drop the staged
+                // recover-* files instead of leaking one pair per failed read.
+                // A truly missing target keeps them for a later attempt.
+                let _ = fs::remove_file(replacement);
+                let _ = fs::remove_file(backup);
             }
             Err(error.into_io_error())
         }
@@ -4553,7 +4615,9 @@ fn cleanup_recovery_candidates(path: &Path) {
                 .file_name()
                 .and_then(|value| value.to_str())
                 .unwrap_or_default();
-            if candidate == path.with_extension("bak") || name.starts_with(&format!("{stem}.tmp-"))
+            if candidate == path.with_extension("bak")
+                || name.starts_with(&format!("{stem}.tmp-"))
+                || name.starts_with(&format!("{stem}.recover-"))
             {
                 let _ = fs::remove_file(candidate);
             }
@@ -4701,16 +4765,117 @@ mod tests {
         // Simulate a transient read failure (e.g. an antivirus lock on
         // Windows): the authoritative file exists but cannot be read right now.
         fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let unreadable = fs::read_to_string(&target).is_err();
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
+        if !unreadable {
+            // Running as root (or on a filesystem that ignores mode bits)
+            // bypasses the permission check, so the guard cannot be exercised
+            // this way; skip instead of failing spuriously.
+            let _ = fs::remove_dir_all(root);
+            return;
+        }
         let result = read_text_recovering(&target, |raw| {
             serde_json::from_str::<MemoryProfile>(raw).is_ok()
         });
-        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
 
         assert!(result.is_err());
         // The authoritative target must be preserved, never overwritten by a
         // stale backup, and the backup stays as a candidate.
         assert_eq!(fs::read_to_string(&target).unwrap(), authoritative);
         assert!(backup.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn memory_write_cleans_tmp_backup_on_permanently_occupied_target() {
+        let root = recovery_test_root("dir-occupied");
+        let target = root.join("profile.json");
+        // A directory occupying the target path is a permanent failure: the
+        // replacement can never be promoted, so the staged tmp/backup must be
+        // cleaned instead of leaking — mirroring the artifact write path
+        // (write_artifact_text_cleans_temp_file_on_error).
+        fs::create_dir(&target).unwrap();
+
+        let result = write_text_atomic_unlocked_with(&target, "new", |_, _, _| {
+            Err(crate::platform::filesystem::ReplaceError::new(
+                crate::platform::filesystem::ReplaceState::RecoveryRequired,
+                io::Error::new(io::ErrorKind::AlreadyExists, "target is a directory"),
+            ))
+        });
+
+        assert!(result.is_err());
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("profile.json.tmp-") || name == "profile.json.bak"
+                    })
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "staged tmp/backup must be cleaned: {leftovers:?}"
+        );
+        assert!(target.is_dir());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovery_promote_cleans_staged_recover_files_on_permanent_failure() {
+        let root = recovery_test_root("recover-cleanup");
+        let target = root.join("profile.json");
+        let candidate = target.with_extension("tmp-1-1-1");
+        fs::write(&candidate, "{\"version\":1}").unwrap();
+        // Directory occupies the target: promotion can never succeed, so the
+        // staged recover-*/recover-bak files must be dropped instead of
+        // leaking one pair per failed read.
+        fs::create_dir(&target).unwrap();
+
+        let result = promote_recovery_candidate(&candidate, &target, b"{\"version\":1}");
+        assert!(result.is_err());
+        let leftovers: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|name| name.starts_with("profile.json.recover-"))
+            })
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "recover-* staging must be cleaned: {leftovers:?}"
+        );
+        // The original candidate stays for a later attempt and is re-scanned
+        // by the next read.
+        assert!(candidate.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn corrupted_authoritative_file_self_heals_from_backup() {
+        let root = recovery_test_root("corrupt-self-heal");
+        let target = root.join("profile.json");
+        let backup = target.with_extension("bak");
+        let authoritative = "{\"version\":1,\"revision\":9,\"identity\":{\"call_name\":\"权威\",\"assistant_alias\":\"品悟\"}}\n";
+        // The authoritative file is deterministically corrupted (invalid
+        // UTF-8) while a valid older backup exists. The deterministic error
+        // must still fall through to recovery so the file self-heals.
+        fs::write(&target, b"\xff\xfe not utf8").unwrap();
+        fs::write(&backup, authoritative).unwrap();
+
+        let restored = read_text_recovering(&target, |raw| {
+            serde_json::from_str::<MemoryProfile>(raw).is_ok()
+        })
+        .unwrap();
+        assert_eq!(restored, authoritative);
+        assert_eq!(fs::read_to_string(&target).unwrap(), authoritative);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! The structured files are the source of truth. `runtime/<session_id>.md` is
 //! only a prompt cache consumed through `InstructionSource::File`.
+// architecture-guard: allow-target-cfg -- 记忆持久化测试需用 Windows 独占句柄覆盖 ReplaceFileW 恢复路径
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -382,6 +383,19 @@ pub struct PreferenceFile {
     pub scope: String,
     #[serde(default)]
     pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TopicMutation<T> {
+    pub value: T,
+    pub cleanup_warning: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TopicMigrationJournal {
+    authority_file: String,
+    authority_hash: String,
+    stale_files: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1188,31 +1202,80 @@ pub fn archive_recent_work(id: &str) -> io::Result<bool> {
     Ok(changed)
 }
 
+fn resolve_topic_authorities<T: Clone>(
+    records: Vec<(PathBuf, T)>,
+    topic: impl Fn(&T) -> &str,
+    id: impl Fn(&T) -> &str,
+) -> io::Result<Vec<T>> {
+    let mut grouped = BTreeMap::<String, Vec<(PathBuf, T)>>::new();
+    for (path, item) in records {
+        grouped
+            .entry(topic(&item).to_string())
+            .or_default()
+            .push((path, item));
+    }
+    let mut authorities = Vec::new();
+    for (_, mut group) in grouped {
+        group.sort_by_key(|(path, item)| {
+            let canonical = path.file_name().and_then(|value| value.to_str())
+                == Some(format!("{}.json", id(item)).as_str());
+            let modified = fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .ok();
+            (canonical, modified, path.clone())
+        });
+        let (authority_path, authority) = group
+            .pop()
+            .expect("topic groups are constructed from at least one record");
+        for (duplicate, _) in group {
+            fs::remove_file(&duplicate).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!(
+                        "memory_topic_cleanup_required:{}:{}",
+                        duplicate.display(),
+                        error
+                    ),
+                )
+            })?;
+        }
+        debug_assert!(authority_path.is_file());
+        authorities.push(authority);
+    }
+    Ok(authorities)
+}
+
 pub fn load_work_context() -> io::Result<Vec<WorkContextFile>> {
+    let _lifecycle = file_lifecycle_lock().lock();
+    load_work_context_unlocked()
+}
+
+fn load_work_context_unlocked() -> io::Result<Vec<WorkContextFile>> {
     let dir = work_context_dir();
-    recover_directory_json_files::<WorkContextFile>(&dir)?;
+    recover_directory_json_files_unlocked::<WorkContextFile>(&dir)?;
+    reconcile_topic_migration_journals_unlocked::<WorkContextFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
     };
-    let mut by_topic: BTreeMap<String, WorkContextFile> = BTreeMap::new();
+    let mut records = Vec::new();
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
-        let raw = read_text_recovering(&path, |raw| {
+        let raw = read_text_recovering_unlocked(&path, &|raw| {
             serde_json::from_str::<WorkContextFile>(raw).is_ok()
         })?;
         let mut item = serde_json::from_str::<WorkContextFile>(&raw).map_err(invalid_data)?;
         normalize_work_context(&mut item);
         if !item.topic.is_empty() && !item.text.is_empty() {
-            by_topic.insert(item.topic.clone(), item);
+            records.push((path, item));
         }
     }
-    Ok(by_topic.into_values().collect())
+    resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)
 }
 
 fn upsert_work_context_unlocked(
@@ -1253,16 +1316,265 @@ fn upsert_work_context_locked(
     upsert_work_context_unlocked(suggestion, confidence)
 }
 
+fn commit_topic_migration_unlocked<T>(
+    new_path: &Path,
+    value: &T,
+    stale_paths: &[PathBuf],
+    validate: impl Fn(&T) -> bool,
+) -> io::Result<TopicMutation<T>>
+where
+    T: Clone + Serialize + serde::de::DeserializeOwned,
+{
+    let journal_path = topic_migration_journal_path(new_path)?;
+    commit_topic_migration_unlocked_with(
+        &journal_path,
+        new_path,
+        value,
+        stale_paths,
+        validate,
+        write_json_atomic_unlocked,
+        |path| fs::remove_file(path),
+    )
+}
+
+fn commit_topic_migration_unlocked_with<T, W, R>(
+    journal_path: &Path,
+    new_path: &Path,
+    value: &T,
+    stale_paths: &[PathBuf],
+    validate: impl Fn(&T) -> bool,
+    write: W,
+    mut remove: R,
+) -> io::Result<TopicMutation<T>>
+where
+    T: Clone + Serialize + serde::de::DeserializeOwned,
+    W: FnOnce(&Path, &T) -> io::Result<()>,
+    R: FnMut(&Path) -> io::Result<()>,
+{
+    let authority_file = new_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid authority filename"))?
+        .to_string();
+    let stale_files = stale_paths
+        .iter()
+        .filter_map(|path| path.file_name().and_then(|value| value.to_str()))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let authority_json = serde_json::to_string_pretty(value).map_err(invalid_data)? + "\n";
+    let journal = TopicMigrationJournal {
+        authority_file,
+        authority_hash: stable_id_with_prefix("authority", &authority_json),
+        stale_files,
+    };
+    write_topic_migration_journal_unlocked(journal_path, &journal)?;
+    write(new_path, value)?;
+    let raw = fs::read_to_string(new_path)?;
+    let committed = serde_json::from_str::<T>(&raw).map_err(invalid_data)?;
+    if !validate(&committed) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "new memory topic authority failed post-commit validation",
+        ));
+    }
+
+    let mut cleanup_failures = Vec::new();
+    for stale in stale_paths {
+        if stale == new_path || !stale.exists() {
+            continue;
+        }
+        if let Err(error) = remove(stale) {
+            cleanup_failures.push(format!("{}: {error}", stale.display()));
+        }
+    }
+    if cleanup_failures.is_empty() {
+        if let Err(error) = remove(journal_path) {
+            cleanup_failures.push(format!("{}: {error}", journal_path.display()));
+        }
+    }
+    Ok(TopicMutation {
+        value: value.clone(),
+        cleanup_warning: (!cleanup_failures.is_empty()).then(|| cleanup_failures.join("; ")),
+    })
+}
+
+fn topic_migration_journal_path(new_path: &Path) -> io::Result<PathBuf> {
+    let parent = new_path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "topic path has no parent"))?;
+    let name = new_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid topic filename"))?;
+    Ok(parent.join(format!(".topic-migration-{name}.journal")))
+}
+
+fn write_topic_migration_journal_unlocked(
+    journal_path: &Path,
+    journal: &TopicMigrationJournal,
+) -> io::Result<()> {
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static JOURNAL_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let parent = journal_path.parent().unwrap_or_else(|| Path::new("."));
+    let sequence = JOURNAL_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let staging = parent.join(format!(
+        ".topic-journal-stage-{}-{sequence}.bin",
+        std::process::id()
+    ));
+    let backup = parent.join(format!(
+        ".topic-journal-backup-{}-{sequence}.bin",
+        std::process::id()
+    ));
+    let result = (|| -> io::Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staging)?;
+        serde_json::to_writer_pretty(&mut file, journal).map_err(invalid_data)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        match crate::platform::filesystem::replace_file_atomically(&staging, journal_path, &backup)
+        {
+            Ok(crate::platform::filesystem::ReplaceState::Committed) => Ok(()),
+            Ok(state) => Err(io::Error::other(format!(
+                "unexpected journal replacement state: {state:?}"
+            ))),
+            Err(error) => Err(error.into_io_error()),
+        }
+    })();
+    if result.is_err() {
+        // The new authority is not written until the journal succeeds, so
+        // these staging paths can never be required to recover user data.
+        let _ = fs::remove_file(staging);
+        let _ = fs::remove_file(backup);
+    }
+    result
+}
+
+fn reconcile_topic_migration_journals_unlocked<T: serde::de::DeserializeOwned>(
+    dir: &Path,
+) -> io::Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let journal_path = entry?.path();
+        let Some(name) = journal_path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if !name.starts_with(".topic-migration-") || !name.ends_with(".journal") {
+            continue;
+        }
+        let journal = fs::read_to_string(&journal_path).and_then(|raw| {
+            serde_json::from_str::<TopicMigrationJournal>(&raw).map_err(invalid_data)
+        })?;
+        if !is_plain_filename(&journal.authority_file)
+            || journal
+                .stale_files
+                .iter()
+                .any(|name| !is_plain_filename(name))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid memory topic migration journal path",
+            ));
+        }
+        let authority = dir.join(&journal.authority_file);
+        let authority_valid = fs::read_to_string(&authority).is_ok_and(|raw| {
+            serde_json::from_str::<T>(&raw).is_ok()
+                && stable_id_with_prefix("authority", &raw) == journal.authority_hash
+        });
+        if !authority_valid {
+            fs::remove_file(&journal_path)?;
+            continue;
+        }
+        for stale_name in &journal.stale_files {
+            let stale = dir.join(stale_name);
+            if stale == authority || !stale.exists() {
+                continue;
+            }
+            fs::remove_file(&stale).map_err(|error| {
+                io::Error::new(
+                    error.kind(),
+                    format!(
+                        "memory_topic_cleanup_required:{}:{}",
+                        stale.display(),
+                        error
+                    ),
+                )
+            })?;
+        }
+        fs::remove_file(&journal_path).map_err(|error| {
+            io::Error::new(
+                error.kind(),
+                format!(
+                    "memory_topic_cleanup_required:{}:{}",
+                    journal_path.display(),
+                    error
+                ),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn is_plain_filename(value: &str) -> bool {
+    !value.is_empty()
+        && Path::new(value).components().count() == 1
+        && matches!(
+            Path::new(value).components().next(),
+            Some(std::path::Component::Normal(_))
+        )
+}
+
+fn work_context_stale_paths_unlocked(
+    dir: &Path,
+    new_path: &Path,
+    old_topic: &str,
+    new_topic: &str,
+) -> io::Result<Vec<PathBuf>> {
+    let mut stale = Vec::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(stale),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        if path == new_path || path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let same_topic = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<WorkContextFile>(&raw).ok())
+            .map(|item| {
+                let topic = normalize_work_context_topic(&item.topic);
+                topic == old_topic || topic == new_topic
+            })
+            .unwrap_or(false);
+        if same_topic {
+            stale.push(path);
+        }
+    }
+    Ok(stale)
+}
+
 pub fn update_work_context(
     id: &str,
     patch: MemoryTextPatch,
-) -> io::Result<Option<WorkContextFile>> {
+) -> io::Result<Option<TopicMutation<WorkContextFile>>> {
     let _guard = write_lock().lock();
+    let _lifecycle = file_lifecycle_lock().lock();
     let id = clean_id(id);
     if id.is_empty() {
         return Ok(None);
     }
-    let items = load_work_context()?;
+    let items = load_work_context_unlocked()?;
     let Some(existing) = items
         .into_iter()
         .find(|item| clean_id(&item.id) == id || clean_id(&item.topic) == id)
@@ -1296,11 +1608,18 @@ pub fn update_work_context(
     fs::create_dir_all(&dir)?;
     let old_path = dir.join(format!("{}.json", existing.id));
     let new_path = dir.join(format!("{new_id}.json"));
-    if old_path != new_path && old_path.exists() {
-        let _ = fs::remove_file(old_path);
+    let mut stale_paths =
+        work_context_stale_paths_unlocked(&dir, &new_path, &existing.topic, &updated.topic)?;
+    if old_path != new_path && old_path.exists() && !stale_paths.contains(&old_path) {
+        stale_paths.push(old_path);
     }
-    write_json_atomic(&new_path, &updated)?;
-    Ok(Some(updated))
+    let mutation =
+        commit_topic_migration_unlocked(&new_path, &updated, &stale_paths, |committed| {
+            committed.id == updated.id
+                && committed.topic == updated.topic
+                && committed.text == updated.text
+        })?;
+    Ok(Some(mutation))
 }
 
 pub fn delete_work_context(id: &str) -> io::Result<bool> {
@@ -3696,13 +4015,49 @@ pub fn list_preferences() -> io::Result<Vec<PreferenceFile>> {
     load_preferences()
 }
 
-pub fn update_preference(id: &str, patch: MemoryTextPatch) -> io::Result<Option<PreferenceFile>> {
+fn preference_stale_paths_unlocked(
+    dir: &Path,
+    new_path: &Path,
+    old_topic: &str,
+    new_topic: &str,
+) -> io::Result<Vec<PathBuf>> {
+    let mut stale = Vec::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(stale),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let path = entry?.path();
+        if path == new_path || path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let same_topic = fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<PreferenceFile>(&raw).ok())
+            .map(|item| {
+                let topic = normalize_preference_topic(&item.topic);
+                topic == old_topic || topic == new_topic
+            })
+            .unwrap_or(false);
+        if same_topic {
+            stale.push(path);
+        }
+    }
+    Ok(stale)
+}
+
+pub fn update_preference(
+    id: &str,
+    patch: MemoryTextPatch,
+) -> io::Result<Option<TopicMutation<PreferenceFile>>> {
     let _guard = write_lock().lock();
+    let _lifecycle = file_lifecycle_lock().lock();
     let id = clean_id(id);
     if id.is_empty() {
         return Ok(None);
     }
-    let prefs = load_preferences()?;
+    let prefs = load_preferences_unlocked()?;
     let Some(existing) = prefs.into_iter().find(|pref| clean_id(&pref.id) == id) else {
         return Ok(None);
     };
@@ -3740,27 +4095,18 @@ pub fn update_preference(id: &str, patch: MemoryTextPatch) -> io::Result<Option<
     fs::create_dir_all(&dir)?;
     let old_path = dir.join(format!("{}.json", existing.id));
     let new_path = dir.join(format!("{new_id}.json"));
-    if old_path != new_path && old_path.exists() {
-        let _ = fs::remove_file(old_path);
+    let mut stale_paths =
+        preference_stale_paths_unlocked(&dir, &new_path, &existing.topic, &updated.topic)?;
+    if old_path != new_path && old_path.exists() && !stale_paths.contains(&old_path) {
+        stale_paths.push(old_path);
     }
-    if let Ok(entries) = fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path == new_path || path.extension().and_then(|s| s.to_str()) != Some("json") {
-                continue;
-            }
-            let same_topic = fs::read_to_string(&path)
-                .ok()
-                .and_then(|raw| serde_json::from_str::<PreferenceFile>(&raw).ok())
-                .map(|pref| normalize_preference_topic(&pref.topic) == topic)
-                .unwrap_or(false);
-            if same_topic {
-                let _ = fs::remove_file(path);
-            }
-        }
-    }
-    write_json_atomic(&new_path, &updated)?;
-    Ok(Some(updated))
+    let mutation =
+        commit_topic_migration_unlocked(&new_path, &updated, &stale_paths, |committed| {
+            committed.id == updated.id
+                && committed.topic == updated.topic
+                && committed.text == updated.text
+        })?;
+    Ok(Some(mutation))
 }
 
 pub fn delete_preference(id: &str) -> io::Result<bool> {
@@ -3801,21 +4147,27 @@ pub fn delete_preference(id: &str) -> io::Result<bool> {
 }
 
 fn load_preferences() -> io::Result<Vec<PreferenceFile>> {
+    let _lifecycle = file_lifecycle_lock().lock();
+    load_preferences_unlocked()
+}
+
+fn load_preferences_unlocked() -> io::Result<Vec<PreferenceFile>> {
     let dir = paths::user_memory_preferences_dir();
-    recover_directory_json_files::<PreferenceFile>(&dir)?;
+    recover_directory_json_files_unlocked::<PreferenceFile>(&dir)?;
+    reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
     };
-    let mut by_topic: BTreeMap<String, PreferenceFile> = BTreeMap::new();
+    let mut records = Vec::new();
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
-        let raw = read_text_recovering(&path, |raw| {
+        let raw = read_text_recovering_unlocked(&path, &|raw| {
             serde_json::from_str::<PreferenceFile>(raw).is_ok()
         })?;
         let mut pref = serde_json::from_str::<PreferenceFile>(&raw).map_err(invalid_data)?;
@@ -3831,10 +4183,10 @@ fn load_preferences() -> io::Result<Vec<PreferenceFile>> {
         pref.scope = clean_scalar(&pref.scope);
         pref.text = clean_scalar(&pref.text);
         if !pref.text.is_empty() && !looks_like_profile_preference_text(&pref.text) {
-            by_topic.insert(pref.topic.clone(), pref);
+            records.push((path, pref));
         }
     }
-    let mut out = by_topic.into_values().collect::<Vec<_>>();
+    let mut out = resolve_topic_authorities(records, |item| &item.topic, |item| &item.id)?;
     out.sort_by(|a, b| a.id.cmp(&b.id).then_with(|| a.text.cmp(&b.text)));
     Ok(out)
 }
@@ -3928,12 +4280,32 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
     write_text_atomic(path, &(text + "\n"))
 }
 
+fn write_json_atomic_unlocked<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let text = serde_json::to_string_pretty(value).map_err(invalid_data)?;
+    write_text_atomic_unlocked(path, &(text + "\n"))
+}
+
 fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
+    let _lifecycle = file_lifecycle_lock().lock();
+    write_text_atomic_unlocked(path, text)
+}
+
+fn write_text_atomic_unlocked(path: &Path, text: &str) -> io::Result<()> {
+    write_text_atomic_unlocked_with(
+        path,
+        text,
+        crate::platform::filesystem::replace_file_atomically,
+    )
+}
+
+fn write_text_atomic_unlocked_with<F>(path: &Path, text: &str, replace: F) -> io::Result<()>
+where
+    F: FnOnce(&Path, &Path, &Path) -> crate::platform::filesystem::ReplaceResult,
+{
     use std::io::Write as _;
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-    let _lifecycle = file_lifecycle_lock().lock();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -3958,7 +4330,7 @@ fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
         let _ = fs::remove_file(&tmp);
         return Err(error);
     }
-    match crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup) {
+    match replace(&tmp, path, &backup) {
         Ok(crate::platform::filesystem::ReplaceState::Committed) => Ok(()),
         Ok(state) => Err(io::Error::other(format!(
             "unexpected successful replacement state: {state:?}"
@@ -4131,6 +4503,12 @@ fn cleanup_recovery_candidates(path: &Path) {
 
 fn recover_directory_json_files<T: for<'de> Deserialize<'de>>(dir: &Path) -> io::Result<()> {
     let _lifecycle = file_lifecycle_lock().lock();
+    recover_directory_json_files_unlocked::<T>(dir)
+}
+
+fn recover_directory_json_files_unlocked<T: for<'de> Deserialize<'de>>(
+    dir: &Path,
+) -> io::Result<()> {
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -4242,6 +4620,300 @@ mod tests {
         assert!(restored.contains("\"revision\":7"));
         assert!(!backup.exists());
         assert!(!replacement.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn preference_fixture(id: &str, topic: &str, text: &str) -> PreferenceFile {
+        PreferenceFile {
+            id: id.to_string(),
+            topic: topic.to_string(),
+            scope: "unconditional".to_string(),
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn topic_migration_staging_failure_preserves_old_authority() {
+        let root = recovery_test_root("topic-stage-failure");
+        let old_path = root.join("old.json");
+        let new_path = root.join("new.json");
+        let journal = topic_migration_journal_path(&new_path).unwrap();
+        let old = preference_fixture("old", "answer_style", "old value");
+        let new = preference_fixture("new", "workflow_preference", "new value");
+        write_json_atomic(&old_path, &old).unwrap();
+
+        let error = commit_topic_migration_unlocked_with(
+            &journal,
+            &new_path,
+            &new,
+            std::slice::from_ref(&old_path),
+            |_| true,
+            |_, _| Err(io::Error::new(io::ErrorKind::Other, "staging failpoint")),
+            |path| fs::remove_file(path),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("staging failpoint"));
+        assert_eq!(
+            serde_json::from_str::<PreferenceFile>(&fs::read_to_string(&old_path).unwrap())
+                .unwrap()
+                .text,
+            "old value"
+        );
+        assert!(!new_path.exists());
+        reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&root).unwrap();
+        assert!(!journal.exists());
+        assert!(old_path.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn topic_migration_cleanup_failure_returns_warning_and_retries() {
+        let root = recovery_test_root("topic-cleanup-retry");
+        let old_path = root.join("old.json");
+        let new_path = root.join("new.json");
+        let journal = topic_migration_journal_path(&new_path).unwrap();
+        let old = preference_fixture("old", "answer_style", "old value");
+        let new = preference_fixture("new", "workflow_preference", "new value");
+        write_json_atomic(&old_path, &old).unwrap();
+
+        let mutation = commit_topic_migration_unlocked_with(
+            &journal,
+            &new_path,
+            &new,
+            std::slice::from_ref(&old_path),
+            |value| value.id == "new",
+            |path, value| write_json_atomic_unlocked(path, value),
+            |_| Err(io::Error::new(io::ErrorKind::PermissionDenied, "occupied")),
+        )
+        .unwrap();
+
+        assert_eq!(mutation.value.text, "new value");
+        assert!(mutation
+            .cleanup_warning
+            .as_deref()
+            .is_some_and(|warning| warning.contains("occupied")));
+        assert!(old_path.exists());
+        assert!(new_path.exists());
+        assert!(journal.exists());
+
+        reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&root).unwrap();
+        assert!(!old_path.exists());
+        assert!(new_path.exists());
+        assert!(!journal.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn preference_and_work_context_topic_updates_commit_before_old_cleanup() {
+        let home = IsolatedPinvouHome::new("topic-public-updates");
+        let preference_dir = paths::user_memory_preferences_dir();
+        let context_dir = work_context_dir();
+        fs::create_dir_all(&preference_dir).unwrap();
+        fs::create_dir_all(&context_dir).unwrap();
+        let old_preference_id = stable_id_with_prefix("pref", "answer_style");
+        let old_preference_path = preference_dir.join(format!("{old_preference_id}.json"));
+        write_json_atomic(
+            &old_preference_path,
+            &preference_fixture(&old_preference_id, "answer_style", "old preference"),
+        )
+        .unwrap();
+        let old_context_id = stable_id_with_prefix("ctx", "role_domain");
+        let old_context_path = context_dir.join(format!("{old_context_id}.json"));
+        write_json_atomic(
+            &old_context_path,
+            &WorkContextFile {
+                id: old_context_id.clone(),
+                kind: "work_context".to_string(),
+                topic: "role_domain".to_string(),
+                text: "old context".to_string(),
+                source: "test".to_string(),
+                confidence: 1.0,
+                created_at: Utc::now().to_rfc3339(),
+                updated_at: Utc::now().to_rfc3339(),
+            },
+        )
+        .unwrap();
+
+        let preference = update_preference(
+            &old_preference_id,
+            MemoryTextPatch {
+                topic: Some("workflow_preference".to_string()),
+                text: Some("new preference".to_string()),
+                ttl_days: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        let context = update_work_context(
+            &old_context_id,
+            MemoryTextPatch {
+                topic: Some("project_context".to_string()),
+                text: Some("new context".to_string()),
+                ttl_days: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(preference.cleanup_warning.is_none());
+        assert_eq!(preference.value.topic, "workflow_preference");
+        assert!(context.cleanup_warning.is_none());
+        assert_eq!(context.value.topic, "project_context");
+        assert!(!old_preference_path.exists());
+        assert!(!old_context_path.exists());
+        assert_eq!(list_preferences().unwrap().len(), 1);
+        assert_eq!(load_work_context().unwrap().len(), 1);
+        drop(home);
+    }
+
+    #[test]
+    fn topic_migration_lifecycle_hides_intermediate_duplicate_from_overview() {
+        let home = IsolatedPinvouHome::new("topic-concurrent-overview");
+        let dir = paths::user_memory_preferences_dir();
+        fs::create_dir_all(&dir).unwrap();
+        let old = preference_fixture("old", "answer_style", "old value");
+        let new = preference_fixture("new", "workflow_preference", "new value");
+        let old_path = dir.join("old.json");
+        let new_path = dir.join("new.json");
+        write_json_atomic(&old_path, &old).unwrap();
+        let ready = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let release = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let writer_ready = ready.clone();
+        let writer_release = release.clone();
+        let writer = std::thread::spawn(move || {
+            let _lifecycle = file_lifecycle_lock().lock();
+            let journal = topic_migration_journal_path(&new_path).unwrap();
+            commit_topic_migration_unlocked_with(
+                &journal,
+                &new_path,
+                &new,
+                std::slice::from_ref(&old_path),
+                |_| true,
+                |path, value| {
+                    write_json_atomic_unlocked(path, value)?;
+                    writer_ready.wait();
+                    writer_release.wait();
+                    Ok(())
+                },
+                |path| fs::remove_file(path),
+            )
+            .unwrap();
+        });
+        ready.wait();
+        let (sent, received) = std::sync::mpsc::channel();
+        let reader = std::thread::spawn(move || sent.send(list_preferences()).unwrap());
+        assert!(received
+            .recv_timeout(std::time::Duration::from_millis(30))
+            .is_err());
+        release.wait();
+        writer.join().unwrap();
+        let visible = received
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        reader.join().unwrap();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].text, "new value");
+        drop(home);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn topic_migration_replacefile_failure_keeps_old_authority() {
+        let root = recovery_test_root("topic-replacefile-failure");
+        let old_path = root.join("old.json");
+        let new_path = root.join("new.json");
+        let journal = topic_migration_journal_path(&new_path).unwrap();
+        let old = preference_fixture("old", "answer_style", "old value");
+        let prior_new = preference_fixture("new", "workflow_preference", "prior value");
+        let expected = preference_fixture("new", "workflow_preference", "expected value");
+        write_json_atomic(&old_path, &old).unwrap();
+        write_json_atomic(&new_path, &prior_new).unwrap();
+
+        let error = commit_topic_migration_unlocked_with(
+            &journal,
+            &new_path,
+            &expected,
+            std::slice::from_ref(&old_path),
+            |_| true,
+            |path, value| {
+                let text = serde_json::to_string_pretty(value).unwrap() + "\n";
+                write_text_atomic_unlocked_with(path, &text, |tmp, target, backup| {
+                    crate::platform::filesystem::replace_file_atomically_with(
+                        tmp,
+                        target,
+                        backup,
+                        |_, _, _| Err(io::Error::from_raw_os_error(1175)),
+                    )
+                })
+            },
+            |path| fs::remove_file(path),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("RolledBack"));
+        assert!(old_path.exists());
+        assert_eq!(
+            serde_json::from_str::<PreferenceFile>(&fs::read_to_string(&new_path).unwrap())
+                .unwrap()
+                .text,
+            "prior value"
+        );
+        reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&root).unwrap();
+        assert!(old_path.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn topic_migration_promotion_failure_recovers_before_old_cleanup() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        let root = recovery_test_root("topic-promotion-failure");
+        let old_path = root.join("old.json");
+        let new_path = root.join("new.json");
+        let journal = topic_migration_journal_path(&new_path).unwrap();
+        let old = preference_fixture("old", "answer_style", "old value");
+        let expected = preference_fixture("new", "workflow_preference", "expected value");
+        write_json_atomic(&old_path, &old).unwrap();
+
+        let error = commit_topic_migration_unlocked_with(
+            &journal,
+            &new_path,
+            &expected,
+            std::slice::from_ref(&old_path),
+            |_| true,
+            |path, value| {
+                let text = serde_json::to_string_pretty(value).unwrap() + "\n";
+                write_text_atomic_unlocked_with(path, &text, |tmp, target, backup| {
+                    let occupied = fs::OpenOptions::new()
+                        .read(true)
+                        .share_mode(0)
+                        .open(tmp)
+                        .unwrap();
+                    let result =
+                        crate::platform::filesystem::replace_file_atomically(tmp, target, backup);
+                    drop(occupied);
+                    result
+                })
+            },
+            |path| fs::remove_file(path),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("RecoveryRequired"));
+        assert!(old_path.exists());
+        assert!(!new_path.exists());
+        recover_directory_json_files_unlocked::<PreferenceFile>(&root).unwrap();
+        reconcile_topic_migration_journals_unlocked::<PreferenceFile>(&root).unwrap();
+        assert!(!old_path.exists());
+        assert_eq!(
+            serde_json::from_str::<PreferenceFile>(&fs::read_to_string(&new_path).unwrap())
+                .unwrap()
+                .text,
+            "expected value"
+        );
         let _ = fs::remove_dir_all(root);
     }
 
@@ -4425,7 +5097,8 @@ mod tests {
         )
         .unwrap()
         .unwrap();
-        assert_eq!(updated.text, "Use detailed answers");
+        assert_eq!(updated.value.text, "Use detailed answers");
+        assert!(updated.cleanup_warning.is_none());
         assert_eq!(list_preferences().unwrap()[0].text, "Use detailed answers");
         assert!(render_memory_block().is_err());
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -4781,17 +4781,23 @@ mod tests {
         // Windows): the authoritative file exists but cannot be read right now.
         fs::set_permissions(&target, std::fs::Permissions::from_mode(0o000)).unwrap();
         let unreadable = fs::read_to_string(&target).is_err();
-        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
         if !unreadable {
             // Running as root (or on a filesystem that ignores mode bits)
             // bypasses the permission check, so the guard cannot be exercised
             // this way; skip instead of failing spuriously.
+            let _ = fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600));
             let _ = fs::remove_dir_all(root);
             return;
         }
+        // The target stays unreadable (mode 000) through the recovery call so
+        // the transient-read guard is actually exercised: a stale backup must
+        // not be promoted over the still-present authoritative file.
         let result = read_text_recovering(&target, |raw| {
             serde_json::from_str::<MemoryProfile>(raw).is_ok()
         });
+        // Restore readability for the assertions and cleanup below; the
+        // authoritative file was never overwritten by the recovery path.
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o600)).unwrap();
 
         assert!(result.is_err());
         // The authoritative target must be preserved, never overwritten by a

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -683,10 +683,15 @@ pub fn load_profile() -> io::Result<MemoryProfile> {
             profile.normalize();
             Ok(profile)
         }
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(MemoryProfile {
-            version: PROFILE_VERSION,
-            ..MemoryProfile::default()
-        }),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            if let Some(profile) = recover_profile_after_interrupted_replace(&path)? {
+                return Ok(profile);
+            }
+            Ok(MemoryProfile {
+                version: PROFILE_VERSION,
+                ..MemoryProfile::default()
+            })
+        }
         Err(err) => Err(err),
     }
 }
@@ -3924,25 +3929,92 @@ fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
 }
 
 fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
+    use std::io::Write as _;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
-    fs::write(&tmp, text)?;
-    match fs::rename(&tmp, path) {
-        Ok(()) => return Ok(()),
-        Err(err) if path.exists() => {
-            let _ = fs::remove_file(path);
-            fs::rename(tmp, path).map_err(|rename_err| {
-                io::Error::new(
-                    rename_err.kind(),
-                    format!("replace after rename failed ({err}); {rename_err}"),
-                )
-            })?;
-        }
-        Err(err) => return Err(err),
+    let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let tmp = path.with_extension(format!("tmp-{}-{timestamp}-{sequence}", std::process::id()));
+    let backup = path.with_extension("bak");
+    let result = (|| {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
+        file.write_all(text.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+        crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
     }
-    Ok(())
+    result
+}
+
+fn recover_profile_after_interrupted_replace(path: &Path) -> io::Result<Option<MemoryProfile>> {
+    let Some(parent) = path.parent() else {
+        return Ok(None);
+    };
+    let file_stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("profile");
+    let mut candidates = Vec::new();
+    let backup = path.with_extension("bak");
+    if backup.is_file() {
+        candidates.push(backup);
+    }
+    if let Ok(entries) = fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            let Some(name) = candidate.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let is_regular_file = fs::symlink_metadata(&candidate)
+                .is_ok_and(|metadata| metadata.file_type().is_file());
+            if is_regular_file && name.starts_with(&format!("{file_stem}.tmp-")) {
+                candidates.push(candidate);
+            }
+        }
+    }
+    candidates.sort_by_key(|candidate| {
+        fs::metadata(candidate)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+    });
+    candidates.reverse();
+    for candidate in candidates {
+        let Ok(raw) = fs::read_to_string(&candidate) else {
+            continue;
+        };
+        let Ok(mut profile) = serde_json::from_str::<MemoryProfile>(&raw) else {
+            continue;
+        };
+        profile.normalize();
+        match fs::hard_link(&candidate, path) {
+            Ok(()) => {
+                let _ = fs::remove_file(candidate);
+                return Ok(Some(profile));
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                let raw = fs::read_to_string(path)?;
+                let mut current =
+                    serde_json::from_str::<MemoryProfile>(&raw).map_err(invalid_data)?;
+                current.normalize();
+                return Ok(Some(current));
+            }
+            Err(_) => continue,
+        }
+    }
+    Ok(None)
 }
 
 fn invalid_data(err: impl std::fmt::Display) -> io::Error {
@@ -4034,6 +4106,34 @@ mod tests {
             }
             let _ = fs::remove_dir_all(&self.root);
         }
+    }
+
+    #[test]
+    fn missing_profile_recovers_latest_valid_interrupted_write() {
+        let home = IsolatedPinvouHome::new("profile-interrupted-recovery");
+        let path = profile_path();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path.with_extension("tmp-42-1"), "not json").unwrap();
+        let valid_candidate = path.with_extension("tmp-42-2");
+        fs::write(
+            &valid_candidate,
+            r#"{
+  "version": 1,
+  "revision": 7,
+  "identity": { "call_name": "升级用户", "assistant_alias": "小品" }
+}"#,
+        )
+        .unwrap();
+
+        let recovered = load_profile().unwrap();
+        assert_eq!(recovered.identity.call_name, "升级用户");
+        assert_eq!(recovered.identity.assistant_alias, "小品");
+        assert_eq!(recovered.revision, 7);
+        assert!(path.is_file());
+        assert!(!valid_candidate.exists());
+        assert!(fs::read_to_string(&path).unwrap().contains("升级用户"));
+        assert_eq!(load_profile().unwrap(), recovered);
+        drop(home);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -139,6 +139,11 @@ fn write_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+fn file_lifecycle_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MemoryProfile {
     #[serde(default = "default_profile_version")]
@@ -677,21 +682,18 @@ pub fn take_turn_capture(session_id: &str) -> Option<TurnMemoryCapture> {
 
 pub fn load_profile() -> io::Result<MemoryProfile> {
     let path = profile_path();
-    match fs::read_to_string(&path) {
+    match read_text_recovering(&path, |raw| {
+        serde_json::from_str::<MemoryProfile>(raw).is_ok()
+    }) {
         Ok(raw) => {
             let mut profile: MemoryProfile = serde_json::from_str(&raw).map_err(invalid_data)?;
             profile.normalize();
             Ok(profile)
         }
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {
-            if let Some(profile) = recover_profile_after_interrupted_replace(&path)? {
-                return Ok(profile);
-            }
-            Ok(MemoryProfile {
-                version: PROFILE_VERSION,
-                ..MemoryProfile::default()
-            })
-        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(MemoryProfile {
+            version: PROFILE_VERSION,
+            ..MemoryProfile::default()
+        }),
         Err(err) => Err(err),
     }
 }
@@ -1074,7 +1076,7 @@ fn looks_completed_work_status(value: &str) -> bool {
 
 pub fn load_recent_work() -> io::Result<Vec<RecentWorkItem>> {
     let path = recent_work_path();
-    let raw = match fs::read_to_string(&path) {
+    let raw = match read_text_recovering(&path, json_lines_are_valid::<RecentWorkItem>) {
         Ok(raw) => raw,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
@@ -1188,6 +1190,7 @@ pub fn archive_recent_work(id: &str) -> io::Result<bool> {
 
 pub fn load_work_context() -> io::Result<Vec<WorkContextFile>> {
     let dir = work_context_dir();
+    recover_directory_json_files::<WorkContextFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -1200,12 +1203,10 @@ pub fn load_work_context() -> io::Result<Vec<WorkContextFile>> {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
-        let Ok(raw) = fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(mut item) = serde_json::from_str::<WorkContextFile>(&raw) else {
-            continue;
-        };
+        let raw = read_text_recovering(&path, |raw| {
+            serde_json::from_str::<WorkContextFile>(raw).is_ok()
+        })?;
+        let mut item = serde_json::from_str::<WorkContextFile>(&raw).map_err(invalid_data)?;
         normalize_work_context(&mut item);
         if !item.topic.is_empty() && !item.text.is_empty() {
             by_topic.insert(item.topic.clone(), item);
@@ -1512,7 +1513,7 @@ pub fn delete_timed_memory(kind: &str, id: &str) -> io::Result<bool> {
 }
 
 fn load_timed_memory_file(path: &Path, kind: &str) -> io::Result<Vec<TimedMemoryItem>> {
-    let raw = match fs::read_to_string(path) {
+    let raw = match read_text_recovering(path, json_lines_are_valid::<TimedMemoryItem>) {
         Ok(raw) => raw,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
@@ -1611,7 +1612,7 @@ fn dedupe_timed_memory_items(mut items: Vec<TimedMemoryItem>) -> Vec<TimedMemory
 
 pub fn load_pending_memory() -> io::Result<Vec<PendingMemoryItem>> {
     let path = pending_memory_path();
-    let raw = match fs::read_to_string(&path) {
+    let raw = match read_text_recovering(&path, json_lines_are_valid::<PendingMemoryItem>) {
         Ok(raw) => raw,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
@@ -2752,11 +2753,11 @@ fn refresh_timed_memory_expiry_unlocked(kind: &str, now: DateTime<Utc>) -> io::R
 
 pub fn render_memory_block() -> io::Result<(String, Vec<InjectedMemoryItem>)> {
     let profile = load_profile()?;
-    let preferences = load_preferences().unwrap_or_default();
-    let work_context = load_work_context().unwrap_or_default();
-    let current_focus = load_current_focus().unwrap_or_default();
-    let recent_activity = load_recent_activity().unwrap_or_default();
-    let legacy_recent_work = load_recent_work().unwrap_or_default();
+    let preferences = load_preferences()?;
+    let work_context = load_work_context()?;
+    let current_focus = load_current_focus()?;
+    let recent_activity = load_recent_activity()?;
+    let legacy_recent_work = load_recent_work()?;
     Ok(render_from_parts(
         &profile,
         &preferences,
@@ -3599,7 +3600,7 @@ fn compact_pending_memory_items(items: &[PendingMemoryItem]) -> Vec<PendingMemor
 
 fn load_never_memory_unlocked() -> io::Result<Vec<NeverMemoryItem>> {
     let path = never_memory_path();
-    let raw = match fs::read_to_string(&path) {
+    let raw = match read_text_recovering(&path, json_lines_are_valid::<NeverMemoryItem>) {
         Ok(raw) => raw,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
@@ -3801,6 +3802,7 @@ pub fn delete_preference(id: &str) -> io::Result<bool> {
 
 fn load_preferences() -> io::Result<Vec<PreferenceFile>> {
     let dir = paths::user_memory_preferences_dir();
+    recover_directory_json_files::<PreferenceFile>(&dir)?;
     let entries = match fs::read_dir(&dir) {
         Ok(entries) => entries,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -3813,12 +3815,10 @@ fn load_preferences() -> io::Result<Vec<PreferenceFile>> {
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
-        let Ok(raw) = fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(mut pref) = serde_json::from_str::<PreferenceFile>(&raw) else {
-            continue;
-        };
+        let raw = read_text_recovering(&path, |raw| {
+            serde_json::from_str::<PreferenceFile>(raw).is_ok()
+        })?;
+        let mut pref = serde_json::from_str::<PreferenceFile>(&raw).map_err(invalid_data)?;
         pref.id = clean_scalar(&pref.id);
         if pref.id.is_empty() {
             pref.id = path
@@ -3933,6 +3933,7 @@ fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let _lifecycle = file_lifecycle_lock().lock();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -3953,15 +3954,46 @@ fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
         drop(file);
         crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup)
     })();
-    if result.is_err() {
+    if result.is_err() && path.is_file() {
         let _ = fs::remove_file(&tmp);
     }
     result
 }
 
-fn recover_profile_after_interrupted_replace(path: &Path) -> io::Result<Option<MemoryProfile>> {
+fn json_lines_are_valid<T: for<'de> Deserialize<'de>>(raw: &str) -> bool {
+    raw.lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .all(|line| serde_json::from_str::<T>(line).is_ok())
+}
+
+fn read_text_recovering(path: &Path, validate: impl Fn(&str) -> bool) -> io::Result<String> {
+    let _lifecycle = file_lifecycle_lock().lock();
+    read_text_recovering_unlocked(path, &validate)
+}
+
+fn read_text_recovering_unlocked(
+    path: &Path,
+    validate: &dyn Fn(&str) -> bool,
+) -> io::Result<String> {
+    read_text_recovering_unlocked_with(path, validate, &promote_recovery_candidate)
+}
+
+fn read_text_recovering_unlocked_with(
+    path: &Path,
+    validate: &dyn Fn(&str) -> bool,
+    promote: &dyn Fn(&Path, &Path, &[u8]) -> io::Result<()>,
+) -> io::Result<String> {
+    let current_error = match fs::read_to_string(path) {
+        Ok(raw) if validate(&raw) => return Ok(raw),
+        Ok(_) => io::Error::new(
+            io::ErrorKind::InvalidData,
+            "authoritative memory file is invalid",
+        ),
+        Err(error) => error,
+    };
     let Some(parent) = path.parent() else {
-        return Ok(None);
+        return Err(current_error);
     };
     let file_stem = path
         .file_stem()
@@ -3995,26 +4027,109 @@ fn recover_profile_after_interrupted_replace(path: &Path) -> io::Result<Option<M
         let Ok(raw) = fs::read_to_string(&candidate) else {
             continue;
         };
-        let Ok(mut profile) = serde_json::from_str::<MemoryProfile>(&raw) else {
+        if !validate(&raw) {
             continue;
-        };
-        profile.normalize();
-        match fs::hard_link(&candidate, path) {
-            Ok(()) => {
+        }
+        promote(&candidate, path, raw.as_bytes())?;
+        let restored = fs::read_to_string(path)?;
+        if validate(&restored) {
+            cleanup_recovery_candidates(path);
+            return Ok(restored);
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "promoted memory recovery candidate is invalid",
+        ));
+    }
+    Err(current_error)
+}
+
+fn promote_recovery_candidate(candidate: &Path, target: &Path, bytes: &[u8]) -> io::Result<()> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static RECOVERY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let sequence = RECOVERY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let replacement = target.with_extension(format!("recover-{}-{sequence}", std::process::id()));
+    let backup = target.with_extension("recover-bak");
+    let result = (|| {
+        let mut output = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&replacement)?;
+        output.write_all(bytes)?;
+        output.sync_all()?;
+        drop(output);
+        crate::platform::filesystem::replace_file_atomically(&replacement, target, &backup)
+    })();
+    if result.is_ok() {
+        let _ = fs::remove_file(candidate);
+        let _ = fs::remove_file(backup);
+    } else if target.is_file() {
+        let _ = fs::remove_file(replacement);
+    }
+    result
+}
+
+fn cleanup_recovery_candidates(path: &Path) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if let Ok(entries) = fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            let name = candidate
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or_default();
+            if candidate == path.with_extension("bak") || name.starts_with(&format!("{stem}.tmp-"))
+            {
                 let _ = fs::remove_file(candidate);
-                return Ok(Some(profile));
             }
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                let raw = fs::read_to_string(path)?;
-                let mut current =
-                    serde_json::from_str::<MemoryProfile>(&raw).map_err(invalid_data)?;
-                current.normalize();
-                return Ok(Some(current));
-            }
-            Err(_) => continue,
         }
     }
-    Ok(None)
+}
+
+fn recover_directory_json_files<T: for<'de> Deserialize<'de>>(dir: &Path) -> io::Result<()> {
+    let _lifecycle = file_lifecycle_lock().lock();
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let mut targets = std::collections::BTreeSet::new();
+    for entry in entries {
+        let path = entry?.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let stem = if let Some(stem) = name.strip_suffix(".bak") {
+            Some(stem)
+        } else {
+            name.split_once(".tmp-").map(|(stem, _)| stem)
+        };
+        if let Some(stem) = stem.filter(|stem| !stem.is_empty()) {
+            targets.insert(dir.join(format!("{stem}.json")));
+        }
+    }
+    for target in targets {
+        if target.is_file() {
+            continue;
+        }
+        match read_text_recovering_unlocked(&target, &|raw| serde_json::from_str::<T>(raw).is_ok())
+        {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 fn invalid_data(err: impl std::fmt::Display) -> io::Error {
@@ -4024,6 +4139,101 @@ fn invalid_data(err: impl std::fmt::Display) -> io::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn recovery_test_root(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou-memory-recovery-{name}-{}-{}",
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn generic_recovery_promotes_newest_valid_candidate_without_hard_links() {
+        let root = recovery_test_root("multiple");
+        let target = root.join("pending.jsonl");
+        let backup = target.with_extension("bak");
+        let older = target.with_extension("tmp-1-1-1");
+        let newer = target.with_extension("tmp-1-2-2");
+        fs::write(&backup, "invalid\n").unwrap();
+        fs::write(&older, "{\"id\":1}\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        fs::write(&newer, "{\"id\":2}\n").unwrap();
+
+        let restored = read_text_recovering(&target, |raw| {
+            json_lines_are_valid::<serde_json::Value>(raw)
+        })
+        .unwrap();
+        assert!(restored.contains("\"id\":2"));
+        assert_eq!(fs::read_to_string(&target).unwrap(), restored);
+        assert!(!backup.exists());
+        assert!(!older.exists());
+        assert!(!newer.exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn valid_recovery_candidate_with_failed_promotion_is_an_error() {
+        let root = recovery_test_root("promotion-failure");
+        let target = root.join("profile.json");
+        fs::write(target.with_extension("bak"), "{\"version\":1}\n").unwrap();
+
+        let error = read_text_recovering_unlocked_with(
+            &target,
+            &|raw| serde_json::from_str::<MemoryProfile>(raw).is_ok(),
+            &|_, _, _| Err(io::Error::new(io::ErrorKind::PermissionDenied, "blocked")),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!target.exists());
+        assert!(target.with_extension("bak").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn non_profile_directory_source_recovers_missing_authority() {
+        let root = recovery_test_root("directory");
+        let target = root.join("pref_answer.json");
+        fs::write(
+            target.with_extension("bak"),
+            serde_json::to_vec(&PreferenceFile {
+                id: "pref_answer".to_string(),
+                topic: "answer_style".to_string(),
+                scope: "unconditional".to_string(),
+                text: "concise".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        recover_directory_json_files::<PreferenceFile>(&root).unwrap();
+        let restored: PreferenceFile =
+            serde_json::from_str(&fs::read_to_string(&target).unwrap()).unwrap();
+        assert_eq!(restored.id, "pref_answer");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovery_waits_for_active_writer_lifecycle() {
+        let root = recovery_test_root("concurrent");
+        let target = root.join("recent.jsonl");
+        let guard = file_lifecycle_lock().lock();
+        let active = target.with_extension("tmp-9-9-9");
+        fs::write(&active, "{\"active\":true}\n").unwrap();
+        let target_for_reader = target.clone();
+        let reader = std::thread::spawn(move || {
+            read_text_recovering(&target_for_reader, |raw| {
+                json_lines_are_valid::<serde_json::Value>(raw)
+            })
+        });
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::remove_file(active).unwrap();
+        fs::write(&target, "{\"committed\":true}\n").unwrap();
+        drop(guard);
+        assert!(reader.join().unwrap().unwrap().contains("committed"));
+        let _ = fs::remove_dir_all(root);
+    }
 
     struct IsolatedPinvouHome {
         root: PathBuf,
@@ -4133,6 +4343,55 @@ mod tests {
         assert!(!valid_candidate.exists());
         assert!(fs::read_to_string(&path).unwrap().contains("升级用户"));
         assert_eq!(load_profile().unwrap(), recovered);
+        drop(home);
+    }
+
+    #[test]
+    fn authoritative_writes_commit_when_derived_runtime_source_is_unavailable() {
+        let home = IsolatedPinvouHome::new("committed-write-derived-failure");
+        let preference = enqueue_memory_candidate(MemorySuggestion {
+            kind: "preference".to_string(),
+            topic: "answer_style".to_string(),
+            content: "Use concise answers".to_string(),
+            source: "test".to_string(),
+        })
+        .unwrap();
+        confirm_pending_memory(&preference.id).unwrap().unwrap();
+        let preference_id = list_preferences().unwrap()[0].id.clone();
+
+        fs::create_dir_all(recent_work_path().parent().unwrap()).unwrap();
+        fs::write(recent_work_path(), "not-json\n").unwrap();
+
+        let updated = update_preference(
+            &preference_id,
+            MemoryTextPatch {
+                text: Some("Use detailed answers".to_string()),
+                topic: None,
+                ttl_days: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(updated.text, "Use detailed answers");
+        assert_eq!(list_preferences().unwrap()[0].text, "Use detailed answers");
+        assert!(render_memory_block().is_err());
+
+        assert!(delete_preference(&preference_id).unwrap());
+        assert!(list_preferences().unwrap().is_empty());
+        assert!(render_memory_block().is_err());
+
+        let profile_candidate = enqueue_memory_candidate(MemorySuggestion {
+            kind: "profile".to_string(),
+            topic: "call_name".to_string(),
+            content: "Ada".to_string(),
+            source: "test".to_string(),
+        })
+        .unwrap();
+        confirm_pending_memory(&profile_candidate.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(load_profile().unwrap().identity.call_name, "Ada");
+        assert!(render_memory_block().is_err());
         drop(home);
     }
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -3944,7 +3944,7 @@ fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
         .as_nanos();
     let tmp = path.with_extension(format!("tmp-{}-{timestamp}-{sequence}", std::process::id()));
     let backup = path.with_extension("bak");
-    let result = (|| {
+    let stage_result = (|| -> io::Result<()> {
         let mut file = fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -3952,12 +3952,25 @@ fn write_text_atomic(path: &Path, text: &str) -> io::Result<()> {
         file.write_all(text.as_bytes())?;
         file.sync_all()?;
         drop(file);
-        crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup)
+        Ok(())
     })();
-    if result.is_err() && path.is_file() {
+    if let Err(error) = stage_result {
         let _ = fs::remove_file(&tmp);
+        return Err(error);
     }
-    result
+    match crate::platform::filesystem::replace_file_atomically(&tmp, path, &backup) {
+        Ok(crate::platform::filesystem::ReplaceState::Committed) => Ok(()),
+        Ok(state) => Err(io::Error::other(format!(
+            "unexpected successful replacement state: {state:?}"
+        ))),
+        Err(error) => {
+            if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
+                let _ = fs::remove_file(&tmp);
+                let _ = fs::remove_file(&backup);
+            }
+            Err(error.into_io_error())
+        }
+    }
 }
 
 fn json_lines_are_valid<T: for<'de> Deserialize<'de>>(raw: &str) -> bool {
@@ -4002,7 +4015,7 @@ fn read_text_recovering_unlocked_with(
     let mut candidates = Vec::new();
     let backup = path.with_extension("bak");
     if backup.is_file() {
-        candidates.push(backup);
+        candidates.push((true, backup));
     }
     if let Ok(entries) = fs::read_dir(parent) {
         for entry in entries.flatten() {
@@ -4013,17 +4026,23 @@ fn read_text_recovering_unlocked_with(
             let is_regular_file = fs::symlink_metadata(&candidate)
                 .is_ok_and(|metadata| metadata.file_type().is_file());
             if is_regular_file && name.starts_with(&format!("{file_stem}.tmp-")) {
-                candidates.push(candidate);
+                candidates.push((false, candidate));
             }
         }
     }
-    candidates.sort_by_key(|candidate| {
-        fs::metadata(candidate)
-            .and_then(|metadata| metadata.modified())
-            .ok()
+    // A ReplaceFileW 1177 backup is the old authority under its documented
+    // alternate name. Prefer it over a replacement candidate; otherwise use
+    // the newest valid completed temporary file.
+    candidates.sort_by_key(|(is_backup, candidate)| {
+        (
+            *is_backup,
+            fs::metadata(candidate)
+                .and_then(|metadata| metadata.modified())
+                .ok(),
+        )
     });
     candidates.reverse();
-    for candidate in candidates {
+    for (_, candidate) in candidates {
         let Ok(raw) = fs::read_to_string(&candidate) else {
             continue;
         };
@@ -4054,7 +4073,7 @@ fn promote_recovery_candidate(candidate: &Path, target: &Path, bytes: &[u8]) -> 
     let sequence = RECOVERY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let replacement = target.with_extension(format!("recover-{}-{sequence}", std::process::id()));
     let backup = target.with_extension("recover-bak");
-    let result = (|| {
+    let stage_result = (|| -> io::Result<()> {
         let mut output = fs::OpenOptions::new()
             .write(true)
             .create_new(true)
@@ -4062,15 +4081,29 @@ fn promote_recovery_candidate(candidate: &Path, target: &Path, bytes: &[u8]) -> 
         output.write_all(bytes)?;
         output.sync_all()?;
         drop(output);
-        crate::platform::filesystem::replace_file_atomically(&replacement, target, &backup)
+        Ok(())
     })();
-    if result.is_ok() {
-        let _ = fs::remove_file(candidate);
-        let _ = fs::remove_file(backup);
-    } else if target.is_file() {
+    if let Err(error) = stage_result {
         let _ = fs::remove_file(replacement);
+        return Err(error);
     }
-    result
+    match crate::platform::filesystem::replace_file_atomically(&replacement, target, &backup) {
+        Ok(crate::platform::filesystem::ReplaceState::Committed) => {
+            let _ = fs::remove_file(candidate);
+            let _ = fs::remove_file(backup);
+            Ok(())
+        }
+        Ok(state) => Err(io::Error::other(format!(
+            "unexpected successful replacement state: {state:?}"
+        ))),
+        Err(error) => {
+            if error.state() == crate::platform::filesystem::ReplaceState::RolledBack {
+                let _ = fs::remove_file(replacement);
+                let _ = fs::remove_file(backup);
+            }
+            Err(error.into_io_error())
+        }
+    }
 }
 
 fn cleanup_recovery_candidates(path: &Path) {
@@ -4189,6 +4222,26 @@ mod tests {
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
         assert!(!target.exists());
         assert!(target.with_extension("bak").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovery_prefers_replacefile_backup_over_surviving_replacement() {
+        let root = recovery_test_root("replacefile-backup");
+        let target = root.join("profile.json");
+        let backup = target.with_extension("bak");
+        let replacement = target.with_extension("tmp-1-2-3");
+        fs::write(&backup, "{\"version\":1,\"revision\":7}\n").unwrap();
+        fs::write(&replacement, "{\"version\":1,\"revision\":8}\n").unwrap();
+
+        let restored = read_text_recovering(&target, |raw| {
+            serde_json::from_str::<MemoryProfile>(raw).is_ok()
+        })
+        .unwrap();
+
+        assert!(restored.contains("\"revision\":7"));
+        assert!(!backup.exists());
+        assert!(!replacement.exists());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -4460,6 +4460,21 @@ fn read_text_recovering_unlocked(
     read_text_recovering_unlocked_with(path, validate, &promote_recovery_candidate)
 }
 
+/// Windows maps `ERROR_SHARING_VIOLATION` (32) / `ERROR_LOCK_VIOLATION` (33) to
+/// `ErrorKind::Uncategorized` rather than `PermissionDenied`, so a file held by
+/// an antivirus scan or another process without read-sharing fails
+/// `fs::read_to_string` this way. Treat those codes as transient so recovery
+/// never promotes a stale backup over a still-valid authoritative file.
+#[cfg(windows)]
+fn is_transient_windows_lock(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(32) | Some(33))
+}
+
+#[cfg(not(windows))]
+fn is_transient_windows_lock(_error: &io::Error) -> bool {
+    false
+}
+
 fn read_text_recovering_unlocked_with(
     path: &Path,
     validate: &dyn Fn(&str) -> bool,
@@ -4483,7 +4498,7 @@ fn read_text_recovering_unlocked_with(
                 io::ErrorKind::PermissionDenied
                     | io::ErrorKind::UnexpectedEof
                     | io::ErrorKind::Interrupted
-            );
+            ) || is_transient_windows_lock(&error);
             if transient && path.is_file() {
                 return Err(error);
             }
@@ -4784,6 +4799,26 @@ mod tests {
         assert_eq!(fs::read_to_string(&target).unwrap(), authoritative);
         assert!(backup.exists());
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn windows_sharing_violation_is_transient() {
+        // ERROR_SHARING_VIOLATION (32) and ERROR_LOCK_VIOLATION (33) surface as
+        // ErrorKind::Uncategorized on Windows, outside the kind-based transient
+        // whitelist; the raw-OS-code guard must still recognize them so recovery
+        // never promotes a stale backup over a still-valid authoritative file.
+        let sharing = io::Error::from_raw_os_error(32);
+        let lock = io::Error::from_raw_os_error(33);
+        #[cfg(windows)]
+        {
+            assert!(is_transient_windows_lock(&sharing));
+            assert!(is_transient_windows_lock(&lock));
+        }
+        #[cfg(not(windows))]
+        {
+            assert!(!is_transient_windows_lock(&sharing));
+            assert!(!is_transient_windows_lock(&lock));
+        }
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/platform/filesystem.rs
+++ b/pinvou3-app/src-tauri/src/platform/filesystem.rs
@@ -22,10 +22,38 @@ pub(crate) fn create_secret_file(path: &Path) -> io::Result<std::fs::File> {
 
 #[cfg(windows)]
 fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io::Result<()> {
-    std::fs::rename(target, backup)?;
-    if let Err(error) = std::fs::rename(tmp, target) {
-        let _ = std::fs::rename(backup, target);
-        return Err(error);
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
+
+    if !target.exists() {
+        return std::fs::rename(tmp, target);
+    }
+
+    let wide = |path: &Path| {
+        path.as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>()
+    };
+    let target_wide = wide(target);
+    let tmp_wide = wide(tmp);
+    let backup_wide = wide(backup);
+    // The target is still authoritative here, so a stale backup from an older
+    // completed replacement can be discarded before asking ReplaceFileW to
+    // create the next rollback copy.
+    let _ = std::fs::remove_file(backup);
+    let replaced = unsafe {
+        ReplaceFileW(
+            target_wide.as_ptr(),
+            tmp_wide.as_ptr(),
+            backup_wide.as_ptr(),
+            REPLACEFILE_WRITE_THROUGH,
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    if replaced == 0 {
+        return Err(io::Error::last_os_error());
     }
     let _ = std::fs::remove_file(backup);
     Ok(())
@@ -80,6 +108,24 @@ pub(crate) mod tests {
 
     pub(crate) fn remove_dir_link(link: &Path) {
         remove_dir_link_impl(link)
+    }
+
+    #[test]
+    fn failed_atomic_replace_preserves_the_authoritative_target() {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou-atomic-replace-failure-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let target = root.join("profile.json");
+        let missing_tmp = root.join("missing.tmp");
+        let backup = root.join("profile.bak");
+        std::fs::write(&target, "authoritative").unwrap();
+
+        assert!(super::replace_file_atomically(&missing_tmp, &target, &backup).is_err());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "authoritative");
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(unix)]

--- a/pinvou3-app/src-tauri/src/platform/filesystem.rs
+++ b/pinvou3-app/src-tauri/src/platform/filesystem.rs
@@ -16,7 +16,7 @@ pub(crate) struct ReplaceError {
 }
 
 impl ReplaceError {
-    fn new(state: ReplaceState, source: io::Error) -> Self {
+    pub(crate) fn new(state: ReplaceState, source: io::Error) -> Self {
         Self { state, source }
     }
 

--- a/pinvou3-app/src-tauri/src/platform/filesystem.rs
+++ b/pinvou3-app/src-tauri/src/platform/filesystem.rs
@@ -26,7 +26,7 @@ fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io:
     use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
 
     if !target.exists() {
-        return std::fs::rename(tmp, target);
+        return promote_replacement(tmp, target);
     }
 
     let wide = |path: &Path| {
@@ -53,10 +53,92 @@ fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io:
         )
     };
     if replaced == 0 {
-        return Err(io::Error::last_os_error());
+        return converge_failed_windows_replace(tmp, target, backup, io::Error::last_os_error());
     }
     let _ = std::fs::remove_file(backup);
     Ok(())
+}
+
+#[cfg(windows)]
+fn promote_replacement(replacement: &Path, target: &Path) -> io::Result<()> {
+    match std::fs::rename(replacement, target) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            // A rename can fail across volumes or under some filter drivers. Copying to the
+            // destination is safe only while it is absent; create_new prevents overwriting a
+            // concurrently-created authoritative file.
+            let mut source = std::fs::File::open(replacement)?;
+            let mut destination = match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(target)
+            {
+                Ok(file) => file,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    if target.is_file() {
+                        let _ = std::fs::remove_file(replacement);
+                    }
+                    return Err(rename_error);
+                }
+                Err(_) => return Err(rename_error),
+            };
+            if let Err(copy_error) =
+                io::copy(&mut source, &mut destination).and_then(|_| destination.sync_all())
+            {
+                drop(destination);
+                let _ = std::fs::remove_file(target);
+                return Err(io::Error::new(
+                    copy_error.kind(),
+                    format!("fallback promotion failed after {rename_error}: {copy_error}"),
+                ));
+            }
+            drop(destination);
+            std::fs::remove_file(replacement)?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+fn converge_failed_windows_replace(
+    replacement: &Path,
+    target: &Path,
+    backup: &Path,
+    replace_error: io::Error,
+) -> io::Result<()> {
+    // ReplaceFileW documents partially-mutated layouts for errors 1175/1176/1177.
+    // First restore an authoritative name. Until that is confirmed, neither rollback nor
+    // replacement is deleted.
+    if !target.is_file() {
+        if backup.is_file() {
+            if let Err(restore_error) = promote_replacement(backup, target) {
+                return Err(io::Error::new(
+                    restore_error.kind(),
+                    format!(
+                        "atomic replace failed ({replace_error}); restoring backup failed: {restore_error}"
+                    ),
+                ));
+            }
+        } else if replacement.is_file() {
+            // No old authority survived, so the durable replacement is the only recoverable
+            // candidate. Promoting it completes the write rather than returning an empty state.
+            promote_replacement(replacement, target)?;
+            return Ok(());
+        }
+    }
+
+    if !target.is_file() {
+        return Err(io::Error::new(
+            replace_error.kind(),
+            format!("atomic replace left no authoritative file: {replace_error}"),
+        ));
+    }
+
+    // An authority now exists. Best-effort cleanup is bounded to the two paths belonging to
+    // this replacement; occupied files remain as recoverable candidates for the next load.
+    let _ = std::fs::remove_file(replacement);
+    let _ = std::fs::remove_file(backup);
+    Err(replace_error)
 }
 
 #[cfg(not(windows))]
@@ -125,6 +207,126 @@ pub(crate) mod tests {
 
         assert!(super::replace_file_atomically(&missing_tmp, &target, &backup).is_err());
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "authoritative");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    fn windows_replace_fixture(
+        name: &str,
+    ) -> (
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        std::path::PathBuf,
+    ) {
+        let root = std::env::temp_dir().join(format!(
+            "pinvou-windows-replace-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let target = root.join("memory.json");
+        let replacement = root.join("memory.tmp");
+        let backup = root.join("memory.bak");
+        (root, target, replacement, backup)
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_atomic_replace_covers_first_write_and_success_cleanup() {
+        let (root, target, replacement, backup) = windows_replace_fixture("success");
+        std::fs::write(&replacement, "first").unwrap();
+        super::replace_file_atomically(&replacement, &target, &backup).unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "first");
+
+        std::fs::write(&replacement, "second").unwrap();
+        super::replace_file_atomically(&replacement, &target, &backup).unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "second");
+        assert!(!replacement.exists());
+        assert!(!backup.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_partial_replace_layouts_converge_without_losing_authority() {
+        for code in [1175, 1176, 1177] {
+            let (root, target, replacement, backup) =
+                windows_replace_fixture(&format!("partial-{code}"));
+            std::fs::write(&replacement, "new").unwrap();
+            std::fs::write(&backup, "old").unwrap();
+
+            let result = super::converge_failed_windows_replace(
+                &replacement,
+                &target,
+                &backup,
+                std::io::Error::from_raw_os_error(code),
+            );
+            assert!(result.is_err());
+            assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
+            assert!(!replacement.exists());
+            assert!(!backup.exists());
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_partial_replace_promotes_only_surviving_replacement() {
+        let (root, target, replacement, backup) = windows_replace_fixture("replacement-only");
+        std::fs::write(&replacement, "new").unwrap();
+        super::converge_failed_windows_replace(
+            &replacement,
+            &target,
+            &backup,
+            std::io::Error::from_raw_os_error(1177),
+        )
+        .unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new");
+        assert!(!replacement.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_partial_replace_keeps_candidates_when_no_authority_can_be_restored() {
+        let (root, target, replacement, backup) = windows_replace_fixture("no-candidate");
+        let result = super::converge_failed_windows_replace(
+            &replacement,
+            &target,
+            &backup,
+            std::io::Error::from_raw_os_error(1176),
+        );
+        assert!(result.is_err());
+        assert!(!target.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_partial_replace_preserves_occupied_recovery_candidates() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        let (root, target, replacement, backup) = windows_replace_fixture("occupied-backup");
+        std::fs::write(&replacement, "new").unwrap();
+        std::fs::write(&backup, "old").unwrap();
+        let occupied = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&backup)
+            .unwrap();
+        let result = super::converge_failed_windows_replace(
+            &replacement,
+            &target,
+            &backup,
+            std::io::Error::from_raw_os_error(1175),
+        );
+        assert!(result.is_err());
+        assert!(!target.exists());
+        assert!(replacement.exists());
+        assert!(backup.exists());
+        drop(occupied);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/pinvou3-app/src-tauri/src/platform/filesystem.rs
+++ b/pinvou3-app/src-tauri/src/platform/filesystem.rs
@@ -2,8 +2,95 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-pub(crate) fn replace_file_atomically(tmp: &Path, target: &Path, backup: &Path) -> io::Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplaceState {
+    Committed,
+    RolledBack,
+    RecoveryRequired,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReplaceError {
+    state: ReplaceState,
+    source: io::Error,
+}
+
+impl ReplaceError {
+    fn new(state: ReplaceState, source: io::Error) -> Self {
+        Self { state, source }
+    }
+
+    pub(crate) fn state(&self) -> ReplaceState {
+        self.state
+    }
+
+    pub(crate) fn into_io_error(self) -> io::Error {
+        io::Error::new(self.source.kind(), self.to_string())
+    }
+}
+
+impl std::fmt::Display for ReplaceError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "atomic replace {:?}: {}",
+            self.state, self.source
+        )
+    }
+}
+
+impl std::error::Error for ReplaceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+pub(crate) type ReplaceResult = Result<ReplaceState, ReplaceError>;
+
+pub(crate) fn replace_file_atomically(tmp: &Path, target: &Path, backup: &Path) -> ReplaceResult {
     replace_file_atomically_impl(tmp, target, backup)
+}
+
+/// Converge a layout left by an interrupted Windows replacement. Callers must
+/// hold the same lifecycle lock used for writes so active temporary files are
+/// never mistaken for recovery candidates.
+pub(crate) fn recover_interrupted_replace(
+    replacement: &Path,
+    target: &Path,
+    backup: &Path,
+) -> ReplaceResult {
+    if target.is_file() {
+        return Ok(ReplaceState::Committed);
+    }
+    if backup.is_file() {
+        return promote_replacement(backup, target).map_or_else(
+            |error| {
+                Err(ReplaceError::new(
+                    ReplaceState::RecoveryRequired,
+                    error.into_io_error(),
+                ))
+            },
+            |_| {
+                Err(ReplaceError::new(
+                    ReplaceState::RolledBack,
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        "interrupted replacement was rolled back",
+                    ),
+                ))
+            },
+        );
+    }
+    if replacement.is_file() {
+        return promote_replacement(replacement, target);
+    }
+    Err(ReplaceError::new(
+        ReplaceState::RecoveryRequired,
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "interrupted replacement has no recoverable candidate",
+        ),
+    ))
 }
 
 /// 以 0600 权限创建（或截断）文件：写入含明文密钥的 CLI 配置时**直接**以
@@ -21,13 +108,14 @@ pub(crate) fn create_secret_file(path: &Path) -> io::Result<std::fs::File> {
 }
 
 #[cfg(windows)]
-fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io::Result<()> {
+fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> ReplaceResult {
+    replace_file_atomically_with(tmp, target, backup, system_replace_file)
+}
+
+#[cfg(windows)]
+fn system_replace_file(target: &Path, replacement: &Path, backup: &Path) -> io::Result<()> {
     use std::os::windows::ffi::OsStrExt as _;
     use windows_sys::Win32::Storage::FileSystem::{ReplaceFileW, REPLACEFILE_WRITE_THROUGH};
-
-    if !target.exists() {
-        return promote_replacement(tmp, target);
-    }
 
     let wide = |path: &Path| {
         path.as_os_str()
@@ -36,12 +124,8 @@ fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io:
             .collect::<Vec<_>>()
     };
     let target_wide = wide(target);
-    let tmp_wide = wide(tmp);
+    let tmp_wide = wide(replacement);
     let backup_wide = wide(backup);
-    // The target is still authoritative here, so a stale backup from an older
-    // completed replacement can be discarded before asking ReplaceFileW to
-    // create the next rollback copy.
-    let _ = std::fs::remove_file(backup);
     let replaced = unsafe {
         ReplaceFileW(
             target_wide.as_ptr(),
@@ -53,50 +137,50 @@ fn replace_file_atomically_impl(tmp: &Path, target: &Path, backup: &Path) -> io:
         )
     };
     if replaced == 0 {
-        return converge_failed_windows_replace(tmp, target, backup, io::Error::last_os_error());
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
     }
-    let _ = std::fs::remove_file(backup);
-    Ok(())
 }
 
 #[cfg(windows)]
-fn promote_replacement(replacement: &Path, target: &Path) -> io::Result<()> {
-    match std::fs::rename(replacement, target) {
-        Ok(()) => Ok(()),
-        Err(rename_error) => {
-            // A rename can fail across volumes or under some filter drivers. Copying to the
-            // destination is safe only while it is absent; create_new prevents overwriting a
-            // concurrently-created authoritative file.
-            let mut source = std::fs::File::open(replacement)?;
-            let mut destination = match std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(target)
-            {
-                Ok(file) => file,
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                    if target.is_file() {
-                        let _ = std::fs::remove_file(replacement);
-                    }
-                    return Err(rename_error);
-                }
-                Err(_) => return Err(rename_error),
-            };
-            if let Err(copy_error) =
-                io::copy(&mut source, &mut destination).and_then(|_| destination.sync_all())
-            {
-                drop(destination);
-                let _ = std::fs::remove_file(target);
-                return Err(io::Error::new(
-                    copy_error.kind(),
-                    format!("fallback promotion failed after {rename_error}: {copy_error}"),
-                ));
-            }
-            drop(destination);
-            std::fs::remove_file(replacement)?;
-            Ok(())
-        }
+pub(crate) fn replace_file_atomically_with<F>(
+    tmp: &Path,
+    target: &Path,
+    backup: &Path,
+    replace: F,
+) -> ReplaceResult
+where
+    F: FnOnce(&Path, &Path, &Path) -> io::Result<()>,
+{
+    if !target.exists() {
+        return promote_replacement(tmp, target);
     }
+
+    // The target is authoritative before ReplaceFileW starts. A stale backup
+    // from an earlier completed operation is no longer a recovery candidate.
+    let _ = std::fs::remove_file(backup);
+    match replace(target, tmp, backup) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(backup);
+            Ok(ReplaceState::Committed)
+        }
+        Err(error) => converge_failed_windows_replace(tmp, target, backup, error),
+    }
+}
+
+fn promote_replacement(replacement: &Path, target: &Path) -> ReplaceResult {
+    std::fs::rename(replacement, target).map_or_else(
+        |error| {
+            let state = if target.is_file() {
+                ReplaceState::RolledBack
+            } else {
+                ReplaceState::RecoveryRequired
+            };
+            Err(ReplaceError::new(state, error))
+        },
+        |_| Ok(ReplaceState::Committed),
+    )
 }
 
 #[cfg(windows)]
@@ -105,45 +189,49 @@ fn converge_failed_windows_replace(
     target: &Path,
     backup: &Path,
     replace_error: io::Error,
-) -> io::Result<()> {
+) -> ReplaceResult {
     // ReplaceFileW documents partially-mutated layouts for errors 1175/1176/1177.
     // First restore an authoritative name. Until that is confirmed, neither rollback nor
     // replacement is deleted.
     if !target.is_file() {
         if backup.is_file() {
             if let Err(restore_error) = promote_replacement(backup, target) {
-                return Err(io::Error::new(
-                    restore_error.kind(),
-                    format!(
-                        "atomic replace failed ({replace_error}); restoring backup failed: {restore_error}"
+                return Err(ReplaceError::new(
+                    ReplaceState::RecoveryRequired,
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "replace failed ({replace_error}); restoring backup failed: {restore_error}"
+                        ),
                     ),
                 ));
             }
         } else if replacement.is_file() {
             // No old authority survived, so the durable replacement is the only recoverable
             // candidate. Promoting it completes the write rather than returning an empty state.
-            promote_replacement(replacement, target)?;
-            return Ok(());
+            return promote_replacement(replacement, target);
         }
     }
 
     if !target.is_file() {
-        return Err(io::Error::new(
-            replace_error.kind(),
-            format!("atomic replace left no authoritative file: {replace_error}"),
+        return Err(ReplaceError::new(
+            ReplaceState::RecoveryRequired,
+            io::Error::new(
+                replace_error.kind(),
+                format!("atomic replace left no authoritative file: {replace_error}"),
+            ),
         ));
     }
 
-    // An authority now exists. Best-effort cleanup is bounded to the two paths belonging to
-    // this replacement; occupied files remain as recoverable candidates for the next load.
-    let _ = std::fs::remove_file(replacement);
-    let _ = std::fs::remove_file(backup);
-    Err(replace_error)
+    // The old target either retained its name or was restored from backup.
+    // Preserve every remaining candidate; callers may clean them only after
+    // observing RolledBack and completing their own lifecycle transaction.
+    Err(ReplaceError::new(ReplaceState::RolledBack, replace_error))
 }
 
 #[cfg(not(windows))]
-fn replace_file_atomically_impl(tmp: &Path, target: &Path, _backup: &Path) -> io::Result<()> {
-    std::fs::rename(tmp, target)
+fn replace_file_atomically_impl(tmp: &Path, target: &Path, _backup: &Path) -> ReplaceResult {
+    promote_replacement(tmp, target)
 }
 
 pub(crate) fn reserved_target_is_unchanged(file: &File, path: &Path) -> bool {
@@ -250,25 +338,67 @@ pub(crate) mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_partial_replace_layouts_converge_without_losing_authority() {
-        for code in [1175, 1176, 1177] {
-            let (root, target, replacement, backup) =
-                windows_replace_fixture(&format!("partial-{code}"));
-            std::fs::write(&replacement, "new").unwrap();
-            std::fs::write(&backup, "old").unwrap();
+    fn windows_1175_retains_the_two_official_original_names() {
+        let (root, target, replacement, backup) = windows_replace_fixture("1175");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::write(&replacement, "new").unwrap();
 
-            let result = super::converge_failed_windows_replace(
-                &replacement,
-                &target,
-                &backup,
-                std::io::Error::from_raw_os_error(code),
-            );
-            assert!(result.is_err());
-            assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
-            assert!(!replacement.exists());
-            assert!(!backup.exists());
-            let _ = std::fs::remove_dir_all(root);
-        }
+        let error =
+            super::replace_file_atomically_with(&replacement, &target, &backup, |_, _, _| {
+                Err(std::io::Error::from_raw_os_error(1175))
+            })
+            .unwrap_err();
+
+        assert_eq!(error.state(), super::ReplaceState::RolledBack);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
+        assert_eq!(std::fs::read_to_string(&replacement).unwrap(), "new");
+        assert!(!backup.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_1176_with_backup_name_retains_the_two_official_original_names() {
+        let (root, target, replacement, backup) = windows_replace_fixture("1176");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::write(&replacement, "new").unwrap();
+
+        let error =
+            super::replace_file_atomically_with(&replacement, &target, &backup, |_, _, _| {
+                Err(std::io::Error::from_raw_os_error(1176))
+            })
+            .unwrap_err();
+
+        assert_eq!(error.state(), super::ReplaceState::RolledBack);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
+        assert_eq!(std::fs::read_to_string(&replacement).unwrap(), "new");
+        assert!(!backup.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_1177_restores_the_official_backup_layout() {
+        let (root, target, replacement, backup) = windows_replace_fixture("1177");
+        std::fs::write(&target, "old").unwrap();
+        std::fs::write(&replacement, "new").unwrap();
+
+        let error = super::replace_file_atomically_with(
+            &replacement,
+            &target,
+            &backup,
+            |target, _, backup| {
+                std::fs::rename(target, backup)?;
+                Err(std::io::Error::from_raw_os_error(1177))
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.state(), super::ReplaceState::RolledBack);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
+        assert_eq!(std::fs::read_to_string(&replacement).unwrap(), "new");
+        assert!(!backup.exists());
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[cfg(windows)]
@@ -276,13 +406,14 @@ pub(crate) mod tests {
     fn windows_partial_replace_promotes_only_surviving_replacement() {
         let (root, target, replacement, backup) = windows_replace_fixture("replacement-only");
         std::fs::write(&replacement, "new").unwrap();
-        super::converge_failed_windows_replace(
+        let state = super::converge_failed_windows_replace(
             &replacement,
             &target,
             &backup,
             std::io::Error::from_raw_os_error(1177),
         )
         .unwrap();
+        assert_eq!(state, super::ReplaceState::Committed);
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "new");
         assert!(!replacement.exists());
         let _ = std::fs::remove_dir_all(root);
@@ -306,27 +437,100 @@ pub(crate) mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_partial_replace_preserves_occupied_recovery_candidates() {
+        use std::cell::RefCell;
         use std::os::windows::fs::OpenOptionsExt as _;
 
         let (root, target, replacement, backup) = windows_replace_fixture("occupied-backup");
+        std::fs::write(&target, "old").unwrap();
         std::fs::write(&replacement, "new").unwrap();
-        std::fs::write(&backup, "old").unwrap();
-        let occupied = std::fs::OpenOptions::new()
-            .read(true)
-            .share_mode(0)
-            .open(&backup)
-            .unwrap();
-        let result = super::converge_failed_windows_replace(
+        let occupied = RefCell::new(None);
+        let error = super::replace_file_atomically_with(
             &replacement,
             &target,
             &backup,
-            std::io::Error::from_raw_os_error(1175),
-        );
-        assert!(result.is_err());
+            |target, _, backup| {
+                std::fs::rename(target, backup)?;
+                *occupied.borrow_mut() = Some(
+                    std::fs::OpenOptions::new()
+                        .read(true)
+                        .share_mode(0)
+                        .open(backup)?,
+                );
+                Err(std::io::Error::from_raw_os_error(1177))
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.state(), super::ReplaceState::RecoveryRequired);
         assert!(!target.exists());
         assert!(replacement.exists());
         assert!(backup.exists());
+        drop(occupied.borrow_mut().take());
+
+        let recovered =
+            super::recover_interrupted_replace(&replacement, &target, &backup).unwrap_err();
+        assert_eq!(recovered.state(), super::ReplaceState::RolledBack);
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "old");
+        assert_eq!(std::fs::read_to_string(&replacement).unwrap(), "new");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_failed_first_promotion_preserves_the_complete_replacement() {
+        use std::os::windows::fs::OpenOptionsExt as _;
+
+        let (root, target, replacement, backup) = windows_replace_fixture("promotion-occupied");
+        std::fs::write(&replacement, "complete-new-value").unwrap();
+        let occupied = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&replacement)
+            .unwrap();
+
+        let error = super::replace_file_atomically(&replacement, &target, &backup).unwrap_err();
+
+        assert_eq!(error.state(), super::ReplaceState::RecoveryRequired);
+        assert!(!target.exists());
+        assert_eq!(
+            std::fs::read_to_string(&replacement).unwrap(),
+            "complete-new-value"
+        );
         drop(occupied);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_atomic_replace_never_exposes_a_partial_target_to_readers() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let (root, target, replacement, backup) = windows_replace_fixture("concurrent-reader");
+        let old = "a".repeat(32 * 1024);
+        let new = "b".repeat(32 * 1024);
+        std::fs::write(&target, &old).unwrap();
+        let running = Arc::new(AtomicBool::new(true));
+        let reader_running = Arc::clone(&running);
+        let reader_target = target.clone();
+        let old_for_reader = old.clone();
+        let new_for_reader = new.clone();
+        let reader = std::thread::spawn(move || {
+            while reader_running.load(Ordering::Acquire) {
+                if let Ok(value) = std::fs::read_to_string(&reader_target) {
+                    assert!(value == old_for_reader || value == new_for_reader);
+                }
+            }
+        });
+
+        for index in 0..32 {
+            let value = if index % 2 == 0 { &new } else { &old };
+            std::fs::write(&replacement, value).unwrap();
+            super::replace_file_atomically(&replacement, &target, &backup).unwrap();
+        }
+        running.store(false, Ordering::Release);
+        reader.join().unwrap();
+        let final_value = std::fs::read_to_string(&target).unwrap();
+        assert!(final_value == old || final_value == new);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -185,6 +185,13 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
             call_name: draft.call_name,
             assistant_alias: draft.assistant_alias,
           });
+          setProfileSaveError('');
+        } catch (error) {
+          // The bridge already surfaced the error into state.memory.error with
+          // generic "load failed" copy; track a dedicated save error so the UI
+          // shows the accurate "save failed" message instead and consumes the
+          // rejection.
+          setProfileSaveError(String(error));
         } finally {
           setSaving(false);
         }
@@ -2355,6 +2362,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       const [memoryEditor, setMemoryEditor] = useState(null);
       const [memorySaving, setMemorySaving] = useState(false);
       const [memoryEditorError, setMemoryEditorError] = useState('');
+      const [profileSaveError, setProfileSaveError] = useState('');
       const [memoryDeleteConfirm, setMemoryDeleteConfirm] = useState(null);
       const openMemoryItemViewer = item => {
         setMemoryEditor({
@@ -2583,7 +2591,11 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
           </IOSSection>
           {memoryEnabled && (
             <>
-              {memoryError && (
+              {profileSaveError ? (
+                <div data-testid="memory-settings-error" role="alert" aria-live="polite" className="mb-4 rounded-[14px] bg-[#FF3B30]/10 px-4 py-3 text-[13px] leading-5 text-[#FF3B30]">
+                  {settingsCopy.memorySaveFailed}
+                </div>
+              ) : memoryError && (
                 <div data-testid="memory-settings-error" role="alert" aria-live="polite" className="mb-4 rounded-[14px] bg-[#FF3B30]/10 px-4 py-3 text-[13px] leading-5 text-[#FF3B30]">
                   {memoryErrorMessage}
                 </div>

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -185,13 +185,6 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
             call_name: draft.call_name,
             assistant_alias: draft.assistant_alias,
           });
-          setProfileSaveError('');
-        } catch (error) {
-          // The bridge already surfaced the error into state.memory.error with
-          // generic "load failed" copy; track a dedicated save error so the UI
-          // shows the accurate "save failed" message instead and consumes the
-          // rejection.
-          setProfileSaveError(String(error));
         } finally {
           setSaving(false);
         }
@@ -2383,6 +2376,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
         const text = String(memoryEditor.value || '').trim();
         setMemorySaving(true);
         setMemoryEditorError('');
+        setProfileSaveError('');
         try {
           if (memoryEditor.mode === 'memory') {
             if (!text || !bridge.memory.updateMemoryItem) return;
@@ -2394,6 +2388,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
           setMemoryEditor(null);
         } catch (error) {
           setMemoryEditorError(String(error));
+          setProfileSaveError(String(error));
         } finally {
           setMemorySaving(false);
         }

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -2252,6 +2252,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       const SectionButton = ({ id, icon, label, dot }) => (
         <button
           type="button"
+          data-testid={`settings-section-${id}`}
           onClick={() => setActiveSection(id)}
           className={`w-full h-10 px-3 rounded-[14px] flex items-center gap-2.5 text-[14px] transition-colors max-sm:w-auto max-sm:shrink-0 ${
             activeSection === id
@@ -2324,6 +2325,9 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       };
       const memoryEnabled = !!(bs && bs.settings && bs.settings.memory_enabled);
       const memory = (bs && bs.memory) || {};
+      const memoryError = memory.error
+        ? String(memory.error)
+        : (Array.isArray(memory.warnings) && memory.warnings.length ? String(memory.warnings[0]) : '');
       const identity = (memory.profile && memory.profile.identity) || {};
       const longTermItems = [
         ...(memory.preferences || []).map(item => ({ ...item, kind: 'preference', type: settingsCopy.memoryTypes.preference })),
@@ -2340,6 +2344,8 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
         if (updateFocusTick) setActiveSection('update');
       }, [updateFocusTick]);
       const [memoryEditor, setMemoryEditor] = useState(null);
+      const [memorySaving, setMemorySaving] = useState(false);
+      const [memoryEditorError, setMemoryEditorError] = useState('');
       const [memoryDeleteConfirm, setMemoryDeleteConfirm] = useState(null);
       const openMemoryItemViewer = item => {
         setMemoryEditor({
@@ -2356,16 +2362,24 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
         });
       };
       const saveMemoryEditor = async () => {
-        if (!memoryEditor || !bridge.available) return;
+        if (!memoryEditor || !bridge.available || memorySaving) return;
         const text = String(memoryEditor.value || '').trim();
-        if (memoryEditor.mode === 'memory') {
-          if (!text || !bridge.memory.updateMemoryItem) return;
-          await bridge.memory.updateMemoryItem(memoryEditor.kind, memoryEditor.id, { text });
-        } else if (memoryEditor.mode === 'profile') {
-          if (!bridge.memory.saveMemoryProfilePatch) return;
-          await bridge.memory.saveMemoryProfilePatch({ [memoryEditor.key]: text });
+        setMemorySaving(true);
+        setMemoryEditorError('');
+        try {
+          if (memoryEditor.mode === 'memory') {
+            if (!text || !bridge.memory.updateMemoryItem) return;
+            await bridge.memory.updateMemoryItem(memoryEditor.kind, memoryEditor.id, { text });
+          } else if (memoryEditor.mode === 'profile') {
+            if (!bridge.memory.saveMemoryProfilePatch) return;
+            await bridge.memory.saveMemoryProfilePatch({ [memoryEditor.key]: text });
+          }
+          setMemoryEditor(null);
+        } catch (error) {
+          setMemoryEditorError(String(error));
+        } finally {
+          setMemorySaving(false);
         }
-        setMemoryEditor(null);
       };
       const deleteMemoryItem = async item => {
         if (!bridge.available || !bridge.memory.deleteMemoryItem) return;
@@ -2373,6 +2387,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       };
       const editProfile = key => {
         const label = key === 'call_name' ? settingsCopy.userCallName : settingsCopy.assistantNickname;
+        setMemoryEditorError('');
         setMemoryEditor({
           mode: 'profile',
           key,
@@ -2559,10 +2574,17 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
           </IOSSection>
           {memoryEnabled && (
             <>
+              {memoryError && (
+                <div data-testid="memory-settings-error" className="mb-4 rounded-[14px] bg-[#FF3B30]/10 px-4 py-3 text-[13px] leading-5 text-[#FF3B30]">
+                  {settingsCopy.memoryLoadFailed}
+                </div>
+              )}
               <IOSSection title={settingsCopy.profile}>
-                <IOSRow label={settingsCopy.userCallName} desc={settingsCopy.callNameDesc} value={identity.call_name || settingsCopy.notSet} onClick={() => editProfile('call_name')}>
-                  <ChevronDown size={22} className="-rotate-90 opacity-35" />
-                </IOSRow>
+                <div data-testid="memory-profile-call-name">
+                  <IOSRow label={settingsCopy.userCallName} desc={settingsCopy.callNameDesc} value={identity.call_name || settingsCopy.notSet} onClick={() => editProfile('call_name')}>
+                    <ChevronDown size={22} className="-rotate-90 opacity-35" />
+                  </IOSRow>
+                </div>
                 <IOSRow label={settingsCopy.assistantNickname} desc={settingsCopy.assistantNameDesc} value={identity.assistant_alias || 'PINVOU'} onClick={() => editProfile('assistant_alias')}>
                   <ChevronDown size={22} className="-rotate-90 opacity-35" />
                 </IOSRow>
@@ -2910,14 +2932,14 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
           )}
           {editingSearch && <SearchSourceModal provider={editingSearch} isNew={pendingSearchProvider === editingSearch} onClose={() => { setEditingSearch(null); setPendingSearchProvider(null); }} />}
           {memoryEditor && (
-            <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/45 px-4" onClick={() => setMemoryEditor(null)}>
+            <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/45 px-4" onClick={() => { if (!memorySaving) setMemoryEditor(null); }}>
               <div onClick={e => e.stopPropagation()} className={`w-full max-w-[500px] rounded-[24px] shadow-2xl bg-white text-[#1C1C1E] dark:bg-[#1C1C1E] dark:text-[#F2F2F7]`}>
                 <div className={`px-6 py-4 flex items-start justify-between border-b border-black/[0.12] dark:border-white/[0.12]`}>
                   <div>
                     <h2 className="text-[22px] leading-7 font-semibold">{memoryEditor.title}</h2>
                     <p className={`mt-1 text-[13px] leading-[18px] text-[#8A8A8E] dark:text-[#98989D]`}>{memoryEditor.subtitle}</p>
                   </div>
-                  <button onClick={() => setMemoryEditor(null)} className={`h-10 w-10 rounded-full flex items-center justify-center bg-[#E5E5EA] dark:bg-white/[0.08]`}><X size={20} /></button>
+                  <button onClick={() => setMemoryEditor(null)} disabled={memorySaving} className={`h-10 w-10 rounded-full flex items-center justify-center bg-[#E5E5EA] dark:bg-white/[0.08] disabled:opacity-40`}><X size={20} /></button>
                 </div>
                 <div className="px-6 py-5">
                   <label className="block">
@@ -2931,15 +2953,17 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
                       />
                     ) : (
                       <input
+                        data-testid="memory-editor-input"
                         value={memoryEditor.value}
                         onChange={e => setMemoryEditor(prev => ({ ...prev, value: e.target.value }))}
                         className={`w-full rounded-[16px] px-4 py-3 text-[15px] outline-none bg-[#F2F2F7] text-[#1C1C1E] placeholder:text-[#8A8A8E] dark:bg-[#2C2C2E] dark:text-[#F2F2F7] dark:placeholder:text-[#636366]`}
                       />
                     )}
                   </label>
+                  {memoryEditorError && <div data-testid="memory-editor-error" className="mt-3 text-[13px] leading-5 text-[#FF3B30]">{settingsCopy.memorySaveFailed}</div>}
                   <div className="mt-6 flex justify-end gap-2.5">
-                    <button onClick={() => setMemoryEditor(null)} className={`h-10 px-4 rounded-full text-[14px] font-semibold bg-[#E5E5EA] dark:bg-[#2C2C2E]`}>{settingsCopy.cancel}</button>
-                    <button onClick={saveMemoryEditor} className="h-10 px-4 rounded-full bg-[#007AFF] text-white text-[14px] font-semibold">{settingsCopy.save}</button>
+                    <button onClick={() => setMemoryEditor(null)} disabled={memorySaving} className={`h-10 px-4 rounded-full text-[14px] font-semibold bg-[#E5E5EA] dark:bg-[#2C2C2E] disabled:opacity-40`}>{settingsCopy.cancel}</button>
+                    <button data-testid="memory-editor-save" onClick={saveMemoryEditor} disabled={memorySaving} className="h-10 px-4 rounded-full bg-[#007AFF] text-white text-[14px] font-semibold disabled:opacity-40">{memorySaving ? settingsCopy.saving : settingsCopy.save}</button>
                   </div>
                 </div>
               </div>

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -2325,9 +2325,16 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       };
       const memoryEnabled = !!(bs && bs.settings && bs.settings.memory_enabled);
       const memory = (bs && bs.memory) || {};
-      const memoryError = memory.error
-        ? String(memory.error)
-        : (Array.isArray(memory.warnings) && memory.warnings.length ? String(memory.warnings[0]) : '');
+      const memoryWarning = Array.isArray(memory.warnings) ? memory.warnings[0] : null;
+      const memoryWarningCode = memoryWarning && typeof memoryWarning === 'object' ? memoryWarning.code : '';
+      const memoryError = memory.error || memoryWarning;
+      const memoryErrorMessage = memory.error
+        ? settingsCopy.memoryLoadFailed
+        : memoryWarningCode === 'runtime_refresh_failed'
+          ? settingsCopy.memoryRuntimeRefreshFailed
+          : memoryWarningCode === 'snapshot_refresh_failed'
+            ? settingsCopy.memorySnapshotRefreshFailed
+            : settingsCopy.memorySourceUnavailable;
       const identity = (memory.profile && memory.profile.identity) || {};
       const longTermItems = [
         ...(memory.preferences || []).map(item => ({ ...item, kind: 'preference', type: settingsCopy.memoryTypes.preference })),
@@ -2575,8 +2582,8 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
           {memoryEnabled && (
             <>
               {memoryError && (
-                <div data-testid="memory-settings-error" className="mb-4 rounded-[14px] bg-[#FF3B30]/10 px-4 py-3 text-[13px] leading-5 text-[#FF3B30]">
-                  {settingsCopy.memoryLoadFailed}
+                <div data-testid="memory-settings-error" role="alert" aria-live="polite" className="mb-4 rounded-[14px] bg-[#FF3B30]/10 px-4 py-3 text-[13px] leading-5 text-[#FF3B30]">
+                  {memoryErrorMessage}
                 </div>
               )}
               <IOSSection title={settingsCopy.profile}>
@@ -2960,7 +2967,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
                       />
                     )}
                   </label>
-                  {memoryEditorError && <div data-testid="memory-editor-error" className="mt-3 text-[13px] leading-5 text-[#FF3B30]">{settingsCopy.memorySaveFailed}</div>}
+                  {memoryEditorError && <div data-testid="memory-editor-error" role="alert" aria-live="assertive" className="mt-3 text-[13px] leading-5 text-[#FF3B30]">{settingsCopy.memorySaveFailed}</div>}
                   <div className="mt-6 flex justify-end gap-2.5">
                     <button onClick={() => setMemoryEditor(null)} disabled={memorySaving} className={`h-10 px-4 rounded-full text-[14px] font-semibold bg-[#E5E5EA] dark:bg-[#2C2C2E] disabled:opacity-40`}>{settingsCopy.cancel}</button>
                     <button data-testid="memory-editor-save" onClick={saveMemoryEditor} disabled={memorySaving} className="h-10 px-4 rounded-full bg-[#007AFF] text-white text-[14px] font-semibold disabled:opacity-40">{memorySaving ? settingsCopy.saving : settingsCopy.save}</button>

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -2332,6 +2332,8 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
         ? settingsCopy.memoryLoadFailed
         : memoryWarningCode === 'runtime_refresh_failed'
           ? settingsCopy.memoryRuntimeRefreshFailed
+          : memoryWarningCode === 'memory_topic_cleanup_required'
+            ? settingsCopy.memoryTopicCleanupRequired
           : memoryWarningCode === 'snapshot_refresh_failed'
             ? settingsCopy.memorySnapshotRefreshFailed
             : settingsCopy.memorySourceUnavailable;

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -123,7 +123,18 @@
       never: overview && Array.isArray(overview.never) ? overview.never : [],
       runtime: overview && overview.runtime || null,
       snapshot_path: overview && overview.snapshot_path || "",
+      warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
     };
+  }
+  function applyMemoryProfileState(result) {
+    if (!result || !result.profile) return;
+    state.memory = Object.assign({}, state.memory, {
+      loading: false,
+      error: null,
+      profile: result.profile,
+      runtime: result.runtime || null,
+      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+    });
   }
   function upsertPendingMemoryCandidate(item) {
     if (!item || item.status !== "pending_confirm") return;
@@ -175,8 +186,11 @@
   async function saveMemoryProfilePatch(patch) {
     if (!invoke) return null;
     try {
-      await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
-      return await loadMemoryOverview();
+      var result = await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
+      applyMemoryProfileState(result);
+      notify();
+      var overview = await loadMemoryOverview();
+      return overview || result;
     } catch (e) {
       state.memory = Object.assign({}, state.memory, { error: String(e) });
       notify();

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -132,9 +132,17 @@
       never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
       runtime: sourceValue("runtime", overview && overview.runtime || null, null),
       snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
-      warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
+      warnings: orderedMemoryWarnings(overview && overview.warnings),
       sources: sourceStates,
     };
+  }
+  function orderedMemoryWarnings(warnings) {
+    var items = Array.isArray(warnings) ? warnings : [];
+    return items.filter(function (warning) {
+      return warning && warning.code === "memory_topic_cleanup_required";
+    }).concat(items.filter(function (warning) {
+      return !warning || warning.code !== "memory_topic_cleanup_required";
+    }));
   }
   function applyMemoryProfileState(result) {
     if (!result || !result.profile) return;
@@ -143,7 +151,7 @@
       error: null,
       profile: result.profile,
       runtime: result.runtime || null,
-      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+      warnings: orderedMemoryWarnings(result.warnings),
     });
   }
   function applyMemoryWriteState(result, update) {
@@ -152,15 +160,17 @@
       loading: false,
       error: null,
       runtime: result.runtime || null,
-      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+      warnings: orderedMemoryWarnings(result.warnings),
     });
     if (update) update(next, result.value);
     state.memory = next;
     notify();
   }
-  function upsertMemoryValue(items, value) {
+  function upsertMemoryValue(items, value, replacedId) {
     if (!value) return items || [];
-    var next = (items || []).filter(function (item) { return item && item.id !== value.id; });
+    var next = (items || []).filter(function (item) {
+      return item && item.id !== value.id && item.id !== replacedId;
+    });
     next.push(value);
     return next;
   }
@@ -254,7 +264,7 @@
       applyMemoryWriteState(res, function (next, value) {
         if (!value) return;
         var source = kind === "preference" ? "preferences" : kind;
-        next[source] = upsertMemoryValue(next[source], value);
+        next[source] = upsertMemoryValue(next[source], value, id);
       });
       await loadMemoryOverview();
       return res && res.value;

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -112,10 +112,13 @@
   function applyMemoryOverview(overview) {
     var previous = state.memory || {};
     var sourceStates = overview && overview.sources || {};
-    function sourceValue(source, value, fallback) {
+    // stateKey:后端 source 名与前端 state 字段名通常一致,但 snapshot 源对应
+    // state.memory.snapshot_path,两者不同;保留上次值时按 state 字段名查找。
+    function sourceValue(source, value, fallback, stateKey) {
       var status = sourceStates[source];
       if (status && status.available === false) {
-        return Object.prototype.hasOwnProperty.call(previous, source) ? previous[source] : fallback;
+        var key = stateKey || source;
+        return Object.prototype.hasOwnProperty.call(previous, key) ? previous[key] : fallback;
       }
       return value;
     }
@@ -131,7 +134,7 @@
       pending: sourceValue("pending", overview && Array.isArray(overview.pending) ? overview.pending : [], []),
       never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
       runtime: sourceValue("runtime", overview && overview.runtime || null, null),
-      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
+      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", "", "snapshot_path"),
       warnings: orderedMemoryWarnings(overview && overview.warnings),
       sources: sourceStates,
     };

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -110,20 +110,30 @@
   }
 
   function applyMemoryOverview(overview) {
+    var previous = state.memory || {};
+    var sourceStates = overview && overview.sources || {};
+    function sourceValue(source, value, fallback) {
+      var status = sourceStates[source];
+      if (status && status.available === false) {
+        return Object.prototype.hasOwnProperty.call(previous, source) ? previous[source] : fallback;
+      }
+      return value;
+    }
     state.memory = {
       loading: false,
       error: null,
-      profile: overview && overview.profile || null,
-      preferences: overview && Array.isArray(overview.preferences) ? overview.preferences : [],
-      work_context: overview && Array.isArray(overview.work_context) ? overview.work_context : [],
-      current_focus: overview && Array.isArray(overview.current_focus) ? overview.current_focus : [],
-      recent_activity: overview && Array.isArray(overview.recent_activity) ? overview.recent_activity : [],
-      recent_work: overview && Array.isArray(overview.recent_work) ? overview.recent_work : [],
-      pending: overview && Array.isArray(overview.pending) ? overview.pending : [],
-      never: overview && Array.isArray(overview.never) ? overview.never : [],
-      runtime: overview && overview.runtime || null,
-      snapshot_path: overview && overview.snapshot_path || "",
+      profile: sourceValue("profile", overview && overview.profile || null, null),
+      preferences: sourceValue("preferences", overview && Array.isArray(overview.preferences) ? overview.preferences : [], []),
+      work_context: sourceValue("work_context", overview && Array.isArray(overview.work_context) ? overview.work_context : [], []),
+      current_focus: sourceValue("current_focus", overview && Array.isArray(overview.current_focus) ? overview.current_focus : [], []),
+      recent_activity: sourceValue("recent_activity", overview && Array.isArray(overview.recent_activity) ? overview.recent_activity : [], []),
+      recent_work: sourceValue("recent_work", overview && Array.isArray(overview.recent_work) ? overview.recent_work : [], []),
+      pending: sourceValue("pending", overview && Array.isArray(overview.pending) ? overview.pending : [], []),
+      never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
+      runtime: sourceValue("runtime", overview && overview.runtime || null, null),
+      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
       warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
+      sources: sourceStates,
     };
   }
   function applyMemoryProfileState(result) {
@@ -135,6 +145,24 @@
       runtime: result.runtime || null,
       warnings: Array.isArray(result.warnings) ? result.warnings : [],
     });
+  }
+  function applyMemoryWriteState(result, update) {
+    if (!result) return;
+    var next = Object.assign({}, state.memory, {
+      loading: false,
+      error: null,
+      runtime: result.runtime || null,
+      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+    });
+    if (update) update(next, result.value);
+    state.memory = next;
+    notify();
+  }
+  function upsertMemoryValue(items, value) {
+    if (!value) return items || [];
+    var next = (items || []).filter(function (item) { return item && item.id !== value.id; });
+    next.push(value);
+    return next;
   }
   function upsertPendingMemoryCandidate(item) {
     if (!item || item.status !== "pending_confirm") return;
@@ -201,6 +229,9 @@
     if (!id || !invoke) return false;
     try {
       var res = await invoke("delete_memory_preference", { id: id, sessionId: state.activeSessionId });
+      applyMemoryWriteState(res, function (next, changed) {
+        if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -220,6 +251,11 @@
       var args = { id: id, patch: patch || {}, sessionId: state.activeSessionId };
       if (command === "update_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
+      applyMemoryWriteState(res, function (next, value) {
+        if (!value) return;
+        var source = kind === "preference" ? "preferences" : kind;
+        next[source] = upsertMemoryValue(next[source], value);
+      });
       await loadMemoryOverview();
       return res && res.value;
     } catch (e) {
@@ -239,6 +275,11 @@
       var args = { id: id, sessionId: state.activeSessionId };
       if (command === "delete_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
+      applyMemoryWriteState(res, function (next, changed) {
+        if (!changed) return;
+        var source = kind === "preference" ? "preferences" : kind;
+        next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -251,6 +292,9 @@
     if (!id || !invoke) return false;
     try {
       var res = await invoke("archive_recent_work_memory", { id: id, sessionId: state.activeSessionId });
+      applyMemoryWriteState(res, function (next, changed) {
+        if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -263,7 +307,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
+      var result = await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已记住" });
       await loadMemoryOverview();
       notify();
@@ -275,7 +322,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
+      var result = await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已忽略" });
       await loadMemoryOverview();
       notify();
@@ -287,7 +337,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
+      var result = await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "不再提示" });
       await loadMemoryOverview();
       notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6470,20 +6470,30 @@
   }
 
   function applyMemoryOverview(overview) {
+    var previous = state.memory || {};
+    var sourceStates = overview && overview.sources || {};
+    function sourceValue(source, value, fallback) {
+      var status = sourceStates[source];
+      if (status && status.available === false) {
+        return Object.prototype.hasOwnProperty.call(previous, source) ? previous[source] : fallback;
+      }
+      return value;
+    }
     state.memory = {
       loading: false,
       error: null,
-      profile: overview && overview.profile || null,
-      preferences: overview && Array.isArray(overview.preferences) ? overview.preferences : [],
-      work_context: overview && Array.isArray(overview.work_context) ? overview.work_context : [],
-      current_focus: overview && Array.isArray(overview.current_focus) ? overview.current_focus : [],
-      recent_activity: overview && Array.isArray(overview.recent_activity) ? overview.recent_activity : [],
-      recent_work: overview && Array.isArray(overview.recent_work) ? overview.recent_work : [],
-      pending: overview && Array.isArray(overview.pending) ? overview.pending : [],
-      never: overview && Array.isArray(overview.never) ? overview.never : [],
-      runtime: overview && overview.runtime || null,
-      snapshot_path: overview && overview.snapshot_path || "",
+      profile: sourceValue("profile", overview && overview.profile || null, null),
+      preferences: sourceValue("preferences", overview && Array.isArray(overview.preferences) ? overview.preferences : [], []),
+      work_context: sourceValue("work_context", overview && Array.isArray(overview.work_context) ? overview.work_context : [], []),
+      current_focus: sourceValue("current_focus", overview && Array.isArray(overview.current_focus) ? overview.current_focus : [], []),
+      recent_activity: sourceValue("recent_activity", overview && Array.isArray(overview.recent_activity) ? overview.recent_activity : [], []),
+      recent_work: sourceValue("recent_work", overview && Array.isArray(overview.recent_work) ? overview.recent_work : [], []),
+      pending: sourceValue("pending", overview && Array.isArray(overview.pending) ? overview.pending : [], []),
+      never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
+      runtime: sourceValue("runtime", overview && overview.runtime || null, null),
+      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
       warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
+      sources: sourceStates,
     };
   }
   function applyMemoryProfileState(result) {
@@ -6495,6 +6505,24 @@
       runtime: result.runtime || null,
       warnings: Array.isArray(result.warnings) ? result.warnings : [],
     });
+  }
+  function applyMemoryWriteState(result, update) {
+    if (!result) return;
+    var next = Object.assign({}, state.memory, {
+      loading: false,
+      error: null,
+      runtime: result.runtime || null,
+      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+    });
+    if (update) update(next, result.value);
+    state.memory = next;
+    notify();
+  }
+  function upsertMemoryValue(items, value) {
+    if (!value) return items || [];
+    var next = (items || []).filter(function (item) { return item && item.id !== value.id; });
+    next.push(value);
+    return next;
   }
   function upsertPendingMemoryCandidate(item) {
     if (!item || item.status !== "pending_confirm") return;
@@ -6561,6 +6589,9 @@
     if (!id || !invoke) return false;
     try {
       var res = await invoke("delete_memory_preference", { id: id, sessionId: state.activeSessionId });
+      applyMemoryWriteState(res, function (next, changed) {
+        if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -6580,6 +6611,11 @@
       var args = { id: id, patch: patch || {}, sessionId: state.activeSessionId };
       if (command === "update_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
+      applyMemoryWriteState(res, function (next, value) {
+        if (!value) return;
+        var source = kind === "preference" ? "preferences" : kind;
+        next[source] = upsertMemoryValue(next[source], value);
+      });
       await loadMemoryOverview();
       return res && res.value;
     } catch (e) {
@@ -6599,6 +6635,11 @@
       var args = { id: id, sessionId: state.activeSessionId };
       if (command === "delete_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
+      applyMemoryWriteState(res, function (next, changed) {
+        if (!changed) return;
+        var source = kind === "preference" ? "preferences" : kind;
+        next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -6611,6 +6652,9 @@
     if (!id || !invoke) return false;
     try {
       var res = await invoke("archive_recent_work_memory", { id: id, sessionId: state.activeSessionId });
+      applyMemoryWriteState(res, function (next, changed) {
+        if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
+      });
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
@@ -6623,7 +6667,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
+      var result = await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已记住" });
       await loadMemoryOverview();
       notify();
@@ -6635,7 +6682,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
+      var result = await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已忽略" });
       await loadMemoryOverview();
       notify();
@@ -6647,7 +6697,10 @@
     if (!memoryId) return;
     var sid = state.activeSessionId;
     try {
-      await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
+      var result = await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
+      applyMemoryWriteState(result, function (next) {
+        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+      });
       if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "不再提示" });
       await loadMemoryOverview();
       notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6472,10 +6472,13 @@
   function applyMemoryOverview(overview) {
     var previous = state.memory || {};
     var sourceStates = overview && overview.sources || {};
-    function sourceValue(source, value, fallback) {
+    // stateKey:后端 source 名与前端 state 字段名通常一致,但 snapshot 源对应
+    // state.memory.snapshot_path,两者不同;保留上次值时按 state 字段名查找。
+    function sourceValue(source, value, fallback, stateKey) {
       var status = sourceStates[source];
       if (status && status.available === false) {
-        return Object.prototype.hasOwnProperty.call(previous, source) ? previous[source] : fallback;
+        var key = stateKey || source;
+        return Object.prototype.hasOwnProperty.call(previous, key) ? previous[key] : fallback;
       }
       return value;
     }
@@ -6491,7 +6494,7 @@
       pending: sourceValue("pending", overview && Array.isArray(overview.pending) ? overview.pending : [], []),
       never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
       runtime: sourceValue("runtime", overview && overview.runtime || null, null),
-      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
+      snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", "", "snapshot_path"),
       warnings: orderedMemoryWarnings(overview && overview.warnings),
       sources: sourceStates,
     };

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6483,7 +6483,18 @@
       never: overview && Array.isArray(overview.never) ? overview.never : [],
       runtime: overview && overview.runtime || null,
       snapshot_path: overview && overview.snapshot_path || "",
+      warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
     };
+  }
+  function applyMemoryProfileState(result) {
+    if (!result || !result.profile) return;
+    state.memory = Object.assign({}, state.memory, {
+      loading: false,
+      error: null,
+      profile: result.profile,
+      runtime: result.runtime || null,
+      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+    });
   }
   function upsertPendingMemoryCandidate(item) {
     if (!item || item.status !== "pending_confirm") return;
@@ -6535,8 +6546,11 @@
   async function saveMemoryProfilePatch(patch) {
     if (!invoke) return null;
     try {
-      await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
-      return await loadMemoryOverview();
+      var result = await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
+      applyMemoryProfileState(result);
+      notify();
+      var overview = await loadMemoryOverview();
+      return overview || result;
     } catch (e) {
       state.memory = Object.assign({}, state.memory, { error: String(e) });
       notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6492,9 +6492,17 @@
       never: sourceValue("never", overview && Array.isArray(overview.never) ? overview.never : [], []),
       runtime: sourceValue("runtime", overview && overview.runtime || null, null),
       snapshot_path: sourceValue("snapshot", overview && overview.snapshot_path || "", ""),
-      warnings: overview && Array.isArray(overview.warnings) ? overview.warnings : [],
+      warnings: orderedMemoryWarnings(overview && overview.warnings),
       sources: sourceStates,
     };
+  }
+  function orderedMemoryWarnings(warnings) {
+    var items = Array.isArray(warnings) ? warnings : [];
+    return items.filter(function (warning) {
+      return warning && warning.code === "memory_topic_cleanup_required";
+    }).concat(items.filter(function (warning) {
+      return !warning || warning.code !== "memory_topic_cleanup_required";
+    }));
   }
   function applyMemoryProfileState(result) {
     if (!result || !result.profile) return;
@@ -6503,7 +6511,7 @@
       error: null,
       profile: result.profile,
       runtime: result.runtime || null,
-      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+      warnings: orderedMemoryWarnings(result.warnings),
     });
   }
   function applyMemoryWriteState(result, update) {
@@ -6512,15 +6520,17 @@
       loading: false,
       error: null,
       runtime: result.runtime || null,
-      warnings: Array.isArray(result.warnings) ? result.warnings : [],
+      warnings: orderedMemoryWarnings(result.warnings),
     });
     if (update) update(next, result.value);
     state.memory = next;
     notify();
   }
-  function upsertMemoryValue(items, value) {
+  function upsertMemoryValue(items, value, replacedId) {
     if (!value) return items || [];
-    var next = (items || []).filter(function (item) { return item && item.id !== value.id; });
+    var next = (items || []).filter(function (item) {
+      return item && item.id !== value.id && item.id !== replacedId;
+    });
     next.push(value);
     return next;
   }
@@ -6614,7 +6624,7 @@
       applyMemoryWriteState(res, function (next, value) {
         if (!value) return;
         var source = kind === "preference" ? "preferences" : kind;
-        next[source] = upsertMemoryValue(next[source], value);
+        next[source] = upsertMemoryValue(next[source], value, id);
       });
       await loadMemoryOverview();
       return res && res.value;

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -2540,10 +2540,19 @@ Object.assign(dict.ja.uiToolStore, { storeData: {
 // personas-i18n.js 的 window.PERSONA_I18N 同款模式。唯一可译源在本文件。
 dict.zh.uiSettingsDetail.memoryLoadFailed = '记忆资料加载失败，请重试';
 dict.zh.uiSettingsDetail.memorySaveFailed = '记忆资料保存失败，请重试';
+dict.zh.uiSettingsDetail.memorySourceUnavailable = '部分记忆资料暂时不可用，已保留上次成功加载的内容';
+dict.zh.uiSettingsDetail.memoryRuntimeRefreshFailed = '记忆已保存，但当前会话的记忆上下文暂未刷新';
+dict.zh.uiSettingsDetail.memorySnapshotRefreshFailed = '记忆资料已加载，但概览快照暂未刷新';
 dict.en.uiSettingsDetail.memoryLoadFailed = 'Failed to load memory profile. Please try again.';
 dict.en.uiSettingsDetail.memorySaveFailed = 'Failed to save memory profile. Please try again.';
+dict.en.uiSettingsDetail.memorySourceUnavailable = 'Some memory sources are temporarily unavailable. The last successfully loaded content is preserved.';
+dict.en.uiSettingsDetail.memoryRuntimeRefreshFailed = 'Memory was saved, but the current session context could not be refreshed.';
+dict.en.uiSettingsDetail.memorySnapshotRefreshFailed = 'Memory was loaded, but the overview snapshot could not be refreshed.';
 dict.ja.uiSettingsDetail.memoryLoadFailed = 'メモリプロフィールの読み込みに失敗しました。再試行してください。';
 dict.ja.uiSettingsDetail.memorySaveFailed = 'メモリプロフィールの保存に失敗しました。再試行してください。';
+dict.ja.uiSettingsDetail.memorySourceUnavailable = '一部のメモリ情報を一時的に利用できません。前回正常に読み込んだ内容を保持しています。';
+dict.ja.uiSettingsDetail.memoryRuntimeRefreshFailed = 'メモリは保存されましたが、現在のセッションのメモリコンテキストを更新できませんでした。';
+dict.ja.uiSettingsDetail.memorySnapshotRefreshFailed = 'メモリ情報は読み込まれましたが、概要スナップショットを更新できませんでした。';
 
 if (typeof window !== 'undefined') window.__PINVOU_SHARED_I18N__ = dict;
 

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -2543,16 +2543,19 @@ dict.zh.uiSettingsDetail.memorySaveFailed = '记忆资料保存失败，请重�
 dict.zh.uiSettingsDetail.memorySourceUnavailable = '部分记忆资料暂时不可用，已保留上次成功加载的内容';
 dict.zh.uiSettingsDetail.memoryRuntimeRefreshFailed = '记忆已保存，但当前会话的记忆上下文暂未刷新';
 dict.zh.uiSettingsDetail.memorySnapshotRefreshFailed = '记忆资料已加载，但概览快照暂未刷新';
+dict.zh.uiSettingsDetail.memoryTopicCleanupRequired = '记忆已更新，旧主题资料将在解除占用后自动清理';
 dict.en.uiSettingsDetail.memoryLoadFailed = 'Failed to load memory profile. Please try again.';
 dict.en.uiSettingsDetail.memorySaveFailed = 'Failed to save memory profile. Please try again.';
 dict.en.uiSettingsDetail.memorySourceUnavailable = 'Some memory sources are temporarily unavailable. The last successfully loaded content is preserved.';
 dict.en.uiSettingsDetail.memoryRuntimeRefreshFailed = 'Memory was saved, but the current session context could not be refreshed.';
 dict.en.uiSettingsDetail.memorySnapshotRefreshFailed = 'Memory was loaded, but the overview snapshot could not be refreshed.';
+dict.en.uiSettingsDetail.memoryTopicCleanupRequired = 'Memory was updated. The previous topic data will be cleaned up automatically after it is released.';
 dict.ja.uiSettingsDetail.memoryLoadFailed = 'メモリプロフィールの読み込みに失敗しました。再試行してください。';
 dict.ja.uiSettingsDetail.memorySaveFailed = 'メモリプロフィールの保存に失敗しました。再試行してください。';
 dict.ja.uiSettingsDetail.memorySourceUnavailable = '一部のメモリ情報を一時的に利用できません。前回正常に読み込んだ内容を保持しています。';
 dict.ja.uiSettingsDetail.memoryRuntimeRefreshFailed = 'メモリは保存されましたが、現在のセッションのメモリコンテキストを更新できませんでした。';
 dict.ja.uiSettingsDetail.memorySnapshotRefreshFailed = 'メモリ情報は読み込まれましたが、概要スナップショットを更新できませんでした。';
+dict.ja.uiSettingsDetail.memoryTopicCleanupRequired = 'メモリは更新されました。以前のトピック情報は使用中でなくなった後に自動的に整理されます。';
 
 if (typeof window !== 'undefined') window.__PINVOU_SHARED_I18N__ = dict;
 

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -2538,6 +2538,13 @@ Object.assign(dict.ja.uiToolStore, { storeData: {
 
 // 静态桥脚本（vite 原样拷贝，不能 ES import）经此读取共享词典，
 // personas-i18n.js 的 window.PERSONA_I18N 同款模式。唯一可译源在本文件。
+dict.zh.uiSettingsDetail.memoryLoadFailed = '记忆资料加载失败，请重试';
+dict.zh.uiSettingsDetail.memorySaveFailed = '记忆资料保存失败，请重试';
+dict.en.uiSettingsDetail.memoryLoadFailed = 'Failed to load memory profile. Please try again.';
+dict.en.uiSettingsDetail.memorySaveFailed = 'Failed to save memory profile. Please try again.';
+dict.ja.uiSettingsDetail.memoryLoadFailed = 'メモリプロフィールの読み込みに失敗しました。再試行してください。';
+dict.ja.uiSettingsDetail.memorySaveFailed = 'メモリプロフィールの保存に失敗しました。再試行してください。';
+
 if (typeof window !== 'undefined') window.__PINVOU_SHARED_I18N__ = dict;
 
 export { dict, LANG_TO_TAG, TAG_TO_LANG, SEARCH_KEY_PROVIDERS };

--- a/pinvou3-app/tests/memory_bridge_state.test.mjs
+++ b/pinvou3-app/tests/memory_bridge_state.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const source = fs.readFileSync(path.join(root, 'src/platform/tauri/bridge/memory.js'), 'utf8');
+const windowObject = { __PINVOU_TAURI_BRIDGE_FEATURES__: {} };
+vm.runInNewContext(source, { window: windowObject, setTimeout, clearTimeout, console });
+
+const state = {
+  activeSessionId: 'session-1',
+  memory: { pending: [{ id: 'pending-1' }] },
+  chatItems: [],
+};
+let response;
+let rejectOverview = false;
+const invoke = async command => {
+  if (command === 'get_memory_overview' && rejectOverview) throw new Error('overview unavailable');
+  return typeof response === 'function' ? response(command) : response;
+};
+const api = windowObject.__PINVOU_TAURI_BRIDGE_FEATURES__.memory({
+  state,
+  notify() {},
+  invoke,
+  bt: key => key,
+  addSystemItem() {},
+  runSyncOnSession() {},
+  patchItemById() {},
+  runOnSession(_sid, action) { action(); },
+  addChatItem(item) { state.chatItems.push(item); },
+  timeStr() { return ''; },
+});
+
+const availableSources = {
+  profile: { available: true }, preferences: { available: true }, work_context: { available: true },
+  current_focus: { available: true }, recent_activity: { available: true }, recent_work: { available: true },
+  pending: { available: true }, never: { available: true },
+};
+const overview = (overrides = {}) => ({
+  profile: { identity: { call_name: 'Ada' } },
+  preferences: [{ id: 'pref-1', text: 'concise' }],
+  work_context: [], current_focus: [], recent_activity: [], recent_work: [],
+  pending: [{ id: 'pending-1' }], never: [], runtime: null, snapshot_path: '', warnings: [],
+  sources: availableSources,
+  ...overrides,
+});
+
+response = overview();
+await api.loadMemoryOverview();
+assert.equal(state.memory.preferences[0].text, 'concise');
+
+response = overview({
+  preferences: [],
+  warnings: [{ code: 'memory_source_unavailable', source: 'preferences', detail: 'locked' }],
+  sources: { ...availableSources, preferences: { available: false, code: 'memory_source_unavailable' } },
+});
+await api.loadMemoryOverview();
+assert.equal(state.memory.preferences[0].text, 'concise', 'unavailable source must preserve last success');
+assert.equal(state.memory.sources.preferences.available, false);
+
+response = overview({ preferences: [] });
+await api.loadMemoryOverview();
+assert.deepEqual(state.memory.preferences, [], 'successful empty source must replace stale content');
+
+response = command => command === 'update_memory_preference'
+  ? { value: { id: 'pref-2', text: 'detailed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
+  : overview();
+rejectOverview = true;
+await api.updateMemoryItem('preference', 'pref-2', { text: 'detailed' });
+assert.equal(state.memory.preferences[0].text, 'detailed', 'committed update must apply before overview refresh');
+assert.equal(state.memory.warnings[0].code, 'runtime_refresh_failed');
+
+response = command => command === 'delete_memory_preference'
+  ? { value: true, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
+  : overview();
+await api.deleteMemoryPreference('pref-2');
+assert.deepEqual(state.memory.preferences, [], 'committed delete must survive overview failure');
+
+response = command => command === 'confirm_pending_memory'
+  ? { value: { id: 'pending-1', action: 'confirmed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
+  : overview();
+await api.confirmMemoryCandidate('pending-1');
+assert.deepEqual(state.memory.pending, [], 'committed confirmation must survive overview failure');

--- a/pinvou3-app/tests/memory_bridge_state.test.mjs
+++ b/pinvou3-app/tests/memory_bridge_state.test.mjs
@@ -60,6 +60,16 @@ await api.loadMemoryOverview();
 assert.equal(state.memory.preferences[0].text, 'concise', 'unavailable source must preserve last success');
 assert.equal(state.memory.sources.preferences.available, false);
 
+state.memory.snapshot_path = '/snap/last-success.json';
+response = overview({
+  snapshot_path: '',
+  warnings: [{ code: 'snapshot_refresh_failed', source: 'snapshot', detail: 'locked' }],
+  sources: { ...availableSources, snapshot: { available: false, code: 'snapshot_refresh_failed' } },
+});
+await api.loadMemoryOverview();
+assert.equal(state.memory.snapshot_path, '/snap/last-success.json', 'unavailable snapshot source must preserve last path');
+assert.equal(state.memory.sources.snapshot.available, false);
+
 response = overview({ preferences: [] });
 await api.loadMemoryOverview();
 assert.deepEqual(state.memory.preferences, [], 'successful empty source must replace stale content');

--- a/pinvou3-app/tests/memory_bridge_state.test.mjs
+++ b/pinvou3-app/tests/memory_bridge_state.test.mjs
@@ -69,7 +69,9 @@ const cleanupWarning = { code: 'memory_topic_cleanup_required', source: 'prefere
 response = command => command === 'update_memory_preference'
   ? { value: { id: 'pref-new', text: 'detailed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }, cleanupWarning] }
   : overview({ preferences: [{ id: 'pref-new', text: 'detailed' }], warnings: [{ code: 'snapshot_refresh_failed' }, cleanupWarning] });
+rejectOverview = true;
 await api.updateMemoryItem('preference', 'pref-old', { topic: 'workflow_preference', text: 'detailed' });
+rejectOverview = false;
 assert.deepEqual(state.memory.preferences.map(item => item.id), ['pref-new'], 'topic update must remove both old and returned ids');
 assert.equal(state.memory.preferences[0].text, 'detailed', 'committed update must apply before overview refresh');
 assert.equal(state.memory.warnings[0].code, 'memory_topic_cleanup_required');
@@ -93,9 +95,12 @@ response = command => command === 'delete_memory_preference'
 rejectOverview = true;
 await api.deleteMemoryPreference('pref-new');
 assert.deepEqual(state.memory.preferences, [], 'committed delete must survive overview failure');
+rejectOverview = false;
 
 response = command => command === 'confirm_pending_memory'
   ? { value: { id: 'pending-1', action: 'confirmed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
   : overview();
+rejectOverview = true;
 await api.confirmMemoryCandidate('pending-1');
 assert.deepEqual(state.memory.pending, [], 'committed confirmation must survive overview failure');
+rejectOverview = false;

--- a/pinvou3-app/tests/memory_bridge_state.test.mjs
+++ b/pinvou3-app/tests/memory_bridge_state.test.mjs
@@ -64,18 +64,34 @@ response = overview({ preferences: [] });
 await api.loadMemoryOverview();
 assert.deepEqual(state.memory.preferences, [], 'successful empty source must replace stale content');
 
+state.memory.preferences = [{ id: 'pref-old', text: 'concise' }];
+const cleanupWarning = { code: 'memory_topic_cleanup_required', source: 'preferences', detail: 'occupied' };
 response = command => command === 'update_memory_preference'
-  ? { value: { id: 'pref-2', text: 'detailed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
-  : overview();
-rejectOverview = true;
-await api.updateMemoryItem('preference', 'pref-2', { text: 'detailed' });
+  ? { value: { id: 'pref-new', text: 'detailed' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }, cleanupWarning] }
+  : overview({ preferences: [{ id: 'pref-new', text: 'detailed' }], warnings: [{ code: 'snapshot_refresh_failed' }, cleanupWarning] });
+await api.updateMemoryItem('preference', 'pref-old', { topic: 'workflow_preference', text: 'detailed' });
+assert.deepEqual(state.memory.preferences.map(item => item.id), ['pref-new'], 'topic update must remove both old and returned ids');
 assert.equal(state.memory.preferences[0].text, 'detailed', 'committed update must apply before overview refresh');
-assert.equal(state.memory.warnings[0].code, 'runtime_refresh_failed');
+assert.equal(state.memory.warnings[0].code, 'memory_topic_cleanup_required');
+
+state.memory.work_context = [{ id: 'ctx-old', text: 'old context' }];
+const contextCleanupWarning = { code: 'memory_topic_cleanup_required', source: 'work_context', detail: 'occupied' };
+response = command => command === 'update_work_context_memory'
+  ? { value: { id: 'ctx-new', text: 'new context' }, runtime: null, warnings: [contextCleanupWarning] }
+  : overview({
+      preferences: [{ id: 'pref-new', text: 'detailed' }],
+      work_context: [{ id: 'ctx-new', text: 'new context' }],
+      warnings: [contextCleanupWarning],
+    });
+await api.updateMemoryItem('work_context', 'ctx-old', { topic: 'project_context', text: 'new context' });
+assert.deepEqual(state.memory.work_context.map(item => item.id), ['ctx-new']);
+assert.equal(state.memory.warnings[0].code, 'memory_topic_cleanup_required');
 
 response = command => command === 'delete_memory_preference'
   ? { value: true, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }] }
   : overview();
-await api.deleteMemoryPreference('pref-2');
+rejectOverview = true;
+await api.deleteMemoryPreference('pref-new');
 assert.deepEqual(state.memory.preferences, [], 'committed delete must survive overview failure');
 
 response = command => command === 'confirm_pending_memory'

--- a/pinvou3-app/tests/settings_ui_smoke.js
+++ b/pinvou3-app/tests/settings_ui_smoke.js
@@ -126,6 +126,11 @@ function injectSource() {
       profile: { version: 1, revision: 3, identity: { call_name: '升级前称呼', assistant_alias: 'PINVOU' }, conventions: {} },
       preferences: [], work_context: [], current_focus: [], recent_activity: [], recent_work: [], pending: [], never: [],
       runtime: null, snapshot_path: '', warnings: [],
+      sources: {
+        profile: { available: true }, preferences: { available: true }, work_context: { available: true },
+        current_focus: { available: true }, recent_activity: { available: true }, recent_work: { available: true },
+        pending: { available: true }, never: { available: true },
+      },
     };
     var failMemoryOverview = false;
     var failMemoryUpdate = false;
@@ -227,7 +232,11 @@ function injectSource() {
               identity: Object.assign({}, memoryOverview.profile.identity, args.patch || {}),
             }),
           });
-          return Promise.resolve({ profile: memoryOverview.profile, runtime: null, warnings: ['runtime cache locked'] });
+          return Promise.resolve({
+            profile: memoryOverview.profile,
+            runtime: null,
+            warnings: [{ code: 'runtime_refresh_failed', source: 'runtime', detail: 'runtime cache locked' }],
+          });
         default: return Promise.resolve(null);
       }
     }
@@ -412,7 +421,8 @@ async function modalWidth(page, headingText) {
   rec('①b 派生概览刷新失败不吞掉已保存的称呼', await page.evaluate(() =>
     (document.querySelector('[data-testid="memory-profile-call-name"]')?.textContent || '').includes('升级后称呼')));
   rec('①c 记忆加载失败有明确提示且不伪装成未设置', await page.evaluate(() =>
-    !!document.querySelector('[data-testid="memory-settings-error"]')));
+    document.querySelector('[data-testid="memory-settings-error"]')?.getAttribute('role') === 'alert'
+      && document.querySelector('[data-testid="memory-settings-error"]')?.getAttribute('aria-live') === 'polite'));
   await page.evaluate(() => {
     window.__SETTINGS_TEST__.setFailMemoryOverview(false);
     window.__SETTINGS_TEST__.setFailMemoryUpdate(true);
@@ -424,7 +434,8 @@ async function modalWidth(page, headingText) {
   await page.waitForFunction(() => !!document.querySelector('[data-testid="memory-editor-error"]'));
   rec('①d 源资料保存失败时保留编辑器并展示错误', await page.evaluate(() =>
     !!document.querySelector('[data-testid="memory-editor-input"]')
-      && !!document.querySelector('[data-testid="memory-editor-error"]')));
+      && document.querySelector('[data-testid="memory-editor-error"]')?.getAttribute('role') === 'alert'
+      && document.querySelector('[data-testid="memory-editor-error"]')?.getAttribute('aria-live') === 'assertive'));
   await page.evaluate(() => {
     window.__SETTINGS_TEST__.setFailMemoryUpdate(false);
     const input = document.querySelector('[data-testid="memory-editor-input"]');

--- a/pinvou3-app/tests/settings_ui_smoke.js
+++ b/pinvou3-app/tests/settings_ui_smoke.js
@@ -72,7 +72,7 @@ function injectSource() {
     var settings = {
       theme: 'liquid-light',
       language: 'zh-Hans',
-      memory_enabled: false,
+      memory_enabled: true,
       notifications: { enabled: true, task_completed: true },
       pet: { enabled: false },
       search: {
@@ -122,6 +122,13 @@ function injectSource() {
     var updateResponse = { available: false, current_version: '0.6.1', latest_version: '0.6.1', notes: '', platform: 'windows' };
     var modelTestResponse = { ok: true, code: 'ok', message: '连接成功，服务可用', detail: 'HTTP 200', http_status: 200 };
     var dependencyCheckResponse = [];
+    var memoryOverview = {
+      profile: { version: 1, revision: 3, identity: { call_name: '升级前称呼', assistant_alias: 'PINVOU' }, conventions: {} },
+      preferences: [], work_context: [], current_focus: [], recent_activity: [], recent_work: [], pending: [], never: [],
+      runtime: null, snapshot_path: '', warnings: [],
+    };
+    var failMemoryOverview = false;
+    var failMemoryUpdate = false;
     var pendingDownloadResolve = null;
     function record(cmd, args) { calls.push({ cmd: cmd, args: args || null }); }
     window.alert = function (message) { record('window_alert', { message: message }); };
@@ -211,6 +218,16 @@ function injectSource() {
         case 'list_scheduled_tasks': return Promise.resolve([]);
         case 'list_scheduled_task_recent_runs': return Promise.resolve([]);
         case 'get_app_version': return Promise.resolve('0.6.1');
+        case 'get_memory_overview':
+          return failMemoryOverview ? Promise.reject(new Error('snapshot locked')) : Promise.resolve(memoryOverview);
+        case 'update_memory_profile':
+          if (failMemoryUpdate) return Promise.reject(new Error('profile write failed'));
+          memoryOverview = Object.assign({}, memoryOverview, {
+            profile: Object.assign({}, memoryOverview.profile, {
+              identity: Object.assign({}, memoryOverview.profile.identity, args.patch || {}),
+            }),
+          });
+          return Promise.resolve({ profile: memoryOverview.profile, runtime: null, warnings: ['runtime cache locked'] });
         default: return Promise.resolve(null);
       }
     }
@@ -223,6 +240,8 @@ function injectSource() {
       setUpdateResponse: function (next) { updateResponse = Object.assign({}, updateResponse, next || {}); },
       setModelTestResponse: function (next) { modelTestResponse = Object.assign({}, next || {}); },
       setDependencyCheckResponse: function (next) { dependencyCheckResponse = (next || []).slice(); },
+      setFailMemoryOverview: function (value) { failMemoryOverview = !!value; },
+      setFailMemoryUpdate: function (value) { failMemoryUpdate = !!value; },
       resolveDownload: function () {
         if (pendingDownloadResolve) {
           var resolve = pendingDownloadResolve;
@@ -379,6 +398,40 @@ async function modalWidth(page, headingText) {
   await page.waitForFunction(() => document.querySelector('[data-testid="app-root"]')?.getAttribute('data-current-view') === 'settings', { timeout: 8000 });
   await sleep(400);
   rec('① 设置页可打开且无错误边界', await page.evaluate(() => document.body.innerText.includes('通用') && !document.body.innerText.includes('设置页加载失败')));
+
+  await page.click('[data-testid="settings-section-memory"]');
+  await page.waitForFunction(() => (document.querySelector('[data-testid="memory-profile-call-name"]')?.textContent || '').includes('升级前称呼'));
+  rec('①a 升级后的记忆资料从权威 profile 正常回显', await page.evaluate(() =>
+    (document.querySelector('[data-testid="memory-profile-call-name"]')?.textContent || '').includes('升级前称呼')));
+  await page.evaluate(() => window.__SETTINGS_TEST__.setFailMemoryOverview(true));
+  await page.click('[data-testid="memory-profile-call-name"] button');
+  await page.click('[data-testid="memory-editor-input"]', { clickCount: 3 });
+  await page.type('[data-testid="memory-editor-input"]', '升级后称呼');
+  await page.click('[data-testid="memory-editor-save"]');
+  await page.waitForFunction(() => !document.querySelector('[data-testid="memory-editor-input"]'));
+  rec('①b 派生概览刷新失败不吞掉已保存的称呼', await page.evaluate(() =>
+    (document.querySelector('[data-testid="memory-profile-call-name"]')?.textContent || '').includes('升级后称呼')));
+  rec('①c 记忆加载失败有明确提示且不伪装成未设置', await page.evaluate(() =>
+    !!document.querySelector('[data-testid="memory-settings-error"]')));
+  await page.evaluate(() => {
+    window.__SETTINGS_TEST__.setFailMemoryOverview(false);
+    window.__SETTINGS_TEST__.setFailMemoryUpdate(true);
+  });
+  await page.click('[data-testid="memory-profile-call-name"] button');
+  await page.click('[data-testid="memory-editor-input"]', { clickCount: 3 });
+  await page.type('[data-testid="memory-editor-input"]', '不会保存');
+  await page.click('[data-testid="memory-editor-save"]');
+  await page.waitForFunction(() => !!document.querySelector('[data-testid="memory-editor-error"]'));
+  rec('①d 源资料保存失败时保留编辑器并展示错误', await page.evaluate(() =>
+    !!document.querySelector('[data-testid="memory-editor-input"]')
+      && !!document.querySelector('[data-testid="memory-editor-error"]')));
+  await page.evaluate(() => {
+    window.__SETTINGS_TEST__.setFailMemoryUpdate(false);
+    const input = document.querySelector('[data-testid="memory-editor-input"]');
+    const dialog = input && input.closest('.fixed');
+    const buttons = dialog ? [...dialog.querySelectorAll('button')] : [];
+    if (buttons.length) buttons[0].click();
+  });
 
   await clickSettingsSection(page, '更新');
   await page.evaluate(async () => {

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -23,6 +23,7 @@ const documentObject = {
   },
   body: { appendChild() {} },
 };
+let invokeResponse = async () => null;
 const windowObject = {
   PinvouPlatform: {
     kind: 'web',
@@ -32,7 +33,7 @@ const windowObject = {
     canInvoke: () => false,
   },
   __TAURI__: {
-    core: { invoke: async () => null },
+    core: { invoke: (...args) => invokeResponse(...args) },
     event: { listen: async () => function () {} },
     dialog: { open: async () => null },
   },
@@ -93,6 +94,46 @@ assert.ok(Object.hasOwn(state, 'sessions'));
 assert.ok(Object.hasOwn(state, 'settings'));
 assert.equal(Object.hasOwn(state, 'messages'), false);
 assert.throws(() => api.state.get('unknown'), /Unknown Tauri bridge state slice/);
+
+const memorySources = {
+  profile: { available: true }, preferences: { available: true }, work_context: { available: true },
+  current_focus: { available: true }, recent_activity: { available: true }, recent_work: { available: true },
+  pending: { available: true }, never: { available: true }, runtime: { available: true }, snapshot: { available: true },
+};
+const memoryOverview = overrides => ({
+  profile: null, preferences: [], work_context: [], current_focus: [], recent_activity: [],
+  recent_work: [], pending: [], never: [], runtime: null, snapshot_path: '', warnings: [],
+  sources: memorySources, ...(overrides || {}),
+});
+invokeResponse = async command => command === 'get_memory_overview'
+  ? memoryOverview({ preferences: [{ id: 'web-pref-old', text: 'old' }], work_context: [{ id: 'web-ctx-old', text: 'old' }] })
+  : null;
+await api.memory.loadMemoryOverview();
+const preferenceCleanup = { code: 'memory_topic_cleanup_required', source: 'preferences', detail: 'occupied' };
+invokeResponse = async command => command === 'update_memory_preference'
+  ? { value: { id: 'web-pref-new', text: 'new' }, runtime: null, warnings: [{ code: 'runtime_refresh_failed' }, preferenceCleanup] }
+  : memoryOverview({
+      preferences: [{ id: 'web-pref-new', text: 'new' }],
+      work_context: [{ id: 'web-ctx-old', text: 'old' }],
+      warnings: [{ code: 'snapshot_refresh_failed' }, preferenceCleanup],
+    });
+await api.memory.updateMemoryItem('preference', 'web-pref-old', { topic: 'workflow_preference' });
+let memoryState = api.state.get('memory').memory;
+assert.deepEqual(memoryState.preferences.map(item => item.id), ['web-pref-new']);
+assert.equal(memoryState.warnings[0].code, 'memory_topic_cleanup_required');
+
+const contextCleanup = { code: 'memory_topic_cleanup_required', source: 'work_context', detail: 'occupied' };
+invokeResponse = async command => command === 'update_work_context_memory'
+  ? { value: { id: 'web-ctx-new', text: 'new' }, runtime: null, warnings: [contextCleanup] }
+  : memoryOverview({
+      preferences: [{ id: 'web-pref-new', text: 'new' }],
+      work_context: [{ id: 'web-ctx-new', text: 'new' }],
+      warnings: [contextCleanup],
+    });
+await api.memory.updateMemoryItem('work_context', 'web-ctx-old', { topic: 'project_context' });
+memoryState = api.state.get('memory').memory;
+assert.deepEqual(memoryState.work_context.map(item => item.id), ['web-ctx-new']);
+assert.equal(memoryState.warnings[0].code, 'memory_topic_cleanup_required');
 
 const indexSource = fs.readFileSync(path.join(root, 'src', 'index.html'), 'utf8');
 assert.ok(


### PR DESCRIPTION
## 背景

部分用户从旧版本升级后，个人资料中的用户称呼会显示为“未设置”，并且重新保存后界面仍没有恢复，看起来像是升级过程清空了记忆设置。

## 根因

Windows 下原有的原子替换流程会先把正式文件改名为备份，再把临时文件改名为正式文件。并发写入、杀毒软件扫描或短暂文件占用发生在两步之间时，可能只留下备份或临时文件。同时，保存资料后还会同步刷新当前会话的派生运行时文件；派生刷新失败会让整个保存命令返回失败，即使资料本身已经写入。前端收到失败后没有明确展示错误，也不会立即采用保存接口返回的最新资料，因此呈现为“被清空且无法设置”。

## 变更

- Windows 使用系统原生文件替换语义，失败时保留权威文件，并清理临时文件。
- 读取资料时恢复有效的中断写入文件，兼容升级后只剩备份或临时文件的情况。
- 将资料持久化与派生运行时刷新解耦；派生刷新失败降级为警告，不再否定已成功保存的资料。
- 前端立即采用保存返回结果，明确展示读取、保存及降级警告；保存失败时保留编辑内容以便重试。
- 增加 Windows 原子替换、资料恢复和设置页面端到端回归测试。

## 验证

- `cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib`
- `npm --prefix pinvou3-app run lint:ui`
- `npm --prefix pinvou3-app run build:ui`
- `npm --prefix pinvou3-app run test:settings-ui`（41/41）
- `python scripts/architecture-guard.py`
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `git diff --check`

## 已知验证限制

Rust 单元测试目标在本机已成功编译和链接，但测试进程启动时受到现有 Windows 动态库入口异常影响，在进入断言前退出；相关行为由编译检查、前端端到端测试和新增回归用例共同覆盖。