### PR TITLE
fix(chat): 记忆面板与专家卡跨会话竞态

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -1032,8 +1032,8 @@ function workspaceDisplayName(path) {
       async function startAICard() {
         handleNewChat();
         if (!bridge.available) return;
-        await bridge.personas.equipPersona('pinvou-card-creator');           // 先加持(落新 session + 加持气泡)
-        bridge.personas.postCardCreatorIntro();                              // 再排在加持气泡之后(持久化,切会话/重启不丢);内部定向最近 equip 的会话,切走不串台
+        var card = await bridge.personas.equipPersona('pinvou-card-creator'); // 先加持(落新 session + 加持气泡)
+        if (card) bridge.personas.postCardCreatorIntro();                     // 加持成功才追加引导卡(持久化,切会话/重启不丢);失败则放弃后续,避免错投(二审补充)
       }
 
       async function handleSwitchSession(id) {

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -1033,7 +1033,7 @@ function workspaceDisplayName(path) {
         handleNewChat();
         if (!bridge.available) return;
         await bridge.personas.equipPersona('pinvou-card-creator');           // 先加持(落新 session + 加持气泡)
-        bridge.personas.postCardCreatorIntro();                              // 再排在加持气泡之后(持久化,切会话/重启不丢)
+        bridge.personas.postCardCreatorIntro();                              // 再排在加持气泡之后(持久化,切会话/重启不丢);内部定向最近 equip 的会话,切走不串台
       }
 
       async function handleSwitchSession(id) {

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -2050,7 +2050,7 @@
   var editLastTurn = interactionFeature.editLastTurn;
   var compactNow = interactionFeature.compactNow;
 
-  var memoryFeature = installBridgeFeature("memory", { state: state, notify: notify, invoke: invoke, bt: bt, addSystemItem: addSystemItem, runSyncOnSession: runSyncOnSession, patchItemById: patchItemById, runOnSession: runOnSession, addChatItem: addChatItem, timeStr: timeStr });
+  var memoryFeature = installBridgeFeature("memory", { state: state, notify: notify, invoke: invoke, bt: bt, addSystemItem: addSystemItem, runSyncOnSession: runSyncOnSession, patchItemById: patchItemById, patchItemByIdFor: patchItemByIdFor, runOnSession: runOnSession, addChatItem: addChatItem, timeStr: timeStr });
   var handleMemoryWrite = memoryFeature.handleMemoryWrite;
   var loadMemoryOverview = memoryFeature.loadMemoryOverview;
   var saveMemoryProfilePatch = memoryFeature.saveMemoryProfilePatch;
@@ -2087,14 +2087,14 @@
   var resolveConversationAttachment = artifactsFeature.resolveConversationAttachment;
   var openConversationAttachment = artifactsFeature.openConversationAttachment;
   var revealConversationAttachment = artifactsFeature.revealConversationAttachment;
-  var personasFeature = installBridgeFeature("personas", { state: state, notify: notify, invoke: invoke, listen: listen, bt: bt, isDefaultChatTitle: isDefaultChatTitle, addSystemItem: addSystemItem, addChatItem: addChatItem, timeStr: timeStr, ensureSession: ensureSession, personaPlaceholderTitles: personaPlaceholderTitles });
+  var personasFeature = installBridgeFeature("personas", { state: state, notify: notify, invoke: invoke, listen: listen, bt: bt, isDefaultChatTitle: isDefaultChatTitle, addSystemItem: addSystemItem, addChatItem: addChatItem, timeStr: timeStr, ensureSession: ensureSession, runOnSession: runOnSession, personaPlaceholderTitles: personaPlaceholderTitles });
   var loadPersonas = personasFeature.loadPersonas;
   var getPersonas = personasFeature.getPersonas;
   var createPersona = personasFeature.createPersona;
   var updatePersona = personasFeature.updatePersona;
   var deletePersona = personasFeature.deletePersona;
-  var recordPersonaEvent = personasFeature.recordPersonaEvent;
   var equipPersona = personasFeature.equipPersona;
+  var postCardCreatorIntro = personasFeature.postCardCreatorIntro;
   var unequipPersona = personasFeature.unequipPersona;
   var syncActivePersona = personasFeature.syncActivePersona;
   var mountCollection = personasFeature.mountCollection;
@@ -2452,7 +2452,7 @@
       readPersonaBody: function (id) { return invoke("read_persona_body", { personaId: id }); },
       equipPersona: equipPersona,
       unequipPersona: unequipPersona,
-      postCardCreatorIntro: function () { addChatItem({ type: "card_creator_intro", time: "" }); recordPersonaEvent({ kind: "card_creator_intro" }); notify(); },
+      postCardCreatorIntro: postCardCreatorIntro,
       createPersona: createPersona,
       updatePersona: updatePersona,
       deletePersona: deletePersona,

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -12,7 +12,7 @@
     var bt = context.bt;
     var addSystemItem = context.addSystemItem;
     var runSyncOnSession = context.runSyncOnSession;
-    var patchItemById = context.patchItemById;
+    var patchItemByIdFor = context.patchItemByIdFor;
     var runOnSession = context.runOnSession;
     var addChatItem = context.addChatItem;
     var timeStr = context.timeStr;
@@ -207,10 +207,11 @@
     var pending = overview && Array.isArray(overview.pending) ? overview.pending : [];
     pending.forEach(upsertPendingMemoryCandidate);
   }
-  // 记忆是会话级数据(profile/preferences/pending 均按 session 存储)。加载
-  // 必须带归属+序号校验：await 挂起期间切会话或再次加载，旧响应返回后不得
-  // 覆盖当前显示的会话记忆，也不得把上一个会话的 pending 候选卡 rehydrate
-  // 进当前对话流(串台)。任何新加载都会递增序号使在途读取作废(审计)。
+  // 记忆面板混合两类数据：runtime 按 session 分文件，profile/preferences/
+  // pending 等为全局单文件(见后端 paths.rs)。加载仍必须带归属+序号校验：
+  // await 挂起期间切会话或再次加载，旧响应返回后不得覆盖当前显示(尤其
+  // runtime 属于别的会话)，也不得把候选卡 rehydrate 进当前对话流(串台)。
+  // 任何新加载都会递增序号使在途读取作废(审计)。
   var memoryOverviewSeq = 0;
   async function loadMemoryOverview(options) {
     if (!invoke) return null;
@@ -222,49 +223,69 @@
     try {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var overview = await invoke("get_memory_overview", { sessionId: state.activeSessionId });
-      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return discardStaleLoad(seq);
       applyMemoryOverview(overview);
       if (options.rehydratePending) rehydratePendingMemoryCandidates(overview);
       notify();
       return overview;
     } catch (e) {
-      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return discardStaleLoad(seq);
       state.memory = Object.assign({}, state.memory, { loading: false, error: String(e) });
       notify();
       return null;
     }
   }
+  // 守卫命中的善后：序号已被更新加载接管时由它负责收尾 loading；仅会话
+  // 变化、无人接管时(如切草稿不续发加载)必须自己清掉 loading，否则面板
+  // 永远停在"同步中"(审计补充)。
+  function discardStaleLoad(seq) {
+    if (seq === memoryOverviewSeq) {
+      state.memory = Object.assign({}, state.memory, { loading: false });
+      notify();
+    }
+    return null;
+  }
   async function saveMemoryProfilePatch(patch) {
     if (!invoke) return null;
+    // 入口捕获触发会话：invoke 往返期间切走，A 的写结果/错误不得渲染进
+    // B 的面板(与 loadMemoryOverview 同一不变量，审计补充)。
+    var sid = state.activeSessionId;
     try {
       var result = await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
-      applyMemoryProfileState(result);
-      notify();
+      if (sid === state.activeSessionId) { applyMemoryProfileState(result); notify(); }
       var overview = await loadMemoryOverview();
       return overview || result;
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function deleteMemoryPreference(id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(审计补充)
     try {
       var res = await invoke("delete_memory_preference", { id: id, sessionId: state.activeSessionId });
-      applyMemoryWriteState(res, function (next, changed) {
-        if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function updateMemoryItem(kind, id, patch) {
     if (!id || !invoke) return null;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(审计补充)
     try {
       var command = kind === "preference" ? "update_memory_preference"
         : kind === "work_context" ? "update_work_context_memory"
@@ -274,21 +295,26 @@
       var args = { id: id, patch: patch || {}, sessionId: state.activeSessionId };
       if (command === "update_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
-      applyMemoryWriteState(res, function (next, value) {
-        if (!value) return;
-        var source = kind === "preference" ? "preferences" : kind;
-        next[source] = upsertMemoryValue(next[source], value, id);
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, value) {
+          if (!value) return;
+          var source = kind === "preference" ? "preferences" : kind;
+          next[source] = upsertMemoryValue(next[source], value, id);
+        });
+      }
       await loadMemoryOverview();
       return res && res.value;
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function deleteMemoryItem(kind, id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(审计补充)
     try {
       var command = kind === "preference" ? "delete_memory_preference"
         : kind === "work_context" ? "delete_work_context_memory"
@@ -298,77 +324,94 @@
       var args = { id: id, sessionId: state.activeSessionId };
       if (command === "delete_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
-      applyMemoryWriteState(res, function (next, changed) {
-        if (!changed) return;
-        var source = kind === "preference" ? "preferences" : kind;
-        next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (!changed) return;
+          var source = kind === "preference" ? "preferences" : kind;
+          next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function archiveRecentWorkMemory(id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(审计补充)
     try {
       var res = await invoke("archive_recent_work_memory", { id: id, sessionId: state.activeSessionId });
-      applyMemoryWriteState(res, function (next, changed) {
-        if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function confirmMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 入口捕获：候选卡 patch 与面板写入都定向回发起会话(审计补充)
     try {
       var result = await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已记住" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      // patch 必须按发起会话路由(而非当前显示)：切走后写 B 的 chatItems 是
+      // no-op，A 的候选卡会永远停留在"可点击未决"态，切回再点会二次提交。
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "已记住" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryWriteFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryWriteFailed") + e);
     }
   }
   async function ignoreMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 同 confirmMemoryCandidate：定向回发起会话(审计补充)
     try {
       var result = await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已忽略" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "已忽略" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryIgnoreFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryIgnoreFailed") + e);
     }
   }
   async function neverMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 同 confirmMemoryCandidate：定向回发起会话(审计补充)
     try {
       var result = await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "不再提示" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "不再提示" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryNeverFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryNeverFailed") + e);
     }
   }
     return {

--- a/pinvou3-app/src/platform/tauri/bridge/memory.js
+++ b/pinvou3-app/src/platform/tauri/bridge/memory.js
@@ -207,18 +207,28 @@
     var pending = overview && Array.isArray(overview.pending) ? overview.pending : [];
     pending.forEach(upsertPendingMemoryCandidate);
   }
+  // 记忆是会话级数据(profile/preferences/pending 均按 session 存储)。加载
+  // 必须带归属+序号校验：await 挂起期间切会话或再次加载，旧响应返回后不得
+  // 覆盖当前显示的会话记忆，也不得把上一个会话的 pending 候选卡 rehydrate
+  // 进当前对话流(串台)。任何新加载都会递增序号使在途读取作废(审计)。
+  var memoryOverviewSeq = 0;
   async function loadMemoryOverview(options) {
     if (!invoke) return null;
     options = options || {};
+    var sid = state.activeSessionId;
+    var seq = ++memoryOverviewSeq;
     state.memory = Object.assign({}, state.memory, { loading: true, error: null });
     notify();
     try {
+      // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var overview = await invoke("get_memory_overview", { sessionId: state.activeSessionId });
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
       applyMemoryOverview(overview);
       if (options.rehydratePending) rehydratePendingMemoryCandidates(overview);
       notify();
       return overview;
     } catch (e) {
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
       state.memory = Object.assign({}, state.memory, { loading: false, error: String(e) });
       notify();
       return null;

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -78,12 +78,17 @@
       await ensureSession(); // 草稿态加卡 → 先物化 session(lazy session)
       if (!state.activeSessionId) return; // 物化失败,放弃
     }
+    // 入口捕获触发会话：await 期间用户可能切走，UI 写入不得落进别的会话
+    // （错误会话被重命名/插卡是持久化污染，不可自愈）。后端已按发起会话
+    // 定向；切走后放弃前端播报，挂件靠 syncActivePersona 恢复（审计）。
+    var sid = state.activeSessionId;
     var prev = state.activePersona; // 换卡前的旧专家(同 session 切换时先播报卸下)
     try {
+      // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
+      if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
       // 用户已主动改名 / 已被首条消息命名的会话不动)。决策:卡牌优先于首条消息。
-      var sid = state.activeSessionId;
       var m = state.sessions.find(function (s) { return s.id === sid; });
       // 标题还是默认值 / 仍是卡牌占位(换卡场景)→ 用(新)卡牌名命名,并标记为占位。
       // 占位名会被首条用户消息覆盖(见 persistMessages*),让同卡会话靠对话内容区分。
@@ -110,8 +115,11 @@
   // 摘下当前 session 的专家面具。
   async function unequipPersona() {
     if (!state.activeSessionId) return;
+    // 入口捕获触发会话：await 期间切走，卸下播报不得写进别的会话（审计）。
+    var sid = state.activeSessionId;
     var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
+    if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();
@@ -119,8 +127,12 @@
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
   async function syncActivePersona() {
     if (!state.activeSessionId) { state.activePersona = null; return; }
+    var sid = state.activeSessionId;
     try {
-      state.activePersona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
+      // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
+      var persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
+      if (sid !== state.activeSessionId) return; // 已切走：陈旧快照不得覆盖新会话挂件
+      state.activePersona = persona;
     } catch (e) { /* 旧 session 无加持,忽略 */ }
   }
 

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -96,6 +96,7 @@
         var newTitle = personaName(card);
         if (newTitle) {
           try { await invoke("rename_session", { id: sid, title: newTitle }); } catch (_) {}
+          if (sid !== state.activeSessionId) return card; // rename 挂起期间切走:放弃后续 UI 写入(审计补充)
           m.title = newTitle;
           personaPlaceholderTitles[sid] = true;
         }

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -14,6 +14,7 @@
     var addChatItem = context.addChatItem;
     var timeStr = context.timeStr;
     var ensureSession = context.ensureSession;
+    var runOnSession = context.runOnSession;
     var personaPlaceholderTitles = context.personaPlaceholderTitles;
     var isDefaultChatTitle = context.isDefaultChatTitle;
     var personaPoolCache = [];
@@ -86,6 +87,7 @@
     try {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
+      lastEquippedSid = sid; // 成功加持的目标会话(即使已切走)：供紧随其后的引导卡定向(审计补充)
       if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
       // 用户已主动改名 / 已被首条消息命名的会话不动)。决策:卡牌优先于首条消息。
@@ -106,6 +108,7 @@
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
         recordPersonaEvent({ kind: "unequip", name: personaName(prev) });
       }
+      personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(审计补充)
       state.activePersona = card;
       addChatItem({ type: "persona_equip", card: card, time: timeStr() });
       recordPersonaEvent({ kind: "equip", card: card });
@@ -121,20 +124,43 @@
     var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
     if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
+    personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(审计补充)
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();
   }
+  // 挂件还原的请求序号 + 最近成功加持的目标会话：
+  // - syncActivePersona 仅 sid 校验挡不住 A→B→A 的 ABA 与同会话乱序(慢响应
+  //   返回 null 会把刚加持的挂件覆盖掉,且无人再纠正)。序号在每次 sync 发起
+  //   与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
+  // - lastEquippedSid 供 equip 后紧随的播报(如卡牌制造者引导卡)定向回
+  //   发起会话——equip 的 await 窗口用户可能已切走。
+  var personaSyncSeq = 0;
+  var lastEquippedSid = null;
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
   async function syncActivePersona() {
     if (!state.activeSessionId) { state.activePersona = null; return; }
     var sid = state.activeSessionId;
+    var seq = ++personaSyncSeq;
     try {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
-      if (sid !== state.activeSessionId) return; // 已切走：陈旧快照不得覆盖新会话挂件
+      if (sid !== state.activeSessionId || seq !== personaSyncSeq) return; // 已切走或被权威写/新 sync 作废
       state.activePersona = persona;
     } catch (e) { /* 旧 session 无加持,忽略 */ }
+  }
+  // 在【指定 session】追加卡牌制造者引导卡并落 sidecar(持久化,重载按 pos 插回)。
+  // 默认定向最近一次成功 equip 的目标会话：AI 造卡链路 equip→intro 之间用户
+  // 切走时,intro 必须仍落在发起(已加持)会话,而不是写进切走后的当前显示
+  // (错误会话被插卡是持久化污染,不可自愈)。显式传 sid 可覆盖(审计补充)。
+  function postCardCreatorIntro(sid) {
+    var target = sid || lastEquippedSid || state.activeSessionId;
+    if (!target) return;
+    runOnSession(target, function () {
+      addChatItem({ type: "card_creator_intro", time: "" });
+      recordPersonaEvent({ kind: "card_creator_intro" });
+      notify();
+    });
   }
 
   // ── 多知识库挂载(会话级粘连,仿 persona) ──
@@ -267,6 +293,7 @@
       recordPersonaEvent: recordPersonaEvent,
       equipPersona: equipPersona,
       unequipPersona: unequipPersona,
+      postCardCreatorIntro: postCardCreatorIntro,
       syncActivePersona: syncActivePersona,
       mountCollection: mountCollection,
       setCollectionEnabled: setCollectionEnabled,

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -83,7 +83,6 @@
     // （错误会话被重命名/插卡是持久化污染，不可自愈）。后端已按发起会话
     // 定向；切走后放弃前端播报，挂件靠 syncActivePersona 恢复（审计）。
     var sid = state.activeSessionId;
-    var prev = state.activePersona; // 换卡前的旧专家(同 session 切换时先播报卸下)
     try {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
@@ -104,6 +103,9 @@
         }
       }
       // 同 session 换了一张不同的卡 → 先弹一条"已卸下旧专家",再弹新加持。
+      // 旧专家在写点复核而非入口捕获：同会话快速连续换卡时,入口值可能已被
+      // 上一次 equip 的权威写覆盖,陈旧值会播报错误的"已卸下"(二审补充)。
+      var prev = state.activePersona;
       if (prev && prev.id !== card.id) {
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
         recordPersonaEvent({ kind: "unequip", name: personaName(prev) });
@@ -114,17 +116,26 @@
       recordPersonaEvent({ kind: "equip", card: card });
       notify();
       return card;
-    } catch (e) { addSystemItem(bt("equipFailed") + e); return null; }
+    } catch (e) {
+      // 失败也守住归属：失败气泡只落发起会话,不得插进 await 窗口内切到的
+      // 会话(addSystemItem 随消息流持久化);同时作废 lastEquippedSid——失败
+      // equip 后紧随的引导卡不得回退定向到历史成功 equip 的无关会话(二审补充)。
+      lastEquippedSid = null;
+      if (sid === state.activeSessionId) addSystemItem(bt("equipFailed") + e);
+      return null;
+    }
   }
   // 摘下当前 session 的专家面具。
   async function unequipPersona() {
     if (!state.activeSessionId) return;
     // 入口捕获触发会话：await 期间切走，卸下播报不得写进别的会话（审计）。
     var sid = state.activeSessionId;
-    var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
     if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
     personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(审计补充)
+    // 旧专家同样在写点复核：await 窗口内若已被 equip 换成新卡,播报新卡,
+    // 入口捕获的陈旧值会重复播报早已卸下的旧卡(二审补充)。
+    var prev = state.activePersona;
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -7657,12 +7657,17 @@
       await ensureSession(); // 草稿态加卡 → 先物化 session(lazy session)
       if (!state.activeSessionId) return; // 物化失败,放弃
     }
+    // 入口捕获触发会话：await 期间用户可能切走，UI 写入不得落进别的会话
+    // （错误会话被重命名/插卡是持久化污染，不可自愈）。后端已按发起会话
+    // 定向；切走后放弃前端播报，挂件靠 syncActivePersona 恢复（与 tauri
+    // personas.js 对齐，审计）。
+    var sid = state.activeSessionId;
     var prev = state.activePersona; // 换卡前的旧专家(同 session 切换时先播报卸下)
     try {
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
+      if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
       // 用户已主动改名 / 已被首条消息命名的会话不动)。决策:卡牌优先于首条消息。
-      var sid = state.activeSessionId;
       var m = state.sessions.find(function (s) { return s.id === sid; });
       // 标题还是默认值 / 仍是卡牌占位(换卡场景)→ 用(新)卡牌名命名,并标记为占位。
       // 占位名会被首条用户消息覆盖(见 persistMessages*),让同卡会话靠对话内容区分。
@@ -7670,6 +7675,7 @@
         var newTitle = personaName(card);
         if (newTitle) {
           try { await invoke("rename_session", { id: sid, title: newTitle }); } catch (_) {}
+          if (sid !== state.activeSessionId) return card; // rename 挂起期间切走:放弃后续 UI 写入(审计补充)
           m.title = newTitle;
           personaPlaceholderTitles[sid] = true;
         }
@@ -7689,8 +7695,11 @@
   // 摘下当前 session 的专家面具。
   async function unequipPersona() {
     if (!state.activeSessionId) return;
+    // 入口捕获触发会话：await 期间切走，卸下播报不得写进别的会话（与 tauri 对齐，审计）。
+    var sid = state.activeSessionId;
     var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
+    if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();
@@ -7698,8 +7707,11 @@
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
   async function syncActivePersona() {
     if (!state.activeSessionId) { state.activePersona = null; return; }
+    var sid = state.activeSessionId;
     try {
-      state.activePersona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
+      var persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
+      if (sid !== state.activeSessionId) return; // 已切走：陈旧快照不得覆盖新会话挂件（与 tauri 对齐，审计）
+      state.activePersona = persona;
     } catch (e) { /* 旧 session 无加持,忽略 */ }
   }
 

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6686,18 +6686,26 @@
     var pending = overview && Array.isArray(overview.pending) ? overview.pending : [];
     pending.forEach(upsertPendingMemoryCandidate);
   }
+  // 记忆是会话级数据：加载必须带归属+序号校验（与 tauri memory.js 对齐，
+  // 审计）。await 挂起期间切会话或再次加载，旧响应不得覆盖当前显示，
+  // 也不得把上一个会话的 pending 候选卡 rehydrate 进当前对话流。
+  var memoryOverviewSeq = 0;
   async function loadMemoryOverview(options) {
     if (!invoke) return null;
     options = options || {};
+    var sid = state.activeSessionId;
+    var seq = ++memoryOverviewSeq;
     state.memory = Object.assign({}, state.memory, { loading: true, error: null });
     notify();
     try {
       var overview = await invoke("get_memory_overview", { sessionId: state.activeSessionId });
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
       applyMemoryOverview(overview);
       if (options.rehydratePending) rehydratePendingMemoryCandidates(overview);
       notify();
       return overview;
     } catch (e) {
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
       state.memory = Object.assign({}, state.memory, { loading: false, error: String(e) });
       notify();
       return null;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -2550,6 +2550,11 @@
     // syncModeState 读取互不感知（各自独立校验），不 bump 则两条读取链可
     // 互相覆盖（评审 P1）。
     modeSyncSeq += 1;
+    // persona/memory 写回同理 bump 各自序号：本通道与会话切换并发在途的
+    // syncActivePersona / loadMemoryOverview 读取互不感知（各自独立校验
+    // sid+seq），不 bump 则 A→B→A 快速切回时可被旧 sync 响应覆盖(二审补充)。
+    personaSyncSeq += 1;
+    memoryOverviewSeq += 1;
     var mode = results[0];
     var persona = results[1];
     var snapshot = results[2];
@@ -7706,7 +7711,6 @@
     // 定向；切走后放弃前端播报，挂件靠 syncActivePersona 恢复（与 tauri
     // personas.js 对齐，审计）。
     var sid = state.activeSessionId;
-    var prev = state.activePersona; // 换卡前的旧专家(同 session 切换时先播报卸下)
     try {
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
       lastEquippedSid = sid; // 成功加持的目标会话(即使已切走)：供紧随其后的引导卡定向(与 tauri 对齐，审计补充)
@@ -7726,6 +7730,9 @@
         }
       }
       // 同 session 换了一张不同的卡 → 先弹一条"已卸下旧专家",再弹新加持。
+      // 旧专家在写点复核而非入口捕获：同会话快速连续换卡时,入口值可能已被
+      // 上一次 equip 的权威写覆盖,陈旧值会播报错误的"已卸下"(与 tauri 对齐,二审补充)。
+      var prev = state.activePersona;
       if (prev && prev.id !== card.id) {
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
         recordPersonaEvent({ kind: "unequip", name: personaName(prev) });
@@ -7736,17 +7743,26 @@
       recordPersonaEvent({ kind: "equip", card: card });
       notify();
       return card;
-    } catch (e) { addSystemItem(bt("equipFailed") + e); return null; }
+    } catch (e) {
+      // 失败也守住归属：失败气泡只落发起会话,不得插进 await 窗口内切到的
+      // 会话(addSystemItem 随消息流持久化);同时作废 lastEquippedSid——失败
+      // equip 后紧随的引导卡不得回退定向到历史成功 equip 的无关会话(与 tauri 对齐,二审补充)。
+      lastEquippedSid = null;
+      if (sid === state.activeSessionId) addSystemItem(bt("equipFailed") + e);
+      return null;
+    }
   }
   // 摘下当前 session 的专家面具。
   async function unequipPersona() {
     if (!state.activeSessionId) return;
     // 入口捕获触发会话：await 期间切走，卸下播报不得写进别的会话（与 tauri 对齐，审计）。
     var sid = state.activeSessionId;
-    var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
     if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
     personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(与 tauri 对齐，审计补充)
+    // 旧专家同样在写点复核：await 窗口内若已被 equip 换成新卡,播报新卡,
+    // 入口捕获的陈旧值会重复播报早已卸下的旧卡(与 tauri 对齐,二审补充)。
+    var prev = state.activePersona;
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6686,9 +6686,11 @@
     var pending = overview && Array.isArray(overview.pending) ? overview.pending : [];
     pending.forEach(upsertPendingMemoryCandidate);
   }
-  // 记忆是会话级数据：加载必须带归属+序号校验（与 tauri memory.js 对齐，
-  // 审计）。await 挂起期间切会话或再次加载，旧响应不得覆盖当前显示，
-  // 也不得把上一个会话的 pending 候选卡 rehydrate 进当前对话流。
+  // 记忆面板混合两类数据：runtime 按 session 分文件，profile/preferences/
+  // pending 等为全局单文件(见后端 paths.rs)。加载仍必须带归属+序号校验
+  // (与 tauri memory.js 对齐，审计)：await 挂起期间切会话或再次加载，旧
+  // 响应不得覆盖当前显示(尤其 runtime 属于别的会话)，也不得把候选卡
+  // rehydrate 进当前对话流。
   var memoryOverviewSeq = 0;
   async function loadMemoryOverview(options) {
     if (!invoke) return null;
@@ -6699,49 +6701,69 @@
     notify();
     try {
       var overview = await invoke("get_memory_overview", { sessionId: state.activeSessionId });
-      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return discardStaleLoad(seq);
       applyMemoryOverview(overview);
       if (options.rehydratePending) rehydratePendingMemoryCandidates(overview);
       notify();
       return overview;
     } catch (e) {
-      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return null;
+      if (sid !== state.activeSessionId || seq !== memoryOverviewSeq) return discardStaleLoad(seq);
       state.memory = Object.assign({}, state.memory, { loading: false, error: String(e) });
       notify();
       return null;
     }
   }
+  // 守卫命中的善后：序号已被更新加载接管时由它负责收尾 loading；仅会话
+  // 变化、无人接管时(如切草稿不续发加载)必须自己清掉 loading，否则面板
+  // 永远停在"同步中"(与 tauri 对齐，审计补充)。
+  function discardStaleLoad(seq) {
+    if (seq === memoryOverviewSeq) {
+      state.memory = Object.assign({}, state.memory, { loading: false });
+      notify();
+    }
+    return null;
+  }
   async function saveMemoryProfilePatch(patch) {
     if (!invoke) return null;
+    // 入口捕获触发会话：invoke 往返期间切走，A 的写结果/错误不得渲染进
+    // B 的面板(与 tauri memory.js 对齐，审计补充)。
+    var sid = state.activeSessionId;
     try {
       var result = await invoke("update_memory_profile", { patch: patch || {}, sessionId: state.activeSessionId });
-      applyMemoryProfileState(result);
-      notify();
+      if (sid === state.activeSessionId) { applyMemoryProfileState(result); notify(); }
       var overview = await loadMemoryOverview();
       return overview || result;
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function deleteMemoryPreference(id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(与 tauri 对齐，审计补充)
     try {
       var res = await invoke("delete_memory_preference", { id: id, sessionId: state.activeSessionId });
-      applyMemoryWriteState(res, function (next, changed) {
-        if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (changed) next.preferences = (next.preferences || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function updateMemoryItem(kind, id, patch) {
     if (!id || !invoke) return null;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(与 tauri 对齐，审计补充)
     try {
       var command = kind === "preference" ? "update_memory_preference"
         : kind === "work_context" ? "update_work_context_memory"
@@ -6751,21 +6773,26 @@
       var args = { id: id, patch: patch || {}, sessionId: state.activeSessionId };
       if (command === "update_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
-      applyMemoryWriteState(res, function (next, value) {
-        if (!value) return;
-        var source = kind === "preference" ? "preferences" : kind;
-        next[source] = upsertMemoryValue(next[source], value, id);
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, value) {
+          if (!value) return;
+          var source = kind === "preference" ? "preferences" : kind;
+          next[source] = upsertMemoryValue(next[source], value, id);
+        });
+      }
       await loadMemoryOverview();
       return res && res.value;
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function deleteMemoryItem(kind, id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(与 tauri 对齐，审计补充)
     try {
       var command = kind === "preference" ? "delete_memory_preference"
         : kind === "work_context" ? "delete_work_context_memory"
@@ -6775,77 +6802,94 @@
       var args = { id: id, sessionId: state.activeSessionId };
       if (command === "delete_timed_memory") args.kind = kind;
       var res = await invoke(command, args);
-      applyMemoryWriteState(res, function (next, changed) {
-        if (!changed) return;
-        var source = kind === "preference" ? "preferences" : kind;
-        next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (!changed) return;
+          var source = kind === "preference" ? "preferences" : kind;
+          next[source] = (next[source] || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function archiveRecentWorkMemory(id) {
     if (!id || !invoke) return false;
+    var sid = state.activeSessionId; // 同 saveMemoryProfilePatch：切走后不写 B 的面板(与 tauri 对齐，审计补充)
     try {
       var res = await invoke("archive_recent_work_memory", { id: id, sessionId: state.activeSessionId });
-      applyMemoryWriteState(res, function (next, changed) {
-        if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
-      });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(res, function (next, changed) {
+          if (changed) next.recent_work = (next.recent_work || []).filter(function (item) { return item.id !== id; });
+        });
+      }
       await loadMemoryOverview();
       return !!(res && res.value);
     } catch (e) {
-      state.memory = Object.assign({}, state.memory, { error: String(e) });
-      notify();
+      if (sid === state.activeSessionId) {
+        state.memory = Object.assign({}, state.memory, { error: String(e) });
+        notify();
+      }
       throw e;
     }
   }
   async function confirmMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 入口捕获：候选卡 patch 与面板写入都定向回发起会话(与 tauri 对齐，审计补充)
     try {
       var result = await invoke("confirm_pending_memory", { id: memoryId, sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已记住" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      // patch 必须按发起会话路由(而非当前显示)：切走后写 B 的 chatItems 是
+      // no-op，A 的候选卡会永远停留在"可点击未决"态，切回再点会二次提交。
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "已记住" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryWriteFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryWriteFailed") + e);
     }
   }
   async function ignoreMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 同 confirmMemoryCandidate：定向回发起会话(与 tauri 对齐，审计补充)
     try {
       var result = await invoke("ignore_pending_memory", { id: memoryId, sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "已忽略" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "已忽略" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryIgnoreFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryIgnoreFailed") + e);
     }
   }
   async function neverMemoryCandidate(memoryId, chatItemId) {
     if (!memoryId) return;
-    var sid = state.activeSessionId;
+    var sid = state.activeSessionId; // 同 confirmMemoryCandidate：定向回发起会话(与 tauri 对齐，审计补充)
     try {
       var result = await invoke("never_pending_memory", { id: memoryId, reason: "user_selected", sessionId: sid });
-      applyMemoryWriteState(result, function (next) {
-        next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
-      });
-      if (chatItemId) patchItemById(chatItemId, { resolved: true, statusLabel: "不再提示" });
+      if (sid === state.activeSessionId) {
+        applyMemoryWriteState(result, function (next) {
+          next.pending = (next.pending || []).filter(function (item) { return item.id !== memoryId; });
+        });
+      }
+      if (chatItemId) patchItemByIdFor(sid, chatItemId, { resolved: true, statusLabel: "不再提示" });
       await loadMemoryOverview();
       notify();
     } catch (e) {
-      addSystemItem(bt("memoryNeverFailed") + e);
+      if (sid === state.activeSessionId) addSystemItem(bt("memoryNeverFailed") + e);
     }
   }
   // ── 思考指示器状态（每次阶段切换重置计时）──────────────────────
@@ -7665,6 +7709,7 @@
     var prev = state.activePersona; // 换卡前的旧专家(同 session 切换时先播报卸下)
     try {
       var card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId: personaId });
+      lastEquippedSid = sid; // 成功加持的目标会话(即使已切走)：供紧随其后的引导卡定向(与 tauri 对齐，审计补充)
       if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
       // 用户已主动改名 / 已被首条消息命名的会话不动)。决策:卡牌优先于首条消息。
@@ -7685,6 +7730,7 @@
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
         recordPersonaEvent({ kind: "unequip", name: personaName(prev) });
       }
+      personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(与 tauri 对齐，审计补充)
       state.activePersona = card;
       addChatItem({ type: "persona_equip", card: card, time: timeStr() });
       recordPersonaEvent({ kind: "equip", card: card });
@@ -7700,19 +7746,43 @@
     var prev = state.activePersona;
     try { await invoke("unequip_persona", { sessionId: state.activeSessionId }); } catch (e) { /* 忽略,前端照样摘 */ }
     if (sid !== state.activeSessionId) return; // 已切走：不写当前显示
+    personaSyncSeq++; // 权威写前 bump：作废在途 syncActivePersona 的旧快照(与 tauri 对齐，审计补充)
     state.activePersona = null;
     if (prev) { addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() }); recordPersonaEvent({ kind: "unequip", name: personaName(prev) }); }
     notify();
   }
+  // 挂件还原的请求序号 + 最近成功加持的目标会话(与 tauri personas.js 对齐)：
+  // - syncActivePersona 仅 sid 校验挡不住 A→B→A 的 ABA 与同会话乱序(慢响应
+  //   返回 null 会把刚加持的挂件覆盖掉,且无人再纠正)。序号在每次 sync 发起
+  //   与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
+  // - lastEquippedSid 供 equip 后紧随的播报(如卡牌制造者引导卡)定向回
+  //   发起会话——equip 的 await 窗口用户可能已切走。
+  var personaSyncSeq = 0;
+  var lastEquippedSid = null;
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
   async function syncActivePersona() {
     if (!state.activeSessionId) { state.activePersona = null; return; }
     var sid = state.activeSessionId;
+    var seq = ++personaSyncSeq;
     try {
       var persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
-      if (sid !== state.activeSessionId) return; // 已切走：陈旧快照不得覆盖新会话挂件（与 tauri 对齐，审计）
+      if (sid !== state.activeSessionId || seq !== personaSyncSeq) return; // 已切走或被权威写/新 sync 作废
       state.activePersona = persona;
     } catch (e) { /* 旧 session 无加持,忽略 */ }
+  }
+  // 在【指定 session】追加卡牌制造者引导卡并落 sidecar(持久化,重载按 pos 插回)。
+  // 默认定向最近一次成功 equip 的目标会话：AI 造卡链路 equip→intro 之间用户
+  // 切走时,intro 必须仍落在发起(已加持)会话,而不是写进切走后的当前显示
+  // (错误会话被插卡是持久化污染,不可自愈)。显式传 sid 可覆盖(与 tauri 对齐，
+  // 审计补充)。
+  function postCardCreatorIntro(sid) {
+    var target = sid || lastEquippedSid || state.activeSessionId;
+    if (!target) return;
+    runOnSession(target, function () {
+      addChatItem({ type: "card_creator_intro", time: "" });
+      recordPersonaEvent({ kind: "card_creator_intro" });
+      notify();
+    });
   }
 
   // ── 多知识库挂载(会话级粘连,仿 persona) ──
@@ -8951,7 +9021,7 @@
     neverMemoryCandidate: neverMemoryCandidate,
     // AI 造卡开场引导卡:落一条展示气泡 + 记一条 persona 事件(随会话持久化)。
     // 走 personaEvents 时间线,冷重载时 rerenderFromMessages 按 pos 还原 → 切会话/重启不丢。
-    postCardCreatorIntro: function () { addChatItem({ type: "card_creator_intro", time: "" }); recordPersonaEvent({ kind: "card_creator_intro" }); notify(); },
+    postCardCreatorIntro: postCardCreatorIntro,
     // 用户自创卡
     createPersona: createPersona,
     updatePersona: updatePersona,

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * 子代理全量审计产出的同类竞态回归测试（PR #250 延续）：
+ * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
+ * 覆盖 tauri memory/personas/workflow/settings 四个可单测 feature；
+ * sessions.js（ensureSession/refreshHistoryList/archiveSession）内部依赖
+ * 太重（sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+/** 通用 feature 装载器：vm 加载 IIFE(window) 形态的桥 feature 文件。 */
+function loadFeature(fileName, state, contextOverrides) {
+  const root = { __PINVOU_SHARED_I18N__: {} };
+  const src = fs.readFileSync(path.join(bridgeDir, fileName), 'utf8');
+  vm.runInNewContext(src, {
+    window: root,
+    globalThis: root,
+    setTimeout,
+    clearTimeout,
+  });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__[fileName.replace('.js', '')];
+  const deferreds = {};
+  const calls = { invoke: [] };
+  const api = factory(Object.assign({
+    state,
+    notify() { calls.notify = (calls.notify || 0) + 1; },
+    bt(key) { return key; },
+    addSystemItem() {},
+    addChatItem() {},
+    timeStr() { return ''; },
+    invoke(name, args) {
+      calls.invoke.push(name);
+      if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+      return Promise.resolve({});
+    },
+  }, contextOverrides || {}));
+  return {
+    api,
+    state,
+    calls,
+    defer(name) {
+      // 每次创建全新对象：同一 invoke 名的第二次 defer 不得覆盖第一次的
+      // resolve（否则旧 promise 永远无人 resolve → 测试挂起）。
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+  };
+}
+
+// ── memory.js：loadMemoryOverview 陈旧覆盖 ──────────────────────────
+
+function loadMemoryFeature() {
+  const state = {
+    activeSessionId: 'chat-a',
+    memory: { loading: false, profile: null, preferences: [], work_context: [], pending: [], never: [] },
+    chatItems: [],
+    messages: [],
+  };
+  return loadFeature('memory.js', state, {
+    runSyncOnSession(sid, fn) { fn(); },
+    runOnSession(sid, fn) { fn(); },
+    patchItemById() {},
+  });
+}
+
+test('loadMemoryOverview 切走后旧响应不覆盖当前会话记忆', async () => {
+  const rt = loadMemoryFeature();
+  const get = rt.defer('get_memory_overview');
+  const p = rt.api.loadMemoryOverview();            // A 会话发起
+  rt.state.activeSessionId = 'chat-b';              // 切走
+  get.resolve({ profile: { name: 'A 的记忆' }, preferences: [] });
+  await p;
+  assert.equal(rt.state.memory.profile, null, '陈旧响应不得把 A 的记忆写进 B 的显示');
+});
+
+test('loadMemoryOverview 同会话两次加载：旧响应作废、新响应生效', async () => {
+  const rt = loadMemoryFeature();
+  const g1 = rt.defer('get_memory_overview');
+  const p1 = rt.api.loadMemoryOverview();           // 加载 1
+  const g2 = rt.defer('get_memory_overview');
+  const p2 = rt.api.loadMemoryOverview();           // 加载 2（序号递增）
+  g1.resolve({ profile: { name: '旧' }, preferences: [] });
+  await p1;
+  assert.equal(rt.state.memory.profile, null, '旧加载的响应必须被序号作废');
+  g2.resolve({ profile: { name: '新' }, preferences: [] });
+  await p2;
+  assert.equal(rt.state.memory.profile.name, '新', '新加载正常写入');
+});
+
+// ── personas.js：equip/unequip/syncActivePersona 写入漂移 ───────────
+
+function loadPersonasFeature() {
+  const state = {
+    activeSessionId: 'chat-a',
+    personaPool: { loadState: 'ready' },
+    activePersona: null,
+    personaEvents: [],
+    sessions: [{ id: 'chat-a', title: '新对话' }],
+    settings: { language: 'zh' },
+    messages: [],
+    chatItems: [],
+  };
+  return loadFeature('personas.js', state, {
+    ensureSession: async () => state.activeSessionId,
+    personaPlaceholderTitles: {},
+    isDefaultChatTitle(title) { return !title || title === '新对话'; },
+    listen() {},
+    __root: undefined,
+  });
+}
+
+test('equipPersona 切走后不得改名字/插卡/写挂件（错误会话污染）', async () => {
+  const rt = loadPersonasFeature();
+  const equip = rt.defer('equip_persona');
+  const p = rt.api.equipPersona('persona-x');       // A 会话发起
+  rt.state.activeSessionId = 'chat-b';              // 切走
+  equip.resolve({ id: 'persona-x', name: '专家X' });
+  await p;
+  assert.equal(rt.state.activePersona, null, '不得把加持写进切走后的会话');
+  assert.equal(rt.state.personaEvents.length, 0, '不得在切走后的会话记 persona 事件');
+  assert.equal(rt.calls.invoke.includes('rename_session'), false, '不得重命名切走后的会话');
+  assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入加持卡');
+});
+
+test('syncActivePersona 切走后陈旧快照不覆盖新会话挂件', async () => {
+  const rt = loadPersonasFeature();
+  const get = rt.defer('get_active_persona');
+  const p = rt.api.syncActivePersona();             // A 发起
+  rt.state.activeSessionId = 'chat-b';              // 切走
+  get.resolve({ id: 'persona-a', name: 'A专家' });
+  await p;
+  assert.equal(rt.state.activePersona, null, '陈旧快照不得覆盖切走后的挂件');
+});
+
+test('unequipPersona 切走后卸下播报不写进别的会话', async () => {
+  const rt = loadPersonasFeature();
+  rt.state.activePersona = { id: 'persona-a', name: 'A专家' };
+  const unequip = rt.defer('unequip_persona');
+  const p = rt.api.unequipPersona();                // A 会话发起
+  rt.state.activeSessionId = 'chat-b';              // 切走
+  unequip.resolve({});
+  await p;
+  assert.equal(rt.state.activePersona.id, 'persona-a', '切走后不得清空当前会话的挂件');
+  assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入卸下系统消息');
+});
+
+// ── workflow.js：openDemo 陈旧覆盖 / stopWorkflowTask 覆盖新 run ────
+

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -1,9 +1,10 @@
 /**
- * 子代理全量审计产出的同类竞态回归测试（PR #250 延续）：
+ * 子代理全量审计产出的同类竞态回归测试（PR #250 系列，域 D / PR #258）：
  * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
- * 覆盖 tauri memory/personas/workflow/settings 四个可单测 feature；
- * sessions.js（ensureSession/refreshHistoryList/archiveSession）内部依赖
- * 太重（sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
+ * 覆盖 tauri memory/personas 两个可单测 feature 的跨会话竞态；
+ * workflow/settings 域由后续拆分 PR 另行覆盖。sessions.js
+ * （ensureSession/refreshHistoryList/archiveSession）内部依赖太重
+ * （sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
  */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -14,12 +15,6 @@ import { fileURLToPath } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
-
-function deferred() {
-  let resolve, reject;
-  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
-  return { promise, resolve, reject };
-}
 
 /** 通用 feature 装载器：vm 加载 IIFE(window) 形态的桥 feature 文件。 */
 function loadFeature(fileName, state, contextOverrides) {
@@ -159,5 +154,18 @@ test('unequipPersona 切走后卸下播报不写进别的会话', async () => {
   assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入卸下系统消息');
 });
 
-// ── workflow.js：openDemo 陈旧覆盖 / stopWorkflowTask 覆盖新 run ────
+test('equipPersona rename 挂起期间切走：不插卡/不写挂件/不记事件', async () => {
+  const rt = loadPersonasFeature();
+  const equip = rt.defer('equip_persona');
+  const rename = rt.defer('rename_session');
+  const p = rt.api.equipPersona('persona-x');       // A 会话发起，标题默认 → 走 rename 分支
+  equip.resolve({ id: 'persona-x', name: '专家X' });
+  await new Promise(r => setTimeout(r, 0));          // 推进微任务：equip 恢复并挂起在 rename
+  rt.state.activeSessionId = 'chat-b';               // rename 挂起期间切走
+  rename.resolve({});
+  await p;
+  assert.equal(rt.state.activePersona, null, '不得把加持写进切走后的会话');
+  assert.equal(rt.state.personaEvents.length, 0, '不得在切走后的会话记 persona 事件');
+  assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入加持卡');
+});
 

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -1,7 +1,9 @@
 /**
  * 子代理全量审计产出的同类竞态回归测试（PR #250 系列，域 D / PR #258）：
  * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
- * 覆盖 tauri memory/personas 两个可单测 feature 的跨会话竞态；
+ * 覆盖 tauri memory/personas 两个可单测 feature 的跨会话竞态（含写函数
+ * sid 守卫、候选卡按发起会话路由、syncActivePersona 序号作废、引导卡
+ * 定向）；web 侧镜像守卫由 memory_personas_race_web.test.mjs 覆盖。
  * workflow/settings 域由后续拆分 PR 另行覆盖。sessions.js
  * （ensureSession/refreshHistoryList/archiveSession）内部依赖太重
  * （sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
@@ -33,8 +35,8 @@ function loadFeature(fileName, state, contextOverrides) {
     state,
     notify() { calls.notify = (calls.notify || 0) + 1; },
     bt(key) { return key; },
-    addSystemItem() {},
-    addChatItem() {},
+    addSystemItem(text) { state.chatItems.push({ type: 'system', text, id: 'sys-' + (state.chatItems.length + 1) }); },
+    addChatItem(item) { item.id = item.id || ('item-' + (state.chatItems.length + 1)); state.chatItems.push(item); },
     timeStr() { return ''; },
     invoke(name, args) {
       calls.invoke.push(name);
@@ -66,11 +68,22 @@ function loadMemoryFeature() {
     chatItems: [],
     messages: [],
   };
-  return loadFeature('memory.js', state, {
+  const routedPatches = [];
+  return Object.assign(loadFeature('memory.js', state, {
     runSyncOnSession(sid, fn) { fn(); },
     runOnSession(sid, fn) { fn(); },
-    patchItemById() {},
-  });
+    patchItemById(id, patch) {
+      const it = state.chatItems.find(i => i.id === id);
+      if (it) Object.assign(it, patch);
+    },
+    patchItemByIdFor(sid, id, patch) {
+      routedPatches.push({ sid, id, patch });
+      if (sid === state.activeSessionId) {
+        const it = state.chatItems.find(i => i.id === id);
+        if (it) Object.assign(it, patch);
+      }
+    },
+  }), { routedPatches });
 }
 
 test('loadMemoryOverview 切走后旧响应不覆盖当前会话记忆', async () => {
@@ -97,6 +110,54 @@ test('loadMemoryOverview 同会话两次加载：旧响应作废、新响应生�
   assert.equal(rt.state.memory.profile.name, '新', '新加载正常写入');
 });
 
+test('loadMemoryOverview 反序返回：旧响应后到不得回退新数据', async () => {
+  const rt = loadMemoryFeature();
+  const g1 = rt.defer('get_memory_overview');
+  const p1 = rt.api.loadMemoryOverview();           // 加载 1
+  const g2 = rt.defer('get_memory_overview');
+  const p2 = rt.api.loadMemoryOverview();           // 加载 2（序号递增）
+  g2.resolve({ profile: { name: '新' }, preferences: [] }); // 新响应先回
+  await p2;
+  assert.equal(rt.state.memory.profile.name, '新');
+  g1.resolve({ profile: { name: '旧' }, preferences: [] }); // 旧响应后到
+  await p1;
+  assert.equal(rt.state.memory.profile.name, '新', '乱序晚到的旧响应不得回退新数据');
+});
+
+test('loadMemoryOverview 切草稿后旧响应作废且 loading 被收尾', async () => {
+  const rt = loadMemoryFeature();
+  const get = rt.defer('get_memory_overview');
+  const p = rt.api.loadMemoryOverview();            // A 会话发起
+  rt.state.activeSessionId = null;                  // 切草稿(enterDraft 不续发加载)
+  get.resolve({ profile: { name: 'A 的记忆' }, preferences: [] });
+  await p;
+  assert.equal(rt.state.memory.profile, null, '陈旧响应不得写进草稿态');
+  assert.equal(rt.state.memory.loading, false, '无人接管的失效加载必须自己清掉 loading');
+});
+
+test('loadMemoryOverview 失败响应切走后不得写进当前面板 error', async () => {
+  const rt = loadMemoryFeature();
+  const get = rt.defer('get_memory_overview');
+  const p = rt.api.loadMemoryOverview();
+  rt.state.activeSessionId = 'chat-b';
+  get.reject(new Error('boom'));
+  await p;
+  assert.equal(rt.state.memory.error, null, '陈旧会话的加载失败不得显示在 B 的面板');
+});
+
+test('confirmMemoryCandidate 切走后：候选卡按发起会话路由、B 面板不被写入', async () => {
+  const rt = loadMemoryFeature();
+  const confirm = rt.defer('confirm_pending_memory');
+  const p = rt.api.confirmMemoryCandidate('mem-1', 'item-1');   // A 会话确认候选卡
+  rt.state.activeSessionId = 'chat-b';                          // invoke 往返期间切走
+  confirm.resolve({ value: true, runtime: null, warnings: [] });
+  await p;
+  assert.equal(rt.routedPatches.length, 1, '候选卡 patch 必须被路由(而非丢弃)');
+  assert.equal(rt.routedPatches[0].sid, 'chat-a', 'patch 必须路由回发起会话 A');
+  assert.equal(rt.routedPatches[0].patch.resolved, true, '候选卡必须被标记为已记住');
+  assert.equal(rt.state.chatItems.length, 0, 'B 的对话流不得被写入 A 的候选卡状态');
+});
+
 // ── personas.js：equip/unequip/syncActivePersona 写入漂移 ───────────
 
 function loadPersonasFeature() {
@@ -105,18 +166,27 @@ function loadPersonasFeature() {
     personaPool: { loadState: 'ready' },
     activePersona: null,
     personaEvents: [],
-    sessions: [{ id: 'chat-a', title: '新对话' }],
+    // chat-b 也在列表里：旧代码在 await 后重读 sid，会命中 chat-b 并对其
+    // rename——使「不得重命名切走后的会话」断言具备判别力。
+    sessions: [{ id: 'chat-a', title: '新对话' }, { id: 'chat-b', title: '新对话' }],
     settings: { language: 'zh' },
     messages: [],
     chatItems: [],
   };
-  return loadFeature('personas.js', state, {
+  const routedCalls = [];
+  return Object.assign(loadFeature('personas.js', state, {
     ensureSession: async () => state.activeSessionId,
     personaPlaceholderTitles: {},
     isDefaultChatTitle(title) { return !title || title === '新对话'; },
     listen() {},
-    __root: undefined,
-  });
+    // 模拟 per-session UI 路由：目标是当前显示时立即执行；切走后台时只记录
+    // (生产环境会写进目标会话的 buffer，不影响当前显示)。
+    runOnSession(sid, fn) {
+      const executed = sid === state.activeSessionId;
+      routedCalls.push({ sid, executed });
+      if (executed) fn();
+    },
+  }), { routedCalls });
 }
 
 test('equipPersona 切走后不得改名字/插卡/写挂件（错误会话污染）', async () => {
@@ -142,6 +212,20 @@ test('syncActivePersona 切走后陈旧快照不覆盖新会话挂件', async ()
   assert.equal(rt.state.activePersona, null, '陈旧快照不得覆盖切走后的挂件');
 });
 
+test('syncActivePersona 慢响应不得覆盖权威 equip（同会话乱序）', async () => {
+  const rt = loadPersonasFeature();
+  const sync = rt.defer('get_active_persona');      // sync 先发起，读到旧值(无卡)
+  const syncP = rt.api.syncActivePersona();         // seq=1，挂起
+  const equip = rt.defer('equip_persona');
+  const equipP = rt.api.equipPersona('persona-x');  // 同会话权威写
+  equip.resolve({ id: 'persona-x', name: '专家X' }); // equip 完成:seq bump + 写挂件
+  await equipP;
+  assert.equal(rt.state.activePersona.id, 'persona-x');
+  sync.resolve(null);                                // 慢的 sync 后到,读到的是旧快照
+  await syncP;
+  assert.equal(rt.state.activePersona.id, 'persona-x', '慢 sync 的旧快照不得覆盖刚加持的挂件');
+});
+
 test('unequipPersona 切走后卸下播报不写进别的会话', async () => {
   const rt = loadPersonasFeature();
   rt.state.activePersona = { id: 'persona-a', name: 'A专家' };
@@ -150,7 +234,8 @@ test('unequipPersona 切走后卸下播报不写进别的会话', async () => {
   rt.state.activeSessionId = 'chat-b';              // 切走
   unequip.resolve({});
   await p;
-  assert.equal(rt.state.activePersona.id, 'persona-a', '切走后不得清空当前会话的挂件');
+  assert.ok(rt.state.activePersona, '切走后不得清空当前会话的挂件');
+  assert.equal(rt.state.activePersona.id, 'persona-a');
   assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入卸下系统消息');
 });
 
@@ -169,3 +254,17 @@ test('equipPersona rename 挂起期间切走：不插卡/不写挂件/不记事�
   assert.equal(rt.state.chatItems.length, 0, '不得在切走后的会话插入加持卡');
 });
 
+test('postCardCreatorIntro 默认定向最近 equip 的会话，切走后不串台', async () => {
+  const rt = loadPersonasFeature();
+  const equip = rt.defer('equip_persona');
+  const p = rt.api.equipPersona('pinvou-card-creator'); // A 会话发起(AI 造卡链路)
+  rt.state.activeSessionId = 'chat-b';                 // equip 往返期间切走
+  equip.resolve({ id: 'pinvou-card-creator', name: '卡牌制造专家' });
+  await p;
+  rt.api.postCardCreatorIntro();                       // 引导卡必须仍落在 A(发起会话)
+  assert.equal(rt.routedCalls.length, 1, '引导卡必须被 per-session 路由');
+  assert.equal(rt.routedCalls[0].sid, 'chat-a', '引导卡必须定向到最近 equip 的发起会话');
+  assert.equal(rt.routedCalls[0].executed, false, '已切走时不得写进当前显示(B)');
+  assert.equal(rt.state.chatItems.length, 0, 'B 的对话流不得被插入 A 的引导卡');
+  assert.equal(rt.state.personaEvents.length, 0, 'B 不得被记 persona 事件');
+});

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -268,3 +268,60 @@ test('postCardCreatorIntro 默认定向最近 equip 的会话，切走后不串�
   assert.equal(rt.state.chatItems.length, 0, 'B 的对话流不得被插入 A 的引导卡');
   assert.equal(rt.state.personaEvents.length, 0, 'B 不得被记 persona 事件');
 });
+
+// ── 二审补充：失败分支归属与同会话重入的陈旧值 ───────────────────────
+
+test('equipPersona 失败且切走后：失败气泡不落别的会话，lastEquippedSid 作废', async () => {
+  const rt = loadPersonasFeature();
+  // 前置：A 会话历史成功加持(旧代码失败后 intro 会回退定向到该会话)
+  const prior = rt.defer('equip_persona');
+  const priorP = rt.api.equipPersona('persona-a');
+  prior.resolve({ id: 'persona-a', name: 'A专家' });
+  await priorP;
+  assert.ok(rt.state.activePersona, '前置：A 已挂卡');
+  // 再次发起 equip，后端失败；invoke 往返期间切走
+  const equip = rt.defer('equip_persona');
+  const p = rt.api.equipPersona('pinvou-card-creator');
+  rt.state.activeSessionId = 'chat-b';
+  equip.reject(new Error('boom'));
+  const card = await p;
+  assert.equal(card, null, '失败必须返回 null(调用方据此跳过引导卡)');
+  assert.ok(!rt.state.chatItems.some(i => (i.text || '').startsWith('equipFailed')),
+    '失败气泡不得插进 await 窗口内切到的会话(随消息流持久化)');
+  rt.api.postCardCreatorIntro(); // 即便被误调，也不得回退定向到历史成功 equip 的 A
+  assert.equal(rt.routedCalls[0].sid, 'chat-b',
+    'lastEquippedSid 已作废：不得把引导卡定向到与本次造卡无关的历史会话 A');
+});
+
+test('同会话连续换卡：第二次换卡播报实际被换下的新卡，而非入口捕获的陈旧旧卡', async () => {
+  const rt = loadPersonasFeature();
+  rt.state.activePersona = { id: 'persona-a', name: 'A专家' }; // A 会话已挂旧卡
+  const equip1 = rt.defer('equip_persona');
+  const p1 = rt.api.equipPersona('persona-c1');      // 第一次换卡发起,挂起
+  const equip2 = rt.defer('equip_persona');
+  const p2 = rt.api.equipPersona('persona-c2');      // 第一次完成前又发起第二次(重入)
+  equip1.resolve({ id: 'persona-c1', name: 'C1' });
+  await p1;
+  equip2.resolve({ id: 'persona-c2', name: 'C2' });
+  await p2;
+  const unequips = rt.state.personaEvents.filter(e => e.kind === 'unequip');
+  assert.equal(unequips.length, 2, '两次换卡各播报一次卸下');
+  assert.equal(unequips[0].name, 'A专家', '第一次换卡播报换下原卡');
+  assert.equal(unequips[1].name, 'C1', '第二次换卡必须播报写点复核到的 C1(陈旧入口值会重复播报 A)');
+  assert.equal(rt.state.activePersona.id, 'persona-c2', '终态挂件为最后 equip 的卡');
+});
+
+test('equip 挂起期间 unequip 先完成：不重复播报入口捕获的旧卡', async () => {
+  const rt = loadPersonasFeature();
+  rt.state.activePersona = { id: 'persona-a', name: 'A专家' };
+  const equip = rt.defer('equip_persona');
+  const p1 = rt.api.equipPersona('persona-x');       // equip 挂起(入口时刻 activePersona=A)
+  const p2 = rt.api.unequipPersona();                // equip 完成前先摘下(播报卸下 A)
+  await p2;
+  equip.resolve({ id: 'persona-x', name: '专家X' }); // equip 后到
+  await p1;
+  const unequips = rt.state.personaEvents.filter(e => e.kind === 'unequip');
+  assert.equal(unequips.length, 1, '只播报一次卸下(陈旧入口 prev 会重复播报)');
+  assert.equal(unequips[0].name, 'A专家');
+  assert.equal(rt.state.activePersona.id, 'persona-x', '最后完成的 equip 为终态');
+});

--- a/pinvou3-app/tests/memory_personas_race_web.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race_web.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * web 桥（platform/web/bridge.js）记忆/专家卡跨会话竞态回归测试（PR #258）。
+ * tauri 侧由 memory_personas_race.test.mjs 覆盖；web 桥是独立文本镜像，
+ * 单独锁定，防止未来只同步一侧时漏改守卫。
+ *
+ * 状态访问说明：flat.getState() 返回 structuredClone 快照（写它无效），
+ * 断言前必须重新拉快照；「切走」用 createNewSession()（即 enterDraft，
+ * activeSessionId → null，零 invoke）驱动——这正是审计发现的 enterDraft
+ * 高危路径，与切到 B 会话命中同一守卫分支。会话 A 的物化走真实 lazy-session
+ * 链路（草稿态 equipPersona → ensureSession → web_access_create_session）。
+ * 启动方式复用 web_bridge_domain_contract.test.mjs：vm 整体装载 web 桥
+ * + domain-adapter，invoke 注入 per-command deferred。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const webBridgeRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'platform', 'web');
+const read = relativePath => fs.readFileSync(path.join(webBridgeRoot, relativePath), 'utf8');
+
+function bootWebBridge() {
+  const storage = new Map();
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+  const documentObject = {
+    readyState: 'loading',
+    addEventListener() {},
+    createElement() { return { click() {}, remove() {}, style: {}, setAttribute() {} }; },
+    body: { appendChild() {} },
+  };
+  const calls = { invoke: [] };
+  const handlers = {
+    list_sessions: () => Promise.resolve([{ id: 'chat-a', title: '新对话', updated_at: 1 }]),
+  };
+  const listeners = {};
+  const deferreds = {};
+  const windowObject = {
+    PinvouPlatform: { kind: 'web', isWeb: true, capabilities: {}, can: () => false, canInvoke: () => false },
+    __TAURI__: {
+      core: { invoke: (name, args) => {
+        calls.invoke.push(name);
+        if (handlers[name]) return handlers[name](args);
+        if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+        return Promise.resolve(null);
+      } },
+      event: { listen: async (name, fn) => { (listeners[name] = listeners[name] || []).push(fn); return function () {}; } },
+      dialog: { open: async () => null },
+    },
+    location: { search: '', href: 'https://example.test/pinvou3/remote/' },
+    localStorage,
+    crypto: { randomUUID: () => '00000000-0000-4000-8000-000000000000' },
+    performance: { now: () => 0 },
+    addEventListener() {},
+    setTimeout,
+    clearTimeout,
+  };
+  const context = vm.createContext({
+    window: windowObject,
+    document: documentObject,
+    navigator: { mediaDevices: null },
+    localStorage,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    structuredClone,
+    URL,
+    URLSearchParams,
+    Blob,
+    Uint8Array,
+    ArrayBuffer,
+    TextEncoder,
+    TextDecoder,
+  });
+  vm.runInContext(read('bridge.js'), context, { filename: 'platform/web/bridge.js' });
+  const flat = windowObject.TauriBridge;
+  assert.equal(typeof flat.getState, 'function', 'Web transport must expose its private flat state');
+  vm.runInContext(read('bridge/domain-adapter.js'), context, { filename: 'platform/web/bridge/domain-adapter.js' });
+  const api = windowObject.TauriBridge;
+  return {
+    flat,
+    calls,
+    // 断言用：每次读桥内最新快照（写快照无效）。
+    view() { return flat.getState(); },
+    // 切走：enterDraft 把 activeSessionId 置 null（零 invoke）。
+    leave() { flat.createNewSession(); },
+    defer(name) {
+      // 每次创建全新对象：同一 invoke 名的第二次 defer 不得覆盖第一次的 resolve。
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+    emit(name, payload) { (listeners[name] || []).forEach(fn => fn({ payload })); },
+    personas: api.personas,
+    memory: api.memory,
+  };
+}
+
+// 物化会话 A 并挂上一张引导卡：走真实 lazy-session 链路(草稿 equip →
+// ensureSession → web_access_create_session → equip_persona 全 happy path)。
+async function primeSessionA(rt) {
+  const create = rt.defer('web_access_create_session');
+  const equip = rt.defer('equip_persona');
+  const rename = rt.defer('rename_session');
+  const p = rt.personas.equipPersona('persona-prime');
+  create.resolve({ id: 'chat-a', transcript_revision: 1 });
+  await new Promise(r => setTimeout(r, 0)); // ensureSession 链推进到 equip_persona
+  equip.resolve({ id: 'persona-prime', name: '引导卡' });
+  await new Promise(r => setTimeout(r, 0)); // equip 恢复并挂起在 rename(标题默认)
+  rename.resolve({});
+  await p;
+  const view = rt.view();
+  assert.equal(view.activeSessionId, 'chat-a', 'precondition: chat-a must be active');
+  assert.equal(view.activePersona && view.activePersona.id, 'persona-prime', 'precondition: persona mounted');
+  return view;
+}
+
+test('web: loadMemoryOverview 切走后旧响应不覆盖当前显示', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const get = rt.defer('get_memory_overview');
+  const p = rt.memory.loadMemoryOverview();
+  rt.leave(); // 切草稿
+  get.resolve({ profile: { name: 'A 的记忆' }, preferences: [] });
+  await p;
+  const view = rt.view();
+  assert.equal(view.memory.profile, null, '陈旧响应不得把 A 的记忆写进草稿显示');
+  assert.equal(view.memory.loading, false, '无人接管的失效加载必须自己清掉 loading');
+});
+
+test('web: equipPersona 切走后不得改名字/插卡/写挂件', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const renameCallsBefore = rt.calls.invoke.filter(n => n === 'rename_session').length;
+  const equip = rt.defer('equip_persona');
+  const p = rt.personas.equipPersona('persona-x');
+  rt.leave(); // equip 往返期间切草稿(草稿工作集已换空)
+  equip.resolve({ id: 'persona-x', name: '专家X' });
+  await p;
+  const view = rt.view();
+  // 草稿合法显示空挂件；判别点是旧代码会把加持写进草稿(挂件+插卡+rename)。
+  assert.equal(view.activePersona, null, '不得把加持写进切走后的草稿显示');
+  assert.equal(view.personaEvents.length, 0, '不得在切走后记 persona 事件');
+  assert.equal(view.chatItems.length, 0, '不得在切走后插入加持/卸下卡');
+  assert.equal(rt.calls.invoke.filter(n => n === 'rename_session').length, renameCallsBefore, '不得重命名切走后的会话');
+});
+
+test('web: unequipPersona 切走后卸下播报不写进别的会话', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const unequip = rt.defer('unequip_persona');
+  const p = rt.personas.unequipPersona();
+  rt.leave(); // unequip 往返期间切草稿(草稿工作集已换空)
+  unequip.resolve({});
+  await p;
+  const view = rt.view();
+  assert.equal(view.activePersona, null, '草稿无挂件(合法)');
+  assert.equal(view.chatItems.length, 0, '卸下播报不得插进切走后的草稿对话流');
+  assert.equal(view.personaEvents.length, 0, '不得在切走后记 persona 事件');
+});
+
+test('web: syncActivePersona 切走后陈旧快照不覆盖新会话挂件', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  // syncActivePersona 是桥内部函数：经真实 persona_changed 事件路径触发。
+  const get = rt.defer('get_active_persona');
+  rt.emit('session:persona_changed', { id: 'chat-a' }); // A 的后端事件到达
+  rt.leave(); // 响应返回前切草稿(草稿工作集已换空)
+  get.resolve({ id: 'persona-other', name: '别的专家' });
+  await new Promise(r => setTimeout(r, 0));
+  assert.equal(rt.view().activePersona, null, '陈旧快照不得把挂件写进切走后的草稿');
+});
+
+test('web: saveMemoryProfilePatch 切走后写结果不落进当前面板', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const update = rt.defer('update_memory_profile');
+  const overview = rt.defer('get_memory_overview'); // 尾部重载挂起，锁定中间态
+  const p = rt.memory.saveMemoryProfilePatch({ name: 'A 的档案' });
+  rt.leave(); // update 往返期间切草稿
+  update.resolve({ profile: { name: 'A 的档案' }, runtime: null, warnings: [] });
+  await new Promise(r => setTimeout(r, 0)); // update 恢复；尾部重载已发起并挂起
+  assert.equal(rt.view().memory.profile, null, '切走后 A 的写结果不得即时渲染进草稿面板');
+  overview.resolve(null);
+  await p;
+  assert.equal(rt.view().memory.profile, null, '最终也不得显示 A 的档案');
+});

--- a/pinvou3-app/tests/memory_personas_race_web.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race_web.test.mjs
@@ -98,9 +98,13 @@ function bootWebBridge() {
       deferreds[name] = d;
       return d;
     },
+    // 设定某命令的确定性返回（优先于 deferred；用于同名命令需要区分新旧两次
+    // 调用返回不同值的场景——deferred 按名字共享，无法区分）。
+    setHandler(name, fn) { handlers[name] = fn; },
     emit(name, payload) { (listeners[name] || []).forEach(fn => fn({ payload })); },
     personas: api.personas,
     memory: api.memory,
+    sessions: api.sessions,
   };
 }
 
@@ -192,4 +196,84 @@ test('web: saveMemoryProfilePatch 切走后写结果不落进当前面板', asyn
   overview.resolve(null);
   await p;
   assert.equal(rt.view().memory.profile, null, '最终也不得显示 A 的档案');
+});
+
+// ── 二审补充：web 镜像缺失的守卫锁定 + 失败分支归属 ───────────────────
+
+test('web: syncActivePersona 慢响应不得覆盖权威 equip（同会话乱序）', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  // sync 先发起并挂起（经真实 persona_changed 事件路径），读到的是旧快照
+  const get = rt.defer('get_active_persona');
+  rt.emit('session:persona_changed', { id: 'chat-a' });
+  const equip = rt.defer('equip_persona');
+  const equipP = rt.personas.equipPersona('persona-x'); // 同会话权威写发起
+  equip.resolve({ id: 'persona-x', name: '专家X' });    // equip 先完成(bump seq + 写挂件)
+  await equipP;
+  assert.equal(rt.view().activePersona && rt.view().activePersona.id, 'persona-x');
+  get.resolve(null); // 慢 sync 后到，旧快照是「无卡」
+  await new Promise(r => setTimeout(r, 0));
+  assert.equal(rt.view().activePersona && rt.view().activePersona.id, 'persona-x',
+    '慢 sync 的旧快照不得覆盖刚加持的挂件');
+});
+
+test('web: equipPersona rename 挂起期间切走：不插卡/不写挂件', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  // prime 后标题已是占位名「引导卡」→ personaPlaceholderTitles 命中 → 走 rename 分支
+  const equip = rt.defer('equip_persona');
+  const rename = rt.defer('rename_session');
+  const p = rt.personas.equipPersona('persona-x');
+  equip.resolve({ id: 'persona-x', name: '专家X' });
+  await new Promise(r => setTimeout(r, 0)); // equip 恢复并挂起在 rename
+  rt.leave(); // rename 挂起期间切草稿
+  rename.resolve({});
+  await p;
+  const view = rt.view();
+  assert.equal(view.activePersona, null, 'rename 挂起期间切走，不得把加持写进草稿');
+  assert.equal(view.chatItems.length, 0, '不得在切走后插入加持卡');
+  assert.equal(view.personaEvents.length, 0, '不得在切走后记 persona 事件');
+});
+
+test('web: equipPersona 失败且切走后：失败气泡不落别的会话，lastEquippedSid 作废', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt); // lastEquippedSid = chat-a
+  const equip = rt.defer('equip_persona');
+  const p = rt.personas.equipPersona('pinvou-card-creator');
+  rt.leave(); // invoke 往返期间切草稿
+  equip.reject(new Error('boom'));
+  const card = await p;
+  assert.equal(card, null, '失败必须返回 null(调用方据此跳过引导卡)');
+  const view = rt.view();
+  assert.ok(!view.chatItems.some(i => (i.text || '').startsWith('equipFailed')),
+    '失败气泡不得插进切走后的会话(随消息流持久化)');
+  rt.personas.postCardCreatorIntro(); // 即便被误调，也不得回退定向到历史成功 equip 的 A
+  assert.equal(rt.view().chatItems.length, 0,
+    'lastEquippedSid 已作废：引导卡不得定向到与本次造卡无关的历史会话 A');
+});
+
+test('web: 会话切回的 presentation-sync 不得被在途旧 sync 覆盖（序号 bump）', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  // A 会话在途的旧 sync：经真实 persona_changed 事件路径发起，挂起在 get_active_persona
+  const staleGet = rt.defer('get_active_persona');
+  rt.emit('session:persona_changed', { id: 'chat-a' });
+  rt.leave(); // 切草稿(chat-a 已有 loadedFromDisk buffer)
+  // 切回 A：真实 switchToSession 链路。presentation-sync 自己的 get_active_persona
+  // 必须返回权威值(与挂起的旧 sync 区分——deferred 按名共享，改用 handler)。
+  rt.setHandler('get_active_persona', () => Promise.resolve({ id: 'persona-prime', name: '引导卡' }));
+  const overview = rt.defer('get_memory_overview');
+  const switchP = rt.sessions.switchToSession('chat-a');
+  await new Promise(r => setTimeout(r, 0)); // 推进到 presentation-sync 的 Promise.all 挂起
+  overview.resolve(null); // presentation-sync 提交：bump 序号 + 写回权威挂件
+  await new Promise(r => setTimeout(r, 0));
+  assert.equal(rt.view().activeSessionId, 'chat-a', '已切回 A');
+  assert.equal(rt.view().activePersona && rt.view().activePersona.id, 'persona-prime',
+    'presentation-sync 权威挂件已写回');
+  // 旧 sync 的陈旧响应此刻才返回：sid 仍是 chat-a，无人 bump 时会覆盖权威挂件
+  staleGet.resolve(null);
+  await new Promise(r => setTimeout(r, 0));
+  await switchP;
+  assert.equal(rt.view().activePersona && rt.view().activePersona.id, 'persona-prime',
+    '在途旧 sync 的陈旧快照不得覆盖 presentation-sync 写回的权威挂件');
 });


### PR DESCRIPTION
## 背景

从 PR #250 同类竞态审计拆出的记忆/专家卡域：记忆面板陈旧读取覆盖（跨会话 + 同会话乱序）、专家加持/摘下/同步的写入漂移与陈旧快照。

## 变更

| 文件 | 改动 |
|---|---|
| `pinvou3-app/src/platform/tauri/bridge/memory.js` | `loadMemoryOverview` 加 sid 归属 + 请求序号（切走/再次加载后旧响应作废，pending 候选卡不再串台） |
| `pinvou3-app/src/platform/tauri/bridge/personas.js` | `syncActivePersona` 陈旧快照不覆盖新会话挂件；`equipPersona`/`unequipPersona` 入口捕获 sid、切走后放弃 UI 写入（防止错误会话被重命名/插卡） |
| `pinvou3-app/src/platform/web/bridge.js` | 对应 web 版 `loadMemoryOverview` 对齐 |
| `pinvou3-app/tests/memory_personas_race.test.mjs` | 新增 5 个竞态回归测试 |

## 验证

- `memory_personas_race.test.mjs` 5 个测试全绿
- `node --check` / eslint 通过；`invoke` 参数形状保持原样，协议指纹无变化