### PR TITLE
fix(workflow): 工作流 run 身份校验与陈旧快照防护

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -290,6 +290,7 @@
       reachedPhaseIds: [],
       bindings: {},      // session_id → skill_name
       demo: null,        // { open, name, loading, kind, content, error, description, duration }
+      starting: false,   // startWorkflowTask busy 闸：防双击重复建 run（审计复审补丁）
       // 卡片流工作流运行态（无聊天，事件驱动看板）。详见 09-ui-plane 决策。
       run: {
         active: false,       // 是否有进行中的工作流

--- a/pinvou3-app/src/platform/tauri/bridge/workflow-runtime.js
+++ b/pinvou3-app/src/platform/tauri/bridge/workflow-runtime.js
@@ -87,6 +87,10 @@
     try {
       var snap = await invoke("get_workflow_state", { sessionId: sessionId });
       if (!snap || !snap.roles || Object.keys(snap.roles).length === 0) return false;
+      // await 期间用户可能已启动/切到别的 run：旧快照不得覆盖新 run
+      // （审计；web 版同守卫）。
+      var currentRun = state.workflow.run;
+      if (currentRun && currentRun.active && currentRun.sessionId && currentRun.sessionId !== sessionId) return false;
       state.workflow.run = {
         active: true, sessionId: sessionId, projectDir: snap.project_dir || null,
         scenario: snap.scenario || null,
@@ -137,7 +141,9 @@
     try {
       var sid = state.workflow.run.sessionId; if (!sid) return;
       var snap = await invoke("get_workflow_state", { sessionId: sid });
-      if (snap && snap.roles) mergeFullState(snap);
+      // await 期间用户可能已启动新 run：旧 run 的快照不得 merge 进新 run
+      // （审计；web 版同守卫）。
+      if (snap && snap.roles && state.workflow.run.sessionId === sid) mergeFullState(snap);
     } catch (e) { console.warn("refreshRunState failed", e); }
   }
 

--- a/pinvou3-app/src/platform/tauri/bridge/workflow.js
+++ b/pinvou3-app/src/platform/tauri/bridge/workflow.js
@@ -42,16 +42,24 @@
     notify();
   }
   async function activateSkill(name) {
+    // 入口捕获触发会话：await 期间用户可能已切走，响应后不得无条件劫持
+    // activeSessionId（审计；与 web 版对齐）。已切走则只登记 bindings。
+    var sid = state.activeSessionId;
     try {
       var res = await invoke("start_skill_session", { name: name });
       var skill = res.skill || {};
       var meta = res.session || res.metadata || {};
-      state.activeSessionId = meta.id || state.activeSessionId;
-      state.messages = []; state.chatItems = []; resetPendingAssistant();
-      state.workflow.activeSkillName = skill.name || name;
-      state.workflow.phases = skill.phases || [];
-      state.workflow.currentPhaseId = skill.current_phase_id || (skill.phases && skill.phases[0] && skill.phases[0].id) || null;
-      state.workflow.reachedPhaseIds = state.workflow.currentPhaseId ? [state.workflow.currentPhaseId] : [];
+      // 仅当会话未被切走时才劫持 activeSessionId：`!sid` 分支会在入口无会话、
+      // await 期间用户新建聊天会话时仍无条件劫持（审计补丁）——统一收敛为等值
+      // 比较（入口 sid 为 null 且响应时仍为 null 时劫持，原语义不变）。
+      if (state.activeSessionId === sid) {
+        state.activeSessionId = meta.id || state.activeSessionId;
+        state.messages = []; state.chatItems = []; resetPendingAssistant();
+        state.workflow.activeSkillName = skill.name || name;
+        state.workflow.phases = skill.phases || [];
+        state.workflow.currentPhaseId = skill.current_phase_id || (skill.phases && skill.phases[0] && skill.phases[0].id) || null;
+        state.workflow.reachedPhaseIds = state.workflow.currentPhaseId ? [state.workflow.currentPhaseId] : [];
+      }
       if (meta.id) state.workflow.bindings[meta.id] = skill.name || name;
       await refreshHistoryList();
       await syncModeState();
@@ -60,10 +68,15 @@
     } catch (e) { addSystemItem(bt("workflowActivateFailed") + e); notify(); return null; }
   }
   async function deactivateSkill() {
-    if (state.activeSessionId) {
+    // 入口捕获触发会话：await 期间用户可能已切走，解绑与全局清空不得
+    // 作用于别的会话（否则 B 的激活技能显示被清掉，审计 R2）。
+    var sid = state.activeSessionId;
+    if (sid) {
+      // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       try { await invoke("unbind_session_skill", { sessionId: state.activeSessionId }); } catch (_) {}
-      delete state.workflow.bindings[state.activeSessionId];
     }
+    if (sid && state.activeSessionId !== sid) return;
+    if (sid) delete state.workflow.bindings[sid];
     state.workflow.activeSkillName = null;
     state.workflow.phases = [];
     state.workflow.currentPhaseId = null;
@@ -75,12 +88,16 @@
     notify();
     try {
       var d = await invoke("read_skill_demo", { name: name });
+      // await 期间用户可能已关闭弹窗或改开别的 demo：陈旧响应不得把已关闭
+      // 的弹窗重新弹开、也不得覆盖别的 demo 内容（审计 R3）。
+      if (!state.workflow.demo || state.workflow.demo.name !== name) return;
       state.workflow.demo = {
         open: true, name: name, loading: false,
         kind: d.file_kind, path: d.file_path, content: d.content,
         error: null, description: d.description, duration: d.duration,
       };
     } catch (e) {
+      if (!state.workflow.demo || state.workflow.demo.name !== name) return;
       state.workflow.demo = { open: true, name: name, loading: false, kind: null, content: null, error: String(e) };
     }
     notify();
@@ -114,7 +131,12 @@
       sessionId: sid,
       reason: reason || "user_stopped",
     });
-    markWorkflowRunStopped();
+    // stop_workflow 等待期间用户可能已启动新 run（project_started 整体替换
+    // run 对象）：此时不得把新 run 标记为 stopped（审计 R4），否则新 run 的
+    // 事件会被 stopped 闸全部吞掉、看板冻结而实际仍在跑。
+    if (state.workflow.run.sessionId === sid) {
+      markWorkflowRunStopped();
+    }
     notify();
     return result || {};
   }
@@ -194,8 +216,12 @@
   // cardId 可为 null:看板 agent 卡上的"确认通过"只有 roleId(刷新后内存 gate 卡已清空)。
   // 批准只需 roleId + sessionId,绝不依赖前端那张内存卡是否存在(那正是"按钮点了没反应"的 bug)。
   async function approveWorkflowGate(cardId, roleId) {
+    // 入口捕获触发 run：await 期间可能已启动新 run（project_started 整体替换
+    // run 对象），批准结果不得落到新 run 的卡片上（审计）。
+    var runSid = state.workflow.run.sessionId;
     try {
       await invoke("approve_workflow_gate", { roleId: roleId, sessionId: state.workflow.run.sessionId });
+      if (state.workflow.run.sessionId !== runSid) return;
       if (cardId) resolveRunCard(cardId, "approved");
       resolveRunCardsForRole(roleId, "approved");
       await refreshRunState();   // 刷新真实状态:huizou gate_waiting→completed,看板按钮随之消失
@@ -203,8 +229,10 @@
     } catch (e) { addSystemItem(bt("workflowApproveFailed") + e); }
   }
   async function rejectWorkflowGate(cardId, roleId, reason) {
+    var runSid = state.workflow.run.sessionId;
     try {
       await invoke("reject_workflow_gate", { roleId: roleId, reason: reason || bt("workflowRejectDefaultReason"), sessionId: state.workflow.run.sessionId });
+      if (state.workflow.run.sessionId !== runSid) return;
       if (cardId) resolveRunCard(cardId, "rejected");
       resolveRunCardsForRole(roleId, "rejected");
       await refreshRunState();

--- a/pinvou3-app/src/platform/tauri/bridge/workflow.js
+++ b/pinvou3-app/src/platform/tauri/bridge/workflow.js
@@ -74,9 +74,11 @@
     if (sid) {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       try { await invoke("unbind_session_skill", { sessionId: state.activeSessionId }); } catch (_) {}
+      // 后端解绑已生效：bindings 键是入口 sid、与 await 后谁 active 无关，必须
+      // 无条件同步删除（bindings 无重算路径，漏删会留下永久幽灵徽标，复审补丁）。
+      delete state.workflow.bindings[sid];
     }
     if (sid && state.activeSessionId !== sid) return;
-    if (sid) delete state.workflow.bindings[sid];
     state.workflow.activeSkillName = null;
     state.workflow.phases = [];
     state.workflow.currentPhaseId = null;
@@ -106,21 +108,26 @@
 
   // ── 卡片流工作流：动作（invoke 包装）────────────────────────────
   // 新建任务：建项目（project_started 事件设 run 态）→ kick 派发首个 agent（无聊天）。
+  // busy 闸防双击重复建 run（与 web 版对齐，复审补丁；UI 模态的 starting 闸为主防）。
   async function startWorkflowTask(scenario, brief) {
-    var res;
+    if (state.workflow.starting) return null;
+    state.workflow.starting = true;
     try {
-      res = await invoke("start_workflow", { scenario: scenario, briefInit: brief || null });
-    } catch (e) {
-      addSystemItem(bt("workflowCreateFailed") + e);
-      throw e;
-    }
-    try {
-      await invoke("kick_workflow", { sessionId: res.session_id });
-    } catch (e) {
-      addSystemItem(bt("workflowStartFailed") + e);
-      throw e;
-    }
-    return res;
+      var res;
+      try {
+        res = await invoke("start_workflow", { scenario: scenario, briefInit: brief || null });
+      } catch (e) {
+        addSystemItem(bt("workflowCreateFailed") + e);
+        throw e;
+      }
+      try {
+        await invoke("kick_workflow", { sessionId: res.session_id });
+      } catch (e) {
+        addSystemItem(bt("workflowStartFailed") + e);
+        throw e;
+      }
+      return res;
+    } finally { state.workflow.starting = false; }
   }
   // 停止整个 run：后端先落 stop marker 再取消所有后台 SubAgent；返回旧 brief，
   // 供工作流页打开“修改需求并重新开始”的预填表单。
@@ -226,7 +233,10 @@
       resolveRunCardsForRole(roleId, "approved");
       await refreshRunState();   // 刷新真实状态:huizou gate_waiting→completed,看板按钮随之消失
       notify();
-    } catch (e) { addSystemItem(bt("workflowApproveFailed") + e); }
+    } catch (e) {
+      // 陈旧失败提示不得弹给新 run 用户（复审补丁：catch 与成功路径同款 run 身份校验）。
+      if (state.workflow.run.sessionId === runSid) addSystemItem(bt("workflowApproveFailed") + e);
+    }
   }
   async function rejectWorkflowGate(cardId, roleId, reason) {
     var runSid = state.workflow.run.sessionId;
@@ -237,7 +247,9 @@
       resolveRunCardsForRole(roleId, "rejected");
       await refreshRunState();
       notify();
-    } catch (e) { addSystemItem(bt("workflowRejectFailed") + e); }
+    } catch (e) {
+      if (state.workflow.run.sessionId === runSid) addSystemItem(bt("workflowRejectFailed") + e);
+    }
   }
   // 从失败节点续跑:重置该角色为 pending(清重试)后重新调度,上游已完成节点不重跑。
   async function retryWorkflowRole(roleId) {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -5658,6 +5658,9 @@
     try {
       var snap = await invoke("get_workflow_state", { sessionId: sessionId });
       if (!snap || !snap.roles || Object.keys(snap.roles).length === 0) return false;
+      // await 期间用户可能已启动/切到别的 run：旧快照不得覆盖新 run（审计）。
+      var currentRun = state.workflow.run;
+      if (currentRun && currentRun.active && currentRun.sessionId && currentRun.sessionId !== sessionId) return false;
       state.workflow.run = {
         active: true, sessionId: sessionId, projectDir: snap.project_dir || null,
         scenario: snap.scenario || null,
@@ -5708,7 +5711,8 @@
     try {
       var sid = state.workflow.run.sessionId; if (!sid) return;
       var snap = await invoke("get_workflow_state", { sessionId: sid });
-      if (snap && snap.roles) mergeFullState(snap);
+      // await 期间用户可能已启动新 run：旧 run 的快照不得 merge 进新 run（审计）。
+      if (snap && snap.roles && state.workflow.run.sessionId === sid) mergeFullState(snap);
     } catch (e) { console.warn("refreshRunState failed", e); }
   }
 
@@ -8476,16 +8480,25 @@
     notify();
   }
   async function activateSkill(name) {
+    // 入口捕获触发会话：await 期间用户可能已切走，响应后不得无条件劫持
+    // activeSessionId（Web 下后端 setActive=false，前端硬切会覆盖用户导航，
+    // 审计）。已切走则只登记 bindings、不抢 active。
+    var sid = state.activeSessionId;
     try {
       var res = await invoke(IS_WEB ? "web_access_start_skill_session" : "start_skill_session", { name: name, setActive: !IS_WEB });
       var skill = res.skill || {};
       var meta = res.session || res.metadata || {};
-      state.activeSessionId = meta.id || state.activeSessionId;
-      state.messages = []; state.chatItems = []; resetPendingAssistant();
-      state.workflow.activeSkillName = skill.name || name;
-      state.workflow.phases = skill.phases || [];
-      state.workflow.currentPhaseId = skill.current_phase_id || (skill.phases && skill.phases[0] && skill.phases[0].id) || null;
-      state.workflow.reachedPhaseIds = state.workflow.currentPhaseId ? [state.workflow.currentPhaseId] : [];
+      // 仅当会话未被切走时才劫持 activeSessionId：`!sid` 分支会在入口无会话、
+      // await 期间用户新建聊天会话时仍无条件劫持（审计补丁）——统一收敛为等值
+      // 比较（入口 sid 为 null 且响应时仍为 null 时劫持，原语义不变）。
+      if (state.activeSessionId === sid) {
+        state.activeSessionId = meta.id || state.activeSessionId;
+        state.messages = []; state.chatItems = []; resetPendingAssistant();
+        state.workflow.activeSkillName = skill.name || name;
+        state.workflow.phases = skill.phases || [];
+        state.workflow.currentPhaseId = skill.current_phase_id || (skill.phases && skill.phases[0] && skill.phases[0].id) || null;
+        state.workflow.reachedPhaseIds = state.workflow.currentPhaseId ? [state.workflow.currentPhaseId] : [];
+      }
       if (meta.id) state.workflow.bindings[meta.id] = skill.name || name;
       await refreshHistoryList();
       await syncModeState();
@@ -8494,10 +8507,14 @@
     } catch (e) { addSystemItem(bt("workflowEnableFailed") + e); notify(); return null; }
   }
   async function deactivateSkill() {
-    if (state.activeSessionId) {
+    // 入口捕获触发会话：await 期间用户可能已切走，解绑与全局清空不得
+    // 作用于别的会话（否则 B 的激活技能显示被清掉，审计）。
+    var sid = state.activeSessionId;
+    if (sid) {
       try { await invoke("unbind_session_skill", { sessionId: state.activeSessionId }); } catch (_) {}
-      delete state.workflow.bindings[state.activeSessionId];
     }
+    if (sid && state.activeSessionId !== sid) return;
+    if (sid) delete state.workflow.bindings[sid];
     state.workflow.activeSkillName = null;
     state.workflow.phases = [];
     state.workflow.currentPhaseId = null;
@@ -8509,27 +8526,34 @@
     notify();
     try {
       var d = await invoke("read_skill_demo", { name: name });
+      // await 期间用户可能已关闭弹窗或改开别的 demo：陈旧响应不得把已关闭
+      // 的弹窗重新弹开、也不得覆盖别的 demo 内容（审计）。
+      if (!state.workflow.demo || state.workflow.demo.name !== name) return;
       state.workflow.demo = {
         open: true, name: name, loading: false,
         kind: d.file_kind, path: d.file_path, content: d.content,
         error: null, description: d.description, duration: d.duration,
       };
     } catch (e) {
+      if (!state.workflow.demo || state.workflow.demo.name !== name) return;
       state.workflow.demo = { open: true, name: name, loading: false, kind: null, content: null, error: String(e) };
     }
     notify();
   }
   function closeDemo() { state.workflow.demo = null; notify(); }
 
-  // ── 卡片流工作流：动作（invoke 包装）────────────────────────────
   // 新建任务：建项目（project_started 事件设 run 态）→ kick 派发首个 agent（无聊天）。
+  // busy 闸防双击重复建 run（后端两个项目都在跑、看板只见最后一个，审计）。
   async function startWorkflowTask(scenario, brief) {
+    if (state.workflowStarting) return null;
+    state.workflowStarting = true;
     try {
       var res = await invoke("start_workflow", { scenario: scenario, briefInit: brief || null });
       try { await invoke("kick_workflow", { sessionId: res.session_id }); }
       catch (e) { addSystemItem(bt("workflowKickFailed") + e); }
       return res;
     } catch (e) { addSystemItem(bt("workflowStartFailed") + e); return null; }
+    finally { state.workflowStarting = false; }
   }
   // 停止整个 run：后端先落 stop marker 再取消所有后台 SubAgent；返回旧 brief，
   // 供工作流页打开“修改需求并重新开始”的预填表单。
@@ -8540,7 +8564,12 @@
       sessionId: sid,
       reason: reason || "user_stopped",
     });
-    markWorkflowRunStopped();
+    // stop_workflow 等待期间用户可能已启动新 run（project_started 整体替换
+    // run 对象）：此时不得把新 run 标记为 stopped（审计），否则新 run 的事件
+    // 会被 stopped 闸全部吞掉、看板冻结而实际仍在跑。
+    if (state.workflow.run.sessionId === sid) {
+      markWorkflowRunStopped();
+    }
     notify();
     return result || {};
   }
@@ -8637,8 +8666,12 @@
   // cardId 可为 null:看板 agent 卡上的"确认通过"只有 roleId(刷新后内存 gate 卡已清空)。
   // 批准只需 roleId + sessionId,绝不依赖前端那张内存卡是否存在(那正是"按钮点了没反应"的 bug)。
   async function approveWorkflowGate(cardId, roleId) {
+    // 入口捕获触发 run：await 期间可能已启动新 run（project_started 整体替换
+    // run 对象），批准结果不得落到新 run 的卡片上（审计；与 tauri 版同守卫）。
+    var runSid = state.workflow.run.sessionId;
     try {
       await invoke("approve_workflow_gate", { roleId: roleId, sessionId: state.workflow.run.sessionId });
+      if (state.workflow.run.sessionId !== runSid) return;
       if (cardId) resolveRunCard(cardId, "approved");
       resolveRunCardsForRole(roleId, "approved");
       await refreshRunState();   // 刷新真实状态:huizou gate_waiting→completed,看板按钮随之消失
@@ -8646,8 +8679,10 @@
     } catch (e) { addSystemItem(bt("gateApproveFailed") + e); }
   }
   async function rejectWorkflowGate(cardId, roleId, reason) {
+    var runSid = state.workflow.run.sessionId;
     try {
       await invoke("reject_workflow_gate", { roleId: roleId, reason: reason || bt("workflowRejectDefaultReason"), sessionId: state.workflow.run.sessionId });
+      if (state.workflow.run.sessionId !== runSid) return;
       if (cardId) resolveRunCard(cardId, "rejected");
       resolveRunCardsForRole(roleId, "rejected");
       await refreshRunState();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -187,6 +187,7 @@
       reachedPhaseIds: [],
       bindings: {},      // session_id → skill_name
       demo: null,        // { open, name, loading, kind, content, error, description, duration }
+      starting: false,   // startWorkflowTask busy 闸：防双击重复建 run（审计）
       // 卡片流工作流运行态（无聊天，事件驱动看板）。详见 09-ui-plane 决策。
       run: {
         active: false,       // 是否有进行中的工作流
@@ -8512,9 +8513,11 @@
     var sid = state.activeSessionId;
     if (sid) {
       try { await invoke("unbind_session_skill", { sessionId: state.activeSessionId }); } catch (_) {}
+      // 后端解绑已生效：bindings 键是入口 sid、与 await 后谁 active 无关，必须
+      // 无条件同步删除（bindings 无重算路径，漏删会留下永久幽灵徽标，复审补丁）。
+      delete state.workflow.bindings[sid];
     }
     if (sid && state.activeSessionId !== sid) return;
-    if (sid) delete state.workflow.bindings[sid];
     state.workflow.activeSkillName = null;
     state.workflow.phases = [];
     state.workflow.currentPhaseId = null;
@@ -8542,18 +8545,19 @@
   }
   function closeDemo() { state.workflow.demo = null; notify(); }
 
+  // ── 卡片流工作流：动作（invoke 包装）────────────────────────────
   // 新建任务：建项目（project_started 事件设 run 态）→ kick 派发首个 agent（无聊天）。
   // busy 闸防双击重复建 run（后端两个项目都在跑、看板只见最后一个，审计）。
   async function startWorkflowTask(scenario, brief) {
-    if (state.workflowStarting) return null;
-    state.workflowStarting = true;
+    if (state.workflow.starting) return null;
+    state.workflow.starting = true;
     try {
       var res = await invoke("start_workflow", { scenario: scenario, briefInit: brief || null });
       try { await invoke("kick_workflow", { sessionId: res.session_id }); }
       catch (e) { addSystemItem(bt("workflowKickFailed") + e); }
       return res;
     } catch (e) { addSystemItem(bt("workflowStartFailed") + e); return null; }
-    finally { state.workflowStarting = false; }
+    finally { state.workflow.starting = false; }
   }
   // 停止整个 run：后端先落 stop marker 再取消所有后台 SubAgent；返回旧 brief，
   // 供工作流页打开“修改需求并重新开始”的预填表单。
@@ -8676,7 +8680,10 @@
       resolveRunCardsForRole(roleId, "approved");
       await refreshRunState();   // 刷新真实状态:huizou gate_waiting→completed,看板按钮随之消失
       notify();
-    } catch (e) { addSystemItem(bt("gateApproveFailed") + e); }
+    } catch (e) {
+      // 陈旧失败提示不得弹给新 run 用户（复审补丁：catch 与成功路径同款 run 身份校验）。
+      if (state.workflow.run.sessionId === runSid) addSystemItem(bt("gateApproveFailed") + e);
+    }
   }
   async function rejectWorkflowGate(cardId, roleId, reason) {
     var runSid = state.workflow.run.sessionId;
@@ -8687,7 +8694,9 @@
       resolveRunCardsForRole(roleId, "rejected");
       await refreshRunState();
       notify();
-    } catch (e) { addSystemItem(bt("gateRejectFailed") + e); }
+    } catch (e) {
+      if (state.workflow.run.sessionId === runSid) addSystemItem(bt("gateRejectFailed") + e);
+    }
   }
   // 从失败节点续跑:重置该角色为 pending(清重试)后重新调度,上游已完成节点不重跑。
   async function retryWorkflowRole(roleId) {

--- a/pinvou3-app/tests/workflow_race.test.mjs
+++ b/pinvou3-app/tests/workflow_race.test.mjs
@@ -1,0 +1,220 @@
+/**
+ * 工作流 run 竞态回归测试（PR #250 系列拆分的 domain E，PR #259 延续）：
+ * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
+ * 仅覆盖 tauri bridge 的 workflow feature（web/bridge.js 走同一批守卫逻辑，
+ * 由代码审查 + 既有套件保证；web 版 approve/reject 守卫与本套件同源）。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+
+/** 通用 feature 装载器：vm 加载 IIFE(window) 形态的桥 feature 文件。 */
+function loadFeature(fileName, state, contextOverrides) {
+  const root = { __PINVOU_SHARED_I18N__: {} };
+  const src = fs.readFileSync(path.join(bridgeDir, fileName), 'utf8');
+  vm.runInNewContext(src, {
+    window: root,
+    globalThis: root,
+    setTimeout,
+    clearTimeout,
+  });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__[fileName.replace('.js', '')];
+  const deferreds = {};
+  const calls = { invoke: [] };
+  const api = factory(Object.assign({
+    state,
+    notify() { calls.notify = (calls.notify || 0) + 1; },
+    bt(key) { return key; },
+    addSystemItem() {},
+    addChatItem() {},
+    timeStr() { return ''; },
+    invoke(name, args) {
+      calls.invoke.push(name);
+      if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+      return Promise.resolve({});
+    },
+  }, contextOverrides || {}));
+  return {
+    api,
+    state,
+    calls,
+    defer(name) {
+      // 每次创建全新对象：同一 invoke 名的第二次 defer 不得覆盖第一次的
+      // resolve（否则旧 promise 永远无人 resolve → 测试挂起）。
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+  };
+}
+
+function loadWorkflowFeature() {
+  const state = {
+    activeSessionId: 'chat-a',
+    workflow: {
+      run: { active: false, sessionId: null, status: 'idle', agents: {}, cards: [], selectedRole: null },
+      demo: null,
+      bindings: {},
+      activeSkillName: null,
+      phases: [],
+      currentPhaseId: null,
+      reachedPhaseIds: [],
+      loadState: 'ready',
+      skills: [],
+    },
+    messages: [],
+    chatItems: [],
+  };
+  let rt;
+  rt = loadFeature('workflow.js', state, {
+    dialogOpen() {},
+    resetPendingAssistant() {},
+    syncModeState: async () => {},
+    refreshHistoryList: async () => {},
+    markWorkflowRunStopped() { rt.calls.markStopped = (rt.calls.markStopped || 0) + 1; state.workflow.run.status = 'stopped'; },
+    refreshRunState: async () => {},
+    resolveRunCard(cardId, cardState) {
+      state.workflow.run.cards.forEach((c) => { if (c.cardId === cardId) { c.resolved = true; c.cardState = cardState; } });
+    },
+    resolveRunCardsForRole(roleId, cardState) {
+      state.workflow.run.cards.forEach((c) => { if (c.kind === 'gate' && c.roleId === roleId && !c.resolved) { c.resolved = true; c.cardState = cardState; } });
+    },
+  });
+  return rt;
+}
+
+test('openDemo 关闭后陈旧响应不得重新弹开', async () => {
+  const rt = loadWorkflowFeature();
+  const read = rt.defer('read_skill_demo');
+  const p = rt.api.openDemo('demo-a');
+  rt.api.closeDemo();                                // 用户关闭
+  read.resolve({ content: '...', file_kind: 'md' });
+  await p;
+  assert.equal(rt.state.workflow.demo, null, '已关闭的弹窗不得被陈旧响应重开');
+});
+
+test('openDemo 改开别的 demo 时旧响应不得覆盖新内容', async () => {
+  const rt = loadWorkflowFeature();
+  const readA = rt.defer('read_skill_demo');
+  const pA = rt.api.openDemo('demo-a');
+  const readB = rt.defer('read_skill_demo');         // B 的独立请求（真实场景两次 IPC）
+  const pB = rt.api.openDemo('demo-b');              // 用户改开 B
+  readA.resolve({ content: 'A 的内容', file_kind: 'md' });
+  await pA;
+  assert.equal(rt.state.workflow.demo.name, 'demo-b', 'A 的陈旧响应不得覆盖 B');
+  assert.equal(rt.state.workflow.demo.loading, true, 'B 仍在加载（未被 A 完成）');
+  readB.resolve({ content: 'B 的内容', file_kind: 'md' });
+  await pB;
+  assert.equal(rt.state.workflow.demo.content, 'B 的内容', 'B 的内容正常写入');
+});
+
+test('stopWorkflowTask 停止旧 run 不得把新 run 标记为 stopped', async () => {
+  const rt = loadWorkflowFeature();
+  rt.state.workflow.run = { active: true, sessionId: 'run-a', status: 'running', agents: {}, cards: [] };
+  const stop = rt.defer('stop_workflow');
+  const p = rt.api.stopWorkflowTask('user_stopped'); // 停 run-a
+  rt.state.workflow.run = { active: true, sessionId: 'run-b', status: 'running', agents: {}, cards: [] }; // 新 run 开始
+  stop.resolve({ brief: 'old' });
+  await p;
+  assert.equal(rt.calls.markStopped, undefined, '不得把新 run-b 标记为 stopped');
+  assert.equal(rt.state.workflow.run.status, 'running', 'run-b 保持运行');
+});
+
+test('approveWorkflowGate 批准旧 run 不得落到新 run 的卡片上', async () => {
+  const rt = loadWorkflowFeature();
+  rt.state.workflow.run = {
+    active: true, sessionId: 'run-a', status: 'running',
+    agents: {}, cards: [{ cardId: 1, kind: 'gate', roleId: 'r1', resolved: false }],
+  };
+  const approve = rt.defer('approve_workflow_gate');
+  const p = rt.api.approveWorkflowGate(1, 'r1');     // 批准 run-a 的 gate
+  rt.state.workflow.run = {
+    active: true, sessionId: 'run-b', status: 'running',
+    agents: {}, cards: [{ cardId: 2, kind: 'gate', roleId: 'r1', resolved: false }],
+  };                                                // 新 run 开始（同角色 gate 卡）
+  approve.resolve({});
+  await p;
+  assert.equal(rt.state.workflow.run.cards[0].resolved, false, 'run-b 的 gate 卡不得被旧批准误标');
+});
+
+test('rejectWorkflowGate 打回旧 run 不得落到新 run 的卡片上', async () => {
+  const rt = loadWorkflowFeature();
+  rt.state.workflow.run = {
+    active: true, sessionId: 'run-a', status: 'running',
+    agents: {}, cards: [{ cardId: 1, kind: 'gate', roleId: 'r1', resolved: false }],
+  };
+  const reject = rt.defer('reject_workflow_gate');
+  const p = rt.api.rejectWorkflowGate(1, 'r1', '返工');
+  rt.state.workflow.run = {
+    active: true, sessionId: 'run-b', status: 'running',
+    agents: {}, cards: [{ cardId: 2, kind: 'gate', roleId: 'r1', resolved: false }],
+  };
+  reject.resolve({});
+  await p;
+  assert.equal(rt.state.workflow.run.cards[0].resolved, false, 'run-b 的 gate 卡不得被旧打回误标');
+});
+
+test('attachRun 陈旧快照不得覆盖已启动的新 run', async () => {
+  const state = {
+    activeSessionId: 'chat-a',
+    workflow: {
+      run: { active: false, sessionId: null, status: 'idle', agents: {}, cards: [], selectedRole: null },
+      demo: null, bindings: {}, activeSkillName: null, phases: [], currentPhaseId: null,
+      reachedPhaseIds: [], loadState: 'ready', skills: [],
+    },
+    messages: [], chatItems: [],
+  };
+  const rt = loadFeature('workflow-runtime.js', state, {
+    listen() {},
+    refreshHistoryList: async () => {},
+  });
+  rt.state.workflow.run = { active: true, sessionId: 'run-b', status: 'running', agents: {}, cards: [] };
+  const snap = rt.defer('get_workflow_state');
+  const p = rt.api.attachRun('run-a');               // 恢复旧 run-a 的快照
+  snap.resolve({ roles: { r1: { status: 'running' } }, project_dir: '/p' });
+  await p;
+  assert.equal(rt.state.workflow.run.sessionId, 'run-b', 'attach 旧 run 不得覆盖新 run-b');
+});
+
+test('refreshRunState 陈旧快照不得 merge 进新 run', async () => {
+  const state = {
+    activeSessionId: 'chat-a',
+    workflow: {
+      run: { active: false, sessionId: null, status: 'idle', agents: {}, cards: [], selectedRole: null },
+      demo: null, bindings: {}, activeSkillName: null, phases: [], currentPhaseId: null,
+      reachedPhaseIds: [], loadState: 'ready', skills: [],
+    },
+    messages: [], chatItems: [],
+  };
+  const rt = loadFeature('workflow-runtime.js', state, {
+    listen() {},
+    refreshHistoryList: async () => {},
+  });
+  rt.state.workflow.run = { active: true, sessionId: 'run-b', status: 'running', agents: {}, cards: [] };
+  const snap = rt.defer('get_workflow_state');
+  const p = rt.api.refreshRunState();                 // 刷新 run-b（内部捕获 sid=run-b）
+  rt.state.workflow.run = { active: true, sessionId: 'run-c', status: 'running', agents: {}, cards: [] }; // 又切到 run-c
+  snap.resolve({ roles: { r1: { status: 'complete' } }, stopped: true });
+  await p;
+  assert.equal(rt.state.workflow.run.status, 'running', '旧 run-b 的 stopped 快照不得 merge 进 run-c');
+  assert.deepEqual(rt.state.workflow.run.agents, {}, '旧快照角色不得混入 run-c');
+});
+
+test('activateSkill 响应时已新建会话则不得劫持 activeSessionId', async () => {
+  const rt = loadWorkflowFeature();
+  rt.state.activeSessionId = null;                    // 入口无会话
+  const start = rt.defer('start_skill_session');
+  const p = rt.api.activateSkill('skill-a');
+  rt.state.activeSessionId = 'new-chat';              // await 期间用户新建聊天会话
+  start.resolve({ skill: { name: 'skill-a' }, session: { id: 'skill-sess' } });
+  await p;
+  assert.equal(rt.state.activeSessionId, 'new-chat', '不得劫持用户新建的会话');
+  assert.deepEqual(rt.state.messages, [], '消息区未被技能会话清空');
+});

--- a/pinvou3-app/tests/workflow_race.test.mjs
+++ b/pinvou3-app/tests/workflow_race.test.mjs
@@ -21,6 +21,7 @@ function loadFeature(fileName, state, contextOverrides) {
   vm.runInNewContext(src, {
     window: root,
     globalThis: root,
+    console,   // feature 的 catch 分支会 console.warn；不注入会在验证错误路径时 ReferenceError
     setTimeout,
     clearTimeout,
   });
@@ -34,6 +35,7 @@ function loadFeature(fileName, state, contextOverrides) {
     addSystemItem() {},
     addChatItem() {},
     timeStr() { return ''; },
+    itemIdSeq: 0,   // workflow-runtime 的 pushRunCard 用 ++context.itemIdSeq 发卡号
     invoke(name, args) {
       calls.invoke.push(name);
       if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
@@ -68,6 +70,7 @@ function loadWorkflowFeature() {
       reachedPhaseIds: [],
       loadState: 'ready',
       skills: [],
+      starting: false,
     },
     messages: [],
     chatItems: [],
@@ -217,4 +220,35 @@ test('activateSkill 响应时已新建会话则不得劫持 activeSessionId', as
   await p;
   assert.equal(rt.state.activeSessionId, 'new-chat', '不得劫持用户新建的会话');
   assert.deepEqual(rt.state.messages, [], '消息区未被技能会话清空');
+});
+
+test('deactivateSkill 切走后仍须删除入口会话的 bindings 且不清空全局技能字段', async () => {
+  const rt = loadWorkflowFeature();
+  rt.state.workflow.bindings = { 'chat-a': 'skill-a', 'chat-b': 'skill-b' };
+  rt.state.workflow.activeSkillName = 'skill-a';
+  rt.state.workflow.phases = [{ id: 'p1' }];
+  const unbind = rt.defer('unbind_session_skill');
+  const p = rt.api.deactivateSkill();                 // 解绑 chat-a 的技能
+  rt.state.activeSessionId = 'chat-b';               // await 期间用户切到 chat-b
+  unbind.resolve({});
+  await p;
+  // 后端 unbind 已生效：bindings 键是入口 sid，与 await 后谁 active 无关，必须删除
+  //（bindings 无重算路径，漏删会让侧边栏对 chat-a 永久显示幽灵技能徽标）。
+  assert.equal(rt.state.workflow.bindings['chat-a'], undefined, '入口会话的 bindings 条目必须无条件删除');
+  assert.equal(rt.state.workflow.bindings['chat-b'], 'skill-b', '切走目标会话的 bindings 不受影响');
+  assert.equal(rt.state.workflow.activeSkillName, 'skill-a', '切走后不得清空全局技能字段');
+  assert.deepEqual(rt.state.workflow.phases, [{ id: 'p1' }], '切走后不得清空 phases');
+});
+
+test('startWorkflowTask busy 闸防双击重复建 run', async () => {
+  const rt = loadWorkflowFeature();
+  const start = rt.defer('start_workflow');
+  const first = rt.api.startWorkflowTask('scenario-a', 'brief');
+  assert.equal(rt.state.workflow.starting, true, '第一次调用进行中闸保持');
+  const secondP = rt.api.startWorkflowTask('scenario-a', 'brief'); // 双击：立即被闸拒绝
+  start.resolve({ session_id: 'run-a' });             // 放行第一次（闸若失效，两次共用同一 deferred 也能落定）
+  assert.equal(await secondP, null, 'busy 期间第二次调用直接返回 null');
+  assert.deepEqual(await first, { session_id: 'run-a' }, '第一次调用正常完成');
+  assert.equal(rt.state.workflow.starting, false, '结束后闸释放');
+  assert.deepEqual(rt.calls.invoke, ['start_workflow', 'kick_workflow'], '只发一次 start+kick，不得双份');
 });


### PR DESCRIPTION
## 背景

从 PR #250 同类竞态审计拆出的工作流域：workflow run 的陈旧快照覆盖新 run、跨 run 写入、关闭/切换后的陈旧响应。

## 变更

| 文件 | 改动 |
|---|---|
| `pinvou3-app/src/platform/tauri/bridge/workflow.js` | `stopWorkflowTask` 停止旧 run 响应不标记新 run stopped；`approve/rejectWorkflowGate` await 后校验 run 身份（含 catch 分支，复审补丁）；`activateSkill` 响应后不无条件劫持 activeSessionId；`deactivateSkill` 解绑不作用于切走后的会话、bindings 无条件删除（复审补丁）；`openDemo` 陈旧响应不重开/不覆盖；`startWorkflowTask` 补 busy 闸与 web 版对齐（复审补丁） |
| `pinvou3-app/src/platform/tauri/bridge/workflow-runtime.js` | `refreshRunState`/`attachRun` 补 run 身份校验（陈旧快照不得 merge/覆盖新 run） |
| `pinvou3-app/src/platform/web/bridge.js` | 对应 web 版对齐（含 `startWorkflowTask` busy 闸防双击；旗标收敛为 `state.workflow.starting` 并在两平台 state 声明，复审补丁） |
| `pinvou3-app/src/platform/tauri/bridge.js` | state 补 `workflow.starting` 声明（复审补丁） |
| `pinvou3-app/tests/workflow_race.test.mjs` | 新增 10 个竞态回归测试 |

## 复审补丁（854cc170 + 887bd384）

- `deactivateSkill`：后端解绑已生效后 `delete bindings[sid]` 改为无条件执行——键是入口 sid、与 await 后谁 active 无关，原提前 return 会漏删并留下永久幽灵徽标（bindings 无重算路径）。
- `approve/rejectWorkflowGate` catch 补 run 身份校验：陈旧失败提示不得弹给新 run 用户。
- tauri `startWorkflowTask` 补 busy 闸（与 web 对齐）；`workflowStarting` 收敛为 `state.workflow.starting` 并在两平台 state 声明。
- 恢复 web/bridge.js 被 busy 闸补丁挤掉的分隔头注释。
- 测试补 deactivateSkill 切走守卫与 busy 闸 2 个用例；装载器补注入 console/itemIdSeq。

## 验证

- `workflow_race.test.mjs` 10 个测试全绿；在 base（最新 main）上原 8 用例全部失败、复审补丁用例在补丁前代码上失败——回归有效性双向实证
- `node --check` / eslint / 协议指纹测试（`bridge_domain_protocol`）/ architecture-guard / fork-guard --fast 全部通过
- 全量 node 测试 145/146：唯一失败 `assistant_message_actions.test.mjs` 在 origin/main 上同样失败（预存在，与本 PR 无关）
- 已 rebase 到最新 main（07e8b9cb），零冲突