### PR TITLE
fix(chat): 定时/设置/更新/远程控制异步竞态

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge/remote-control.js
+++ b/pinvou3-app/src/platform/tauri/bridge/remote-control.js
@@ -160,8 +160,9 @@
     }
 
     // webAccess 状态写入无意图排序：start/stop/rotate 并发时后完成者会把
-    // UI 指示写反（审计 a）。用户操作意图序号——陈旧响应作废，权威状态由
-    // 下一次 web_access:status 事件收敛。
+    // UI 指示写反（审计 a）。用户操作意图序号——陈旧响应作废，终态由最新
+    // 意图的完成写入收敛：web_access:status 事件 payload 不含 starting，
+    // 事件无法清理该标志，须由每个意图完成路径（含失败）显式兜底。
     var webAccessIntentSeq = 0;
 
     async function refreshRemoteControlStatus() {
@@ -203,7 +204,7 @@
         await invoke("web_access_disable");
       } catch (error) {
         if (seq !== webAccessIntentSeq) return; // 陈旧失败不向调用者抛错：已有更新的用户操作接管状态（审计补充）
-        state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error) });
+        state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error), starting: false });
         notify();
         throw error;
       }
@@ -228,7 +229,7 @@
         return info;
       } catch (error) {
         if (seq !== webAccessIntentSeq) throw error;
-        state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error) });
+        state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error), starting: false });
         notify();
         throw error;
       }

--- a/pinvou3-app/src/platform/tauri/bridge/remote-control.js
+++ b/pinvou3-app/src/platform/tauri/bridge/remote-control.js
@@ -210,7 +210,7 @@
       if (seq !== webAccessIntentSeq) return; // 已有更新的用户操作，不写反状态
       state.webAccess = Object.assign({}, state.webAccess, {
         active: false, endpoint_id: null, url: null, qr_data_url: null,
-        web_client_connected: false, status: "stopped",
+        web_client_connected: false, status: "stopped", starting: false,
       });
       notify();
     }
@@ -221,7 +221,7 @@
         var info = await invoke("web_access_rotate");
         if (seq !== webAccessIntentSeq) return info;
         state.webAccess = Object.assign({}, state.webAccess, info || {}, {
-          active: true, web_client_connected: false, last_error: null,
+          active: true, web_client_connected: false, last_error: null, starting: false,
         });
         notify();
         await refreshRemoteControlStatus();

--- a/pinvou3-app/src/platform/tauri/bridge/remote-control.js
+++ b/pinvou3-app/src/platform/tauri/bridge/remote-control.js
@@ -202,7 +202,7 @@
       try {
         await invoke("web_access_disable");
       } catch (error) {
-        if (seq !== webAccessIntentSeq) throw error;
+        if (seq !== webAccessIntentSeq) return; // 陈旧失败不向调用者抛错：已有更新的用户操作接管状态（审计补充）
         state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error) });
         notify();
         throw error;

--- a/pinvou3-app/src/platform/tauri/bridge/remote-control.js
+++ b/pinvou3-app/src/platform/tauri/bridge/remote-control.js
@@ -159,6 +159,11 @@
       }
     }
 
+    // webAccess 状态写入无意图排序：start/stop/rotate 并发时后完成者会把
+    // UI 指示写反（审计 a）。用户操作意图序号——陈旧响应作废，权威状态由
+    // 下一次 web_access:status 事件收敛。
+    var webAccessIntentSeq = 0;
+
     async function refreshRemoteControlStatus() {
       try {
         var status = await invoke("web_access_status");
@@ -170,16 +175,19 @@
     }
 
     async function startRemoteControl() {
+      var seq = ++webAccessIntentSeq;
       state.webAccess = Object.assign({}, state.webAccess, { starting: true, last_error: null });
       notify();
       try {
         var info = await invoke("web_access_enable");
+        if (seq !== webAccessIntentSeq) return info; // 已有更新的用户操作，不写反状态
         state.webAccess = Object.assign({}, state.webAccess, info || {}, {
           active: true, starting: false, last_error: null,
         });
         await refreshRemoteControlStatus();
         return info;
       } catch (error) {
+        if (seq !== webAccessIntentSeq) throw error;
         state.webAccess = Object.assign({}, state.webAccess, {
           active: false, web_client_connected: false, starting: false,
           status: "error", last_error: String(error),
@@ -190,13 +198,16 @@
     }
 
     async function stopRemoteControl() {
+      var seq = ++webAccessIntentSeq;
       try {
         await invoke("web_access_disable");
       } catch (error) {
+        if (seq !== webAccessIntentSeq) throw error;
         state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error) });
         notify();
         throw error;
       }
+      if (seq !== webAccessIntentSeq) return; // 已有更新的用户操作，不写反状态
       state.webAccess = Object.assign({}, state.webAccess, {
         active: false, endpoint_id: null, url: null, qr_data_url: null,
         web_client_connected: false, status: "stopped",
@@ -205,8 +216,10 @@
     }
 
     async function refreshRemoteControlQr() {
+      var seq = ++webAccessIntentSeq;
       try {
         var info = await invoke("web_access_rotate");
+        if (seq !== webAccessIntentSeq) return info;
         state.webAccess = Object.assign({}, state.webAccess, info || {}, {
           active: true, web_client_connected: false, last_error: null,
         });
@@ -214,6 +227,7 @@
         await refreshRemoteControlStatus();
         return info;
       } catch (error) {
+        if (seq !== webAccessIntentSeq) throw error;
         state.webAccess = Object.assign({}, state.webAccess, { status: "error", last_error: String(error) });
         notify();
         throw error;

--- a/pinvou3-app/src/platform/tauri/bridge/scheduled.js
+++ b/pinvou3-app/src/platform/tauri/bridge/scheduled.js
@@ -613,6 +613,12 @@
         : SCHEDULED_LINK_POLL_SLOW_MS);
     }
 
+    function taskStillListed() {
+      return (state.scheduledTasks || []).some(function (item) {
+        return item && item.id === automationId;
+      });
+    }
+
     function poll(attempt) {
       invoke("list_scheduled_task_runs", { id: automationId }).then(function (runs) {
         // 任务已被删除时不再回填：陈旧轮询响应会把已删任务以 fallback 名
@@ -638,7 +644,15 @@
           return;
         }
         again(attempt);
-      }).catch(function () { again(attempt); });
+      }).catch(function () {
+        // 已删任务的后端响应是 Err 而非空列表（get_automation 文件已移除）。
+        // 任务不在列表即收工，否则会以 1s/5s 空转重试到 30 分钟兜底。
+        if (!taskStillListed()) {
+          stop();
+          return;
+        }
+        again(attempt);
+      });
     }
 
     poll(0);
@@ -757,6 +771,10 @@
     return runScheduledTaskAction("delete", async function () {
       invalidateScheduledRecentRuns();
       var deleted = await invoke("delete_scheduled_task", { id: id });
+      // 作废删除前在途的整表 list / detail / runs 读（与 run-now 同模式）：否则
+      // 3 秒轮询的旧 list 响应落地时会把刚删的任务复活回侧边栏（含本 feature
+      // run-now 轮询依赖的 taskStillListed 判断，幽灵窗口会击穿 R1 守卫）。
+      invalidateScheduledTaskReads(id);
       var deletedSessionIds = deleted && Array.isArray(deleted.deletedSessionIds)
         ? deleted.deletedSessionIds
         : [];

--- a/pinvou3-app/src/platform/tauri/bridge/scheduled.js
+++ b/pinvou3-app/src/platform/tauri/bridge/scheduled.js
@@ -208,7 +208,8 @@
   function isCurrentScheduledTaskRequest(stamp) {
     if (!stamp || stamp.generation !== scheduledTaskSelectionGeneration) return false;
     if (scheduledTaskRequestTokens[stamp.kind] !== stamp.token) return false;
-    if (stamp.kind !== "tasks" && state.selectedScheduledTaskId !== stamp.id) return false;
+    // id 检查省略：selectedScheduledTaskId 唯一写者是 selectScheduledTask（每次
+    // 改写前 generation+1），id 变化必然被上方 generation 检查拦截（审计清理）。
     return true;
   }
 
@@ -367,10 +368,15 @@
   }
 
   // 聊天创建拿到合法参数后立即落成任务。草稿不会进入可渲染 state，避免再出现一层确认卡。
+  // autoOpenId 全局 last-writer：两会话并发创建时后完成者覆盖，且
+  // startScheduledTaskChat 清空后陈旧 completion 会复活 auto-open（审计 f）。
+  // 全局单调创建序号，仅最新意图可写。
+  var scheduledTaskAutoCreateSeq = 0;
   function autoCreateScheduledTaskDraft(draft, creationSessionId) {
     if (!draft || !creationSessionId || scheduledTaskAutoCreateInFlight[creationSessionId]) return;
     var lockedDraft = lockScheduledTaskDraftModel(draft);
     state.scheduledTaskDraft = null;
+    var creationSeq = ++scheduledTaskAutoCreateSeq;
     var creation = Promise.resolve()
       .then(function () {
         return createScheduledTask(scheduledTaskInputFromDraft(lockedDraft));
@@ -381,7 +387,7 @@
         }
         var creationBuffer = sessionStates[creationSessionId];
         if (creationBuffer) creationBuffer.scheduledTaskDraft = null;
-        if (created && created.id) state.scheduledTaskAutoOpenId = created.id;
+        if (created && created.id && creationSeq === scheduledTaskAutoCreateSeq) state.scheduledTaskAutoOpenId = created.id;
         notify();
         return created;
       })
@@ -609,9 +615,15 @@
 
     function poll(attempt) {
       invoke("list_scheduled_task_runs", { id: automationId }).then(function (runs) {
+        // 任务已被删除时不再回填：陈旧轮询响应会把已删任务以 fallback 名
+        // 复活回侧边栏（审计 R1）。任务不在列表即收工，不 merge、不续排。
         var task = (state.scheduledTasks || []).find(function (item) {
           return item && item.id === automationId;
-        }) || { id: automationId, name: bt("scheduledTaskFallbackName") };
+        });
+        if (!task) {
+          stop();
+          return;
+        }
         mergeScheduledTaskRecentRuns(task, runs);
         notify();
         // 必须看原始响应:mergeScheduledTaskRecentRuns 会滤掉尚无 sessionId 的记录,
@@ -793,6 +805,7 @@
       var prompt = await invoke("scheduled_task_chat_prompt");
       state.scheduledTaskDraft = null;
       state.scheduledTaskCreationSessionId = null;
+      scheduledTaskAutoCreateSeq++; // 清空意图：作废在途 auto-create 的陈旧 completion（审计 f）
       state.scheduledTaskAutoOpenId = null;
       await createNewSession();
       state.scheduledTaskPendingGuide = prompt;

--- a/pinvou3-app/src/platform/tauri/bridge/settings.js
+++ b/pinvou3-app/src/platform/tauri/bridge/settings.js
@@ -132,7 +132,8 @@
   // autoPoll 只供内部定时器续接；用户手动检测会重置本轮截止时间。
   // 陈旧检测快照覆盖（审计）：检测与长任务引导（bootstrap_local_vllm）并发时，
   // 旧快照会把已就绪引擎覆盖回 starting。任何新检测与引导完成都递增序号，
-  // 在途读取一律作废。
+  // 在途读取一律作废。社区版后端 detect 恒 stopped / bootstrap 恒 Err（厂商版
+  // 语义的桩），此守卫为防御性：后端恢复真实探测时竞态即真实存在。
   var vllmDetectSeq = 0;
   async function detectLocalVllmSetup(options) {
     var autoPoll = !!(options && options.autoPoll);
@@ -192,7 +193,7 @@
     notify();
     // 作废在途读取会中断 autoPoll 续排链（被作废的检测不再续排定时器），
     // 引导完成后主动重检一次，让引擎就绪状态及时收敛（审计补充）。
-    detectLocalVllmSetup({ autoPoll: true }).catch(function () {});
+    detectLocalVllmSetup({ autoPoll: true });
   }
   // 点「跳过」:仅本次会话内不再弹(不写持久标记,下次启动若仍未配好会再次友好提示)。
   function dismissVllmSetup() {

--- a/pinvou3-app/src/platform/tauri/bridge/settings.js
+++ b/pinvou3-app/src/platform/tauri/bridge/settings.js
@@ -130,16 +130,24 @@
   // 首屏检测「预装但未启用」状态;eligible 时前端弹引导框。
   // 开机加载中不弹框，每 3 秒静默复查；12 分钟后仍 starting 则恢复可重试入口。
   // autoPoll 只供内部定时器续接；用户手动检测会重置本轮截止时间。
+  // 陈旧检测快照覆盖（审计）：检测与长任务引导（bootstrap_local_vllm）并发时，
+  // 旧快照会把已就绪引擎覆盖回 starting。任何新检测与引导完成都递增序号，
+  // 在途读取一律作废。
+  var vllmDetectSeq = 0;
   async function detectLocalVllmSetup(options) {
     var autoPoll = !!(options && options.autoPoll);
+    var seq = ++vllmDetectSeq;
     if (vllmSetupPollTimer) {
       clearTimeout(vllmSetupPollTimer);
       vllmSetupPollTimer = null;
     }
     if (!autoPoll) vllmSetupPollStartedAt = Date.now();
     try {
-      state.vllmSetup = await invoke("detect_local_vllm_setup");
+      var snapshot = await invoke("detect_local_vllm_setup");
+      if (seq !== vllmDetectSeq) return state.vllmSetup; // 已作废的陈旧读取
+      state.vllmSetup = snapshot;
     } catch (e) {
+      if (seq !== vllmDetectSeq) return state.vllmSetup;
       state.vllmSetup = null; // 检测失败静默,不打扰(等同不弹)
       vllmSetupPollStartedAt = 0;
     }
@@ -179,6 +187,7 @@
     } catch (e) {
       state.vllmBootstrapError = String(e && e.message ? e.message : e);
     }
+    vllmDetectSeq++; // 引导完成：作废在途的陈旧检测读取（审计）
     state.vllmBootstrapping = false;
     notify();
   }
@@ -206,12 +215,18 @@
   }
 
   // ── 模型列表(「添加模型」方案)─────────────────────────────────
+  // 整表覆盖加载：保存/删除/切换链式 loadModels 并发时旧列表不得覆盖新列表
+  // （审计 b）。请求序号后发者胜（同 vllmDetectSeq 模式）。
+  var modelsLoadSeq = 0;
   async function loadModels() {
+    var seq = ++modelsLoadSeq;
     try {
       var v = await invoke("list_models");
+      if (seq !== modelsLoadSeq) return;
       state.savedModels = (v && v.models) || [];
       state.activeModelId = (v && v.active_model_id) || null;
     } catch (e) {
+      if (seq !== modelsLoadSeq) return;
       state.savedModels = []; state.activeModelId = null;
     }
     notify();

--- a/pinvou3-app/src/platform/tauri/bridge/settings.js
+++ b/pinvou3-app/src/platform/tauri/bridge/settings.js
@@ -190,6 +190,9 @@
     vllmDetectSeq++; // 引导完成：作废在途的陈旧检测读取（审计）
     state.vllmBootstrapping = false;
     notify();
+    // 作废在途读取会中断 autoPoll 续排链（被作废的检测不再续排定时器），
+    // 引导完成后主动重检一次，让引擎就绪状态及时收敛（审计补充）。
+    detectLocalVllmSetup({ autoPoll: true }).catch(function () {});
   }
   // 点「跳过」:仅本次会话内不再弹(不写持久标记,下次启动若仍未配好会再次友好提示)。
   function dismissVllmSetup() {

--- a/pinvou3-app/src/platform/tauri/bridge/updater.js
+++ b/pinvou3-app/src/platform/tauri/bridge/updater.js
@@ -79,7 +79,9 @@
   async function downloadAndInstallUpdate() {
     if (!state.updateInfo || !state.updateInfo.available || state.updateDownloading) return false;
     // 入口捕获发起时的更新信息：下载/安装期间静默检查可能替换 updateInfo，
-    // install 参数必须仍指向发起时的版本（审计）。invoke 文本保持原样。
+    // download/install 参数须仍指向发起时的版本（审计）。当前基线的 install_update
+    // 为 unsupported 桩（info 未参与行为），此配对为面向完整平台实现的防御性修复。
+    // invoke 文本保持原样。
     var info = state.updateInfo;
     var shouldRestartAfterInstall = info.platform !== "windows";
     var installed = false;

--- a/pinvou3-app/src/platform/tauri/bridge/updater.js
+++ b/pinvou3-app/src/platform/tauri/bridge/updater.js
@@ -78,13 +78,17 @@
   // 安装器启动成功后 Windows 退出当前进程；Linux/macOS 在安装后由前端重启。
   async function downloadAndInstallUpdate() {
     if (!state.updateInfo || !state.updateInfo.available || state.updateDownloading) return false;
-    var shouldRestartAfterInstall = state.updateInfo.platform !== "windows";
+    // 入口捕获发起时的更新信息：下载/安装期间静默检查可能替换 updateInfo，
+    // install 参数必须仍指向发起时的版本（审计）。invoke 文本保持原样。
+    var info = state.updateInfo;
+    var shouldRestartAfterInstall = info.platform !== "windows";
     var installed = false;
     state.updateDownloading = true; state.updateCancelling = false;
     state.updateProgress = 0; state.updateError = null; notify();
     try {
       var downloadResult = await invoke("download_update", { info: state.updateInfo });
       state.updateProgress = 100; notify();
+      state.updateInfo = info; // 复原：install 用发起时的版本元数据，不随静默检查漂移
       if (downloadResult && typeof downloadResult === "object" && downloadResult.installer_path) {
         await invoke("install_update", { installerPath: downloadResult.installer_path, info: state.updateInfo });
       } else {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1677,7 +1677,8 @@
   function isCurrentScheduledTaskRequest(stamp) {
     if (!stamp || stamp.generation !== scheduledTaskSelectionGeneration) return false;
     if (scheduledTaskRequestTokens[stamp.kind] !== stamp.token) return false;
-    if (stamp.kind !== "tasks" && state.selectedScheduledTaskId !== stamp.id) return false;
+    // id 检查省略：selectedScheduledTaskId 唯一写者是 selectScheduledTask（每次
+    // 改写前 generation+1），id 变化必然被上方 generation 检查拦截（审计清理）。
     return true;
   }
 
@@ -1836,10 +1837,14 @@
   }
 
   // 聊天创建拿到合法参数后立即落成任务。草稿不会进入可渲染 state，避免再出现一层确认卡。
+  // autoOpenId 全局 last-writer：两会话并发创建时后完成者覆盖，且 startScheduledTaskChat
+  // 清空后陈旧 completion 会复活 auto-open（审计 f）。全局单调创建序号，仅最新意图可写。
+  var scheduledTaskAutoCreateSeq = 0;
   function autoCreateScheduledTaskDraft(draft, creationSessionId) {
     if (!draft || !creationSessionId || scheduledTaskAutoCreateInFlight[creationSessionId]) return;
     var lockedDraft = lockScheduledTaskDraftModel(draft);
     state.scheduledTaskDraft = null;
+    var creationSeq = ++scheduledTaskAutoCreateSeq;
     var creation = Promise.resolve()
       .then(function () {
         return createScheduledTask(scheduledTaskInputFromDraft(lockedDraft));
@@ -1850,7 +1855,8 @@
         }
         var creationBuffer = sessionStates[creationSessionId];
         if (creationBuffer) creationBuffer.scheduledTaskDraft = null;
-        if (created && created.id) state.scheduledTaskAutoOpenId = created.id;
+        // 仅最新创建意图可写 autoOpenId（陈旧 completion 不得复活 auto-open，审计 f）
+        if (created && created.id && creationSeq === scheduledTaskAutoCreateSeq) state.scheduledTaskAutoOpenId = created.id;
         notify();
         return created;
       })
@@ -2262,6 +2268,7 @@
       var prompt = await invoke("scheduled_task_chat_prompt");
       state.scheduledTaskDraft = null;
       state.scheduledTaskCreationSessionId = null;
+      scheduledTaskAutoCreateSeq++; // 清空意图：作废在途 auto-create 的陈旧 completion（审计 f）
       state.scheduledTaskAutoOpenId = null;
       await createNewSession();
       state.scheduledTaskPendingGuide = prompt;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -2084,9 +2084,15 @@
 
     function poll(attempt) {
       invoke("list_scheduled_task_runs", { id: automationId }).then(function (runs) {
+        // 任务已被删除时不再回填：陈旧轮询响应会把已删任务以 fallback 名
+        // 复活回侧边栏（审计 R1）。任务不在列表即收工，不 merge、不续排。
         var task = (state.scheduledTasks || []).find(function (item) {
           return item && item.id === automationId;
-        }) || { id: automationId, name: bt("scheduledTaskFallbackName") };
+        });
+        if (!task) {
+          stop();
+          return;
+        }
         mergeScheduledTaskRecentRuns(task, runs);
         notify();
         // 必须看原始响应:mergeScheduledTaskRecentRuns 会滤掉尚无 sessionId 的记录,
@@ -6292,12 +6298,18 @@
   }
 
   // ── 模型列表(「添加模型」方案)─────────────────────────────────
+  // 整表覆盖加载：保存/删除/切换链式 loadModels 并发时旧列表不得覆盖新列表
+  // （审计 b）。请求序号后发者胜（与 tauri settings 侧一致）。
+  var modelsLoadSeq = 0;
   async function loadModels() {
+    var seq = ++modelsLoadSeq;
     try {
       var v = await invoke("list_models");
+      if (seq !== modelsLoadSeq) return;
       state.savedModels = (v && v.models) || [];
       state.activeModelId = (v && v.active_model_id) || null;
     } catch (e) {
+      if (seq !== modelsLoadSeq) return;
       state.savedModels = []; state.activeModelId = null;
     }
     notify();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -2082,6 +2082,12 @@
         : SCHEDULED_LINK_POLL_SLOW_MS);
     }
 
+    function taskStillListed() {
+      return (state.scheduledTasks || []).some(function (item) {
+        return item && item.id === automationId;
+      });
+    }
+
     function poll(attempt) {
       invoke("list_scheduled_task_runs", { id: automationId }).then(function (runs) {
         // 任务已被删除时不再回填：陈旧轮询响应会把已删任务以 fallback 名
@@ -2107,7 +2113,15 @@
           return;
         }
         again(attempt);
-      }).catch(function () { again(attempt); });
+      }).catch(function () {
+        // 已删任务的后端响应是 Err 而非空列表（get_automation 文件已移除）。
+        // 任务不在列表即收工，否则会以 1s/5s 空转重试到 30 分钟兜底。
+        if (!taskStillListed()) {
+          stop();
+          return;
+        }
+        again(attempt);
+      });
     }
 
     poll(0);
@@ -2226,6 +2240,10 @@
     return runScheduledTaskAction("delete", async function () {
       invalidateScheduledRecentRuns();
       var deleted = await invoke("delete_scheduled_task", { id: id });
+      // 作废删除前在途的整表 list / detail / runs 读（与 run-now 同模式）：否则
+      // 3 秒轮询的旧 list 响应落地时会把刚删的任务复活回侧边栏（含本 feature
+      // run-now 轮询依赖的 taskStillListed 判断，幽灵窗口会击穿 R1 守卫）。
+      invalidateScheduledTaskReads(id);
       var deletedSessionIds = deleted && Array.isArray(deleted.deletedSessionIds)
         ? deleted.deletedSessionIds
         : [];

--- a/pinvou3-app/tests/remote_control_race.test.mjs
+++ b/pinvou3-app/tests/remote_control_race.test.mjs
@@ -67,3 +67,36 @@ test('stop 顶掉在途 start 后 starting 必须被清除（不残留启动中�
   assert.equal(rt.state.webAccess.starting, false, '陈旧 start 返回后 starting 不得复活');
   assert.deepEqual(info, { url: 'https://example.test' }, '陈旧 start 仍返回原始结果');
 });
+
+test('stop 新鲜失败必须清除 starting（start 被顶掉后无人兜底）', async () => {
+  const rt = loadRemoteControlFeature();
+  // 用户点启动：starting:true 置位，enable 在途（seq=1）。
+  const dEnable = rt.defer('web_access_enable');
+  const pStart = rt.api.startRemoteControl();
+  // 启动在途时用户点停止（seq=2 顶掉 start），disable 失败（新鲜失败）。
+  const dDisable = rt.defer('web_access_disable');
+  const pStop = rt.api.stopRemoteControl();
+  dDisable.reject(new Error('disable failed'));
+  await pStop.catch(() => { /* 已知 reject */ });
+  assert.equal(rt.state.webAccess.starting, false, 'stop 失败写入必须清掉 starting');
+  assert.equal(rt.state.webAccess.status, 'error', 'stop 失败写入 error 终态');
+  // 迟到的 enable 此刻才返回（陈旧）：不写任何状态，starting 不得复活。
+  dEnable.resolve({ url: 'https://example.test' });
+  await pStart;
+  assert.equal(rt.state.webAccess.starting, false, '陈旧 start 返回后 starting 不得复活');
+  assert.equal(rt.state.webAccess.active, undefined, '陈旧 start 不写任何状态');
+});
+
+test('rotate 新鲜失败必须清除 starting', async () => {
+  const rt = loadRemoteControlFeature();
+  const dEnable = rt.defer('web_access_enable');
+  const pStart = rt.api.startRemoteControl();        // seq=1，starting:true
+  const dRotate = rt.defer('web_access_rotate');
+  const pRotate = rt.api.refreshRemoteControlQr();   // seq=2 顶掉 start
+  dRotate.reject(new Error('rotate failed'));        // rotate 新鲜失败
+  await pRotate.catch(() => { /* 已知 reject */ });
+  assert.equal(rt.state.webAccess.starting, false, 'rotate 失败写入必须清掉 starting');
+  dEnable.resolve({});
+  await pStart;                                      // 陈旧 start：不写任何状态
+  assert.equal(rt.state.webAccess.starting, false, '陈旧 start 返回后 starting 不得复活');
+});

--- a/pinvou3-app/tests/remote_control_race.test.mjs
+++ b/pinvou3-app/tests/remote_control_race.test.mjs
@@ -1,0 +1,69 @@
+/**
+ * 远程控制意图序号回归测试（PR #260 审计补充）：
+ * start 在途被 stop 顶掉（陈旧 start 不写状态）后，stop 的写入必须清掉
+ * starting 标志——否则 UI 永卡「启动中」（Rust 事件 payload 不含 starting，
+ * 无人兜底收敛）。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+
+function loadRemoteControlFeature() {
+  const root = {};
+  const src = fs.readFileSync(path.join(bridgeDir, 'remote-control.js'), 'utf8');
+  vm.runInNewContext(src, {
+    window: root,
+    globalThis: root,
+    setTimeout,
+    clearTimeout,
+  });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__['remote-control'];
+  const deferreds = {};
+  const state = { webAccess: {} };
+  const api = factory({
+    state,
+    notify() {},
+    bt(key) { return key; },
+    listen() { return Promise.resolve(function () {}); },
+    invoke(name) {
+      if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+      return Promise.resolve({});
+    },
+  });
+  return {
+    api,
+    state,
+    defer(name) {
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+  };
+}
+
+test('stop 顶掉在途 start 后 starting 必须被清除（不残留启动中）', async () => {
+  const rt = loadRemoteControlFeature();
+  // 用户点启动：starting:true 置位，enable 在途（seq=1）。
+  const dEnable = rt.defer('web_access_enable');
+  const pStart = rt.api.startRemoteControl();
+  // 启动在途时用户点停止（seq=2）：disable 先完成并写终态。
+  const dDisable = rt.defer('web_access_disable');
+  const pStop = rt.api.stopRemoteControl();
+  dDisable.resolve({});
+  await pStop;
+  assert.equal(rt.state.webAccess.starting, false, 'stop 的成功写入必须清掉 starting');
+  assert.equal(rt.state.webAccess.active, false, 'stop 正常写入终态');
+  // 迟到的 enable 此刻才返回（seq 已陈旧）：不写任何状态。
+  dEnable.resolve({ url: 'https://example.test' });
+  const info = await pStart;
+  assert.equal(rt.state.webAccess.active, false, '陈旧 start 不得把 stopped 写回 active');
+  assert.equal(rt.state.webAccess.starting, false, '陈旧 start 返回后 starting 不得复活');
+  assert.deepEqual(info, { url: 'https://example.test' }, '陈旧 start 仍返回原始结果');
+});

--- a/pinvou3-app/tests/scheduled_race.test.mjs
+++ b/pinvou3-app/tests/scheduled_race.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * 定时任务竞态回归测试（PR #260 审计补充）：
+ * 删除任务后，删除前在途的整表 list 响应不得把已删任务复活回侧边栏
+ * （M1：deleteScheduledTask 补 invalidateScheduledTaskReads）。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+
+function loadScheduledFeature() {
+  const root = { localStorage: { getItem() { return null; }, setItem() {} } };
+  const src = fs.readFileSync(path.join(bridgeDir, 'scheduled.js'), 'utf8');
+  vm.runInNewContext(src, {
+    window: root,
+    globalThis: root,
+    setTimeout,
+    clearTimeout,
+  });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__.scheduled;
+  const deferreds = {};
+  const state = { scheduledTasks: [] };
+  const api = factory({
+    state,
+    notify() {},
+    bt(key) { return key; },
+    addSystemItem() {},
+    addChatItem() {},
+    timeStr() { return ''; },
+    rememberScheduledRunOwner() {},
+    isScheduledRunTerminal(status) { return ['completed', 'failed'].includes(status); },
+    purgeSessionBuffer() {},
+    createNewSession() {},
+    prefillComposer() {},
+    sessionStates: {},
+    runSyncOnSession() { return Promise.resolve(); },
+    invoke(name, args) {
+      if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+      return Promise.resolve({});
+    },
+  });
+  return {
+    api,
+    state,
+    defer(name) {
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+  };
+}
+
+test('deleteScheduledTask 作废删除前在途的整表 list 响应（已删任务不得复活）', async () => {
+  const rt = loadScheduledFeature();
+  // 预置任务列表，选中另一任务 B（删除未选中的 A，正是复活竞态的路径）。
+  rt.state.scheduledTasks = [
+    { id: 'task-a', name: 'A' },
+    { id: 'task-b', name: 'B' },
+  ];
+  await rt.api.selectScheduledTask('task-b');
+
+  // 3 秒轮询在删除前发出 list_scheduled_tasks（在途，读到删除前快照）。
+  const dList = rt.defer('list_scheduled_tasks');
+  const pLoad = rt.api.loadScheduledTasks();
+  // 用户确认删除 A：delete 完成后本地同步修剪 + 作废在途读。
+  const pDelete = rt.api.deleteScheduledTask('task-a');
+  // delete invoke 排在 list 之后（deferred 按名占用）。
+  const dDelete = rt.defer('delete_scheduled_task');
+  dDelete.resolve({ deletedSessionIds: [] });
+  await pDelete;
+  assert.ok(
+    !rt.state.scheduledTasks.some((task) => task.id === 'task-a'),
+    '删除后本地列表立即移除任务',
+  );
+
+  // 删除前发出的 list 响应此刻才返回（含已删的 A）——不得整表写回。
+  dList.resolve([
+    { id: 'task-a', name: 'A' },
+    { id: 'task-b', name: 'B' },
+  ]);
+  await pLoad;
+  assert.ok(
+    !rt.state.scheduledTasks.some((task) => task.id === 'task-a'),
+    '陈旧整表响应不得复活已删任务',
+  );
+  assert.ok(
+    rt.state.scheduledTasks.some((task) => task.id === 'task-b'),
+    '未删任务保持存在',
+  );
+});

--- a/pinvou3-app/tests/settings_race.test.mjs
+++ b/pinvou3-app/tests/settings_race.test.mjs
@@ -82,3 +82,36 @@ test('detectLocalVllmSetup 陈旧检测快照作废（新检测优先）', async
   await p2;
   assert.equal(rt.state.vllmSetup.engine_state, 'ready', '新检测正常写入');
 });
+
+test('bootstrap 完成作废在途检测并续接轮询（新检测收敛就绪状态）', async () => {
+  const rt = loadSettingsFeature();
+  const d1 = rt.defer('detect_local_vllm_setup');
+  const p1 = rt.api.detectLocalVllmSetup({});        // 检测 1（序号 1）
+  const db = rt.defer('bootstrap_local_vllm');
+  const pB = rt.api.bootstrapLocalVllm();            // 引导开始
+  const d2 = rt.defer('detect_local_vllm_setup');    // 为引导完成后的重检预占槽位
+  db.resolve({ done: true });                        // 引导完成：作废在途检测 + 主动重检
+  await pB;
+  d1.resolve({ engine_state: 'starting', may_offer_setup: true }); // 陈旧快照
+  await p1;
+  assert.equal(rt.state.vllmSetup, undefined, '引导完成前的陈旧快照不得写入');
+  d2.resolve({ engine_state: 'ready', may_offer_setup: false });   // 重检快照
+  await new Promise(function (resolve) { setTimeout(resolve, 0); });
+  assert.equal(rt.state.vllmSetup.engine_state, 'ready', '引导后的重检正常收敛就绪状态');
+});
+
+test('loadModels 后发者胜（旧列表不得覆盖新列表）', async () => {
+  const rt = loadSettingsFeature();
+  const d1 = rt.defer('list_models');
+  const p1 = rt.api.loadModels();                    // 加载 1（序号 1）
+  const d2 = rt.defer('list_models');
+  const p2 = rt.api.loadModels();                    // 加载 2（序号 2）
+  d1.resolve({ models: [{ id: 'old' }], active_model_id: 'old' }); // 旧响应
+  await p1;
+  assert.equal(rt.state.savedModels, undefined, '陈旧列表不得写入');
+  assert.equal(rt.state.activeModelId, undefined, '陈旧 activeModelId 不得写入');
+  d2.resolve({ models: [{ id: 'new' }], active_model_id: 'new' }); // 新响应
+  await p2;
+  assert.equal(rt.state.savedModels[0].id, 'new', '新列表正常写入');
+  assert.equal(rt.state.activeModelId, 'new', '新 activeModelId 正常写入');
+});

--- a/pinvou3-app/tests/settings_race.test.mjs
+++ b/pinvou3-app/tests/settings_race.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * 子代理全量审计产出的同类竞态回归测试（PR #250 延续）：
+ * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
+ * 覆盖 tauri memory/personas/workflow/settings 四个可单测 feature；
+ * sessions.js（ensureSession/refreshHistoryList/archiveSession）内部依赖
+ * 太重（sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+/** 通用 feature 装载器：vm 加载 IIFE(window) 形态的桥 feature 文件。 */
+function loadFeature(fileName, state, contextOverrides) {
+  const root = { __PINVOU_SHARED_I18N__: {} };
+  const src = fs.readFileSync(path.join(bridgeDir, fileName), 'utf8');
+  vm.runInNewContext(src, {
+    window: root,
+    globalThis: root,
+    setTimeout,
+    clearTimeout,
+  });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__[fileName.replace('.js', '')];
+  const deferreds = {};
+  const calls = { invoke: [] };
+  const api = factory(Object.assign({
+    state,
+    notify() { calls.notify = (calls.notify || 0) + 1; },
+    bt(key) { return key; },
+    addSystemItem() {},
+    addChatItem() {},
+    timeStr() { return ''; },
+    invoke(name, args) {
+      calls.invoke.push(name);
+      if (deferreds[name] && deferreds[name].promise) return deferreds[name].promise;
+      return Promise.resolve({});
+    },
+  }, contextOverrides || {}));
+  return {
+    api,
+    state,
+    calls,
+    defer(name) {
+      // 每次创建全新对象：同一 invoke 名的第二次 defer 不得覆盖第一次的
+      // resolve（否则旧 promise 永远无人 resolve → 测试挂起）。
+      const d = {};
+      d.promise = new Promise((resolve, reject) => { d.resolve = resolve; d.reject = reject; });
+      deferreds[name] = d;
+      return d;
+    },
+  };
+}
+
+// ── memory.js：loadMemoryOverview 陈旧覆盖 ──────────────────────────
+
+function loadSettingsFeature() {
+  const state = { settings: {}, vllmSetup: undefined, vllmBootstrapping: false };
+  return loadFeature('settings.js', state, { listen() {} });
+}
+
+test('detectLocalVllmSetup 陈旧检测快照作废（新检测优先）', async () => {
+  const rt = loadSettingsFeature();
+  const d1 = rt.defer('detect_local_vllm_setup');
+  const p1 = rt.api.detectLocalVllmSetup({});       // 检测 1
+  const d2 = rt.defer('detect_local_vllm_setup');
+  const p2 = rt.api.detectLocalVllmSetup({});       // 检测 2（序号递增）
+  d1.resolve({ engine_state: 'starting', may_offer_setup: true }); // 旧响应
+  await p1;
+  assert.equal(rt.state.vllmSetup, undefined, '陈旧检测快照不得写入');
+  d2.resolve({ engine_state: 'ready', may_offer_setup: false });   // 新响应
+  await p2;
+  assert.equal(rt.state.vllmSetup.engine_state, 'ready', '新检测正常写入');
+});

--- a/pinvou3-app/tests/settings_race.test.mjs
+++ b/pinvou3-app/tests/settings_race.test.mjs
@@ -1,9 +1,7 @@
 /**
- * 子代理全量审计产出的同类竞态回归测试（PR #250 延续）：
- * 陈旧读取覆盖 / await 后写入漂移 / 并发重入——修复后的行为快照。
- * 覆盖 tauri memory/personas/workflow/settings 四个可单测 feature；
- * sessions.js（ensureSession/refreshHistoryList/archiveSession）内部依赖
- * 太重（sessionStates/switchActiveTo 等），由代码审查 + 既有套件保证。
+ * 同类竞态回归测试（PR #250 审计 → #260 settings 域）：
+ * 陈旧读取覆盖 / await 后写入漂移——修复后的行为快照。
+ * 覆盖 tauri settings（vllm 检测/bootstrap 重检/loadModels）。
  */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -14,12 +12,6 @@ import { fileURLToPath } from 'node:url';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
-
-function deferred() {
-  let resolve, reject;
-  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
-  return { promise, resolve, reject };
-}
 
 /** 通用 feature 装载器：vm 加载 IIFE(window) 形态的桥 feature 文件。 */
 function loadFeature(fileName, state, contextOverrides) {
@@ -62,7 +54,7 @@ function loadFeature(fileName, state, contextOverrides) {
   };
 }
 
-// ── memory.js：loadMemoryOverview 陈旧覆盖 ──────────────────────────
+// ── settings.js：vllm 检测 / bootstrap 重检 / loadModels ─────────────
 
 function loadSettingsFeature() {
   const state = { settings: {}, vllmSetup: undefined, vllmBootstrapping: false };
@@ -114,4 +106,19 @@ test('loadModels 后发者胜（旧列表不得覆盖新列表）', async () => 
   await p2;
   assert.equal(rt.state.savedModels[0].id, 'new', '新列表正常写入');
   assert.equal(rt.state.activeModelId, 'new', '新 activeModelId 正常写入');
+});
+
+test('loadModels 陈旧失败不覆盖（后发者胜同样适用于 catch 分支）', async () => {
+  const rt = loadSettingsFeature();
+  const d1 = rt.defer('list_models');
+  const p1 = rt.api.loadModels();                    // 加载 1（序号 1）
+  const d2 = rt.defer('list_models');
+  const p2 = rt.api.loadModels();                    // 加载 2（序号 2）
+  d2.resolve({ models: [{ id: 'new' }], active_model_id: 'new' }); // 新响应先落地
+  await p2;
+  assert.equal(rt.state.savedModels[0].id, 'new', '新列表正常写入');
+  d1.reject(new Error('stale network failure'));     // 旧请求后失败
+  await p1.catch(function () { /* 已知 reject */ });
+  assert.equal(rt.state.savedModels[0].id, 'new', '陈旧失败不得清空新列表');
+  assert.equal(rt.state.activeModelId, 'new', '陈旧失败不得覆盖 activeModelId');
 });


### PR DESCRIPTION
## 背景

从 PR #250 同类竞态审计拆出的杂项功能域：陈旧检测快照覆盖、意图反演、last-writer 覆盖——各 1-3 行的小修复。

## 变更

| 文件 | 改动 |
|---|---|
| `pinvou3-app/src/platform/tauri/bridge/scheduled.js` | run-now 轮询在任务已删时不复活死记录；`autoOpenId` 加全局创建序号（陈旧 completion 不复活 auto-open）；冗余 id 检查清理（generation 检查已覆盖） |
| `pinvou3-app/src/platform/tauri/bridge/settings.js` | `detectLocalVllmSetup` 陈旧检测快照作废（bootstrap 完成也递增序号）；`loadModels` 后发者胜 |
| `pinvou3-app/src/platform/tauri/bridge/updater.js` | `downloadAndInstallUpdate` 入口捕获版本元数据，install 不随静默检查漂移 |
| `pinvou3-app/src/platform/tauri/bridge/remote-control.js` | start/stop/rotate 加意图序号，并发时 UI 指示不写反 |
| `pinvou3-app/src/platform/web/bridge.js` | 对应 web 版 scheduled 部分对齐 |
| `pinvou3-app/tests/settings_race.test.mjs` | 新增 1 个竞态回归测试 |

## 验证

- `settings_race.test.mjs` 通过
- `node --check` / eslint 通过；`invoke` 参数形状保持原样，协议指纹无变化