### PR TITLE
fix(build): 修复系统提示词导出工具编译

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -503,6 +503,13 @@ jobs:
         working-directory: pinvou3-app/src-tauri
         run: cargo clippy --lib --no-deps
 
+      # dump_system_prompt 由 dev-tools feature 隔离，默认的 lib/clippy/test 均不会
+      # 编译它；显式检查，防止 CodeWhale Prompt API 升级再次漏适配。
+      - name: cargo check --bin dump_system_prompt (dev-tools)
+        if: ${{ env.RUN_HEAVY_RUST_CHECKS == 'true' }}
+        working-directory: pinvou3-app/src-tauri
+        run: cargo check --bin dump_system_prompt --features dev-tools
+
       # cargo-deny 只与 Cargo/lock/deny/gitlink 等依赖与策略路径有关。
       - name: cargo-deny (advisories/licenses/bans/sources)
         if: ${{ env.RUN_HEAVY_RUST_CHECKS == 'true' && needs.changes.outputs.rust_dependencies == 'true' }}
@@ -722,7 +729,9 @@ jobs:
           npm --prefix pinvou3-app run test:tauri-effective-config
 
       - name: Windows Rust 全目标检查
-        run: cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml --all-targets
+        run: >-
+          cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml
+          --all-targets --features dev-tools
 
       - name: Windows Rust 单元测试链接检查
         run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run

--- a/pinvou3-app/src-tauri/src/bin/dump_system_prompt.rs
+++ b/pinvou3-app/src-tauri/src/bin/dump_system_prompt.rs
@@ -12,7 +12,6 @@
 //!     > /tmp/pinvou3_system_prompt.txt
 
 use anyhow::Result;
-use deepseek_tui::memory;
 use deepseek_tui::prompts::{self, PromptSessionContext};
 use deepseek_tui::tui::app::AppMode;
 use deepseek_tui::tui::approval::ApprovalMode;
@@ -25,39 +24,38 @@ fn main() -> Result<()> {
     let bridge = Pinvou3Bridge::boot()?;
     let cfg = bridge.build_engine_config_for_session(sid);
 
-    // 复刻 Engine::new (core/engine.rs:454-475) 的入参装配
-    let user_memory_block = memory::compose_block(cfg.memory_enabled, &cfg.memory_path);
-
-    let session_ctx = PromptSessionContext {
-        user_memory_block: user_memory_block.as_deref(),
-        goal_objective: None, // Engine::new 里通过 goal_objective_for_prompt 算,新 session 无 goal => None
-        project_context_pack_enabled: cfg.project_context_pack_enabled,
-        locale_tag: &cfg.locale_tag,
-        translation_enabled: cfg.translation_enabled,
-        model_id: &cfg.model,
-        show_thinking: cfg.show_thinking,
-        // v0.8.57:上游把 allow_shell 从 PromptSessionContext 移除(#2949,decouple
-        // 静态前缀,allow_shell 改走 per-turn <runtime_prompt> tag),dump 同步去掉。
-        // v0.8.60 上游新增字段:
-        //   context_window_override: None = 用 model_id 派生的默认窗口(qwen36 → 256K)。
-        //   verbosity: None = GUI 不用 concise 输出模式(与 bridge Op::SendMessage 一致)。
-        context_window_override: None,
-        verbosity: None,
-        // CodeWhale r4 后技能发现只使用显式 EngineConfig.skills_dir；当前 app 注入
-        // ~/.pinvou3/bundle/skills(技能市场私有区,两 mode 行为一致)。底座不再追加
-        // 其他根，因此此兼容扫描开关无实际影响，取 false。
-        skills_scan_codewhale_only: false,
-    };
-
-    // v0.8.57:上游把 system prompt 改成 **mode-independent**(mode/approval 移出静态前缀,
-    // 函数签名去掉这两个参数)。pinvou3 的 composer 在 apply_static_prompt_composer 里以
-    // 常量 Yolo/Auto 构造宽 ctx → dump 出来的就是生产 Yolo(Execute) 静态 prompt,与 `plan`/
-    // `agent` 参数无关(仅用于下方 meta 展示)。
     let (mode, approval) = match std::env::args().nth(1).as_deref() {
         Some("plan") => (AppMode::Plan, ApprovalMode::Never),
         Some("agent") => (AppMode::Agent, ApprovalMode::Suggest),
         _ => (AppMode::Yolo, ApprovalMode::Auto),
     };
+
+    // CodeWhale 的原生记忆装配已收口到 Engine 内部。Pinvou 当前明确关闭该能力；
+    // 若未来启用，必须先为此诊断工具提供与 Engine 等价的公开装配入口，避免静默漏项。
+    anyhow::ensure!(
+        !cfg.memory_enabled,
+        "dump_system_prompt 尚不支持 CodeWhale 原生记忆，请先同步 Engine 的公开 prompt 装配入口"
+    );
+
+    let session_ctx = PromptSessionContext {
+        user_memory_block: None,
+        goal_objective: None, // Engine::new 里通过 goal_objective_for_prompt 算,新 session 无 goal => None
+        project_context_pack_enabled: cfg.project_context_pack_enabled,
+        locale_tag: &cfg.locale_tag,
+        translation_enabled: cfg.translation_enabled,
+        model_id: &cfg.model,
+        // v0.8.57:上游把 allow_shell 从 PromptSessionContext 移除(#2949,decouple
+        // 静态前缀,allow_shell 改走 per-turn <runtime_prompt> tag),dump 同步去掉。
+        // context_window_override 当前不输出到 prompt；此工具不构造 API provider，故取 None。
+        context_window_override: None,
+        verbosity: cfg.verbosity.as_deref(),
+        skills_scan_codewhale_only: cfg.skills_scan_codewhale_only,
+        plugin_registry: cfg.plugin_registry.as_deref(),
+        mode,
+    };
+
+    // CodeWhale 当前要求稳定前缀上下文携带 mode，因此保持 CLI 选择与上下文一致。
+    // Pinvou 的静态 composer 目前仍统一输出 Execute 层，Plan 约束另由 per-turn reminder 注入。
     let prompt = prompts::system_prompt_for_mode_with_context_skills_session_and_approval(
         &cfg.workspace,
         None,
@@ -76,7 +74,6 @@ fn main() -> Result<()> {
     eprintln!("model_id     = {}", cfg.model);
     eprintln!("approval     = {approval:?}");
     eprintln!("mode         = {mode:?}");
-    eprintln!("show_thinking= {}", cfg.show_thinking);
     eprintln!("byte_len     = {}", text.len());
     eprintln!("line_count   = {}", text.lines().count());
     eprintln!("─────────────────────────────");


### PR DESCRIPTION
## 背景

CodeWhale v0.9.5 移除了公开 `memory` 模块及 prompt 中的 `show_thinking`，并为 `PromptSessionContext` 增加了插件快照和模式字段。`dump_system_prompt` 未同步适配，启用 `dev-tools` 编译时失败；现有 CI 又未启用该 feature，导致回归漏检。

## 变更

- 按当前 Prompt API 构造 `PromptSessionContext`，传入实际 verbosity、技能扫描配置、插件快照和 CLI 模式。
- Pinvou 当前关闭 CodeWhale 原生记忆；诊断工具显式使用空记忆，并在未来配置启用时失败退出，避免生成不完整 prompt。
- 在 Rust lint 门禁中显式编译 `dump_system_prompt`，Windows 全目标检查也启用 `dev-tools`。

## 验证

- `cargo check --locked --manifest-path pinvou3-app/src-tauri/Cargo.toml --bin dump_system_prompt --features dev-tools`
- `cargo check --locked --manifest-path pinvou3-app/src-tauri/Cargo.toml --all-targets --features dev-tools`
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `python scripts/architecture-guard.py`
- `git diff --check`
- 工作流 YAML 解析通过

上述 Cargo 检查通过，仅输出 CodeWhale 现有 `private_interfaces` 警告。另尝试实际运行诊断工具两次，均在本地 Windows 完整链接阶段超过 5 分钟工具时限，未获得运行结果；未出现新的源码诊断。

## 风险

不改变应用生产路径；影响仅限开发诊断二进制及 CI 编译覆盖。`context_window_override` 当前不输出到 prompt，工具仍保持 `None`，与其不构造 API provider 的边界一致。