### PR TITLE
fix(deps): 升级 webbrowser 至 1.2.4 修复 RUSTSEC-2026-0257

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -9283,15 +9283,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -9283,9 +9283,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
  "jni 0.22.4",
  "log",


### PR DESCRIPTION
## 背景

`rust-lint` 门禁（cargo-deny advisories）因 **webbrowser 1.2.1** 触发 **RUSTSEC-2026-0257** 而失败：

> Unix `BROWSER` handling allows browser argument injection——受影响版本把调用方提供的 URL 直接替换进 `BROWSER` 环境变量模板后做空白分词；若 URL 含空格且模板含 `%s`，可注入 `--remote-debugging-port` / `--proxy-server` 等浏览器参数（复现于 Chromium），1.2.2 起已修复。

## 变更

- `pinvou3-app/src-tauri/Cargo.lock`：`webbrowser 1.2.1 → 1.2.4`（精确升级，仅 6 行改动、2 个 commit）
- 依赖链：`codewhale-tui` 以 `webbrowser = "1.0"`（宽松约束）引入；1.2.4 的 `objc2-app-kit` 等新依赖已在 lock 中（tauri 侧已锁定同版本），无新增传递依赖
- 1.2.2 的 Unix `BROWSER` 模板重写引入回归（冗余 URL 追加与替换顺序缺陷，webbrowser-rs #120/#121），1.2.4 已修复；CodeWhale submodule 已锁定 1.2.4，两端对齐

## 验证

- `cargo metadata --locked` 通过（lock 一致）
- `cargo deny check advisories licenses bans sources` 通过（本地复跑，不再报 RUSTSEC-2026-0257）
- commit 信息通过 `scripts/validate-commit-msg.py`

## 与 #262 的关系

本 PR 与 #262（rustc wrapper SIGBUS 修复）相互独立：只是 #262 改动 `Cargo.toml` 触发了 `rust_dependencies` 门禁路径，才暴露了 main 上既有的该漏洞。本 PR 单独升级依赖，避免把依赖变更混入 #262。
