### PR TITLE
fix(ci): rust-test/windows-rust-test 补全三端栈溢出防护

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -551,8 +551,13 @@ jobs:
     # (GitHub 默认 6h,此处收紧到 45min,与 mac-build 的 50min 量级一致)。
     timeout-minutes: 45
     env:
-      # 同 rust-lint:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
-      RUSTC_WRAPPER: sccache
+      # sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
+      # 经 rustc-stack-wrapper 链式调用 sccache:先把 RUST_MIN_STACK=16MiB 注入
+      # 编译期 rustc 进程(规避 codewhale-tui O2 编译的栈溢出/SIGBUS,三端同源风险),
+      # 再交给 sccache 缓存。必须用 ${{ github.workspace }} 绝对路径(Cargo 按进程
+      # cwd 解析 RUSTC_WRAPPER 相对路径会双拼成不存在的路径)。
+      RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
+      RUSTC_WRAPPER_CHAIN: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
       SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}
@@ -680,8 +685,13 @@ jobs:
       # reqwest 0.13 → aws-lc-sys(非 FIPS)。Windows x86_64 需 NASM 汇编;runner 默认无 NASM,
       # 用预生成 NASM 对象规避(aws-lc-rs 官方支持,无需额外装 NASM)。
       AWS_LC_SYS_PREBUILT_NASM: "1"
-      # 同 rust-test:sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
-      RUSTC_WRAPPER: sccache
+      # sccache 内容哈希缓存,仓库内 crate 源码不变即全命中。
+      # 经 rustc-stack-wrapper.cmd 链式调用 sccache:先把 RUST_MIN_STACK=16MiB 注入
+      # 编译期 rustc 进程(规避 codewhale-tui O2 编译的栈溢出,三端同源风险),
+      # 再交给 sccache 缓存。Windows 上 Cargo 执行 wrapper 需 .cmd 后缀才能走
+      # cmd /C;必须用 ${{ github.workspace }} 绝对路径(避免按 cwd 双拼解析)。
+      RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
+      RUSTC_WRAPPER_CHAIN: sccache
       SCCACHE_GHA_ENABLED: "true"
       # PR/merge queue 只读(对齐 rust-cache save-if 仅 main 的配额保护);main push 读写。
       SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'push' && 'READ_WRITE' || 'READ_ONLY' }}

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -155,3 +155,27 @@ jobs:
           CARGO_TERM_COLOR=never cargo test 2>&1 | tee cargo-test.log
           grep -q "compiler_stack_contract" cargo-test.log
           grep -q "test result: ok" cargo-test.log
+
+      # 5) 链式 wrapper(RUSTC_WRAPPER_CHAIN,如 sccache):验证 wrapper 先注入
+      #    RUST_MIN_STACK、再委托给链上命令执行(pr-check.yml 的 rust-test /
+      #    windows-rust-test 用此链保留 sccache 缓存 + 栈注入两全)。
+      #    Unix 用 `env` 充当链上命令直接观测注入结果;Windows 静态断言链分支
+      #    存在(cmd 嵌套引号在 Git Bash/MSYS 下会被路径转换破坏)。
+      - name: 链式 wrapper —— 委托链上命令且仍注入 16 MiB
+        shell: bash
+        run: |
+          set -euxo pipefail
+          tmp="$(mktemp -d)"
+          cd "$tmp"
+          cp "$GITHUB_WORKSPACE/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper" . 2>/dev/null || true
+          cp "$GITHUB_WORKSPACE/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd" . 2>/dev/null || true
+          chmod +x rustc-stack-wrapper 2>/dev/null || true
+          unset RUST_MIN_STACK
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            grep -q "RUSTC_WRAPPER_CHAIN" rustc-stack-wrapper.cmd
+            grep -q "set RUST_MIN_STACK=16777216" rustc-stack-wrapper.cmd
+          else
+            # `env env`:链上命令 `env` 执行参数中的 `env`(无参),打印当前环境,
+            # 应包含经 wrapper 注入的 RUST_MIN_STACK=16777216。
+            RUSTC_WRAPPER_CHAIN=env ./rustc-stack-wrapper env | grep -q "^RUST_MIN_STACK=16777216$"
+          fi

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -5,7 +5,7 @@ name: rustc-wrapper-smoke
 #   因 .cargo/config.toml 残留 wrapper 配置而 os error 193;config.toml 不配置
 #   [build] rustc-wrapper(全局键无法按平台条件化),默认三端直接可用。
 # - run-dev.sh 的 wrapper 平台选择(scripts/rustc-stack-wrapper-select.sh):
-#   Darwin/Linux 注入 sh 版;Windows (MINGW*/MSYS*/CYGWIN*) 透传不注入,
+#   Darwin/Linux 注入 sh 版;Windows (MINGW*/MSYS*/CYGWIN*) 注入 .cmd 版,
 #   导出的 RUSTC_WRAPPER 不得指向无扩展名 Unix 文件(os error 193)。
 # - 按平台注入 RUSTC_WRAPPER 后(windows → .cmd 版,unix → sh 版),Cargo 必须
 #   能执行 wrapper;编译器进程 env 含 RUST_MIN_STACK=16777216。
@@ -70,10 +70,10 @@ jobs:
 
       # 2) run-dev.sh 的 wrapper 平台选择(单一真相源 rustc-stack-wrapper-select.sh):
       #    验证 run-dev.sh 实际使用的 selector 在 Windows(Git Bash/MSYS,
-      #    uname -s 为 MINGW*/MSYS*/CYGWIN*)下输出空、不指向无扩展名 Unix
-      #    文件——否则本地开发经 run-dev.sh 注入后会 os error 193,阻断
-      #    Windows 上所有 Cargo 命令。
-      - name: run-dev.sh selector —— Windows 不注入 Unix wrapper
+      #    uname -s 为 MINGW*/MSYS*/CYGWIN*)下输出 .cmd 版、不指向无扩展名
+      #    Unix 文件——否则本地开发经 run-dev.sh 注入后会 os error 193,
+      #    阻断 Windows 上所有 Cargo 命令。
+      - name: run-dev.sh selector —— Windows 注入 .cmd 版 wrapper
         shell: bash
         run: |
           set -euxo pipefail
@@ -85,12 +85,14 @@ jobs:
             echo "FAIL: run-dev.sh 仍直接无条件 export 无扩展名 Unix wrapper"
             exit 1
           fi
-          # selector 平台行为:Windows 输出空(透传),Unix 输出存在的 sh 文件。
+          # selector 平台行为:Windows 输出 .cmd 版(Windows 原生路径),
+          # Unix 输出存在的 sh 文件。
           out="$(bash "$select_script")"
           case "$(uname -s)" in
             MINGW*|MSYS*|CYGWIN*)
-              [ -z "$out" ] || { echo "FAIL: Windows selector 应输出空, got: $out"; exit 1; }
-              echo "OK: Windows selector 输出空(透传,不注入)"
+              [ -n "$out" ] || { echo "FAIL: Windows selector 应输出 .cmd wrapper"; exit 1; }
+              echo "$out" | grep -qi '\.cmd$' || { echo "FAIL: Windows selector 应指向 .cmd 版, got: $out"; exit 1; }
+              echo "OK: Windows selector → $out"
               ;;
             Darwin|Linux)
               [ -n "$out" ] || { echo "FAIL: Unix selector 应输出 sh wrapper"; exit 1; }

--- a/pinvou3-app/run-dev.sh
+++ b/pinvou3-app/run-dev.sh
@@ -55,11 +55,9 @@ export PINVOU_REMOTE_RELAY_WS_URL="${PINVOU_REMOTE_RELAY_WS_URL:-ws://127.0.0.1:
 # 平台选择由 scripts/rustc-stack-wrapper-select.sh 统一决定(run-dev.sh
 # 与 CI smoke 共用同一 selector,避免入口与验证漂移):
 #   - Darwin/Linux:注入 sh 版 wrapper(macOS 有 SIGBUS 实测,Linux 同源);
-#   - Windows (MINGW*/MSYS*/CYGWIN*):**不设置** RUSTC_WRAPPER。Windows
-#     无 SIGBUS 触发(仅 macOS 实测),且无扩展名 Unix shell 文件无法被
-#     Windows 原生 Cargo 执行(CreateProcess → os error 193,会阻断本地
-#     所有 Cargo 命令);如需统一 16 MiB 行为,CI 的 Windows job 显式
-#     注入 .cmd 版(见 pr-check.yml windows-rust-test)。
+#   - Windows (MINGW*/MSYS*/CYGWIN*):注入 .cmd 版 wrapper(栈溢出根因
+#     三端同源,Windows 本地 dev 同样需要 16 MiB 栈;.cmd 经 cmd /C 执行,
+#     无扩展名 sh 会 os error 193)。
 # 契约测试 tests/compiler_stack_contract.rs 守护"运行时进程不继承"。
 RUSTC_WRAPPER_VALUE="$(src-tauri/scripts/rustc-stack-wrapper-select.sh)"
 if [ -n "$RUSTC_WRAPPER_VALUE" ]; then

--- a/pinvou3-app/src-tauri/.cargo/config.toml
+++ b/pinvou3-app/src-tauri/.cargo/config.toml
@@ -39,12 +39,13 @@
 # run-dev.sh 与 rustc-wrapper-smoke 共用,输出空 = 不注入):
 #   - macOS/Linux 开发:pinvou3-app/run-dev.sh 调用 selector,注入
 #     scripts/rustc-stack-wrapper(无扩展名 sh,带 shebang)
-#   - Windows 开发:selector 输出空(Git Bash/MSYS 下注入无扩展名 Unix
-#     文件会 os error 193),默认透传即可;如需统一行为,可设
-#     RUSTC_WRAPPER=scripts/rustc-stack-wrapper.cmd
+#   - Windows 开发:run-dev.sh 调用 selector,注入
+#     scripts/rustc-stack-wrapper.cmd(经 cmd /C 执行;无扩展名 sh 会
+#     os error 193)
 #   - CI:pr-check(rust-lint)、mac-build、release-packages
 #     (Linux x64/arm64、macOS universal)注入 sh 版;
-#     release-packages 的 Windows x64 注入 .cmd 版
+#     release-packages 的 Windows x64 与 pr-check 的 windows-rust-test
+#     注入 .cmd 版
 # 注入的 RUST_MIN_STACK=16MiB 只作用于编译期 rustc 进程;cargo run /
 # cargo test 目标进程不经过 wrapper,运行时线程栈语义(约 2 MiB)不变。
 # 与 rust-lang/rust #160535(默认栈提升到 16 MiB)同方向。

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
@@ -10,8 +10,8 @@
 # (优先级高于 .cargo/config.toml,Windows 上同样可靠)。平台选择统一走
 # rustc-stack-wrapper-select.sh(单一真相源,输出空 = 不注入):
 #   - macOS/Linux 开发:pinvou3-app/run-dev.sh 调用 selector 注入本文件
-#   - Windows 开发:selector 输出空(本文件是无扩展名 Unix shell,
-#     Windows 原生 Cargo 无法执行 → os error 193),默认透传即可
+#   - Windows 开发:run-dev.sh 调用 selector 注入 .cmd 版(本文件是
+#     无扩展名 Unix shell,Windows 原生 Cargo 无法执行 → os error 193)
 #   - CI:pr-check(rust-lint)、mac-build、release-packages
 #     (Linux x64/arm64、macOS universal)按平台注入 sh 版;
 #     Windows 发布 / windows-rust-test job 注入 rustc-stack-wrapper.cmd 版
@@ -21,8 +21,8 @@
 #
 # 注意:本文件是 Unix(sh)版本。Windows 上 Cargo 需要 .cmd 后缀才能走
 # cmd /C(见 rustc-stack-wrapper.cmd);栈溢出根因三端同源(macOS 实测 SIGBUS、
-# Windows 实测栈溢出),Windows 本地 dev 经 selector 透传,CI 的 Windows job
-# (发布 / windows-rust-test)显式注入 .cmd 版。
+# Windows 实测栈溢出),Windows 本地 dev 经 selector 注入 .cmd 版,CI 的
+# Windows job(发布 / windows-rust-test)同样注入 .cmd 版。
 export RUST_MIN_STACK="${RUST_MIN_STACK:-16777216}"
 # 链式 wrapper(如 sccache):cargo 调用 `$RUSTC_WRAPPER rustc <args>` 时,若设置了
 # RUSTC_WRAPPER_CHAIN,则在本脚本之后插入该命令,形成

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
@@ -14,14 +14,15 @@
 #     Windows 原生 Cargo 无法执行 → os error 193),默认透传即可
 #   - CI:pr-check(rust-lint)、mac-build、release-packages
 #     (Linux x64/arm64、macOS universal)按平台注入 sh 版;
-#     Windows 发布 job 注入 rustc-stack-wrapper.cmd 版
+#     Windows 发布 / windows-rust-test job 注入 rustc-stack-wrapper.cmd 版
 # 本脚本只包装编译期 rustc 调用;cargo run / cargo test 启动的应用与
 # 测试进程不经过本脚本,不会继承 RUST_MIN_STACK,默认线程栈语义
 # (约 2 MiB)不变。与 rust-lang/rust #160535(默认栈提升到 16 MiB)同方向。
 #
 # 注意:本文件是 Unix(sh)版本。Windows 上 Cargo 需要 .cmd 后缀才能走
-# cmd /C(见 rustc-stack-wrapper.cmd);Windows 无 SIGBUS 触发(仅 macOS
-# 实测),本地透传即可,CI 的 Windows 发布 job 注入 .cmd 版本。
+# cmd /C(见 rustc-stack-wrapper.cmd);栈溢出根因三端同源(macOS 实测 SIGBUS、
+# Windows 实测栈溢出),Windows 本地 dev 经 selector 透传,CI 的 Windows job
+# (发布 / windows-rust-test)显式注入 .cmd 版。
 export RUST_MIN_STACK="${RUST_MIN_STACK:-16777216}"
 # 链式 wrapper(如 sccache):cargo 调用 `$RUSTC_WRAPPER rustc <args>` 时,若设置了
 # RUSTC_WRAPPER_CHAIN,则在本脚本之后插入该命令,形成

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
@@ -23,4 +23,11 @@
 # cmd /C(见 rustc-stack-wrapper.cmd);Windows 无 SIGBUS 触发(仅 macOS
 # 实测),本地透传即可,CI 的 Windows 发布 job 注入 .cmd 版本。
 export RUST_MIN_STACK="${RUST_MIN_STACK:-16777216}"
+# 链式 wrapper(如 sccache):cargo 调用 `$RUSTC_WRAPPER rustc <args>` 时,若设置了
+# RUSTC_WRAPPER_CHAIN,则在本脚本之后插入该命令,形成
+# cargo → 本脚本 → RUSTC_WRAPPER_CHAIN → rustc。这样既能保留 sccache 缓存,
+# 又把 RUST_MIN_STACK 只注入到编译期 rustc 进程(不泄漏到 cargo run/test 目标)。
+if [ -n "${RUSTC_WRAPPER_CHAIN:-}" ]; then
+  exec "${RUSTC_WRAPPER_CHAIN}" "$@"
+fi
 exec "$@"

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh
@@ -8,9 +8,10 @@
 # 无扩展名 sh 会 os error 193,阻断所有 Cargo 命令),因此由正式
 # Cargo 入口按平台决定是否注入:
 #   - Darwin/Linux:注入 sh 版(编译 codewhale-tui 有 SIGBUS 实测风险);
-#   - Windows (MINGW*/MSYS*/CYGWIN*):透传不注入。Windows 无 SIGBUS
-#     触发(仅 macOS 实测);且无扩展名 Unix shell 文件无法被 Windows
-#     原生 Cargo 执行(CreateProcess → os error 193)。
+#   - Windows (MINGW*/MSYS*/CYGWIN*):透传不注入。栈溢出根因三端同源
+#     (Windows 无 SIGBUS 信号、表现为栈溢出,已由 windows-rust-test 实测),
+#     但无扩展名 Unix shell 文件无法被 Windows 原生 Cargo 执行
+#     (CreateProcess → os error 193),故本地透传、由 CI 注入 .cmd 版。
 #
 # 本脚本是"平台选择"的单一真相源:run-dev.sh 与 CI smoke
 # (rustc-wrapper-smoke.yml)都执行它,保证正式入口与实际验证一致。

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh
@@ -8,24 +8,27 @@
 # 无扩展名 sh 会 os error 193,阻断所有 Cargo 命令),因此由正式
 # Cargo 入口按平台决定是否注入:
 #   - Darwin/Linux:注入 sh 版(编译 codewhale-tui 有 SIGBUS 实测风险);
-#   - Windows (MINGW*/MSYS*/CYGWIN*):透传不注入。栈溢出根因三端同源
+#   - Windows (MINGW*/MSYS*/CYGWIN*):注入 .cmd 版。栈溢出根因三端同源
 #     (Windows 无 SIGBUS 信号、表现为栈溢出,已由 windows-rust-test 实测),
-#     但无扩展名 Unix shell 文件无法被 Windows 原生 Cargo 执行
-#     (CreateProcess → os error 193),故本地透传、由 CI 注入 .cmd 版。
+#     本地 dev 同样需要 16 MiB 栈;无扩展名 sh 无法被 Windows 原生 Cargo
+#     执行(CreateProcess → os error 193),故注入 .cmd 版。
 #
 # 本脚本是"平台选择"的单一真相源:run-dev.sh 与 CI smoke
 # (rustc-wrapper-smoke.yml)都执行它,保证正式入口与实际验证一致。
 # 输出空时调用方不得设置 RUSTC_WRAPPER。
 #
-# 注意:本脚本不做路径转换(cygpath 等)。Windows 分支刻意输出空,
-# 避免 MSYS 风格路径(C:\ vs /c/)与空格转义在 CreateProcess 下出错。
+# 注意:Windows 分支用 cygpath -m 把 MSYS 风格路径(/c/...)转成 Windows
+# 原生路径(C:/...)。原生 cargo.exe 的 CreateProcess 无法解析 /c/...,
+# MSYS 对 env 变量的自动路径转换也不可靠,显式转换更稳妥。用 -m(正斜杠)
+# 而非 -w(反斜杠):反斜杠经 shell echo 二次解析可能被吃掉(\a/\r/\c)。
 case "$(uname -s)" in
   Darwin|Linux)
     # 与本脚本同目录的 sh wrapper(绝对路径,不依赖调用方 cwd)
     echo "$(cd "$(dirname "$0")" && pwd)/rustc-stack-wrapper"
     ;;
   MINGW*|MSYS*|CYGWIN*)
-    # Windows:透传,不注入
+    # 与本脚本同目录的 .cmd wrapper(cygpath 转 Windows 原生路径)
+    cygpath -m "$(cd "$(dirname "$0")" && pwd)/rustc-stack-wrapper.cmd"
     ;;
   *)
     # 未知平台:透传,不注入

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
@@ -2,11 +2,13 @@
 rem rustc-stack-wrapper(Windows 版):仅为编译期 rustc 进程注入更大的默认
 rem 线程栈,规避 rustc/LLVM 编译 codewhale-tui 时的栈溢出(MachineLateinstrs
 rem Cleanup 递归,rustc 1.96/1.97 稳定复现;std 线程默认栈三端均为 2 MiB)。
-rem 接入方式:CI 的 Windows 发布 job 通过 RUSTC_WRAPPER 环境变量注入
-rem 本文件(见 release-packages.yml build-windows-x64);
+rem 接入方式:CI 的 Windows job(发布 build-windows-x64 与 windows-rust-test)
+rem 通过 RUSTC_WRAPPER 环境变量注入本文件;
 rem 平台选择统一走 rustc-stack-wrapper-select.sh(输出空 = 不注入):
-rem Windows 本地无 SIGBUS 触发(仅 macOS 实测),selector 输出空、
-rem 默认透传即可;如需统一 16 MiB 行为再手动设 RUSTC_WRAPPER 指向本文件。
+rem 栈溢出根因三端同源(macOS 实测 SIGBUS、Windows 实测栈溢出),但 Windows
+rem 本地 dev 经 selector 输出空、默认透传(无扩展名 sh 无法被 Windows 原生
+rem Cargo 执行 → os error 193);如需本地统一 16 MiB 再手动设 RUSTC_WRAPPER
+rem 指向本文件。
 rem cargo run / cargo test 目标进程不经过本文件,运行时线程栈语义不变。
 rem Unix 请用无扩展名版本 scripts/rustc-stack-wrapper(sh,带 shebang)。
 rem 本文件全部行以 @ 开头,cmd 全程无回显,rustc stdout 纯净。
@@ -15,7 +17,7 @@ rem 链式 wrapper(如 sccache):设置了 RUSTC_WRAPPER_CHAIN 时,在本文件�
 rem 再调用它,形成 cargo → 本文件 → RUSTC_WRAPPER_CHAIN → rustc。这样既能
 rem 保留 sccache 缓存,又把 RUST_MIN_STACK 只注入编译期 rustc 进程,
 rem 不泄漏到 cargo run / cargo test 目标。
-if defined RUSTC_WRAPPER_CHAIN (
+if not "%RUSTC_WRAPPER_CHAIN%"=="" (
   %RUSTC_WRAPPER_CHAIN% %*
 ) else (
   %*

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
@@ -11,4 +11,12 @@ rem cargo run / cargo test 目标进程不经过本文件,运行时线程栈语�
 rem Unix 请用无扩展名版本 scripts/rustc-stack-wrapper(sh,带 shebang)。
 rem 本文件全部行以 @ 开头,cmd 全程无回显,rustc stdout 纯净。
 if not defined RUST_MIN_STACK set RUST_MIN_STACK=16777216
-%*
+rem 链式 wrapper(如 sccache):设置了 RUSTC_WRAPPER_CHAIN 时,在本文件之后
+rem 再调用它,形成 cargo → 本文件 → RUSTC_WRAPPER_CHAIN → rustc。这样既能
+rem 保留 sccache 缓存,又把 RUST_MIN_STACK 只注入编译期 rustc 进程,
+rem 不泄漏到 cargo run / cargo test 目标。
+if defined RUSTC_WRAPPER_CHAIN (
+  %RUSTC_WRAPPER_CHAIN% %*
+) else (
+  %*
+)

--- a/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
+++ b/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.cmd
@@ -2,13 +2,13 @@
 rem rustc-stack-wrapper(Windows 版):仅为编译期 rustc 进程注入更大的默认
 rem 线程栈,规避 rustc/LLVM 编译 codewhale-tui 时的栈溢出(MachineLateinstrs
 rem Cleanup 递归,rustc 1.96/1.97 稳定复现;std 线程默认栈三端均为 2 MiB)。
-rem 接入方式:CI 的 Windows job(发布 build-windows-x64 与 windows-rust-test)
-rem 通过 RUSTC_WRAPPER 环境变量注入本文件;
+rem 接入方式:Windows 本地 dev 经 run-dev.sh → selector 注入本文件;CI 的
+rem Windows job(发布 build-windows-x64 与 windows-rust-test)通过
+rem RUSTC_WRAPPER 环境变量注入本文件;
 rem 平台选择统一走 rustc-stack-wrapper-select.sh(输出空 = 不注入):
-rem 栈溢出根因三端同源(macOS 实测 SIGBUS、Windows 实测栈溢出),但 Windows
-rem 本地 dev 经 selector 输出空、默认透传(无扩展名 sh 无法被 Windows 原生
-rem Cargo 执行 → os error 193);如需本地统一 16 MiB 再手动设 RUSTC_WRAPPER
-rem 指向本文件。
+rem 栈溢出根因三端同源(macOS 实测 SIGBUS、Windows 实测栈溢出),Windows
+rem 本地 dev 经 selector 注入本文件(无扩展名 sh 无法被 Windows 原生
+rem Cargo 执行 → os error 193,故用 .cmd 版经 cmd /C 执行)。
 rem cargo run / cargo test 目标进程不经过本文件,运行时线程栈语义不变。
 rem Unix 请用无扩展名版本 scripts/rustc-stack-wrapper(sh,带 shebang)。
 rem 本文件全部行以 @ 开头,cmd 全程无回显,rustc stdout 纯净。


### PR DESCRIPTION
## Summary

把 PR #262 的编译器栈溢出规避措施补全到全部三个平台：`rust-test`(Linux) 与 `windows-rust-test`(Windows) 两个仍用 `RUSTC_WRAPPER: sccache` 的 job 现在也能注入 `RUST_MIN_STACK=16MiB`，从而修复 Windows 上编译 codewhale-tui 时的 rustc/LLVM 栈溢出；同时把 Windows 本地 dev 从透传改为注入 `.cmd` 版 wrapper，一并消除本地开发路径的同源风险。

## Background

#262 的 `rustc-stack-wrapper`(注入 `RUST_MIN_STACK=16MiB`)已覆盖 macOS 构建、Linux 发布、Windows 发布与 `rust-lint`，但 `rust-test` / `windows-rust-test` 因 `RUSTC_WRAPPER` 已被 sccache 占用而未接入。合并 #262 后移除了 codewhale-tui 的 `opt-level=1` 降级，这两个 job 编译 codewhale-tui(dev 下 O2)时触发栈溢出——Windows 的 CI 失败即由此而来。栈溢出根因三端同源(macOS 实测 SIGBUS、Windows 实测栈溢出)，Windows 本地 dev 原先透传不注入，同样会触发，因此一并补齐。

## Changes

- 给 `rustc-stack-wrapper`(sh)与 `rustc-stack-wrapper.cmd`(Windows)增加 `RUSTC_WRAPPER_CHAIN` 链式调用，形成 `cargo → rustc-stack-wrapper → sccache → rustc`：先注入 16 MiB 栈，再交给 sccache 缓存；`RUST_MIN_STACK` 仍只作用于编译期 rustc 进程，不泄漏到 `cargo run/test` 目标。
- `rust-test` / `windows-rust-test` 改为注入对应平台 wrapper 并设置 `RUSTC_WRAPPER_CHAIN=sccache`。
- `rustc-wrapper-smoke.yml` 新增第 5 步，验证链式委托时仍注入 16 MiB(Unix 实测、Windows 静态断言)。
- Windows 本地 dev 同样补齐：`rustc-stack-wrapper-select.sh` 的 `MINGW*/MSYS*/CYGWIN*` 分支从透传不注入改为注入 `rustc-stack-wrapper.cmd`，并用 `cygpath -m` 把 MSYS 路径(`/c/...`)转成 Windows 原生正斜杠路径(`C:/...`)供原生 cargo.exe 的 CreateProcess 解析；同步订正 `run-dev.sh`、`.cargo/config.toml`、两个 wrapper 的注释，以及 smoke 的 step2 断言。

## Verification

- `sh -n` 两个 sh 脚本通过；本地实测 sh wrapper 链式/透传均正确输出 `RUST_MIN_STACK=16777216`。
- `.github/workflows/` 4 个 workflow 文件均通过 `yaml.safe_load` 解析。
- `python3 scripts/tests/test_ci_gate_policy.py` 9 项全过。
- commit 信息通过 `python3 scripts/validate-commit-msg.py`。
- 改动不触及 Rust 源码/CodeWhale fork，未跑完整三端编译。

## Impact and notes

- `.cmd` 链式 + sccache 的端到端执行无法在 macOS 本地验证，靠 smoke 静态断言 + `windows-rust-test` 在 main push 上实际跑一次最终确认(该 job 不进 PR 门禁)。
- 影响面：`rust-test` / `windows-rust-test` 的编译缓存链路、`rustc-wrapper-smoke`，以及 Windows 本地 dev 的 wrapper 注入(此前透传、现在注入 `.cmd` 版)；`RUST_MIN_STACK` 仍只作用于编译期 rustc 进程，运行时语义不变。

## Submission checklist

- [x] I based this PR on the latest `main`.
- [x] Every commit includes a matching `Signed-off-by` trailer (`git commit -s`).
- [x] I removed sensitive data, private data, internal URLs, and logs.
- [x] I updated tests and documentation where behavior changed.
- [ ] If the `CodeWhale` gitlink or fork behavior changed, this PR also updates the fork inventory, fingerprints, and result-oriented tests.
