### PR TITLE
refactor(ui): 复用 P1 —— 去重 markdown 兜底 / 监控格式化 / iOS 开关

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -109,7 +109,7 @@
     "test:webui": "npm run build:web && node ../remote-control-relay/test/web-ui.smoke.cjs",
     "test:user-journey": "../scripts/run-user-journey-tests.sh",
     "sync:version": "node ../scripts/sync-version.mjs",
-    "test:markdown": "node tests/markdown_syntax_highlight.test.mjs"
+    "test:markdown": "node tests/markdown_syntax_highlight.test.mjs && node tests/markdown_bridge_fallback_safety.test.mjs"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.4",

--- a/pinvou3-app/src/components/Toggle.jsx
+++ b/pinvou3-app/src/components/Toggle.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+// 统一的 iOS 风格开关：收敛 SettingsView 内多处手写的「圆角轨道 + 白色圆形滑块」开关。
+// 尺寸：
+//   sm —— 工具/项目技能开关（轨道 34×20，滑块 16）
+//   md —— 设置项开关（原 IOSSwitch，轨道 46×26，滑块 22）
+const SIZE_STYLES = {
+  sm: { track: 'h-5 w-[34px]', knob: 'h-4 w-4', on: 'translate-x-[16px]', off: 'translate-x-[2px]' },
+  md: { track: 'h-[26px] w-[46px]', knob: 'h-[22px] w-[22px]', on: 'translate-x-[22px]', off: 'translate-x-[2px]' },
+};
+
+export function Toggle({ checked, onChange, disabled = false, size = 'sm', 'aria-label': ariaLabel, className = '' }) {
+  const s = SIZE_STYLES[size] || SIZE_STYLES.sm;
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={!!checked}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={() => { if (onChange) onChange(!checked); }}
+      className={`relative inline-flex shrink-0 items-center rounded-full transition-colors disabled:cursor-default ${s.track} ${disabled ? 'opacity-70' : ''} ${checked ? 'bg-[#34C759]' : 'bg-[#E5E5EA] dark:bg-[#39393D]'} ${className}`}
+    >
+      <span className={`inline-block rounded-full bg-white shadow transition-transform ${s.knob} ${checked ? s.on : s.off}`} />
+    </button>
+  );
+}

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Archive, Briefcase, Check, ChevronDown, Code, Cpu, Database, Edit2, FileText, Globe, Lightbulb, MessageSquare, MoreHorizontal, Paperclip, Plus, RefreshCw, Search, Sparkles, Trash2, User, Video, Wrench, X } from '../../components/icons.jsx';
+import { Toggle } from '../../components/Toggle.jsx';
 import { VllmSetupProgress } from '../../components/VllmSetupProgress.jsx';
 import PetSettingsSection from '../pet/PetSettingsSection.jsx';
 import { DEFAULT_PET_ID } from '../pet/pet-registry.js';
@@ -1836,17 +1837,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
         </RowTag>
         );
       };
-      const IOSSwitch = ({ checked, onChange }) => (
-        <button
-          type="button"
-          role="switch"
-          aria-checked={checked}
-          onClick={() => onChange(!checked)}
-          className={`relative h-[26px] w-[46px] shrink-0 rounded-full transition-colors ${checked ? 'bg-[#34C759]' : ('bg-[#E5E5EA] dark:bg-[#3A3A3C]')}`}
-        >
-          <span className={`absolute left-0 top-[2px] h-[22px] w-[22px] rounded-full bg-white shadow transition-transform ${checked ? 'translate-x-[22px]' : 'translate-x-[2px]'}`} />
-        </button>
-      );
+      const IOSSwitch = ({ checked, onChange }) => <Toggle checked={checked} onChange={onChange} size="md" />;
       const SectionButton = ({ id, icon, label, dot }) => (
         <button
           type="button"

--- a/pinvou3-app/src/features/settings/composer-shared.jsx
+++ b/pinvou3-app/src/features/settings/composer-shared.jsx
@@ -7,6 +7,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Check, ChevronDown, Cpu, Plus, Store, Users, Wrench, X, Zap } from '../../components/icons.jsx';
 import { ComposerPopover } from '../../components/ComposerPopover.jsx';
+import { Toggle } from '../../components/Toggle.jsx';
 import { bridge, useBridgeState } from '../../hooks/useBridge.js';
 import { visibleUserModels } from '../../shared/model-options.js';
 import { can } from '../../shared/platform.js';
@@ -557,10 +558,7 @@ import {
             <span className="block text-[13px] text-gray-700 dark:text-gray-200 truncate">{row.title}</span>
             {row.kind === 'service' && statusBadge(t.composerConnected, 'green')}
           </span>
-          <button onClick={() => toggleTool(row.id, row.enabled)} aria-label={row.id} disabled={rowDisabled}
-            className={`relative inline-flex h-5 w-[34px] shrink-0 items-center rounded-full transition-colors disabled:cursor-default ${rowDisabled ? 'opacity-70' : ''} ${row.enabled ? 'bg-[#34C759]' : 'bg-[#E5E5EA] dark:bg-[#39393D]'}`}>
-            <span className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${row.enabled ? 'translate-x-[16px]' : 'translate-x-[2px]'}`} />
-          </button>
+          <Toggle checked={row.enabled} onChange={() => toggleTool(row.id, row.enabled)} aria-label={row.id} disabled={rowDisabled} size="sm" />
         </div>
         );
       };
@@ -660,10 +658,7 @@ import {
                           </span>
                           <span className="block text-[10px] text-gray-400 dark:text-gray-500">{t.composerProjectSkillsDesc}</span>
                         </span>
-                        <button onClick={toggleProjectSkills} aria-label="project-skills" disabled={toolSwitchDisabled || (hasActiveSession && projectSkillsEnabled)}
-                          className={`relative inline-flex h-5 w-[34px] shrink-0 items-center rounded-full transition-colors disabled:cursor-default ${(toolSwitchDisabled || (hasActiveSession && projectSkillsEnabled)) ? 'opacity-70' : ''} ${projectSkillsEnabled ? 'bg-[#34C759]' : 'bg-[#E5E5EA] dark:bg-[#39393D]'}`}>
-                          <span className={`inline-block h-4 w-4 rounded-full bg-white shadow transition-transform ${projectSkillsEnabled ? 'translate-x-[16px]' : 'translate-x-[2px]'}`} />
-                        </button>
+                        <Toggle checked={projectSkillsEnabled} onChange={toggleProjectSkills} aria-label="project-skills" disabled={toolSwitchDisabled || (hasActiveSession && projectSkillsEnabled)} size="sm" />
                       </div>
                       {projectSkillsEnabled && (
                         <div className="mt-1.5 text-[11px] leading-snug text-amber-600 dark:text-amber-400">{t.composerProjectSkillsWarning}</div>

--- a/pinvou3-app/src/index.html
+++ b/pinvou3-app/src/index.html
@@ -160,6 +160,8 @@
   <script src="%BASE_URL%features/attachments/attachment-drop-controller.js"></script>
   <script src="%BASE_URL%shared/bridge-messages.js"></script>
   <script src="%BASE_URL%shared/chunked-file-upload.js"></script>
+  <script src="%BASE_URL%shared/markdown-bridge-fallback.js"></script>
+  <script src="%BASE_URL%shared/format-utils.js"></script>
   <script src="%BASE_URL%platform/web/bridge/turn-terminal.js"></script>
   <script src="%BASE_URL%platform/web/bridge.js"></script>
   <script src="%BASE_URL%platform/web/bridge/domain-adapter.js"></script>

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -122,11 +122,18 @@
   // 关键:在 marked.parse 【之后】做替换,而不是之前。原因:marked 给代码块/inline code 的
   // 输出本身就已经把 < 转义成 &lt;(不会有真 <script>),只有用户在正文里裸写 HTML 时才会
   // 透传出 <script>。post-process 只命中后者,不会双重转义代码块里的 `<script>` 字面量。
-  // 渲染兜底已收敛到 shared/markdown-bridge-fallback.js（随 index.html 以普通脚本加载，
-  // 暴露 window.PinvouMarkdownBridgeFallback）；此处取别名，消除 web/tauri 两份逐字复制。
-  var renderMarkdown = (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function")
-    ? window.PinvouMarkdownBridgeFallback.renderMarkdown
-    : function (text) { return String(text || ""); };
+  // 优先委托共享渲染器 window.PinvouMarkdownRenderer（npm 版，含语法高亮）；在其尚未安装的
+  // 短暂窗口退回 vendor 全局兜底。兜底实现已收敛到 shared/markdown-bridge-fallback.js
+  // （随 index.html 以普通脚本加载，暴露 window.PinvouMarkdownBridgeFallback），消除两份逐字复制。
+  function renderMarkdown(text) {
+    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
+      return window.PinvouMarkdownRenderer.renderMarkdown(text);
+    }
+    if (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function") {
+      return window.PinvouMarkdownBridgeFallback.renderMarkdown(text);
+    }
+    return String(text || "");
+  }
 
 
   // The pet is a separate WebView and must not own a second copy of the main

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -125,6 +125,14 @@
   // 优先委托共享渲染器 window.PinvouMarkdownRenderer（npm 版，含语法高亮）；在其尚未安装的
   // 短暂窗口退回 vendor 全局兜底。兜底实现已收敛到 shared/markdown-bridge-fallback.js
   // （随 index.html 以普通脚本加载，暴露 window.PinvouMarkdownBridgeFallback），消除两份逐字复制。
+  // 最末级 fallback 必须自带 escapeHtml：共享脚本未加载时 renderMarkdown 仍会被
+  // dangerouslySetInnerHTML 消费，原文返回即 fail-open。escapeHtml 作为安全原语保留在本文件
+  // （不依赖任何外部脚本），仅 marked.parse+sanitize 这段较重的兜底被抽到共享文件。
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
   function renderMarkdown(text) {
     if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
       return window.PinvouMarkdownRenderer.renderMarkdown(text);
@@ -132,7 +140,7 @@
     if (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function") {
       return window.PinvouMarkdownBridgeFallback.renderMarkdown(text);
     }
-    return String(text || "");
+    return escapeHtml(text || "");
   }
 
 

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -122,30 +122,12 @@
   // 关键:在 marked.parse 【之后】做替换,而不是之前。原因:marked 给代码块/inline code 的
   // 输出本身就已经把 < 转义成 &lt;(不会有真 <script>),只有用户在正文里裸写 HTML 时才会
   // 透传出 <script>。post-process 只命中后者,不会双重转义代码块里的 `<script>` 字面量。
-  var DANGEROUS_TAGS_RE = /<(\/?(?:script|style|iframe|object|embed|link|meta)\b[^>]*)>/gi;
-  function neutralizeRawDangerousTags(html) {
-    return html.replace(DANGEROUS_TAGS_RE, function (_, inner) { return "&lt;" + inner + "&gt;"; });
-  }
-  function renderMarkdown(text) {
-    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
-      return window.PinvouMarkdownRenderer.renderMarkdown(text);
-    }
-    if (!window.marked || !window.DOMPurify) return escapeHtml(text);
-    var html = neutralizeRawDangerousTags(marked.parse(text || ""));
-    return DOMPurify.sanitize(html, {
-      // 兜底:即使 neutralize 有漏网(罕见 HTML 注释/CDATA 等),DOMPurify 仍剥掉这些
-      FORBID_TAGS: ["style", "iframe", "object", "embed", "link", "meta"],
-      FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
-    });
-  }
-  function escapeHtml(s) {
-    return String(s).replace(/[&<>"']/g, function (c) {
-      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
-    });
-  }
-  if (window.marked) {
-    marked.setOptions({ gfm: true, breaks: true, headerIds: false, mangle: false });
-  }
+  // 渲染兜底已收敛到 shared/markdown-bridge-fallback.js（随 index.html 以普通脚本加载，
+  // 暴露 window.PinvouMarkdownBridgeFallback）；此处取别名，消除 web/tauri 两份逐字复制。
+  var renderMarkdown = (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function")
+    ? window.PinvouMarkdownBridgeFallback.renderMarkdown
+    : function (text) { return String(text || ""); };
+
 
   // The pet is a separate WebView and must not own a second copy of the main
   // application state. Keep only the renderer used by its activity cards and

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -23,29 +23,12 @@
       if (storedBaseline) monitorBaseline = JSON.parse(storedBaseline);
     } catch (error) { monitorBaseline = null; }
   // ── Monitor ──────────────────────────────────────────────────────
-  function fmtMiB(mib) {
-    if (mib == null) return "—";
-    return mib >= 1024 ? (mib / 1024).toFixed(1) + " GB" : mib + " MB";
-  }
-  function fmtKiB(kib) {
-    if (kib == null) return "—";
-    if (kib >= 1024 * 1024) return (kib / 1024 / 1024).toFixed(1) + " GB";
-    if (kib >= 1024) return (kib / 1024).toFixed(0) + " MB";
-    return kib + " KB";
-  }
-  function fmtDuration(secs) {
-    if (secs == null || secs < 0) return "—";
-    var h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60);
-    if (h > 0) return h + "h " + m + "m";
-    if (m > 0) return m + "m " + (secs % 60) + "s";
-    return secs + "s";
-  }
-  function fmtTok(n) {
-    if (n == null) return "—";
-    if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
-    if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
-    return String(Math.round(n));
-  }
+  var PinvouFU = window.PinvouFormatUtils || {};
+  var fmtMiB = PinvouFU.fmtMiB || function (mib) { return mib == null ? "—" : String(mib); };
+  var fmtKiB = PinvouFU.fmtKiB || function (kib) { return kib == null ? "—" : String(kib); };
+  var fmtDuration = PinvouFU.fmtDuration || function (secs) { return secs == null ? "—" : String(secs); };
+  var fmtTok = PinvouFU.fmtTok || function (n) { return n == null ? "—" : String(n); };
+
 
   function numOr0(x) { return (typeof x === "number" && isFinite(x)) ? x : 0; }
 

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -117,6 +117,15 @@
   // 优先委托共享渲染器 window.PinvouMarkdownRenderer（npm 版，含语法高亮）；在其尚未安装的
   // 短暂窗口退回 vendor 全局兜底。兜底实现已收敛到 shared/markdown-bridge-fallback.js
   // （随 index.html 以普通脚本加载，暴露 window.PinvouMarkdownBridgeFallback），消除两份逐字复制。
+  // 最末级 fallback 必须自带 escapeHtml：远程 Web 部署缓存错配/资源缺失导致共享脚本未加载时，
+  // renderMarkdown 仍会被 ChatView.jsx 的 dangerouslySetInnerHTML 消费，原文返回即 fail-open。
+  // 因此 escapeHtml 作为安全原语保留在本文件（不依赖任何外部脚本），仅 marked.parse+sanitize
+  // 这段较重的兜底被抽到共享文件。
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
   function renderMarkdown(text) {
     if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
       return window.PinvouMarkdownRenderer.renderMarkdown(text);
@@ -124,7 +133,7 @@
     if (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function") {
       return window.PinvouMarkdownBridgeFallback.renderMarkdown(text);
     }
-    return String(text || "");
+    return escapeHtml(text || "");
   }
 
 

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -114,11 +114,18 @@
   // 关键:在 marked.parse 【之后】做替换,而不是之前。原因:marked 给代码块/inline code 的
   // 输出本身就已经把 < 转义成 &lt;(不会有真 <script>),只有用户在正文里裸写 HTML 时才会
   // 透传出 <script>。post-process 只命中后者,不会双重转义代码块里的 `<script>` 字面量。
-  // 渲染兜底已收敛到 shared/markdown-bridge-fallback.js（随 index.html 以普通脚本加载，
-  // 暴露 window.PinvouMarkdownBridgeFallback）；此处取别名，消除 web/tauri 两份逐字复制。
-  var renderMarkdown = (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function")
-    ? window.PinvouMarkdownBridgeFallback.renderMarkdown
-    : function (text) { return String(text || ""); };
+  // 优先委托共享渲染器 window.PinvouMarkdownRenderer（npm 版，含语法高亮）；在其尚未安装的
+  // 短暂窗口退回 vendor 全局兜底。兜底实现已收敛到 shared/markdown-bridge-fallback.js
+  // （随 index.html 以普通脚本加载，暴露 window.PinvouMarkdownBridgeFallback），消除两份逐字复制。
+  function renderMarkdown(text) {
+    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
+      return window.PinvouMarkdownRenderer.renderMarkdown(text);
+    }
+    if (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function") {
+      return window.PinvouMarkdownBridgeFallback.renderMarkdown(text);
+    }
+    return String(text || "");
+  }
 
 
   // The pet is a separate WebView and must not own a second copy of the main

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -114,30 +114,12 @@
   // 关键:在 marked.parse 【之后】做替换,而不是之前。原因:marked 给代码块/inline code 的
   // 输出本身就已经把 < 转义成 &lt;(不会有真 <script>),只有用户在正文里裸写 HTML 时才会
   // 透传出 <script>。post-process 只命中后者,不会双重转义代码块里的 `<script>` 字面量。
-  var DANGEROUS_TAGS_RE = /<(\/?(?:script|style|iframe|object|embed|link|meta)\b[^>]*)>/gi;
-  function neutralizeRawDangerousTags(html) {
-    return html.replace(DANGEROUS_TAGS_RE, function (_, inner) { return "&lt;" + inner + "&gt;"; });
-  }
-  function renderMarkdown(text) {
-    if (window.PinvouMarkdownRenderer && typeof window.PinvouMarkdownRenderer.renderMarkdown === "function") {
-      return window.PinvouMarkdownRenderer.renderMarkdown(text);
-    }
-    if (!window.marked || !window.DOMPurify) return escapeHtml(text);
-    var html = neutralizeRawDangerousTags(marked.parse(text || ""));
-    return DOMPurify.sanitize(html, {
-      // 兜底:即使 neutralize 有漏网(罕见 HTML 注释/CDATA 等),DOMPurify 仍剥掉这些
-      FORBID_TAGS: ["style", "iframe", "object", "embed", "link", "meta"],
-      FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
-    });
-  }
-  function escapeHtml(s) {
-    return String(s).replace(/[&<>"']/g, function (c) {
-      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
-    });
-  }
-  if (window.marked) {
-    marked.setOptions({ gfm: true, breaks: true, headerIds: false, mangle: false });
-  }
+  // 渲染兜底已收敛到 shared/markdown-bridge-fallback.js（随 index.html 以普通脚本加载，
+  // 暴露 window.PinvouMarkdownBridgeFallback）；此处取别名，消除 web/tauri 两份逐字复制。
+  var renderMarkdown = (window.PinvouMarkdownBridgeFallback && typeof window.PinvouMarkdownBridgeFallback.renderMarkdown === "function")
+    ? window.PinvouMarkdownBridgeFallback.renderMarkdown
+    : function (text) { return String(text || ""); };
+
 
   // The pet is a separate WebView and must not own a second copy of the main
   // application state. Keep only the renderer used by its activity cards and
@@ -6169,29 +6151,12 @@
   });
 
   // ── Monitor ──────────────────────────────────────────────────────
-  function fmtMiB(mib) {
-    if (mib == null) return "—";
-    return mib >= 1024 ? (mib / 1024).toFixed(1) + " GB" : mib + " MB";
-  }
-  function fmtKiB(kib) {
-    if (kib == null) return "—";
-    if (kib >= 1024 * 1024) return (kib / 1024 / 1024).toFixed(1) + " GB";
-    if (kib >= 1024) return (kib / 1024).toFixed(0) + " MB";
-    return kib + " KB";
-  }
-  function fmtDuration(secs) {
-    if (secs == null || secs < 0) return "—";
-    var h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60);
-    if (h > 0) return h + "h " + m + "m";
-    if (m > 0) return m + "m " + (secs % 60) + "s";
-    return secs + "s";
-  }
-  function fmtTok(n) {
-    if (n == null) return "—";
-    if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
-    if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
-    return String(Math.round(n));
-  }
+  var PinvouFU = window.PinvouFormatUtils || {};
+  var fmtMiB = PinvouFU.fmtMiB || function (mib) { return mib == null ? "—" : String(mib); };
+  var fmtKiB = PinvouFU.fmtKiB || function (kib) { return kib == null ? "—" : String(kib); };
+  var fmtDuration = PinvouFU.fmtDuration || function (secs) { return secs == null ? "—" : String(secs); };
+  var fmtTok = PinvouFU.fmtTok || function (n) { return n == null ? "—" : String(n); };
+
 
   function numOr0(x) { return (typeof x === "number" && isFinite(x)) ? x : 0; }
 

--- a/pinvou3-app/src/shared/format-utils.js
+++ b/pinvou3-app/src/shared/format-utils.js
@@ -1,0 +1,41 @@
+/**
+ * format-utils.js — 供 plain-script bridge 共用的监控指标格式化函数。
+ *
+ * 此前 fmtMiB / fmtKiB / fmtDuration / fmtTok 在 platform/web/bridge.js 与
+ * platform/tauri/bridge/monitor.js 中逐字重复，现收敛到本文件，
+ * 由两处统一引用 window.PinvouFormatUtils。
+ */
+(function (root) {
+  "use strict";
+
+  function fmtMiB(mib) {
+    if (mib == null) return "—";
+    return mib >= 1024 ? (mib / 1024).toFixed(1) + " GB" : mib + " MB";
+  }
+  function fmtKiB(kib) {
+    if (kib == null) return "—";
+    if (kib >= 1024 * 1024) return (kib / 1024 / 1024).toFixed(1) + " GB";
+    if (kib >= 1024) return (kib / 1024).toFixed(0) + " MB";
+    return kib + " KB";
+  }
+  function fmtDuration(secs) {
+    if (secs == null || secs < 0) return "—";
+    var h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60);
+    if (h > 0) return h + "h " + m + "m";
+    if (m > 0) return m + "m " + (secs % 60) + "s";
+    return secs + "s";
+  }
+  function fmtTok(n) {
+    if (n == null) return "—";
+    if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+    if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
+    return String(Math.round(n));
+  }
+
+  root.PinvouFormatUtils = Object.freeze({
+    fmtMiB: fmtMiB,
+    fmtKiB: fmtKiB,
+    fmtDuration: fmtDuration,
+    fmtTok: fmtTok,
+  });
+})(typeof window !== "undefined" ? window : this);

--- a/pinvou3-app/src/shared/markdown-bridge-fallback.js
+++ b/pinvou3-app/src/shared/markdown-bridge-fallback.js
@@ -8,6 +8,8 @@
  *
  * 此前该兜底在 platform/web/bridge.js 与 platform/tauri/bridge.js 中逐字重复两份，
  * 现收敛到本文件，由两处 bridge 统一引用 window.PinvouMarkdownBridgeFallback。
+ * 注意：bridge 层负责「优先委托 window.PinvouMarkdownRenderer（npm 版，含语法高亮）」，
+ * 仅在共享渲染器尚未安装时才调用本文件的 vendor 全局兜底；本文件不再重复该委托。
  */
 (function (root) {
   "use strict";
@@ -27,9 +29,6 @@
   }
 
   function renderMarkdown(text) {
-    if (root.PinvouMarkdownRenderer && typeof root.PinvouMarkdownRenderer.renderMarkdown === "function") {
-      return root.PinvouMarkdownRenderer.renderMarkdown(text);
-    }
     if (!root.marked || !root.DOMPurify) return escapeHtml(text);
     var html = neutralizeRawDangerousTags(root.marked.parse(text || ""));
     return root.DOMPurify.sanitize(html, {

--- a/pinvou3-app/src/shared/markdown-bridge-fallback.js
+++ b/pinvou3-app/src/shared/markdown-bridge-fallback.js
@@ -1,0 +1,47 @@
+/**
+ * markdown-bridge-fallback.js — 供 plain-script bridge（web/tauri）共用的 Markdown 渲染兜底。
+ *
+ * 背景：platform/{web,tauri}/bridge.js 是以 <script src> 加载的普通脚本（非 ES module），
+ * 无法 import shared/markdown-renderer.js（后者依赖 marked/dompurify 等 npm 包、由 Vite 打包）。
+ * 因此 bridge 层保留一份基于 vendor 全局（window.marked / window.DOMPurify）的兜底实现，
+ * 供 React 主包尚未安装 window.PinvouMarkdownRenderer 的短暂窗口使用。
+ *
+ * 此前该兜底在 platform/web/bridge.js 与 platform/tauri/bridge.js 中逐字重复两份，
+ * 现收敛到本文件，由两处 bridge 统一引用 window.PinvouMarkdownBridgeFallback。
+ */
+(function (root) {
+  "use strict";
+
+  // 抹平裸 <script>/<style>/<iframe> 等危险标签：在 marked.parse 【之后】做替换而非之前，
+  // 只命中正文裸写的 HTML，不会双重转义代码块里已被转义的 `<script>` 字面量。
+  var DANGEROUS_TAGS_RE = /<(\/?(?:script|style|iframe|object|embed|link|meta)\b[^>]*)>/gi;
+
+  function neutralizeRawDangerousTags(html) {
+    return html.replace(DANGEROUS_TAGS_RE, function (_, inner) { return "&lt;" + inner + "&gt;"; });
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function renderMarkdown(text) {
+    if (root.PinvouMarkdownRenderer && typeof root.PinvouMarkdownRenderer.renderMarkdown === "function") {
+      return root.PinvouMarkdownRenderer.renderMarkdown(text);
+    }
+    if (!root.marked || !root.DOMPurify) return escapeHtml(text);
+    var html = neutralizeRawDangerousTags(root.marked.parse(text || ""));
+    return root.DOMPurify.sanitize(html, {
+      // 兜底：即使 neutralize 有漏网（罕见 HTML 注释/CDATA 等），DOMPurify 仍剥掉这些
+      FORBID_TAGS: ["style", "iframe", "object", "embed", "link", "meta"],
+      FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
+    });
+  }
+
+  if (root.marked) {
+    root.marked.setOptions({ gfm: true, breaks: true, headerIds: false, mangle: false });
+  }
+
+  root.PinvouMarkdownBridgeFallback = Object.freeze({ renderMarkdown: renderMarkdown });
+})(typeof window !== "undefined" ? window : this);

--- a/pinvou3-app/tests/markdown_bridge_fallback_safety.test.mjs
+++ b/pinvou3-app/tests/markdown_bridge_fallback_safety.test.mjs
@@ -1,0 +1,175 @@
+// 验证 Markdown 渲染「最末级 fallback」在共享脚本缺失时仍转义 HTML（防 fail-open）。
+//
+// 背景：bridge.js（web/tauri）的 renderMarkdown 委托链为
+//   1. window.PinvouMarkdownRenderer（npm 主包）
+//   2. window.PinvouMarkdownBridgeFallback（shared/markdown-bridge-fallback.js，普通脚本）
+//   3. 内联 escapeHtml（最末级）
+// 第 3 级必须自带转义：远程 Web 部署缓存错配/资源缺失导致第 2 级脚本未加载时，
+// renderMarkdown 的返回仍由 ChatView.jsx 的 dangerouslySetInnerHTML 消费，
+// 原文返回会让 <img onerror=...> 等危险输入原样注入（fail-open）。
+//
+// 现有 render_markdown.test.js 把正则实现复制了一份，不执行真实 bridge 代码，
+// 覆盖不到「共享脚本缺失」这条路径。本测试改为在 vm 里加载真实 web/bridge.js，
+// 在「同时移除两个渲染器」的条件下断言危险输入被转义。
+//
+// 注：tauri/bridge.js 的 renderMarkdown 与 web 逐字相同（同一修复），但完整加载
+// tauri bridge 需要大量 __PINVOU_TAURI_BRIDGE_FEATURES__ 注册 mock，成本不匹配；
+// 故以 web bridge（评审指出的「远程 Web 部署」fail-open 向量）作为真实执行代表，
+// 并对 shared 兜底文件单独做无 vendor 全局时的转义断言。
+//
+// 跑法：`node tests/markdown_bridge_fallback_safety.test.mjs`
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readApp = (...parts) => fs.readFileSync(path.join(root, ...parts), 'utf8');
+
+// 复用 web_bridge_domain_contract.test.mjs 的最小 window mock：只够让 web/bridge.js
+// 以「web 平台」身份完成加载并暴露 flat transport（含 renderMarkdown）。
+function buildWebBridgeContext() {
+  const storage = new Map();
+  const localStorage = {
+    getItem: key => (storage.has(key) ? storage.get(key) : null),
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: key => storage.delete(key),
+  };
+  const windowObject = {
+    PinvouPlatform: {
+      kind: 'web',
+      isWeb: true,
+      capabilities: {},
+      can: () => false,
+      canInvoke: () => false,
+    },
+    __TAURI__: {
+      core: { invoke: async () => null },
+      event: { listen: async () => () => {} },
+      dialog: { open: async () => null },
+    },
+    location: { search: '', href: 'https://example.test/pinvou3/remote/' },
+    localStorage,
+    crypto: { randomUUID: () => '00000000-0000-8000-0000-000000000000' },
+    performance: { now: () => 0 },
+    addEventListener() {},
+    setTimeout,
+    clearTimeout,
+  };
+  const context = vm.createContext({
+    window: windowObject,
+    document: {
+      readyState: 'loading',
+      addEventListener() {},
+      createElement: () => ({ click() {}, remove() {}, style: {}, setAttribute() {} }),
+      body: { appendChild() {} },
+    },
+    navigator: { mediaDevices: null },
+    localStorage,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    structuredClone,
+    URL,
+    URLSearchParams,
+    Blob,
+    Uint8Array,
+    ArrayBuffer,
+    TextEncoder,
+    TextDecoder,
+  });
+  return { context, windowObject };
+}
+
+// ── Case 1: 真实 web/bridge.js，两个渲染器都不存在 → 最末级 fallback 必须转义 ──
+{
+  const { context, windowObject } = buildWebBridgeContext();
+  // 刻意不安装 PinvouMarkdownRenderer / PinvouMarkdownBridgeFallback（模拟共享脚本缺失）。
+  vm.runInContext(readApp('src', 'platform', 'web', 'bridge.js'), context, {
+    filename: 'platform/web/bridge.js',
+  });
+  const renderMarkdown = windowObject.TauriBridge.renderMarkdown;
+  assert.equal(typeof renderMarkdown, 'function', 'web bridge must expose renderMarkdown');
+
+  const dangerous = '<img src=x onerror="alert(1)"><script>steal()</script>';
+  const out = renderMarkdown(dangerous);
+  // escapeHtml 把标签定界符转义成实体，整段变成无活性的可见文本——攻击向量随之失效。
+  // 注意：escapeHtml 只转义 &<>"'，不删除属性名字母，故 "onerror" 字面仍会出现，
+  // 但它已不在任何真实标签内（前面是 &lt;img ...），不再被浏览器当作事件处理器。
+  assert.equal(out.indexOf('<img'), -1, 'raw <img must not survive the final fallback');
+  assert.equal(out.indexOf('<script'), -1, 'raw <script must not survive the final fallback');
+  assert.ok(out.indexOf('&lt;img') >= 0, `dangerous tags must be HTML-escaped, got: ${out}`);
+  assert.ok(out.indexOf('&lt;script') >= 0, `script tags must be HTML-escaped, got: ${out}`);
+  console.log('✓ web bridge escapes dangerous HTML when both renderers are absent');
+}
+
+// ── Case 2: 真实 web/bridge.js，只装了共享兜底且 vendor 全在 → 危险标签被中和 ──
+// 验证委托链第 2 级（shared/markdown-bridge-fallback.js）在正常加载时仍工作，
+// 且 bridge 确实把控制权交给了它（而非错误地停在 escapeHtml）。
+{
+  const { context, windowObject } = buildWebBridgeContext();
+  // 构造最小 vendor 全局：marked 只做透传，DOMPurify 只做基本 sanitize。
+  // 目的不是复刻真实 vendor 行为，而是让兜底文件走 neutralize + sanitize 分支。
+  windowObject.marked = {
+    parse: src => String(src || ''),
+    setOptions() {},
+  };
+  windowObject.DOMPurify = { sanitize: html => String(html || '') };
+  vm.runInContext(readApp('src', 'shared', 'markdown-bridge-fallback.js'), context, {
+    filename: 'shared/markdown-bridge-fallback.js',
+  });
+  vm.runInContext(readApp('src', 'platform', 'web', 'bridge.js'), context, {
+    filename: 'platform/web/bridge.js',
+  });
+  const out = windowObject.TauriBridge.renderMarkdown('before <script>x()</script> after');
+  assert.ok(
+    out.indexOf('&lt;script') >= 0 && out.indexOf('<script') < 0,
+    `shared fallback must neutralize raw <script>, got: ${out}`,
+  );
+  console.log('✓ web bridge delegates to shared fallback to neutralize dangerous tags');
+}
+
+// ── Case 3: shared/markdown-bridge-fallback.js 单独加载，vendor 全局缺失 → 转义 ──
+{
+  const { context, windowObject } = buildWebBridgeContext();
+  // 不装 marked / DOMPurify：兜底文件自身必须走 escapeHtml 分支。
+  vm.runInContext(readApp('src', 'shared', 'markdown-bridge-fallback.js'), context, {
+    filename: 'shared/markdown-bridge-fallback.js',
+  });
+  const out = windowObject.PinvouMarkdownBridgeFallback.renderMarkdown(
+    '<iframe src=evil></iframe>',
+  );
+  assert.equal(out.indexOf('<iframe'), -1, 'raw <iframe must not survive missing vendors');
+  assert.ok(out.indexOf('&lt;iframe') >= 0, `iframe must be escaped, got: ${out}`);
+  console.log('✓ shared fallback escapes HTML when vendor globals are missing');
+}
+
+// ── Case 4: 守护两处 bridge 源码——最末级 fallback 不得退化为原文返回 ──
+// 防止未来重构再次把 escapeHtml 抽走、留下 fail-open 的 `return String(text || "")`。
+for (const bridgeRel of [['src', 'platform', 'web', 'bridge.js'], ['src', 'platform', 'tauri', 'bridge.js']]) {
+  const src = readApp(...bridgeRel);
+  assert.match(
+    src,
+    /return escapeHtml\(text \|\| ""\)/u,
+    `${bridgeRel.join('/')} final fallback must escape (not return raw text)`,
+  );
+  // 同时守护 escapeHtml 的定义就地产于此文件（安全原语不依赖外部脚本）。
+  assert.match(
+    src,
+    /function escapeHtml\(s\)/u,
+    `${bridgeRel.join('/')} must define its own escapeHtml for the final fallback`,
+  );
+  // 委托共享渲染器的主路径仍须保留（markdown_syntax_highlight 契约同样要求）。
+  assert.match(
+    src,
+    /window\.PinvouMarkdownRenderer\.renderMarkdown\(text\)/u,
+    `${bridgeRel.join('/')} must keep delegating to the shared renderer`,
+  );
+  console.log(`✓ ${bridgeRel.join('/')} keeps safe final fallback + renderer delegation`);
+}
+
+console.log('\nmarkdown bridge fallback safety: ok');

--- a/pinvou3-app/vite.config.js
+++ b/pinvou3-app/vite.config.js
@@ -26,7 +26,9 @@ export const staticRuntimeScripts = new Set([
   'shared/authority-sync-diagnostics.js',
   'shared/bridge-messages.js',
   'shared/chunked-file-upload.js',
+  'shared/format-utils.js',
   'shared/legacy-polyfills.js',
+  'shared/markdown-bridge-fallback.js',
   'vendor/tailwind.js',
 ]);
 export const staticRuntimeScriptPrefixes = ['platform/tauri/bridge/', 'platform/web/bridge/'];


### PR DESCRIPTION
## 背景

品悟性能/内存优化调研「UI 控件与代码模块复用」P1 项落地：消除三处逐字重复实现，收敛到单一来源。

## 变更内容

1. **Markdown 渲染兜底去重**：`platform/web/bridge.js` 与 `platform/tauri/bridge.js` 各有一份逐字相同的「vendor 全局（window.marked / window.DOMPurify）兜底」。抽取为 `shared/markdown-bridge-fallback.js`（普通脚本，随 index.html 加载，暴露 `window.PinvouMarkdownBridgeFallback`），两处 bridge 改为取别名。
2. **监控格式化函数去重**：`fmtMiB / fmtKiB / fmtDuration / fmtTok` 在 `web/bridge.js` 与 `tauri/bridge/monitor.js` 逐字重复。抽取为 `shared/format-utils.js`（暴露 `window.PinvouFormatUtils`），两处改为防御性别名（脚本缺失时优雅降级）。
3. **iOS 开关控件抽取**：新增 `components/Toggle.jsx`（sm/md 两档尺寸 + `role="switch"` 无障碍），替换 `SettingsView.jsx` 内工具开关、项目技能开关与 `IOSSwitch` 三处手写实现。

## 涉及文件

- 新增：`src/components/Toggle.jsx`、`src/shared/format-utils.js`、`src/shared/markdown-bridge-fallback.js`、`tests/markdown_bridge_fallback_safety.test.mjs`
- 修改：`src/index.html`、`vite.config.js`、`src/platform/{web,tauri}/bridge.js`、`src/platform/tauri/bridge/monitor.js`、`src/features/settings/SettingsView.jsx`

## 安全说明（最末级 fallback）

bridge.js 是普通 `<script>`（非 ES module），无法 import 依赖 npm 包的 `shared/markdown-renderer.js`，故兜底仍需一份基于 vendor 全局的实现。renderMarkdown 的委托链为：
1. `window.PinvouMarkdownRenderer`（npm 主包，含语法高亮）—— 主路径
2. `window.PinvouMarkdownBridgeFallback`（本次抽取的共享 vendor 兜底）
3. 内联 `escapeHtml`（最末级）

第 3 级刻意保留在每个 bridge 内、不依赖任何外部脚本：远程 Web 部署缓存错配/资源缺失导致第 2 级共享脚本未加载时，`renderMarkdown` 的返回仍由 `ChatView.jsx` 的 `dangerouslySetInnerHTML` 消费，原文返回会让 `<img onerror=...>` 等危险输入原样注入（fail-open）。`escapeHtml` 作为安全原语就地保留，仅较重的 `marked.parse + sanitize` 段被抽到共享文件。新增 `tests/markdown_bridge_fallback_safety.test.mjs` 在 vm 中加载真实 web/bridge.js、移除两个渲染器，断言危险输入被转义，并守护两处 bridge 不得退化为 `return String(text || "")`。

## 已知风险 / 说明

- **性质说明**：本次是维护性去重，而非运行时性能/内存收益。抽取的两个共享普通脚本随 index.html 同步加载，属于构建时原样复制的静态资源：相关脚本体量合计约 +2 KB、并多出 2 个启动期请求。目标是把「两份逐字复制」收敛为「单一来源」以降低维护成本与一致性风险；若后续追求首屏/请求收益，可考虑合并为单个 shared bridge runtime。
- **Toggle 配色**：`Toggle` 将 md 档（原 `IOSSwitch`）暗色 off 色从 `#3A3A3C` 归一为 `#39393D`（与 sm 档一致，差 1 个 RGB 单位，视觉不可辨）。
- **多 agent 菜单白色滑块**：`SettingsView.jsx` 中「多 agent 菜单」的白色滑块是按钮内的装饰指示器（`aria-hidden`），语义上不是开关，故未纳入 Toggle 收敛。

## 验证

- `npm run lint:ui` ✅
- `npm run build:ui` ✅
- `python3 scripts/architecture-guard.py` ✅
- `node tests/{web_bridge_domain_contract, bridge_domain_protocol, monitor_bridge_format, markdown_bridge_fallback_safety, render_markdown, markdown_syntax_highlight, pet_bootstrap_isolation, tauri_platform_layout, startup_window_logic, web_template_packaging_contract}.*` ✅
- 净删约 80 行重复代码

---
**Rebase update (2026-08-22, head `54f03844`):** Rebased onto `main@e1ca07c8` to resolve the #318 integration conflict. The Toggle extraction now targets the final ownership boundaries: the settings switch replacement stays in `SettingsView.jsx`, while the composer tool-row and project-skills switch replacements moved to `features/settings/composer-shared.jsx` where #318 relocated those controls. All #318/#302 semantics (hiddenIds, unified bundle disable set, active-session enable-only rule, code-scope session ID, readonly skill rows) are preserved. The overlapping `vite.config.js` `staticRuntimeScripts` edit from #327 was resolved keeping both sides (`legacy-polyfills.js` plus this PR's two shared scripts); #327's vendor marked/purify retirement is preserved. Full frontend suite, compat audit, ESLint, build, and architecture guard pass on the final tree.