### PR TITLE
fix: 修复中断/回收/删除路径的指标与 turn capture 泄漏（Rust 侧）

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -465,6 +465,15 @@ pub async fn delete_session(
     };
     if result.is_ok() {
         pool.forget_session(&id);
+        // 会话删除兜底：清掉进程级 store 里该 session 的打点残留，避免随会话删除
+        // 缓慢增长的自测指标泄漏（warmed_sessions 在每轮 TurnComplete 插入、从不回收）。
+        if let Some(m) = app
+            .try_state::<crate::features::monitor::MonitorState>()
+            .map(|s| s.self_metrics())
+        {
+            m.drop_session(&id);
+        }
+        crate::features::memory::discard_turn_capture(&id);
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -1540,6 +1540,15 @@ impl AppEngine {
         session_id: &str,
         shell_cleanup_failed: bool,
     ) -> bool {
+        // 回收/中断不经过 TurnComplete：清掉 self_metrics 打点与 memory turn capture，
+        // 避免中断轮在进程级 map 里永久驻留。
+        if let Some(m) = app
+            .try_state::<crate::features::monitor::MonitorState>()
+            .map(|s| s.self_metrics())
+        {
+            m.on_turn_aborted(session_id);
+        }
+        crate::features::memory::discard_turn_capture(session_id);
         match finish_reclaimed_lifecycle_turn(
             &self.turn_lifecycle,
             app,

--- a/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
@@ -1025,6 +1025,12 @@ pub(crate) fn spawn_event_forwarder(
                 }
             }
         }
+        // 事件流中断/停止不经过 TurnComplete：清掉本轮 self_metrics 打点与 memory
+        // turn capture，否则 inflight / turn_capture_store 会按 session 永久驻留。
+        if let Some(m) = &self_metrics {
+            m.on_turn_aborted(&session_id);
+        }
+        crate::features::memory::discard_turn_capture(&session_id);
         match finish_reclaimed_lifecycle_turn(
             &turn_lifecycle,
             &app,

--- a/pinvou3-app/src-tauri/src/features/memory/io.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/io.rs
@@ -220,6 +220,16 @@ pub fn take_turn_capture(session_id: &str) -> Option<TurnMemoryCapture> {
     })
 }
 
+/// 中断/会话回收时丢弃该 session 的进行中 turn capture，避免进程级 store 永久驻留。
+/// 与 take_turn_capture 的区别：不构建返回值、不触发记忆复盘（中断轮不应复盘）。
+pub fn discard_turn_capture(session_id: &str) {
+    let session_id = clean_id(session_id);
+    if session_id.is_empty() {
+        return;
+    }
+    turn_capture_store().lock().remove(&session_id);
+}
+
 pub fn load_profile() -> io::Result<MemoryProfile> {
     let path = profile_path();
     match read_text_recovering(&path, |raw| {

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -40,13 +40,13 @@ pub use self::io::{
 // ---- 实体存储读写 pub 入口（io）----
 pub use self::io::{
     append_turn_assistant, archive_recent_work, clear_profile, confirm_pending_memory,
-    delete_preference, delete_timed_memory, delete_work_context, enqueue_memory_candidate,
-    ignore_pending_memory, list_preferences, list_preferences_with_cleanup, load_current_focus,
-    load_never_memory, load_pending_memory, load_profile, load_recent_activity, load_recent_work,
-    load_work_context, load_work_context_with_cleanup, memory_enabled, never_pending_memory,
-    record_turn_tool_complete, record_turn_tool_start, record_turn_user, save_profile,
-    take_turn_capture, update_preference, update_profile, update_timed_memory, update_work_context,
-    upsert_recent_work,
+    delete_preference, delete_timed_memory, delete_work_context, discard_turn_capture,
+    enqueue_memory_candidate, ignore_pending_memory, list_preferences, list_preferences_with_cleanup,
+    load_current_focus, load_never_memory, load_pending_memory, load_profile, load_recent_activity,
+    load_recent_work, load_work_context, load_work_context_with_cleanup, memory_enabled,
+    never_pending_memory, record_turn_tool_complete, record_turn_tool_start, record_turn_user,
+    save_profile, take_turn_capture, update_preference, update_profile, update_timed_memory,
+    update_work_context, upsert_recent_work,
 };
 
 // ---- LLM 后台复盘（llm_review）----

--- a/pinvou3-app/src-tauri/src/features/memory/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/mod.rs
@@ -41,12 +41,13 @@ pub use self::io::{
 pub use self::io::{
     append_turn_assistant, archive_recent_work, clear_profile, confirm_pending_memory,
     delete_preference, delete_timed_memory, delete_work_context, discard_turn_capture,
-    enqueue_memory_candidate, ignore_pending_memory, list_preferences, list_preferences_with_cleanup,
-    load_current_focus, load_never_memory, load_pending_memory, load_profile, load_recent_activity,
-    load_recent_work, load_work_context, load_work_context_with_cleanup, memory_enabled,
-    never_pending_memory, record_turn_tool_complete, record_turn_tool_start, record_turn_user,
-    save_profile, take_turn_capture, update_preference, update_profile, update_timed_memory,
-    update_work_context, upsert_recent_work,
+    enqueue_memory_candidate, ignore_pending_memory, list_preferences,
+    list_preferences_with_cleanup, load_current_focus, load_never_memory, load_pending_memory,
+    load_profile, load_recent_activity, load_recent_work, load_work_context,
+    load_work_context_with_cleanup, memory_enabled, never_pending_memory,
+    record_turn_tool_complete, record_turn_tool_start, record_turn_user, save_profile,
+    take_turn_capture, update_preference, update_profile, update_timed_memory, update_work_context,
+    upsert_recent_work,
 };
 
 // ---- LLM 后台复盘（llm_review）----

--- a/pinvou3-app/src-tauri/src/features/monitor/self_metrics.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/self_metrics.rs
@@ -171,6 +171,15 @@ impl SelfMetrics {
         self.set_last_event(format!("turn_aborted session={session_id}"));
     }
 
+    /// 会话删除：清掉该 session 的全部打点残留（inflight + warmed_sessions）。
+    /// `warmed_sessions` 在每轮 TurnComplete 时按 session_id 插入但从不随会话回收，
+    /// 已完成并删除的会话会让条目永久驻留 → 随会话删除缓慢增长的泄漏，此处兜底。
+    /// 幂等（remove / HashSet::remove）。
+    pub fn drop_session(&self, session_id: &str) {
+        self.inflight.lock().remove(session_id);
+        self.warmed_sessions.lock().remove(session_id);
+    }
+
     pub fn snapshot(&self) -> SelfPerfSnapshot {
         let p = self.perf.lock();
         SelfPerfSnapshot {
@@ -216,6 +225,27 @@ mod tests {
         assert_eq!(s.gen_tokens_total, 0);
         assert_eq!(s.prompt_tokens_total, 0);
         assert_eq!(s.ttft_count, 0);
+    }
+
+    #[test]
+    fn self_metrics_drop_session_clears_warmed_and_inflight() {
+        let m = SelfMetrics::default();
+        // s1 正常完成 → 标记 warmed；s2 inflight 打点未收尾。
+        m.on_turn_started("s1");
+        m.on_first_delta("s1");
+        m.on_turn_complete("s1", 10, 5, None, None);
+        m.on_turn_started("s2");
+        let dbg = m.debug_snapshot();
+        assert_eq!(dbg.inflight_count, 1);
+        assert_eq!(dbg.warmed_sessions_count, 1);
+        // 删除 s1：warmed 应清空。删除 s2：inflight 应清空。
+        m.drop_session("s1");
+        m.drop_session("s2");
+        let dbg = m.debug_snapshot();
+        assert_eq!(dbg.inflight_count, 0);
+        assert_eq!(dbg.warmed_sessions_count, 0);
+        // drop_session 幂等：再删一次无副作用。
+        m.drop_session("s1");
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/monitor/self_metrics.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/self_metrics.rs
@@ -164,6 +164,13 @@ impl SelfMetrics {
         ));
     }
 
+    /// Turn aborted（停止/会话回收，未走到 TurnComplete）：移除 inflight 打点条目，
+    /// 避免该 session 的 TurnTiming 永久驻留。不写 perf 累计、不标 warmed（中断轮非完成轮）。
+    pub fn on_turn_aborted(&self, session_id: &str) {
+        self.inflight.lock().remove(session_id);
+        self.set_last_event(format!("turn_aborted session={session_id}"));
+    }
+
     pub fn snapshot(&self) -> SelfPerfSnapshot {
         let p = self.perf.lock();
         SelfPerfSnapshot {
@@ -194,6 +201,22 @@ impl SelfMetrics {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn self_metrics_aborted_turn_clears_inflight_without_marking_warmed() {
+        let m = SelfMetrics::default();
+        m.on_turn_started("s1");
+        m.on_first_delta("s1");
+        m.on_turn_aborted("s1");
+        let dbg = m.debug_snapshot();
+        assert_eq!(dbg.inflight_count, 0);
+        assert_eq!(dbg.warmed_sessions_count, 0);
+        // 中断轮不污染 perf 累计：不写 tokens、不计 TTFT/TPS。
+        let s = m.snapshot();
+        assert_eq!(s.gen_tokens_total, 0);
+        assert_eq!(s.prompt_tokens_total, 0);
+        assert_eq!(s.ttft_count, 0);
+    }
 
     #[test]
     fn self_metrics_first_turn_per_session_records_ttft_tps() {

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -216,21 +216,10 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     // ToolStoreView 随左栏切换会卸载；连接是长流程（装 CLI ~40s + 扫码），进度/监听/秒表
     // 若放组件 useState，一离开工具商店就全丢 → 回来按钮又变“连接”。故挂在模块级单例，
     // 活在组件生命周期之外；组件只订阅它做镜像渲染。
-    // 统一注册 Tauri 事件监听并收集 unlisten 句柄，供 conn.disposeListeners() 清理。
-    // ev.listen 返回 Promise<unlisten>，若 dispose 在 resolve 前发生，迟到的句柄不能
-    // 再 push 进已清空的数组（否则监听永远漏注销）→ 直接注销。
-    function track(ev, conn, event, handler) {
-      ev.listen(event, handler)
-        .then(u => { if (conn.disposed) { try { u(); } catch (_) {} } else { conn.unlisteners.push(u); } })
-        .catch(() => {});
-    }
-
     const feishuConn = {
       flow: null,
       tick: null,
       listenersReady: false,
-      unlisteners: [],
-      disposed: false,
       subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
@@ -244,13 +233,6 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
-      disposeListeners() {
-        this.disposed = true;
-        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
-        this.unlisteners = [];
-        this.listenersReady = false;
-        this.stopTick();
-      },
     };
     // 后端连接事件只注册一次（幂等，跨 ToolStoreView 多次挂载不重复注册）。
     function ensureFeishuListeners(copy = {}) {
@@ -259,7 +241,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       feishuConn.listenersReady = true;
-      track(ev, feishuConn, 'feishu:progress', (e) => {
+      ev.listen('feishu:progress', (e) => {
         const p = e.payload || {};
         feishuConn.setFlow(f => {
           const nf = f ? { ...f, steps: { ...(f.steps || {}) } } : { phase: 'running', steps: {}, active: null, pct: 0, sec: 0, log: '' };
@@ -270,7 +252,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           return nf;
         });
       });
-      track(ev, feishuConn, 'feishu:qr', (e) => {
+      ev.listen('feishu:qr', (e) => {
         const p = e.payload || {};
         feishuConn.stopTick();
         feishuConn.setFlow(f => {
@@ -282,7 +264,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           };
         });
       });
-      track(ev, feishuConn, 'feishu:connected', () => {
+      ev.listen('feishu:connected', () => {
         feishuConn.stopTick();
         feishuConn.setFlow(f => ({ ...(f || {}), phase: 'done', steps: { ...((f && f.steps) || {}), qr: 'done' } }));
         // 连上 → 按规则写技能（默认启用）+ 广播刷新；跟视图无关，放全局做。
@@ -290,7 +272,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         // 稍后自动收起流程卡（详情里的“已连接”态改由 feishuConnected 驱动）
         setTimeout(() => feishuConn.setFlow(null), 1800);
       });
-      track(ev, feishuConn, 'feishu:error', (e) => {
+      ev.listen('feishu:error', (e) => {
         const p = e.payload || {};
         feishuConn.stopTick();
         feishuConn.setFlow(f => {
@@ -302,7 +284,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 企业微信连接流程 · 跨视图持久 store(镜像 feishuConn;企微纯扫码单段）──
     const wecomConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -315,13 +297,6 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
-      disposeListeners() {
-        this.disposed = true;
-        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
-        this.unlisteners = [];
-        this.listenersReady = false;
-        this.stopTick();
-      },
     };
     function ensureWecomListeners(copy = {}) {
       if (wecomConn.listenersReady) return;
@@ -329,7 +304,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       wecomConn.listenersReady = true;
-      track(ev, wecomConn, 'wecom:qr', (e) => {
+      ev.listen('wecom:qr', (e) => {
         const p = e.payload || {};
         wecomConn.stopTick();
         wecomConn.setFlow(f => {
@@ -339,13 +314,13 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase };
         });
       });
-      track(ev, wecomConn, 'wecom:connected', () => {
+      ev.listen('wecom:connected', () => {
         wecomConn.stopTick();
         wecomConn.setFlow(f => ({ ...(f || {}), phase: 'done', steps: { ...((f && f.steps) || {}), qr: 'done' } }));
         invokeTauri('wecom_apply_skills').catch(() => {});
         setTimeout(() => wecomConn.setFlow(null), 1800);
       });
-      track(ev, wecomConn, 'wecom:error', (e) => {
+      ev.listen('wecom:error', (e) => {
         const p = e.payload || {};
         wecomConn.stopTick();
         wecomConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });
@@ -354,7 +329,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 钉钉连接流程 · 跨视图持久 store(镜像企微;纯扫码单段）──
     const dingtalkConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -367,13 +342,6 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
-      disposeListeners() {
-        this.disposed = true;
-        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
-        this.unlisteners = [];
-        this.listenersReady = false;
-        this.stopTick();
-      },
     };
     function ensureDingtalkListeners(copy = {}) {
       if (dingtalkConn.listenersReady) return;
@@ -382,7 +350,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       dingtalkConn.listenersReady = true;
-      track(ev, dingtalkConn, 'dingtalk:qr', (e) => {
+      ev.listen('dingtalk:qr', (e) => {
         const p = e.payload || {};
         dingtalkConn.stopTick();
         dingtalkConn.setFlow(f => {
@@ -392,7 +360,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase, userCode: p.user_code };
         });
       });
-      track(ev, dingtalkConn, 'dingtalk:connected', async () => {
+      ev.listen('dingtalk:connected', async () => {
         dingtalkConn.stopTick();
         try {
           await invokeTauri('dingtalk_apply_skills');
@@ -402,7 +370,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           dingtalkConn.setFlow(f => ({ ...(f || {}), phase: 'error', err: skillsFailed(String(e).slice(0, 220)), errStep: 'qr', steps: { ...((f && f.steps) || {}), qr: 'error' } }));
         }
       });
-      track(ev, dingtalkConn, 'dingtalk:error', (e) => {
+      ev.listen('dingtalk:error', (e) => {
         const p = e.payload || {};
         dingtalkConn.stopTick();
         dingtalkConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });
@@ -411,7 +379,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 腾讯会议连接流程 · 跨视图持久 store(镜像钉钉;纯 OAuth 扫码单段）──
     const tmeetConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -424,13 +392,6 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
-      disposeListeners() {
-        this.disposed = true;
-        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
-        this.unlisteners = [];
-        this.listenersReady = false;
-        this.stopTick();
-      },
     };
     function ensureTmeetListeners(copy = {}) {
       if (tmeetConn.listenersReady) return;
@@ -439,7 +400,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       tmeetConn.listenersReady = true;
-      track(ev, tmeetConn, 'tmeet:qr', (e) => {
+      ev.listen('tmeet:qr', (e) => {
         const p = e.payload || {};
         tmeetConn.stopTick();
         if (p.url) {
@@ -454,7 +415,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase, browserAuth: true };
         });
       });
-      track(ev, tmeetConn, 'tmeet:connected', async () => {
+      ev.listen('tmeet:connected', async () => {
         tmeetConn.stopTick();
         try {
           // 二次确认真实登录态（统一 readiness；原 tmeet_status 调用已退役）
@@ -469,7 +430,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           tmeetConn.setFlow(f => ({ ...(f || {}), phase: 'error', err: String(e && e.message ? e.message : e).slice(0, 220), errStep: 'qr', steps: { ...((f && f.steps) || {}), qr: 'error' } }));
         }
       });
-      track(ev, tmeetConn, 'tmeet:error', (e) => {
+      ev.listen('tmeet:error', (e) => {
         const p = e.payload || {};
         tmeetConn.stopTick();
         tmeetConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -217,8 +217,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     // 若放组件 useState，一离开工具商店就全丢 → 回来按钮又变“连接”。故挂在模块级单例，
     // 活在组件生命周期之外；组件只订阅它做镜像渲染。
     // 统一注册 Tauri 事件监听并收集 unlisten 句柄，供 conn.disposeListeners() 清理。
+    // ev.listen 返回 Promise<unlisten>，若 dispose 在 resolve 前发生，迟到的句柄不能
+    // 再 push 进已清空的数组（否则监听永远漏注销）→ 直接注销。
     function track(ev, conn, event, handler) {
-      ev.listen(event, handler).then(u => conn.unlisteners.push(u)).catch(() => {});
+      ev.listen(event, handler)
+        .then(u => { if (conn.disposed) { try { u(); } catch (_) {} } else { conn.unlisteners.push(u); } })
+        .catch(() => {});
     }
 
     const feishuConn = {
@@ -226,6 +230,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       tick: null,
       listenersReady: false,
       unlisteners: [],
+      disposed: false,
       subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
@@ -240,6 +245,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
       disposeListeners() {
+        this.disposed = true;
         this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
         this.unlisteners = [];
         this.listenersReady = false;
@@ -296,7 +302,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 企业微信连接流程 · 跨视图持久 store(镜像 feishuConn;企微纯扫码单段）──
     const wecomConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -310,6 +316,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
       disposeListeners() {
+        this.disposed = true;
         this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
         this.unlisteners = [];
         this.listenersReady = false;
@@ -347,7 +354,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 钉钉连接流程 · 跨视图持久 store(镜像企微;纯扫码单段）──
     const dingtalkConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -361,6 +368,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
       disposeListeners() {
+        this.disposed = true;
         this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
         this.unlisteners = [];
         this.listenersReady = false;
@@ -403,7 +411,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 腾讯会议连接流程 · 跨视图持久 store(镜像钉钉;纯 OAuth 扫码单段）──
     const tmeetConn = {
-      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], disposed: false, subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -417,6 +425,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
       disposeListeners() {
+        this.disposed = true;
         this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
         this.unlisteners = [];
         this.listenersReady = false;

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -216,10 +216,16 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     // ToolStoreView 随左栏切换会卸载；连接是长流程（装 CLI ~40s + 扫码），进度/监听/秒表
     // 若放组件 useState，一离开工具商店就全丢 → 回来按钮又变“连接”。故挂在模块级单例，
     // 活在组件生命周期之外；组件只订阅它做镜像渲染。
+    // 统一注册 Tauri 事件监听并收集 unlisten 句柄，供 conn.disposeListeners() 清理。
+    function track(ev, conn, event, handler) {
+      ev.listen(event, handler).then(u => conn.unlisteners.push(u)).catch(() => {});
+    }
+
     const feishuConn = {
       flow: null,
       tick: null,
       listenersReady: false,
+      unlisteners: [],
       subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
@@ -233,6 +239,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
+      disposeListeners() {
+        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
+        this.unlisteners = [];
+        this.listenersReady = false;
+        this.stopTick();
+      },
     };
     // 后端连接事件只注册一次（幂等，跨 ToolStoreView 多次挂载不重复注册）。
     function ensureFeishuListeners(copy = {}) {
@@ -241,7 +253,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       feishuConn.listenersReady = true;
-      ev.listen('feishu:progress', (e) => {
+      track(ev, feishuConn, 'feishu:progress', (e) => {
         const p = e.payload || {};
         feishuConn.setFlow(f => {
           const nf = f ? { ...f, steps: { ...(f.steps || {}) } } : { phase: 'running', steps: {}, active: null, pct: 0, sec: 0, log: '' };
@@ -252,7 +264,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           return nf;
         });
       });
-      ev.listen('feishu:qr', (e) => {
+      track(ev, feishuConn, 'feishu:qr', (e) => {
         const p = e.payload || {};
         feishuConn.stopTick();
         feishuConn.setFlow(f => {
@@ -264,7 +276,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           };
         });
       });
-      ev.listen('feishu:connected', () => {
+      track(ev, feishuConn, 'feishu:connected', () => {
         feishuConn.stopTick();
         feishuConn.setFlow(f => ({ ...(f || {}), phase: 'done', steps: { ...((f && f.steps) || {}), qr: 'done' } }));
         // 连上 → 按规则写技能（默认启用）+ 广播刷新；跟视图无关，放全局做。
@@ -272,7 +284,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         // 稍后自动收起流程卡（详情里的“已连接”态改由 feishuConnected 驱动）
         setTimeout(() => feishuConn.setFlow(null), 1800);
       });
-      ev.listen('feishu:error', (e) => {
+      track(ev, feishuConn, 'feishu:error', (e) => {
         const p = e.payload || {};
         feishuConn.stopTick();
         feishuConn.setFlow(f => {
@@ -284,7 +296,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 企业微信连接流程 · 跨视图持久 store(镜像 feishuConn;企微纯扫码单段）──
     const wecomConn = {
-      flow: null, tick: null, listenersReady: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -297,6 +309,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
+      disposeListeners() {
+        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
+        this.unlisteners = [];
+        this.listenersReady = false;
+        this.stopTick();
+      },
     };
     function ensureWecomListeners(copy = {}) {
       if (wecomConn.listenersReady) return;
@@ -304,7 +322,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       wecomConn.listenersReady = true;
-      ev.listen('wecom:qr', (e) => {
+      track(ev, wecomConn, 'wecom:qr', (e) => {
         const p = e.payload || {};
         wecomConn.stopTick();
         wecomConn.setFlow(f => {
@@ -314,13 +332,13 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase };
         });
       });
-      ev.listen('wecom:connected', () => {
+      track(ev, wecomConn, 'wecom:connected', () => {
         wecomConn.stopTick();
         wecomConn.setFlow(f => ({ ...(f || {}), phase: 'done', steps: { ...((f && f.steps) || {}), qr: 'done' } }));
         invokeTauri('wecom_apply_skills').catch(() => {});
         setTimeout(() => wecomConn.setFlow(null), 1800);
       });
-      ev.listen('wecom:error', (e) => {
+      track(ev, wecomConn, 'wecom:error', (e) => {
         const p = e.payload || {};
         wecomConn.stopTick();
         wecomConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });
@@ -329,7 +347,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 钉钉连接流程 · 跨视图持久 store(镜像企微;纯扫码单段）──
     const dingtalkConn = {
-      flow: null, tick: null, listenersReady: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -342,6 +360,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
+      disposeListeners() {
+        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
+        this.unlisteners = [];
+        this.listenersReady = false;
+        this.stopTick();
+      },
     };
     function ensureDingtalkListeners(copy = {}) {
       if (dingtalkConn.listenersReady) return;
@@ -350,7 +374,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       dingtalkConn.listenersReady = true;
-      ev.listen('dingtalk:qr', (e) => {
+      track(ev, dingtalkConn, 'dingtalk:qr', (e) => {
         const p = e.payload || {};
         dingtalkConn.stopTick();
         dingtalkConn.setFlow(f => {
@@ -360,7 +384,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase, userCode: p.user_code };
         });
       });
-      ev.listen('dingtalk:connected', async () => {
+      track(ev, dingtalkConn, 'dingtalk:connected', async () => {
         dingtalkConn.stopTick();
         try {
           await invokeTauri('dingtalk_apply_skills');
@@ -370,7 +394,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           dingtalkConn.setFlow(f => ({ ...(f || {}), phase: 'error', err: skillsFailed(String(e).slice(0, 220)), errStep: 'qr', steps: { ...((f && f.steps) || {}), qr: 'error' } }));
         }
       });
-      ev.listen('dingtalk:error', (e) => {
+      track(ev, dingtalkConn, 'dingtalk:error', (e) => {
         const p = e.payload || {};
         dingtalkConn.stopTick();
         dingtalkConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });
@@ -379,7 +403,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
 
     // ── 腾讯会议连接流程 · 跨视图持久 store(镜像钉钉;纯 OAuth 扫码单段）──
     const tmeetConn = {
-      flow: null, tick: null, listenersReady: false, subs: new Set(),
+      flow: null, tick: null, listenersReady: false, unlisteners: [], subs: new Set(),
       subscribe(fn) { this.subs.add(fn); return () => { this.subs.delete(fn); }; },
       setFlow(u) { this.flow = (typeof u === 'function') ? u(this.flow) : u; this.subs.forEach(fn => { try { fn(this.flow); } catch (_) {} }); },
       startTick() {
@@ -392,6 +416,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         }), 1000);
       },
       stopTick() { if (this.tick) { clearInterval(this.tick); this.tick = null; } },
+      disposeListeners() {
+        this.unlisteners.forEach(u => { try { u(); } catch (_) {} });
+        this.unlisteners = [];
+        this.listenersReady = false;
+        this.stopTick();
+      },
     };
     function ensureTmeetListeners(copy = {}) {
       if (tmeetConn.listenersReady) return;
@@ -400,7 +430,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const ev = isTauriAvailable() ? tauriEvents : null;
       if (!ev) return;
       tmeetConn.listenersReady = true;
-      ev.listen('tmeet:qr', (e) => {
+      track(ev, tmeetConn, 'tmeet:qr', (e) => {
         const p = e.payload || {};
         tmeetConn.stopTick();
         if (p.url) {
@@ -415,7 +445,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             qr: p.qr_data_url, qrUrl: p.url, qrPhase: p.phase, browserAuth: true };
         });
       });
-      ev.listen('tmeet:connected', async () => {
+      track(ev, tmeetConn, 'tmeet:connected', async () => {
         tmeetConn.stopTick();
         try {
           // 二次确认真实登录态（统一 readiness；原 tmeet_status 调用已退役）
@@ -430,7 +460,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           tmeetConn.setFlow(f => ({ ...(f || {}), phase: 'error', err: String(e && e.message ? e.message : e).slice(0, 220), errStep: 'qr', steps: { ...((f && f.steps) || {}), qr: 'error' } }));
         }
       });
-      ev.listen('tmeet:error', (e) => {
+      track(ev, tmeetConn, 'tmeet:error', (e) => {
         const p = e.payload || {};
         tmeetConn.stopTick();
         tmeetConn.setFlow(f => { const step = (f && f.active) || 'cli'; return { ...(f || { steps: {} }), phase: 'error', err: String(p.message || connFailed), errStep: step, steps: { ...((f && f.steps) || {}), [step]: 'error' } }; });


### PR DESCRIPTION
## 背景

品悟性能/内存优化调研「内存泄漏」维度：修复已核实的泄漏。

根因：`SelfMetrics.inflight`、`turn_capture_store` 是进程级 map、按 `session_id` 键控，但「开始打点/记录」在所有路径都做、「收尾清理」只在唯一的 `TurnComplete` 分支做。事件流中断 / 会话回收路径只发 `Terminal`/`ForwarderStopped` 事件，从不清理，导致条目永久驻留；`warmed_sessions` 在每轮 `TurnComplete` 插入但从不随会话回收。

## 变更内容

1. **SelfMetrics.inflight / warmed_sessions**：新增 `on_turn_aborted`，在 forwarder 事件流停止路径与 `finish_reclaimed_turn`（回收/中断）路径移除 inflight 条目（不写 perf 累计、不标 warmed）。
2. **turn_capture_store**：新增 `memory::discard_turn_capture`，中断/回收时丢弃进行中的 turn capture（不触发记忆复盘）。
3. **会话删除路径**（h3c-hexin 评审跟进）：新增 `SelfMetrics::drop_session`（幂等清 inflight + warmed_sessions），在 `delete_session` 成功后调用；并顺带 `discard_turn_capture` 清理同类残留。回归测试 `self_metrics_drop_session_clears_warmed_and_inflight`。

## 评审跟进（zhuowp，2026-08-20 CHANGES_REQUESTED）

- **ToolStore 监听部分已整体移除**（`6a124156`）：核实确认两项指摘均属实——`disposeListeners()` 在仓库内无任何调用方；且 `disposed` 标记永不复位，dispose 后重新 `ensure*Listeners()` 注册的句柄会被 `track()` 立即注销，"重新初始化"路径实际不可用。
- 采纳评审给出的第二个选项：移除未使用的 ToolStore 部分（`track()` / `disposeListeners()` / `unlisteners` / `disposed`），`ToolStoreView.jsx` 还原至 main，PR 范围收敛为已验证的 Rust 侧 map 清理。未接入 HMR/teardown 生命周期：仓库内 `import.meta.hot` 零先例，4 个连接单例是有意设计的 app 生命周期常驻（跨视图存活、`listenersReady` 幂等守卫防重复注册，无实际泄漏），为让 `disposeListeners()` 有调用方而发明生命周期不属于本 PR 范围。

## 涉及文件

- `src-tauri/src/features/assistant/engine.rs`
- `src-tauri/src/features/assistant/forwarder.rs`
- `src-tauri/src/features/monitor/self_metrics.rs`（含回归测试）
- `src-tauri/src/features/memory/mod.rs` / `io.rs`
- `src-tauri/src/app/commands/sessions.rs`

## 验证

- `cargo fmt --check` ✅
- `cargo test --lib 'features::monitor::'` ✅（37 passed / 2 ignored，含 `self_metrics_aborted_turn_clears_inflight_without_marking_warmed`、`self_metrics_drop_session_clears_warmed_and_inflight`）
- `cargo test --lib 'features::memory::'` ✅（45 passed）
- `npm run lint:ui` ✅
- `node tests/tool_store_smoke.js` ✅（39/39 PASS，确认还原 ToolStoreView 后工具商店全旅程无回归）

## 已知风险 / 说明

- macOS 本地 `cargo test` 需按仓库约定注入 `RUSTC_WRAPPER=pinvou3-app/src-tauri/scripts/rustc-stack-wrapper` 绕过依赖 `codewhale-tui` 的 LLVM codegen 栈溢出（SIGBUS，已知环境问题），CI 的 Linux 门禁无此问题。
- `on_turn_aborted`、`discard_turn_capture`、`drop_session` 均幂等（`remove` / `HashSet::remove`），forwarder 停止与 `finish_reclaimed_turn` 双路径调用、以及重复删除会话都不会产生副作用。
- 停止按钮路径（`TurnComplete(Interrupted)`）不在本次范围：该路径的 inflight / turn_capture 已由 `on_turn_complete` / `take_turn_capture` 移除，不泄漏；是否让中断轮不写 perf / 不标 warmed / 不复盘属产品语义，另行讨论。
