### PR TITLE
perf(chat): 长会话消息流 content-visibility 离屏合成优化

### DIFF
--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1634,19 +1634,20 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                 ) : (
                   <>
                     {visibleChatItems.map((item) => (
-                      <ChatBubble
-                        key={item.id}
-                        item={item}
-                        sessionId={activeSessionId}
-                        theme={theme}
-                        t={t}
-                        onPrefill={(text) => setInputText(text)}
-                        onSend={sendChatMessage}
-                        editable={!busy && !isMultiAgentReadOnly && item.id === lastUserId}
-                        onOpenEditor={onOpenEditor}
-                        isLatestArtifact={latestArtifactIds.has(item.id)}
-                        allowScheduledTaskDraft={isScheduledTaskCreationChat}
-                      />
+                      <div key={item.id} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 600px' }}>
+                        <ChatBubble
+                          item={item}
+                          sessionId={activeSessionId}
+                          theme={theme}
+                          t={t}
+                          onPrefill={(text) => setInputText(text)}
+                          onSend={sendChatMessage}
+                          editable={!busy && !isMultiAgentReadOnly && item.id === lastUserId}
+                          onOpenEditor={onOpenEditor}
+                          isLatestArtifact={latestArtifactIds.has(item.id)}
+                          allowScheduledTaskDraft={isScheduledTaskCreationChat}
+                        />
+                      </div>
                     ))}
                     {busy && <ThinkingBubble thinking={bs && bs.thinking} theme={theme} t={t} isLocal={activeModelLocal} />}
                   </>

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1633,22 +1633,31 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
                   />
                 ) : (
                   <>
-                    {visibleChatItems.map((item) => (
-                      <div key={item.id} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 600px' }}>
-                        <ChatBubble
-                          item={item}
-                          sessionId={activeSessionId}
-                          theme={theme}
-                          t={t}
-                          onPrefill={(text) => setInputText(text)}
-                          onSend={sendChatMessage}
-                          editable={!busy && !isMultiAgentReadOnly && item.id === lastUserId}
-                          onOpenEditor={onOpenEditor}
-                          isLatestArtifact={latestArtifactIds.has(item.id)}
-                          allowScheduledTaskDraft={isScheduledTaskCreationChat}
-                        />
-                      </div>
-                    ))}
+                    {visibleChatItems.map((item) => {
+                      // reasoning 由统一 UI 的 ConversationTimeline 负责，legacy 路径不展示；
+                      // ChatBubble 不认识该类型会返回 null。其余 ChatBubble 返回 null 的情况
+                      // （空流式 assistant、已忽略的记忆候选、未知类型）由 .cv-bubble:empty
+                      // 兜底。空内容绝不能被 content-visibility wrapper 包裹：离屏时空 div 会按
+                      // contain-intrinsic-size 各占 600px，污染 scrollHeight 造成滚动条缩跳与
+                      // 滚底跳变（http://localhost 无关，Safari 18+/Chromium 均复现）。
+                      if (item.type === 'reasoning') return null;
+                      return (
+                        <div key={item.id} className="cv-bubble" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 600px' }}>
+                          <ChatBubble
+                            item={item}
+                            sessionId={activeSessionId}
+                            theme={theme}
+                            t={t}
+                            onPrefill={(text) => setInputText(text)}
+                            onSend={sendChatMessage}
+                            editable={!busy && !isMultiAgentReadOnly && item.id === lastUserId}
+                            onOpenEditor={onOpenEditor}
+                            isLatestArtifact={latestArtifactIds.has(item.id)}
+                            allowScheduledTaskDraft={isScheduledTaskCreationChat}
+                          />
+                        </div>
+                      );
+                    })}
                     {busy && <ThinkingBubble thinking={bs && bs.thinking} theme={theme} t={t} isLocal={activeModelLocal} />}
                   </>
                 )}

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -790,7 +790,7 @@ export function ConversationTurn({
       : null;
 
   return (
-    <section className="space-y-4" data-conversation-turn={turn.id}>
+    <section className="space-y-4" data-conversation-turn={turn.id} style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 600px' }}>
       {userContent}
       <div className="flex items-start gap-3">
         {assistantAvatar || (

--- a/pinvou3-app/src/styles/base.css
+++ b/pinvou3-app/src/styles/base.css
@@ -38,6 +38,15 @@
       .max-sm-hide-scrollbar::-webkit-scrollbar { display: none; }
     }
 
+    /* content-visibility 离屏渲染优化兜底：ChatBubble 对部分类型（空流式 assistant、
+       已忽略的记忆候选、未知类型）返回 null，其 wrapper 变成空 div。空的
+       content-visibility 容器离屏时仍按 contain-intrinsic-size 占位（auto 600px），
+       污染 scrollHeight 造成长会话滚动条缩跳与滚底跳变（Chromium 与 Safari 18+ 均复现）。
+       :empty 让空 wrapper 完全移出布局；reasoning 等明确不渲染项已在 legacy 列表 map
+       处跳过（见 ChatView.jsx），本规则兜底其余返回 null 的情况，无需与 ChatBubble
+       内部分支保持同步。 */
+    .cv-bubble:empty { display: none; }
+
     /* Chat message styles */
     .msg-md h1,.msg-md h2,.msg-md h3,.msg-md h4 { font-weight:600; margin:0.6em 0 0.3em; }
     .msg-md h1 { font-size:1.4em; } .msg-md h2 { font-size:1.2em; } .msg-md h3 { font-size:1.05em; }

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -1810,6 +1810,40 @@ async function expand(page) {
       && !legacyConversationA11y.compactCollapsed.detailsPresent,
     JSON.stringify(legacyConversationA11y));
 
+  // ⑩b legacy 长会话离屏合成不应为 ChatBubble 返回 null 的项（reasoning / 已忽略记忆候选 /
+  // 未知类型）产生空 content-visibility wrapper：空 wrapper 离屏时仍按
+  // contain-intrinsic-size(auto 600px) 占位，会污染 scrollHeight 造成滚动条缩跳与滚底跳变。
+  // 修复 = legacy 列表 map 跳过 reasoning + .cv-bubble:empty{display:none} 兜底其余 null 情况。
+  await clickText(page, '第三季度财报分析');
+  await sleep(1500);
+  const legacyReasoningGuard = await page.evaluate(async () => {
+    const emit = async (name, payload) => {
+      const handlers = window.__TAURI_EVENT_HANDLERS__[name] || [];
+      for (const handler of handlers) await handler({ payload });
+    };
+    // 向普通 s1 会话注入多条 reasoning 历史（每轮一条），模拟长 legacy 会话。
+    for (let i = 0; i < 12; i++) {
+      await emit('chat:reasoning_start', { session_id: 's1', index: `legacy-reasoning-${i}` });
+      await emit('chat:reasoning_delta', { session_id: 's1', index: `legacy-reasoning-${i}`, text: `离屏推理历史 ${i} `.repeat(40) });
+      await emit('chat:reasoning_done', { session_id: 's1', index: `legacy-reasoning-${i}` });
+    }
+    await new Promise(r => setTimeout(r, 400));
+    const wrappers = [...document.querySelectorAll('.cv-bubble')];
+    const emptyWrappers = wrappers.filter(w => w.children.length === 0);
+    const reasoningLeaked = document.body.innerText.includes('离屏推理历史');
+    const totalHeight = wrappers.reduce((sum, w) => sum + w.getBoundingClientRect().height, 0);
+    return {
+      wrapperCount: wrappers.length,
+      emptyCount: emptyWrappers.length,
+      reasoningLeaked,
+      // 12 条空 reasoning 若未被修复，离屏至少占 12 * 600 = 7200px；修复后应为 0。
+      emptyContributionPx: Math.round(totalHeight),
+    };
+  });
+  rec('⑩b legacy 离屏合不为 reasoning/隐藏项留空 wrapper（防 scrollHeight 污染）',
+    legacyReasoningGuard.emptyCount === 0 && !legacyReasoningGuard.reasoningLeaked,
+    JSON.stringify(legacyReasoningGuard));
+
   if (errs.length) console.log('⚠️ PAGEERRORS:', errs.slice(0, 3).join(' | '));
   await browser.close();
 


### PR DESCRIPTION
## 背景

品悟性能/内存优化调研「硬件加速」最高优先级项：聊天消息流 / 会话时间线完全未虚拟化，长会话下渲染成本随消息数线性增长。`tauri.conf.json` 无 `hardwareAcceleration` 字段属正常（Tauri v2 默认开启 GPU 合成），真正的短板在长列表渲染与流式重绘。

> 说明：本 PR 落的是 `content-visibility: auto` —— 让浏览器**跳过离屏内容的布局与绘制**（含光栅化），并不是提升 GPU 合成层或硬件加速。Chromium（WebView2）全支持；Safari/WebKit 18.0+ 起 macOS WKWebView 也实际执行该属性，较旧版本不支持时自动忽略，无副作用。

## 变更内容

对消息项加 `content-visibility: auto` + `contain-intrinsic-size: auto 600px`，让浏览器跳过离屏消息的布局与绘制，长会话滚动与流式期间显著降低重绘成本；DOM 结构不变（渐进增强，不支持的 WebView 自动忽略）。

1. 统一路径 `ConversationTimeline` 的 `ConversationTurn` 根 `<section>`。
2. legacy 路径 `ChatView` 的消息列表：每项包一层 `div`（`key` 移到 wrapper），同样加离屏渲染跳过。
3. **（评审修复）** legacy 空壳防护：`ChatBubble` 对 `reasoning`、空流式 assistant、已忽略的记忆候选与未知类型返回 `null`，离屏时空 wrapper 仍按 `contain-intrinsic-size(auto 600px)` 占位，会污染 `scrollHeight` 造成长会话大段空白、滚动条缩跳与滚底跳变。
   - legacy 列表 map 跳过 `reasoning`（ChatBubble 本就不展示该类型）。
   - `base.css` 加 `.cv-bubble:empty{display:none}` 兜底其余返回 null 的情况，无需与 ChatBubble 内部分支保持同步。

## 涉及文件

- `src/features/conversation/ConversationTimeline.jsx`
- `src/features/chat/ChatView.jsx`
- `src/styles/base.css`
- `tests/ui_smoke.js`

## 验证

- `npm run lint:ui` ✅
- `npm run build:ui` ✅
- `node tests/{chat_turn_error_isolation, chat_usage_context_window, assistant_message_actions, deepseek_conversation_timeline}.*` ✅
- UI smoke 55/55 ✅（含新增 ⑩b：legacy 模式注入 12 条 reasoning 后断言无空 wrapper、reasoning 文本不泄漏；反向验证：禁用两处防护后 emptyCount=12 测试失败）

## 已知风险 / 说明

- `content-visibility: auto` 是渐进增强：Chromium（WebView2）与 Safari/WebKit 18.0+ 全支持；macOS WKWebView 较旧版本不支持时自动忽略，无副作用。
- 这是「离屏布局/绘制跳过」而非「真虚拟化」：DOM 节点仍在内存中，仅跳过离屏渲染。若要进一步降低 DOM 内存，需引入 react-window/virtuoso 做真虚拟化（与自动滚底/滚动锚定耦合，属后续项）。
- legacy 路径的 wrapper `div` 是布局中性的块级元素，`space-y-4` 间距由 wrapper 承接，视觉无变化。
