### PR TITLE
feat(marketplace): 能力包统一模型（注册表 + 凭据 schema + 就绪态）

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -624,19 +624,23 @@ pub struct BundleReadinessResult {
 }
 
 /// 统一就绪态查询：
-/// - CLI 包（feishu/wecom/dingtalk/tmeet）→ 分派到各连接器 status，connected 即 ready
-/// - ima（凭据型技能包）→ ima_status 的 credentials_present（凭据齐即 ready）
+/// - CLI 包（feishu/wecom/dingtalk/tmeet）→ 分派到各连接器 status，connected 即 ready；
+///   installed 取 status 的 installed/configured 真实字段
+/// - ima（凭据型技能包）→ ima_status：ready = connected（凭据齐且 companion 技能已装），
+///   installed = 凭据或技能任一已配置
 /// - MCP/技能/上传包 → 注册表 `readiness_for`（credentials 必填项查系统凭据现算）
 #[tauri::command]
 pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult, String> {
     use crate::features::marketplace::bundle::{
-        readiness_for, BundleKind, BundleRegistry, CredentialTarget, Readiness,
+        keyring_target, readiness_for, BundleKind, BundleRegistry, Readiness,
     };
     let reg = BundleRegistry::new();
     let Some(bundle) = reg.bundle(&bundle_id) else {
         return Err(format!("未知能力包 '{bundle_id}'"));
     };
-    let (ready, reason, detail) = match bundle.kind {
+    // CLI/ima 包的 installed 在注册表是保守占位（恒 false），此处用连接器 status
+    // 的真实字段覆盖，避免对消费方产出 (installed=false, ready=true) 的矛盾组合。
+    let (installed, ready, reason, detail) = match bundle.kind {
         BundleKind::Cli => {
             let (connected, detail) = match bundle_id.as_str() {
                 "feishu" => {
@@ -657,7 +661,18 @@ pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult
                 }
                 other => return Err(format!("未知 CLI 包 '{other}'")),
             };
+            // wecom/dingtalk/tmeet 返回 installed（CLI 二进制在位），
+            // feishu 返回 configured（已配置）；都没有则退化为 connected。
+            let installed = detail
+                .as_ref()
+                .and_then(|v| {
+                    v.get("installed")
+                        .or_else(|| v.get("configured"))
+                        .and_then(|x| x.as_bool())
+                })
+                .unwrap_or(connected);
             (
+                installed,
                 connected,
                 if connected {
                     None
@@ -673,15 +688,20 @@ pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult
                 .get("credentials_present")
                 .and_then(|x| x.as_bool())
                 .unwrap_or(false);
-            (
-                creds,
-                if creds {
-                    None
-                } else {
-                    Some("missing_credentials".to_string())
-                },
-                Some(v),
-            )
+            let skill = v
+                .get("skill_installed")
+                .and_then(|x| x.as_bool())
+                .unwrap_or(false);
+            // ready 与 ima_status.connected 同义：凭据齐且 companion 技能已装
+            let ready = creds && skill;
+            let reason = if ready {
+                None
+            } else if !creds {
+                Some("missing_credentials".to_string())
+            } else {
+                Some("skill_not_installed".to_string())
+            };
+            (creds || skill, ready, reason, Some(v))
         }
         _ => {
             let store = crate::platform::credential_store::SystemCredentialStore::new();
@@ -690,11 +710,7 @@ pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult
                     .credentials
                     .iter()
                     .find(|c| c.key == key)
-                    .map(|c| match c.target {
-                        CredentialTarget::Env => "env",
-                        CredentialTarget::Bearer => "bearer",
-                        CredentialTarget::Credential => "credential",
-                    })
+                    .map(|c| keyring_target(c.target))
                     .unwrap_or("env");
                 store
                     .get(
@@ -706,15 +722,16 @@ pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult
                     .flatten()
                     .is_some()
             };
-            match readiness_for(&bundle, has) {
-                Readiness::Ready => (true, None, None),
-                Readiness::NotReady(reason) => (false, Some(reason.to_string()), None),
-            }
+            let (ready, reason) = match readiness_for(&bundle, has) {
+                Readiness::Ready => (true, None),
+                Readiness::NotReady(reason) => (false, Some(reason.to_string())),
+            };
+            (bundle.installed, ready, reason, None)
         }
     };
     Ok(BundleReadinessResult {
         bundle_id,
-        installed: bundle.installed,
+        installed,
         ready,
         reason,
         detail,

--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -608,4 +608,122 @@ pub(super) fn uninstall_marketplace_skill_sync(skill_id: &str) -> Result<(), Str
     crate::features::marketplace::skill_scope::remove_skill_from_disabled_scopes(skill_id);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// 能力包就绪态（修复方案 V1：统一 bundle_readiness，收敛五个连接器 status 命令）
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleReadinessResult {
+    pub bundle_id: String,
+    pub installed: bool,
+    pub ready: bool,
+    pub reason: Option<String>,
+    /// 原连接器 status 的完整 detail（CLI/ima 型透传，向前兼容）
+    pub detail: Option<serde_json::Value>,
+}
+
+/// 统一就绪态查询：
+/// - CLI 包（feishu/wecom/dingtalk/tmeet）→ 分派到各连接器 status，connected 即 ready
+/// - ima（凭据型技能包）→ ima_status 的 credentials_present（凭据齐即 ready）
+/// - MCP/技能/上传包 → 注册表 `readiness_for`（credentials 必填项查系统凭据现算）
+#[tauri::command]
+pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult, String> {
+    use crate::features::marketplace::bundle::{
+        readiness_for, BundleKind, BundleRegistry, CredentialTarget, Readiness,
+    };
+    let reg = BundleRegistry::new();
+    let Some(bundle) = reg.bundle(&bundle_id) else {
+        return Err(format!("未知能力包 '{bundle_id}'"));
+    };
+    let (ready, reason, detail) = match bundle.kind {
+        BundleKind::Cli => {
+            let (connected, detail) = match bundle_id.as_str() {
+                "feishu" => {
+                    let v = crate::features::connectors::feishu::feishu_status().await?;
+                    (connected_of(&v), Some(v))
+                }
+                "wecom" => {
+                    let v = crate::features::connectors::wecom::wecom_status().await?;
+                    (connected_of(&v), Some(v))
+                }
+                "dingtalk" => {
+                    let v = crate::features::connectors::dingtalk::dingtalk_status().await?;
+                    (connected_of(&v), Some(v))
+                }
+                "tmeet" => {
+                    let v = crate::features::connectors::tmeet::tmeet_status().await?;
+                    (connected_of(&v), Some(v))
+                }
+                other => return Err(format!("未知 CLI 包 '{other}'")),
+            };
+            (
+                connected,
+                if connected {
+                    None
+                } else {
+                    Some("not_connected".to_string())
+                },
+                detail,
+            )
+        }
+        BundleKind::Skill if bundle.id == "ima" => {
+            let v = crate::features::connectors::ima::ima_status().await?;
+            let creds = v
+                .get("credentials_present")
+                .and_then(|x| x.as_bool())
+                .unwrap_or(false);
+            (
+                creds,
+                if creds {
+                    None
+                } else {
+                    Some("missing_credentials".to_string())
+                },
+                Some(v),
+            )
+        }
+        _ => {
+            let store = crate::platform::credential_store::SystemCredentialStore::new();
+            let has = |key: &str| {
+                let target = bundle
+                    .credentials
+                    .iter()
+                    .find(|c| c.key == key)
+                    .map(|c| match c.target {
+                        CredentialTarget::Env => "env",
+                        CredentialTarget::Bearer => "bearer",
+                        CredentialTarget::Credential => "credential",
+                    })
+                    .unwrap_or("env");
+                store
+                    .get(
+                        &crate::platform::credential_store::CredentialReference::for_mcp_secret(
+                            &bundle_id, target, key,
+                        ),
+                    )
+                    .ok()
+                    .flatten()
+                    .is_some()
+            };
+            match readiness_for(&bundle, has) {
+                Readiness::Ready => (true, None, None),
+                Readiness::NotReady(reason) => (false, Some(reason.to_string()), None),
+            }
+        }
+    };
+    Ok(BundleReadinessResult {
+        bundle_id,
+        installed: bundle.installed,
+        ready,
+        reason,
+        detail,
+    })
+}
+
+fn connected_of(v: &serde_json::Value) -> bool {
+    v.get("connected")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false)
+}
 use super::prelude::*;

--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -704,24 +704,39 @@ pub async fn bundle_readiness(bundle_id: String) -> Result<BundleReadinessResult
             (creds || skill, ready, reason, Some(v))
         }
         _ => {
-            let store = crate::platform::credential_store::SystemCredentialStore::new();
-            let has = |key: &str| {
-                let target = bundle
-                    .credentials
-                    .iter()
-                    .find(|c| c.key == key)
-                    .map(|c| keyring_target(c.target))
-                    .unwrap_or("env");
-                store
-                    .get(
-                        &crate::platform::credential_store::CredentialReference::for_mcp_secret(
-                            &bundle_id, target, key,
-                        ),
-                    )
-                    .ok()
-                    .flatten()
-                    .is_some()
-            };
+            // keychain 读可能阻塞数秒甚至数分钟（macOS 首次访问弹授权窗），
+            // 与 ima/install 命令一致移出 async 线程：spawn_blocking 里按声明序
+            // 预查必填凭据（同 key 多 target 取首个声明，保持原 find-first 语义），
+            // has 闭包只读内存结果。
+            let mut specs: Vec<(String, &'static str)> = Vec::new();
+            for c in &bundle.credentials {
+                if c.required && !specs.iter().any(|(k, _)| k == &c.key) {
+                    specs.push((c.key.clone(), keyring_target(c.target)));
+                }
+            }
+            let id = bundle_id.clone();
+            let present: std::collections::HashSet<String> =
+                tokio::task::spawn_blocking(move || {
+                    let store = crate::platform::credential_store::SystemCredentialStore::new();
+                    specs
+                        .into_iter()
+                        .filter(|(key, target)| {
+                            store
+                                .get(
+                                    &crate::platform::credential_store::CredentialReference::for_mcp_secret(
+                                        &id, target, key,
+                                    ),
+                                )
+                                .ok()
+                                .flatten()
+                                .is_some()
+                        })
+                        .map(|(key, _)| key)
+                        .collect()
+                })
+                .await
+                .map_err(|e| format!("spawn_blocking: {e}"))?;
+            let has = |key: &str| present.contains(key);
             let (ready, reason) = match readiness_for(&bundle, has) {
                 Readiness::Ready => (true, None),
                 Readiness::NotReady(reason) => (false, Some(reason.to_string())),

--- a/pinvou3-app/src-tauri/src/app/commands/protocol_tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/protocol_tests.rs
@@ -230,7 +230,8 @@ command_protocol!(
         "install_marketplace_skill",
         "import_skill_package",
         "import_skill_package_bytes",
-        "uninstall_marketplace_skill"
+        "uninstall_marketplace_skill",
+        "bundle_readiness"
     ]
 );
 command_protocol!(

--- a/pinvou3-app/src-tauri/src/features/connectors/feishu.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/feishu.rs
@@ -84,9 +84,17 @@ pub async fn feishu_ensure_cli() -> Result<Value, String> {
 
 /// 查询当前飞书连接状态:`lark-cli auth status --json`。
 /// 返回 lark-cli 的原始 JSON(含 appId / identities.user.status 等);未配置 app
-/// 或未登录则 connected=false。
+/// 或未登录则 connected=false。未装 CLI 时返回结构化 `installed:false`
+/// (与 wecom/dingtalk/tmeet 一致),不向消费方抛 Err。
 pub async fn feishu_status() -> Result<Value, String> {
     tokio::task::spawn_blocking(|| {
+        // 没装就别 spawn auth status —— 未装用户每次白等子进程且拿到的是 Err,
+        // 统一返回结构化未装态(其余 CLI 连接器同款短路)。
+        if !lark_cli_present() {
+            return Ok::<Value, String>(json!({
+                "ok": false, "connected": false, "configured": false, "installed": false
+            }));
+        }
         let (ok, so, se) = cc::run(lark(&["auth", "status", "--json"]))?;
         let parsed = cc::parse_json(&so).or_else(|| cc::parse_json(&se));
         let connected = parsed
@@ -107,6 +115,7 @@ pub async fn feishu_status() -> Result<Value, String> {
             "ok": ok,
             "connected": connected,
             "configured": configured,
+            "installed": true,
         }))
     })
     .await

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -1,46 +1,80 @@
-//! 能力包统一模型 — 步骤 1：schema + 注册表 + kind 推导（只读，不改安装/门禁/投影）。
+//! 能力包统一模型 — 步骤 1/2：schema + 注册表 + kind 推导 + 就绪态（只读，不改安装/门禁/投影）。
 //!
-//! 设计依据：`docs/capability-governance.md` §3（能力包线）。一切外部能力统一建模为包：
+//! 设计依据：`docs/capability-governance.md` §3（能力包线）+ 实施修复方案（V1-V7）。
+//! 一切外部能力统一建模为包：
 //!
 //! ```text
-//! Bundle = { id, name, mcp_servers: [], skills: [], cli: [] }
+//! Bundle = { id, name, mcp_servers: [], skills: [], cli: [],
+//!            credentials: [ { key, target: env|credential|bearer, required } ] }
 //! ```
 //!
 //! - 包是唯一真相源；`mcp.json`、会话 skills 组合目录降级为投影（后续步骤实施）
 //! - 包类型不做存储标签，`bundle_kind` 由内容现算（可信代码推导，防自报标签提权）
 //! - 一个包 = 一个开关；包内技能可见性唯一跟随所属包
+//! - **installed 与 ready 分离**：installed 是存储态（装没装，二态）；ready 是派生态
+//!   （不进存储，查询时现算）——CLI 包按授权存在与否、凭据型按 credentials 必填项
+//!   是否齐（查系统凭据）、本地免凭据包恒 ready。UI 统一消费 (installed, ready) 二元组。
 //!
 //! 注册表汇总四类源：MCP manifest（`bundle/mcp-servers/<id>/manifest.json`）、
-//! 预置技能（编译内嵌）、CLI 连接器（内置常量表，UI 元数据从 tool-common.jsx 迁移）、
-//! 已上传技能（`bundle/skills/` 带 `.installed-from=upload:` 标记）。
+//! 预置技能（编译内嵌）、CLI 连接器（内置常量表）、已上传技能
+//! （`bundle/skills/` 带 `.installed-from=upload:` 标记）。
 
 use serde::{Deserialize, Serialize};
 
 use super::skill_marketplace::SkillMarketplaceManager;
 use super::MarketplaceManager;
 
-// 内置 CLI 连接器清单（UI 元数据从 tool-common.jsx 的 feishuCli/wecomCli/dingtalkCli/
-// tmeetCli/imaOpenapi 条目迁移；安装态 = CLI 安装 + 扫码/凭据配置，状态机后续步骤定义）。
+// 内置 CLI 连接器清单（修复方案 V2：ima 无 CLI 二进制，移出 CLI 包，归凭据型技能包）。
 const BUILTIN_CLI_BUNDLES: &[(&str, &str)] = &[
     ("feishu", "飞书（Lark）"),
     ("wecom", "企业微信"),
     ("dingtalk", "钉钉"),
     ("tmeet", "腾讯会议"),
-    ("ima", "腾讯 ima"),
 ];
 
-/// 包形态（内容现算，不落存储）。
+/// 凭据目标：env（mcp.json 环境变量占位）、credential（系统凭据存储）、bearer（Authorization 头）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialTarget {
+    Env,
+    Credential,
+    Bearer,
+}
+
+/// 包声明的凭据项（修复方案一：从 config_fields/secret_env/secret_headers 收敛）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialSpec {
+    pub key: String,
+    pub target: CredentialTarget,
+    pub required: bool,
+}
+
+/// 包形态（内容现算，不落存储）。优先级定死（修复方案 V2）：
+/// cli 非空 → Cli > servers+skills 均非空 → Bundle > servers 非空 → Mcp > skills 非空 → Skill。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BundleKind {
-    /// 纯 MCP：mcp_servers 非空、其余空
-    Mcp,
+    /// CLI 包：cli 非空（飞书/企微/钉钉/腾讯会议等内置连接器）
+    Cli,
     /// 组合包：mcp_servers 与 skills 均非空（MCP 函数 + 使用引导一体）
     Bundle,
-    /// CLI 包：cli 非空（飞书/企微/钉钉/tmeet/ima 等内置连接器）
-    Cli,
-    /// 纯技能包：仅 skills（市场预置、用户上传）
+    /// 纯 MCP：mcp_servers 非空、skills/cli 空
+    Mcp,
+    /// 纯技能包：仅 skills（市场预置、用户上传；含凭据型技能包如 ima）
     Skill,
+}
+
+/// 空包错误：mcp_servers/skills/cli 全空（修复方案 V7，schema 层拦截，不默认归 Skill）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidBundle;
+
+/// 就绪态（派生态，不进存储）。UI 消费 (installed, ready)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Readiness {
+    Ready,
+    /// 未就绪；reason 给前端提示（如缺凭据的 key 列表）
+    NotReady(&'static str),
 }
 
 /// 能力包清单条目（前端消费；id 沿用现有命名空间：MCP 工具 id / 技能 id / CLI 连接器 id）。
@@ -55,6 +89,8 @@ pub struct BundleInfo {
     pub skills: Vec<String>,
     /// 包内 CLI 连接器 id（无则空）
     pub cli: Vec<String>,
+    /// 包声明的凭据项（收敛自 config_fields/secret_env/secret_headers）
+    pub credentials: Vec<CredentialSpec>,
     pub installed: bool,
     /// 用户上传（非预置），前端用默认图标渲染
     pub user_uploaded: bool,
@@ -84,15 +120,18 @@ impl BundleRegistry {
     /// - MCP manifest 的 `companion_skills` 声明 → 技能归入该 MCP 包（组合包）
     /// - 未被任何 MCP 引用的预置技能 → 独立纯技能包
     /// - 用户上传技能 → 独立纯技能包
-    /// - 内置 CLI 连接器 → CLI 包（ima 无 CLI 二进制，走 OpenAPI 凭据，kind 仍按内容推导）
+    /// - 内置 CLI 连接器 → CLI 包（修复方案 V2：ima 移出，归凭据型技能包）
+    /// - ima（凭据型）：OpenAPI 凭据 + companion 技能 ima-skills → 纯技能包（凭据型）
     pub fn list_bundles(&self) -> Vec<BundleInfo> {
         let mut out: Vec<BundleInfo> = Vec::new();
-        let mut skill_claimed: Vec<String> = Vec::new(); // 已被 MCP 包认领的技能 id
+        // 已被 MCP/凭据型包认领的技能 id（ima-skills 须在预置扫描前声明，避免先独立成包）
+        let mut skill_claimed: Vec<String> = vec!["ima-skills".to_string()];
 
-        // 1) MCP 源（含组合包）
+        // 1) MCP 源（含组合包；凭据项从 manifest config_fields/secret_env 收敛）
         for tool in self.mcp_manager.available_tools() {
             let companions = tool.companion_skills.clone();
             skill_claimed.extend(companions.iter().cloned());
+            let credentials = tool_credentials(&tool);
             out.push(BundleInfo {
                 id: tool.id.clone(),
                 name: tool.name.clone(),
@@ -104,6 +143,7 @@ impl BundleRegistry {
                 mcp_servers: vec![tool.id.clone()],
                 skills: companions,
                 cli: Vec::new(),
+                credentials,
                 installed: self.mcp_manager.installed_ids().contains(&tool.id),
                 user_uploaded: false,
             });
@@ -124,6 +164,7 @@ impl BundleRegistry {
                 mcp_servers: Vec::new(),
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
+                credentials: Vec::new(),
                 installed: skill.installed,
                 user_uploaded: false,
             });
@@ -141,12 +182,13 @@ impl BundleRegistry {
                 mcp_servers: Vec::new(),
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
+                credentials: Vec::new(),
                 installed: true,
                 user_uploaded: true,
             });
         }
 
-        // 4) CLI 连接器源（内置常量表；ima 为 OpenAPI 凭据型，仍归 CLI 线）
+        // 4) CLI 连接器源（内置常量表；V2 后不含 ima）
         for (id, name) in BUILTIN_CLI_BUNDLES {
             out.push(BundleInfo {
                 id: (*id).to_string(),
@@ -155,10 +197,36 @@ impl BundleRegistry {
                 mcp_servers: Vec::new(),
                 skills: Vec::new(),
                 cli: vec![(*id).to_string()],
+                credentials: Vec::new(),
                 installed: self.cli_bundle_installed(id),
                 user_uploaded: false,
             });
         }
+
+        // 5) 凭据型技能包：ima（OpenAPI 凭据 + companion 技能 ima-skills；V2 归 Skill）
+        let ima_skills = ["ima-skills"];
+        out.push(BundleInfo {
+            id: "ima".to_string(),
+            name: "腾讯 ima".to_string(),
+            kind: BundleKind::Skill,
+            mcp_servers: Vec::new(),
+            skills: ima_skills.iter().map(|s| s.to_string()).collect(),
+            cli: Vec::new(),
+            credentials: vec![
+                CredentialSpec {
+                    key: "IMA_CLIENT_ID".to_string(),
+                    target: CredentialTarget::Credential,
+                    required: true,
+                },
+                CredentialSpec {
+                    key: "IMA_API_KEY".to_string(),
+                    target: CredentialTarget::Credential,
+                    required: true,
+                },
+            ],
+            installed: self.cli_bundle_installed("ima"),
+            user_uploaded: false,
+        });
 
         out
     }
@@ -175,16 +243,103 @@ impl BundleRegistry {
     }
 }
 
-/// 纯函数：由内容推导包形态（与 [`BundleInfo::kind`] 同一逻辑，供规则查表复用）。
-pub fn derive_bundle_kind(mcp_servers: &[String], skills: &[String], cli: &[String]) -> BundleKind {
+/// 纯函数：由内容推导包形态（修复方案 V2 优先级定死 + V7 空包报错）。
+/// 优先级：cli 非空 → Cli > servers+skills 均非空 → Bundle > servers 非空 → Mcp
+/// > skills 非空 → Skill；全空 → Err（空包在 schema 层拦截，不默认归 Skill）。
+pub fn derive_bundle_kind(
+    mcp_servers: &[String],
+    skills: &[String],
+    cli: &[String],
+) -> Result<BundleKind, InvalidBundle> {
     if !cli.is_empty() {
-        BundleKind::Cli
+        Ok(BundleKind::Cli)
     } else if !mcp_servers.is_empty() && !skills.is_empty() {
-        BundleKind::Bundle
+        Ok(BundleKind::Bundle)
     } else if !mcp_servers.is_empty() {
-        BundleKind::Mcp
+        Ok(BundleKind::Mcp)
+    } else if !skills.is_empty() {
+        Ok(BundleKind::Skill)
     } else {
-        BundleKind::Skill
+        Err(InvalidBundle)
+    }
+}
+
+/// 从 MCP ToolManifest 收敛凭据声明（修复方案一）：config_fields → credentials，
+/// secret_env/secret_headers 按 target 映射（env/bearer），required 语义保留。
+fn tool_credentials(tool: &super::ToolManifest) -> Vec<CredentialSpec> {
+    let mut out: Vec<CredentialSpec> = Vec::new();
+    for f in &tool.config_fields {
+        let target = match f.target.as_str() {
+            "bearer" => CredentialTarget::Bearer,
+            "credential" => CredentialTarget::Credential,
+            _ => CredentialTarget::Env,
+        };
+        out.push(CredentialSpec {
+            key: f.key.clone(),
+            target,
+            required: f.required,
+        });
+    }
+    for s in &tool.secret_env {
+        out.push(CredentialSpec {
+            key: s.key.clone(),
+            target: CredentialTarget::Env,
+            required: s.required,
+        });
+    }
+    for s in &tool.secret_headers {
+        out.push(CredentialSpec {
+            key: s.source_key.clone(),
+            target: CredentialTarget::Bearer,
+            required: s.required,
+        });
+    }
+    out
+}
+
+/// 就绪态判定（派生态，现算不进存储）。
+/// - CLI 包：授权存在与否——由命令层经 `bundle_readiness` 分派到各 status 查询注入
+///   （注册表不直连 CLI 运行时，注入闭包保持依赖方向 app → features）
+/// - 凭据型：credentials 必填项在系统凭据存储中齐不齐（现算）
+/// - 本地免凭据：恒 Ready
+pub fn readiness_for(bundle: &BundleInfo, credential_has: impl Fn(&str) -> bool) -> Readiness {
+    match bundle.kind {
+        // CLI 包授权态由调用方（命令层）注入；此处按 installed 保守返回——
+        // 命令层 `bundle_readiness` 覆盖 CLI 分派后，此分支不达。
+        BundleKind::Cli => {
+            if bundle.installed {
+                Readiness::Ready
+            } else {
+                Readiness::NotReady("cli_not_installed")
+            }
+        }
+        BundleKind::Mcp | BundleKind::Bundle => {
+            // 本地免凭据（无必填凭据）恒 Ready；有必填凭据则查系统凭据
+            let missing: Vec<&str> = bundle
+                .credentials
+                .iter()
+                .filter(|c| c.required && !credential_has(&c.key))
+                .map(|c| c.key.as_str())
+                .collect();
+            if missing.is_empty() {
+                Readiness::Ready
+            } else {
+                Readiness::NotReady("missing_credentials")
+            }
+        }
+        BundleKind::Skill => {
+            let missing: Vec<&str> = bundle
+                .credentials
+                .iter()
+                .filter(|c| c.required && !credential_has(&c.key))
+                .map(|c| c.key.as_str())
+                .collect();
+            if missing.is_empty() {
+                Readiness::Ready
+            } else {
+                Readiness::NotReady("missing_credentials")
+            }
+        }
     }
 }
 
@@ -231,34 +386,145 @@ mod tests {
         );
         // 预置技能（被认领 + 独立）
         for (name, marker) in [
-            ("government-writing", "pinvou3-marketplace:government-writing"),
+            (
+                "government-writing",
+                "pinvou3-marketplace:government-writing",
+            ),
             ("visualizer", "pinvou3-marketplace:visualizer"),
         ] {
-            write(&format!("bundle/skills/{name}/SKILL.md"), "---\nname: {name}\n---\n# hi");
             write(
-                &format!("bundle/skills/{name}/.installed-from"),
-                marker,
+                &format!("bundle/skills/{name}/SKILL.md"),
+                "---\nname: {name}\n---\n# hi",
             );
+            write(&format!("bundle/skills/{name}/.installed-from"), marker);
         }
         // 上传技能
-        write("bundle/skills/my-upload/SKILL.md", "---\nname: my-upload\n---\n# hi");
+        write(
+            "bundle/skills/my-upload/SKILL.md",
+            "---\nname: my-upload\n---\n# hi",
+        );
         write("bundle/skills/my-upload/.installed-from", "upload:pkg.zip");
     }
 
     #[test]
     fn derives_bundle_kind_by_content() {
         let mcp = |id: &str| id.to_string();
-        assert_eq!(derive_bundle_kind(&[], &[], &[]), BundleKind::Skill);
-        assert_eq!(derive_bundle_kind(&[mcp("a")], &[], &[]), BundleKind::Mcp);
+        // V7：空包报错，不默认归 Skill
+        assert_eq!(derive_bundle_kind(&[], &[], &[]), Err(InvalidBundle));
+        // V2 优先级：cli 恒赢 > Bundle > Mcp > Skill
+        assert_eq!(
+            derive_bundle_kind(&[mcp("a")], &[], &[]),
+            Ok(BundleKind::Mcp)
+        );
         assert_eq!(
             derive_bundle_kind(&[mcp("a")], &[mcp("s")], &[]),
-            BundleKind::Bundle
+            Ok(BundleKind::Bundle)
         );
-        assert_eq!(derive_bundle_kind(&[], &[], &[mcp("feishu")]), BundleKind::Cli);
         assert_eq!(
-            derive_bundle_kind(&[mcp("a")], &[], &[mcp("feishu")]),
-            BundleKind::Cli
+            derive_bundle_kind(&[], &[mcp("s")], &[]),
+            Ok(BundleKind::Skill)
         );
+        assert_eq!(
+            derive_bundle_kind(&[], &[], &[mcp("feishu")]),
+            Ok(BundleKind::Cli)
+        );
+        // 即使有 servers+skills，cli 非空仍归 Cli
+        assert_eq!(
+            derive_bundle_kind(&[mcp("a")], &[mcp("s")], &[mcp("feishu")]),
+            Ok(BundleKind::Cli)
+        );
+    }
+
+    #[test]
+    fn readiness_rules() {
+        let b = |kind: BundleKind, creds: Vec<CredentialSpec>| BundleInfo {
+            id: "x".into(),
+            name: "x".into(),
+            kind,
+            mcp_servers: vec![],
+            skills: vec![],
+            cli: vec![],
+            credentials: creds,
+            installed: true,
+            user_uploaded: false,
+        };
+        // 本地免凭据 → 恒 Ready
+        assert_eq!(
+            readiness_for(&b(BundleKind::Mcp, vec![]), |_| false),
+            Readiness::Ready
+        );
+        // 必填凭据缺失 → NotReady
+        let creds = vec![CredentialSpec {
+            key: "AMAP_KEY".into(),
+            target: CredentialTarget::Env,
+            required: true,
+        }];
+        assert_eq!(
+            readiness_for(&b(BundleKind::Mcp, creds.clone()), |k| k != "AMAP_KEY"),
+            Readiness::NotReady("missing_credentials")
+        );
+        assert_eq!(
+            readiness_for(&b(BundleKind::Mcp, creds), |k| k == "AMAP_KEY"),
+            Readiness::Ready
+        );
+        // 非必填凭据缺失不影响 ready
+        let opt = vec![CredentialSpec {
+            key: "OPT".into(),
+            target: CredentialTarget::Credential,
+            required: false,
+        }];
+        assert_eq!(
+            readiness_for(&b(BundleKind::Skill, opt), |_| false),
+            Readiness::Ready
+        );
+        // CLI 未安装 → NotReady（命令层注入真实授权态后此分支不达）
+        let mut cli_b = b(BundleKind::Cli, vec![]);
+        cli_b.installed = false;
+        assert_eq!(
+            readiness_for(&cli_b, |_| false),
+            Readiness::NotReady("cli_not_installed")
+        );
+    }
+
+    #[test]
+    fn collects_tool_credentials() {
+        let tool = super::super::ToolManifest {
+            id: "t".into(),
+            name: "t".into(),
+            description: String::new(),
+            version: String::new(),
+            icon: String::new(),
+            category: String::new(),
+            mcp_tools: vec![],
+            command: String::new(),
+            args: vec![],
+            env: Default::default(),
+            secret_env: vec![super::super::SecretEnv {
+                key: "SEC".into(),
+                provider: String::new(),
+                required: true,
+            }],
+            secret_headers: vec![],
+            validate_on_install: false,
+            config_fields: vec![super::super::ConfigField {
+                key: "KEY".into(),
+                label: String::new(),
+                required: true,
+                target: "env".into(),
+                secret: false,
+            }],
+            routing_rules: vec![],
+            tool_table_entries: vec![],
+            pip_dependencies: vec![],
+            servers: vec![],
+            companion_skills: vec![],
+        };
+        let creds = tool_credentials(&tool);
+        assert_eq!(creds.len(), 2);
+        assert_eq!(creds[0].key, "KEY");
+        assert_eq!(creds[0].target, CredentialTarget::Env);
+        assert!(creds[0].required);
+        assert_eq!(creds[1].key, "SEC");
     }
 
     #[test]
@@ -269,12 +535,27 @@ mod tests {
             let reg = BundleRegistry::new();
             let bundles = reg.list_bundles();
             // 四类源都存在
-            assert!(bundles.iter().any(|b| b.kind == BundleKind::Mcp), "应含纯 MCP 包");
-            assert!(bundles.iter().any(|b| b.kind == BundleKind::Bundle), "应含组合包");
-            assert!(bundles.iter().any(|b| b.kind == BundleKind::Skill), "应含纯技能包");
-            assert!(bundles.iter().any(|b| b.kind == BundleKind::Cli), "应含 CLI 包");
+            assert!(
+                bundles.iter().any(|b| b.kind == BundleKind::Mcp),
+                "应含纯 MCP 包"
+            );
+            assert!(
+                bundles.iter().any(|b| b.kind == BundleKind::Bundle),
+                "应含组合包"
+            );
+            assert!(
+                bundles.iter().any(|b| b.kind == BundleKind::Skill),
+                "应含纯技能包"
+            );
+            assert!(
+                bundles.iter().any(|b| b.kind == BundleKind::Cli),
+                "应含 CLI 包"
+            );
             // gongwen 组合包应携带 government-writing 技能
-            let gongwen = bundles.iter().find(|b| b.id == "gongwen").expect("gongwen 应存在");
+            let gongwen = bundles
+                .iter()
+                .find(|b| b.id == "gongwen")
+                .expect("gongwen 应存在");
             assert!(
                 gongwen.skills.contains(&"government-writing".to_string()),
                 "gongwen 应携带 government-writing"
@@ -287,16 +568,39 @@ mod tests {
                 "被认领技能不得独立成包"
             );
             // 上传技能 = 独立纯技能包 + user_uploaded
-            let upload = bundles.iter().find(|b| b.id == "my-upload").expect("上传技能包应存在");
+            let upload = bundles
+                .iter()
+                .find(|b| b.id == "my-upload")
+                .expect("上传技能包应存在");
             assert_eq!(upload.kind, BundleKind::Skill);
             assert!(upload.user_uploaded);
-            // CLI 包 id 覆盖内置清单
+            // CLI 包 id 覆盖内置清单（V2：ima 不在 CLI 包）
             for (id, _) in BUILTIN_CLI_BUNDLES {
                 assert!(
-                    bundles.iter().any(|b| b.id == *id && b.kind == BundleKind::Cli),
+                    bundles
+                        .iter()
+                        .any(|b| b.id == *id && b.kind == BundleKind::Cli),
                     "CLI 包 {id} 应存在"
                 );
             }
+            // V2：ima 归凭据型技能包（Skill），且携带 ima-skills + 凭据声明
+            let ima = bundles
+                .iter()
+                .find(|b| b.id == "ima")
+                .expect("ima 包应存在");
+            assert_eq!(ima.kind, BundleKind::Skill, "ima 应归 Skill");
+            assert!(ima.skills.contains(&"ima-skills".to_string()));
+            assert!(
+                ima.credentials
+                    .iter()
+                    .any(|c| c.key == "IMA_API_KEY" && c.required),
+                "ima 应声明必填凭据"
+            );
+            // ima-skills 不得再独立成包（被 ima 认领）
+            assert!(
+                !bundles.iter().any(|b| b.id == "ima-skills"),
+                "ima-skills 不得独立成包"
+            );
             // id 唯一（一个包 = 一个开关的前提）
             let mut ids: Vec<&str> = bundles.iter().map(|b| b.id.as_str()).collect();
             ids.sort_unstable();

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -154,6 +154,16 @@ impl BundleRegistry {
         let mut out: Vec<BundleInfo> = Vec::new();
         // 已被 MCP/凭据型包认领的技能 id（ima-skills 须在预置扫描前声明，避免先独立成包）
         let mut skill_claimed: Vec<String> = vec!["ima-skills".to_string()];
+        // 跨源 id 查重，优先级 = 注册序：MCP manifest > 内置 CLI/ima > 技能源。
+        // 否则同名包（如上传技能撞 MCP 工具 id weather）会让 bundle() 的 find
+        // 只命中先入者，后者永远不可寻址，违反"一个包 = 一个开关"。
+        let mut taken_ids: Vec<String> = Vec::new();
+        // 内置 CLI/ima id 编译期即保留：上传/预置技能撞名时以内置包为准
+        let builtin_ids: Vec<String> = BUILTIN_CLI_BUNDLES
+            .iter()
+            .map(|(id, _)| (*id).to_string())
+            .chain(std::iter::once("ima".to_string()))
+            .collect();
         let installed_mcp_ids = self.mcp_manager.installed_ids();
 
         // 1) MCP 源（含组合包；凭据项从 manifest config_fields/secret_env 收敛）
@@ -167,6 +177,7 @@ impl BundleRegistry {
                 Vec::new()
             };
             skill_claimed.extend(companions.iter().cloned());
+            taken_ids.push(tool.id.clone());
             let credentials = tool_credentials(&tool);
             let config_fields = tool_config_fields(&tool);
             // auth_required 功能事实：有必填凭据或远程 server（OAuth）即需授权；
@@ -194,12 +205,15 @@ impl BundleRegistry {
             });
         }
 
-        // 2) 预置技能源（未被认领的独立成包）
+        // 2) 预置技能源（未被认领的独立成包；id 不得与 MCP/内置 CLI/ima 撞名）
         for skill in self.skill_manager.list_skills() {
             if skill.user_uploaded {
                 continue; // 上传技能单独处理
             }
             if skill_claimed.contains(&skill.id) {
+                continue;
+            }
+            if taken_ids.contains(&skill.id) || builtin_ids.contains(&skill.id) {
                 continue;
             }
             out.push(BundleInfo {
@@ -220,9 +234,14 @@ impl BundleRegistry {
             });
         }
 
-        // 3) 上传技能源（独立纯技能包；后续步骤改走统一安装管线）
+        // 3) 上传技能源（独立纯技能包；后续步骤改走统一安装管线）。
+        //    id 撞 MCP/内置 CLI/ima 名时跳过：注册表侧无重命名权，冲突须上传侧
+        //    预防（本 PR 仅保证清单不再产出不可寻址的重复 id）。
         for skill in self.skill_manager.list_skills() {
             if !skill.user_uploaded {
+                continue;
+            }
+            if taken_ids.contains(&skill.id) || builtin_ids.contains(&skill.id) {
                 continue;
             }
             out.push(BundleInfo {
@@ -246,6 +265,9 @@ impl BundleRegistry {
         // 4) CLI 连接器源（内置常量表；V2 后不含 ima。V4 硬约束：desc/version/
         //    auth_required 内容迁移随步骤 6（前端数据源切换）同 PR 完成，此处结构占位）
         for (id, name) in BUILTIN_CLI_BUNDLES {
+            if taken_ids.contains(&(*id).to_string()) {
+                continue; // 自建 manifest 撞内置连接器 id：以先注册的 MCP 源为准
+            }
             let cli = vec![(*id).to_string()];
             out.push(BundleInfo {
                 id: (*id).to_string(),
@@ -268,6 +290,9 @@ impl BundleRegistry {
         // 凭据 key 与真实存储对齐：ima 走 `CredentialReference::for_ima_secret`
         // （ima 专用 service，key 为 client_id/api_key，见 connectors/ima.rs），
         // 非 mcp secret 命名空间——通用 readiness 路径查不到，命令层特判走 ima_status。
+        if taken_ids.iter().any(|i| i == "ima") {
+            return out; // 自建 manifest 撞内置 ima id：以先注册的 MCP 源为准
+        }
         let ima_skills: Vec<String> = vec!["ima-skills".to_string()];
         let ima_credentials = vec![
             CredentialSpec {
@@ -777,6 +802,52 @@ mod tests {
                 .expect("government-writing 应独立成包");
             assert_eq!(skill.kind, BundleKind::Skill);
             assert!(skill.installed, "存量单装技能保持已装态");
+        });
+    }
+
+    /// 跨源 id 撞名（真实场景：上传技能 weather 撞 MCP 工具 weather）：
+    /// 注册表按优先级（MCP > 内置 CLI/ima > 技能源）只保留一个包，
+    /// 保证 bundle() 可寻址、id 唯一。
+    #[test]
+    fn cross_source_id_collision_keeps_single_bundle() {
+        with_temp_home(|| {
+            let home = std::env::var("PINVOU3_HOME").unwrap();
+            seed_fixture(std::path::Path::new(&home), true);
+            let write = |rel: &str, content: &str| {
+                let p = std::path::Path::new(&home).join(rel);
+                std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+                std::fs::write(p, content).unwrap();
+            };
+            // 上传技能撞 MCP 工具 id（weather）与内置 CLI id（wecom）
+            for name in ["weather", "wecom"] {
+                write(
+                    &format!("bundle/skills/{name}/SKILL.md"),
+                    &format!("---\nname: {name}\n---\n# hi"),
+                );
+                write(
+                    &format!("bundle/skills/{name}/.installed-from"),
+                    "upload:p.zip",
+                );
+            }
+            let reg = BundleRegistry::new();
+            let bundles = reg.list_bundles();
+            // weather 只出现一次，且是 MCP 包（高优先级源胜出）
+            let weather: Vec<_> = bundles.iter().filter(|b| b.id == "weather").collect();
+            assert_eq!(weather.len(), 1, "撞名 id 只得一个包");
+            assert_eq!(weather[0].kind, BundleKind::Mcp, "MCP 源优先于上传技能");
+            // wecom 只出现一次，且是内置 CLI 包（builtin 预留优先于上传技能）
+            let wecom: Vec<_> = bundles.iter().filter(|b| b.id == "wecom").collect();
+            assert_eq!(wecom.len(), 1, "撞名 id 只得一个包");
+            assert_eq!(
+                wecom[0].kind,
+                BundleKind::Cli,
+                "内置 CLI 预留优先于上传技能"
+            );
+            // id 全局唯一
+            let mut ids: Vec<&str> = bundles.iter().map(|b| b.id.as_str()).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            assert_eq!(ids.len(), bundles.len(), "包 id 必须唯一");
         });
     }
 }

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -358,9 +358,12 @@ mod tests {
     use super::*;
 
     /// 把 PINVOU3_HOME 指到干净临时目录跑闭包,跑完恢复并清理。
-    /// 注：与 marketplace/mod.rs 测试的 ENV_LOCK 不互斥（各自持锁），
-    /// 并行跑存在环境变量竞争——CI rust-test 当前 skipped，修复环境后需共享锁。
+    /// 与 marketplace/mod.rs / paths 测试共享 ENV_LOCK（V6：CI rust-test 已启用，
+    /// 并行跑会互相覆盖 PINVOU3_HOME，必须串行）。
     fn with_temp_home<F: FnOnce()>(f: F) {
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let dir = std::env::temp_dir().join(format!("pinvou3-bundle-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -49,6 +49,16 @@ pub struct CredentialSpec {
     pub required: bool,
 }
 
+/// 配置弹窗字段的功能事实（修复方案 V4 下沉部分）。
+/// label/placeholder/helpText 属 i18n 展示资产，留前端 overlay 按包 id 索引，不进后端。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigFieldSpec {
+    pub key: String,
+    pub required: bool,
+    pub target: CredentialTarget,
+    pub secret: bool,
+}
+
 /// 包形态（内容现算，不落存储）。优先级定死（修复方案 V2）：
 /// cli 非空 → Cli > servers+skills 均非空 → Bundle > servers 非空 → Mcp > skills 非空 → Skill。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,6 +101,12 @@ pub struct BundleInfo {
     pub cli: Vec<String>,
     /// 包声明的凭据项（收敛自 config_fields/secret_env/secret_headers）
     pub credentials: Vec<CredentialSpec>,
+    /// 功能事实（修复方案 V4 下沉；icon/color/todayImg/welcomeQueries/i18n 留前端 overlay）
+    pub description: String,
+    pub version: String,
+    pub auth_required: bool,
+    /// 配置弹窗字段功能事实（label/placeholder/helpText 留前端）
+    pub config_fields: Vec<ConfigFieldSpec>,
     pub installed: bool,
     /// 用户上传（非预置），前端用默认图标渲染
     pub user_uploaded: bool,
@@ -140,6 +156,13 @@ impl BundleRegistry {
             };
             skill_claimed.extend(companions.iter().cloned());
             let credentials = tool_credentials(&tool);
+            let config_fields = tool_config_fields(&tool);
+            // auth_required 功能事实：有必填凭据或远程 server（OAuth）即需授权；
+            // 本地免凭据工具（obsidian/pptx/gongwen）不需要。
+            let auth_required = !config_fields.is_empty()
+                || !tool.secret_env.is_empty()
+                || !tool.secret_headers.is_empty()
+                || !tool.servers.is_empty();
             out.push(BundleInfo {
                 id: tool.id.clone(),
                 name: tool.name.clone(),
@@ -152,6 +175,10 @@ impl BundleRegistry {
                 skills: companions,
                 cli: Vec::new(),
                 credentials,
+                description: tool.description.clone(),
+                version: tool.version.clone(),
+                auth_required,
+                config_fields,
                 installed: installed_mcp_ids.contains(&tool.id),
                 user_uploaded: false,
             });
@@ -173,6 +200,10 @@ impl BundleRegistry {
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
                 credentials: Vec::new(),
+                description: skill.description.clone(),
+                version: String::new(),
+                auth_required: false,
+                config_fields: Vec::new(),
                 installed: skill.installed,
                 user_uploaded: false,
             });
@@ -191,12 +222,17 @@ impl BundleRegistry {
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
                 credentials: Vec::new(),
+                description: skill.description.clone(),
+                version: String::new(),
+                auth_required: false,
+                config_fields: Vec::new(),
                 installed: true,
                 user_uploaded: true,
             });
         }
 
-        // 4) CLI 连接器源（内置常量表；V2 后不含 ima）
+        // 4) CLI 连接器源（内置常量表；V2 后不含 ima。V4 硬约束：desc/version/
+        //    auth_required 内容迁移随步骤 6（前端数据源切换）同 PR 完成，此处结构占位）
         for (id, name) in BUILTIN_CLI_BUNDLES {
             out.push(BundleInfo {
                 id: (*id).to_string(),
@@ -206,6 +242,10 @@ impl BundleRegistry {
                 skills: Vec::new(),
                 cli: vec![(*id).to_string()],
                 credentials: Vec::new(),
+                description: String::new(),
+                version: String::new(),
+                auth_required: true,
+                config_fields: Vec::new(),
                 installed: self.cli_bundle_installed(id),
                 user_uploaded: false,
             });
@@ -230,6 +270,23 @@ impl BundleRegistry {
                     key: "IMA_API_KEY".to_string(),
                     target: CredentialTarget::Credential,
                     required: true,
+                },
+            ],
+            description: String::new(),
+            version: String::new(),
+            auth_required: true,
+            config_fields: vec![
+                ConfigFieldSpec {
+                    key: "IMA_CLIENT_ID".to_string(),
+                    required: true,
+                    target: CredentialTarget::Credential,
+                    secret: true,
+                },
+                ConfigFieldSpec {
+                    key: "IMA_API_KEY".to_string(),
+                    required: true,
+                    target: CredentialTarget::Credential,
+                    secret: true,
                 },
             ],
             installed: self.cli_bundle_installed("ima"),
@@ -300,6 +357,40 @@ fn tool_credentials(tool: &super::ToolManifest) -> Vec<CredentialSpec> {
             key: s.source_key.clone(),
             target: CredentialTarget::Bearer,
             required: s.required,
+        });
+    }
+    out
+}
+
+/// 配置弹窗字段功能事实（V4 下沉；label/placeholder/helpText 属 i18n 展示资产留前端）。
+fn tool_config_fields(tool: &super::ToolManifest) -> Vec<ConfigFieldSpec> {
+    let mut out: Vec<ConfigFieldSpec> = Vec::new();
+    for f in &tool.config_fields {
+        out.push(ConfigFieldSpec {
+            key: f.key.clone(),
+            required: f.required,
+            target: match f.target.as_str() {
+                "bearer" => CredentialTarget::Bearer,
+                "credential" => CredentialTarget::Credential,
+                _ => CredentialTarget::Env,
+            },
+            secret: f.secret,
+        });
+    }
+    for s in &tool.secret_env {
+        out.push(ConfigFieldSpec {
+            key: s.key.clone(),
+            required: s.required,
+            target: CredentialTarget::Env,
+            secret: true,
+        });
+    }
+    for s in &tool.secret_headers {
+        out.push(ConfigFieldSpec {
+            key: s.source_key.clone(),
+            required: s.required,
+            target: CredentialTarget::Bearer,
+            secret: true,
         });
     }
     out
@@ -461,6 +552,10 @@ mod tests {
             skills: vec![],
             cli: vec![],
             credentials: creds,
+            description: String::new(),
+            version: String::new(),
+            auth_required: false,
+            config_fields: vec![],
             installed: true,
             user_uploaded: false,
         };

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -1,0 +1,307 @@
+//! 能力包统一模型 — 步骤 1：schema + 注册表 + kind 推导（只读，不改安装/门禁/投影）。
+//!
+//! 设计依据：`docs/capability-governance.md` §3（能力包线）。一切外部能力统一建模为包：
+//!
+//! ```text
+//! Bundle = { id, name, mcp_servers: [], skills: [], cli: [] }
+//! ```
+//!
+//! - 包是唯一真相源；`mcp.json`、会话 skills 组合目录降级为投影（后续步骤实施）
+//! - 包类型不做存储标签，`bundle_kind` 由内容现算（可信代码推导，防自报标签提权）
+//! - 一个包 = 一个开关；包内技能可见性唯一跟随所属包
+//!
+//! 注册表汇总四类源：MCP manifest（`bundle/mcp-servers/<id>/manifest.json`）、
+//! 预置技能（编译内嵌）、CLI 连接器（内置常量表，UI 元数据从 tool-common.jsx 迁移）、
+//! 已上传技能（`bundle/skills/` 带 `.installed-from=upload:` 标记）。
+
+use serde::{Deserialize, Serialize};
+
+use super::skill_marketplace::SkillMarketplaceManager;
+use super::MarketplaceManager;
+
+// 内置 CLI 连接器清单（UI 元数据从 tool-common.jsx 的 feishuCli/wecomCli/dingtalkCli/
+// tmeetCli/imaOpenapi 条目迁移；安装态 = CLI 安装 + 扫码/凭据配置，状态机后续步骤定义）。
+const BUILTIN_CLI_BUNDLES: &[(&str, &str)] = &[
+    ("feishu", "飞书（Lark）"),
+    ("wecom", "企业微信"),
+    ("dingtalk", "钉钉"),
+    ("tmeet", "腾讯会议"),
+    ("ima", "腾讯 ima"),
+];
+
+/// 包形态（内容现算，不落存储）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BundleKind {
+    /// 纯 MCP：mcp_servers 非空、其余空
+    Mcp,
+    /// 组合包：mcp_servers 与 skills 均非空（MCP 函数 + 使用引导一体）
+    Bundle,
+    /// CLI 包：cli 非空（飞书/企微/钉钉/tmeet/ima 等内置连接器）
+    Cli,
+    /// 纯技能包：仅 skills（市场预置、用户上传）
+    Skill,
+}
+
+/// 能力包清单条目（前端消费；id 沿用现有命名空间：MCP 工具 id / 技能 id / CLI 连接器 id）。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleInfo {
+    pub id: String,
+    pub name: String,
+    pub kind: BundleKind,
+    /// 包内 MCP server id（无则空）
+    pub mcp_servers: Vec<String>,
+    /// 包内技能 id（无则空）
+    pub skills: Vec<String>,
+    /// 包内 CLI 连接器 id（无则空）
+    pub cli: Vec<String>,
+    pub installed: bool,
+    /// 用户上传（非预置），前端用默认图标渲染
+    pub user_uploaded: bool,
+}
+
+/// 注册表：从现有源汇总包清单。只读；安装/门禁/投影迁移见后续步骤。
+pub struct BundleRegistry {
+    mcp_manager: MarketplaceManager,
+    skill_manager: SkillMarketplaceManager,
+}
+
+impl Default for BundleRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BundleRegistry {
+    pub fn new() -> Self {
+        Self {
+            mcp_manager: MarketplaceManager::new(),
+            skill_manager: SkillMarketplaceManager::new(),
+        }
+    }
+
+    /// 全部能力包（含未安装）。组合规则：
+    /// - MCP manifest 的 `companion_skills` 声明 → 技能归入该 MCP 包（组合包）
+    /// - 未被任何 MCP 引用的预置技能 → 独立纯技能包
+    /// - 用户上传技能 → 独立纯技能包
+    /// - 内置 CLI 连接器 → CLI 包（ima 无 CLI 二进制，走 OpenAPI 凭据，kind 仍按内容推导）
+    pub fn list_bundles(&self) -> Vec<BundleInfo> {
+        let mut out: Vec<BundleInfo> = Vec::new();
+        let mut skill_claimed: Vec<String> = Vec::new(); // 已被 MCP 包认领的技能 id
+
+        // 1) MCP 源（含组合包）
+        for tool in self.mcp_manager.available_tools() {
+            let companions = tool.companion_skills.clone();
+            skill_claimed.extend(companions.iter().cloned());
+            out.push(BundleInfo {
+                id: tool.id.clone(),
+                name: tool.name.clone(),
+                kind: if companions.is_empty() {
+                    BundleKind::Mcp
+                } else {
+                    BundleKind::Bundle
+                },
+                mcp_servers: vec![tool.id.clone()],
+                skills: companions,
+                cli: Vec::new(),
+                installed: self.mcp_manager.installed_ids().contains(&tool.id),
+                user_uploaded: false,
+            });
+        }
+
+        // 2) 预置技能源（未被认领的独立成包）
+        for skill in self.skill_manager.list_skills() {
+            if skill.user_uploaded {
+                continue; // 上传技能单独处理
+            }
+            if skill_claimed.contains(&skill.id) {
+                continue;
+            }
+            out.push(BundleInfo {
+                id: skill.id.clone(),
+                name: skill.title.clone(),
+                kind: BundleKind::Skill,
+                mcp_servers: Vec::new(),
+                skills: vec![skill.id.clone()],
+                cli: Vec::new(),
+                installed: skill.installed,
+                user_uploaded: false,
+            });
+        }
+
+        // 3) 上传技能源（独立纯技能包；后续步骤改走统一安装管线）
+        for skill in self.skill_manager.list_skills() {
+            if !skill.user_uploaded {
+                continue;
+            }
+            out.push(BundleInfo {
+                id: skill.id.clone(),
+                name: skill.title.clone(),
+                kind: BundleKind::Skill,
+                mcp_servers: Vec::new(),
+                skills: vec![skill.id.clone()],
+                cli: Vec::new(),
+                installed: true,
+                user_uploaded: true,
+            });
+        }
+
+        // 4) CLI 连接器源（内置常量表；ima 为 OpenAPI 凭据型，仍归 CLI 线）
+        for (id, name) in BUILTIN_CLI_BUNDLES {
+            out.push(BundleInfo {
+                id: (*id).to_string(),
+                name: (*name).to_string(),
+                kind: BundleKind::Cli,
+                mcp_servers: Vec::new(),
+                skills: Vec::new(),
+                cli: vec![(*id).to_string()],
+                installed: self.cli_bundle_installed(id),
+                user_uploaded: false,
+            });
+        }
+
+        out
+    }
+
+    pub fn bundle(&self, id: &str) -> Option<BundleInfo> {
+        self.list_bundles().into_iter().find(|b| b.id == id)
+    }
+
+    /// CLI 包安装态：飞书/企微/钉钉/腾讯会议走 CLI 认证状态，ima 走凭据配置态。
+    /// 现有判定散落在前端连接态/后端 status 命令，此处先给保守默认（未安装），
+    /// 安装态状态机后续步骤统一定义。
+    fn cli_bundle_installed(&self, _id: &str) -> bool {
+        false
+    }
+}
+
+/// 纯函数：由内容推导包形态（与 [`BundleInfo::kind`] 同一逻辑，供规则查表复用）。
+pub fn derive_bundle_kind(mcp_servers: &[String], skills: &[String], cli: &[String]) -> BundleKind {
+    if !cli.is_empty() {
+        BundleKind::Cli
+    } else if !mcp_servers.is_empty() && !skills.is_empty() {
+        BundleKind::Bundle
+    } else if !mcp_servers.is_empty() {
+        BundleKind::Mcp
+    } else {
+        BundleKind::Skill
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    /// 把 PINVOU3_HOME 指到干净临时目录跑闭包,跑完恢复并清理。
+    /// 注：与 marketplace/mod.rs 测试的 ENV_LOCK 不互斥（各自持锁），
+    /// 并行跑存在环境变量竞争——CI rust-test 当前 skipped，修复环境后需共享锁。
+    fn with_temp_home<F: FnOnce()>(f: F) {
+        let dir = std::env::temp_dir().join(format!("pinvou3-bundle-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &dir);
+        f();
+        match prev {
+            Some(v) => std::env::set_var("PINVOU3_HOME", v),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// fixture：临时 home 下构造 mcp-servers manifest + 技能目录 + 上传标记。
+    fn seed_fixture(home: &std::path::Path) {
+        let write = |rel: &str, content: &str| {
+            let p = home.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            let mut f = std::fs::File::create(&p).unwrap();
+            f.write_all(content.as_bytes()).unwrap();
+        };
+        // 组合包 gongwen（companion 声明 government-writing）
+        write(
+            "bundle/mcp-servers/gongwen/manifest.json",
+            r#"{"id":"gongwen","name":"公文写作","description":"d","version":"1.0.0","icon":"","category":"office","mcp_tools":[],"command":"","args":[],"companion_skills":["government-writing"]}"#,
+        );
+        // 纯 MCP 包 weather
+        write(
+            "bundle/mcp-servers/weather/manifest.json",
+            r#"{"id":"weather","name":"高德天气","description":"d","version":"1.0.0","icon":"","category":"life","mcp_tools":[],"command":"","args":[]}"#,
+        );
+        // 预置技能（被认领 + 独立）
+        for (name, marker) in [
+            ("government-writing", "pinvou3-marketplace:government-writing"),
+            ("visualizer", "pinvou3-marketplace:visualizer"),
+        ] {
+            write(&format!("bundle/skills/{name}/SKILL.md"), "---\nname: {name}\n---\n# hi");
+            write(
+                &format!("bundle/skills/{name}/.installed-from"),
+                marker,
+            );
+        }
+        // 上传技能
+        write("bundle/skills/my-upload/SKILL.md", "---\nname: my-upload\n---\n# hi");
+        write("bundle/skills/my-upload/.installed-from", "upload:pkg.zip");
+    }
+
+    #[test]
+    fn derives_bundle_kind_by_content() {
+        let mcp = |id: &str| id.to_string();
+        assert_eq!(derive_bundle_kind(&[], &[], &[]), BundleKind::Skill);
+        assert_eq!(derive_bundle_kind(&[mcp("a")], &[], &[]), BundleKind::Mcp);
+        assert_eq!(
+            derive_bundle_kind(&[mcp("a")], &[mcp("s")], &[]),
+            BundleKind::Bundle
+        );
+        assert_eq!(derive_bundle_kind(&[], &[], &[mcp("feishu")]), BundleKind::Cli);
+        assert_eq!(
+            derive_bundle_kind(&[mcp("a")], &[], &[mcp("feishu")]),
+            BundleKind::Cli
+        );
+    }
+
+    #[test]
+    fn registry_lists_all_source_kinds() {
+        with_temp_home(|| {
+            let home = std::env::var("PINVOU3_HOME").unwrap();
+            seed_fixture(std::path::Path::new(&home));
+            let reg = BundleRegistry::new();
+            let bundles = reg.list_bundles();
+            // 四类源都存在
+            assert!(bundles.iter().any(|b| b.kind == BundleKind::Mcp), "应含纯 MCP 包");
+            assert!(bundles.iter().any(|b| b.kind == BundleKind::Bundle), "应含组合包");
+            assert!(bundles.iter().any(|b| b.kind == BundleKind::Skill), "应含纯技能包");
+            assert!(bundles.iter().any(|b| b.kind == BundleKind::Cli), "应含 CLI 包");
+            // gongwen 组合包应携带 government-writing 技能
+            let gongwen = bundles.iter().find(|b| b.id == "gongwen").expect("gongwen 应存在");
+            assert!(
+                gongwen.skills.contains(&"government-writing".to_string()),
+                "gongwen 应携带 government-writing"
+            );
+            // government-writing 不应再以独立技能包出现（已被认领）
+            assert!(
+                !bundles
+                    .iter()
+                    .any(|b| b.id == "government-writing" && b.kind == BundleKind::Skill),
+                "被认领技能不得独立成包"
+            );
+            // 上传技能 = 独立纯技能包 + user_uploaded
+            let upload = bundles.iter().find(|b| b.id == "my-upload").expect("上传技能包应存在");
+            assert_eq!(upload.kind, BundleKind::Skill);
+            assert!(upload.user_uploaded);
+            // CLI 包 id 覆盖内置清单
+            for (id, _) in BUILTIN_CLI_BUNDLES {
+                assert!(
+                    bundles.iter().any(|b| b.id == *id && b.kind == BundleKind::Cli),
+                    "CLI 包 {id} 应存在"
+                );
+            }
+            // id 唯一（一个包 = 一个开关的前提）
+            let mut ids: Vec<&str> = bundles.iter().map(|b| b.id.as_str()).collect();
+            ids.sort_unstable();
+            ids.dedup();
+            assert_eq!(ids.len(), bundles.len(), "包 id 必须唯一");
+        });
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -1,6 +1,6 @@
 //! 能力包统一模型 — 步骤 1/2：schema + 注册表 + kind 推导 + 就绪态（只读，不改安装/门禁/投影）。
 //!
-//! 设计依据：`docs/capability-governance.md` §3（能力包线）+ 实施修复方案（V1-V7）。
+//! 设计依据：能力包统一模型实施修复方案（V1-V7，见本模块各处注释与 PR #279 讨论）。
 //! 一切外部能力统一建模为包：
 //!
 //! ```text
@@ -39,6 +39,18 @@ pub enum CredentialTarget {
     Env,
     Credential,
     Bearer,
+}
+
+/// CredentialTarget → 系统凭据存储 keyring target（`CredentialReference::for_mcp_secret`
+/// 的 target 段）。存储侧唯一映射点：bearer 密钥在 install 时落 `"header"`
+/// （见 `manifest_secret_targets` / install 的 `resolve_secret_placeholder`），
+/// 查询侧必须复用本函数，禁止另写映射导致存取漂移。
+pub fn keyring_target(target: CredentialTarget) -> &'static str {
+    match target {
+        CredentialTarget::Env => "env",
+        CredentialTarget::Bearer => "header",
+        CredentialTarget::Credential => "credential",
+    }
 }
 
 /// 包声明的凭据项（修复方案一：从 config_fields/secret_env/secret_headers 收敛）。
@@ -166,11 +178,9 @@ impl BundleRegistry {
             out.push(BundleInfo {
                 id: tool.id.clone(),
                 name: tool.name.clone(),
-                kind: if companions.is_empty() {
-                    BundleKind::Mcp
-                } else {
-                    BundleKind::Bundle
-                },
+                // kind 由内容现算（防自报标签提权）：servers 非空，有 companion 即组合包
+                kind: derive_bundle_kind(std::slice::from_ref(&tool.id), &companions, &[])
+                    .expect("MCP 源 servers 恒非空"),
                 mcp_servers: vec![tool.id.clone()],
                 skills: companions,
                 cli: Vec::new(),
@@ -195,7 +205,8 @@ impl BundleRegistry {
             out.push(BundleInfo {
                 id: skill.id.clone(),
                 name: skill.title.clone(),
-                kind: BundleKind::Skill,
+                kind: derive_bundle_kind(&[], std::slice::from_ref(&skill.id), &[])
+                    .expect("技能源 skills 恒非空"),
                 mcp_servers: Vec::new(),
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
@@ -217,7 +228,8 @@ impl BundleRegistry {
             out.push(BundleInfo {
                 id: skill.id.clone(),
                 name: skill.title.clone(),
-                kind: BundleKind::Skill,
+                kind: derive_bundle_kind(&[], std::slice::from_ref(&skill.id), &[])
+                    .expect("技能源 skills 恒非空"),
                 mcp_servers: Vec::new(),
                 skills: vec![skill.id.clone()],
                 cli: Vec::new(),
@@ -234,13 +246,14 @@ impl BundleRegistry {
         // 4) CLI 连接器源（内置常量表；V2 后不含 ima。V4 硬约束：desc/version/
         //    auth_required 内容迁移随步骤 6（前端数据源切换）同 PR 完成，此处结构占位）
         for (id, name) in BUILTIN_CLI_BUNDLES {
+            let cli = vec![(*id).to_string()];
             out.push(BundleInfo {
                 id: (*id).to_string(),
                 name: (*name).to_string(),
-                kind: BundleKind::Cli,
+                kind: derive_bundle_kind(&[], &[], &cli).expect("CLI 源 cli 恒非空"),
                 mcp_servers: Vec::new(),
                 skills: Vec::new(),
-                cli: vec![(*id).to_string()],
+                cli,
                 credentials: Vec::new(),
                 description: String::new(),
                 version: String::new(),
@@ -252,43 +265,43 @@ impl BundleRegistry {
         }
 
         // 5) 凭据型技能包：ima（OpenAPI 凭据 + companion 技能 ima-skills；V2 归 Skill）
-        let ima_skills = ["ima-skills"];
+        // 凭据 key 与真实存储对齐：ima 走 `CredentialReference::for_ima_secret`
+        // （ima 专用 service，key 为 client_id/api_key，见 connectors/ima.rs），
+        // 非 mcp secret 命名空间——通用 readiness 路径查不到，命令层特判走 ima_status。
+        let ima_skills: Vec<String> = vec!["ima-skills".to_string()];
+        let ima_credentials = vec![
+            CredentialSpec {
+                key: "client_id".to_string(),
+                target: CredentialTarget::Credential,
+                required: true,
+            },
+            CredentialSpec {
+                key: "api_key".to_string(),
+                target: CredentialTarget::Credential,
+                required: true,
+            },
+        ];
         out.push(BundleInfo {
             id: "ima".to_string(),
             name: "腾讯 ima".to_string(),
-            kind: BundleKind::Skill,
+            kind: derive_bundle_kind(&[], &ima_skills, &[]).expect("ima skills 恒非空"),
             mcp_servers: Vec::new(),
-            skills: ima_skills.iter().map(|s| s.to_string()).collect(),
+            skills: ima_skills,
             cli: Vec::new(),
-            credentials: vec![
-                CredentialSpec {
-                    key: "IMA_CLIENT_ID".to_string(),
-                    target: CredentialTarget::Credential,
-                    required: true,
-                },
-                CredentialSpec {
-                    key: "IMA_API_KEY".to_string(),
-                    target: CredentialTarget::Credential,
-                    required: true,
-                },
-            ],
+            // config_fields 与 credentials 是同一份功能事实，由 credentials 派生避免漂移
+            config_fields: ima_credentials
+                .iter()
+                .map(|c| ConfigFieldSpec {
+                    key: c.key.clone(),
+                    required: c.required,
+                    target: c.target,
+                    secret: true,
+                })
+                .collect(),
+            credentials: ima_credentials,
             description: String::new(),
             version: String::new(),
             auth_required: true,
-            config_fields: vec![
-                ConfigFieldSpec {
-                    key: "IMA_CLIENT_ID".to_string(),
-                    required: true,
-                    target: CredentialTarget::Credential,
-                    secret: true,
-                },
-                ConfigFieldSpec {
-                    key: "IMA_API_KEY".to_string(),
-                    required: true,
-                    target: CredentialTarget::Credential,
-                    secret: true,
-                },
-            ],
             installed: self.cli_bundle_installed("ima"),
             user_uploaded: false,
         });
@@ -300,8 +313,9 @@ impl BundleRegistry {
         self.list_bundles().into_iter().find(|b| b.id == id)
     }
 
-    /// CLI 包安装态：飞书/企微/钉钉/腾讯会议走 CLI 认证状态，ima 走凭据配置态。
-    /// 现有判定散落在前端连接态/后端 status 命令，此处先给保守默认（未安装），
+    /// CLI/ima 包安装态的保守占位（恒 false）：连接器 installed 需查询 CLI 二进制
+    /// 或凭据存储（async/运行时状态），同步注册表不直连——权威 (installed, ready)
+    /// 由命令层 `bundle_readiness` 从各连接器 status 现算并覆盖本字段。
     /// 安装态状态机后续步骤统一定义。
     fn cli_bundle_installed(&self, _id: &str) -> bool {
         false
@@ -403,8 +417,9 @@ fn tool_config_fields(tool: &super::ToolManifest) -> Vec<ConfigFieldSpec> {
 /// - 本地免凭据：恒 Ready
 pub fn readiness_for(bundle: &BundleInfo, credential_has: impl Fn(&str) -> bool) -> Readiness {
     match bundle.kind {
-        // CLI 包授权态由调用方（命令层）注入；此处按 installed 保守返回——
-        // 命令层 `bundle_readiness` 覆盖 CLI 分派后，此分支不达。
+        // CLI 包授权态由调用方（命令层）注入；命令层 `bundle_readiness` 对 CLI 包
+        // 先分派到连接器 status，不会走到本函数——此分支仅为纯函数完备性保留，
+        // 按 installed 保守返回，不得作为 CLI 包的真实就绪态来源。
         BundleKind::Cli => {
             if bundle.installed {
                 Readiness::Ready
@@ -412,21 +427,9 @@ pub fn readiness_for(bundle: &BundleInfo, credential_has: impl Fn(&str) -> bool)
                 Readiness::NotReady("cli_not_installed")
             }
         }
-        BundleKind::Mcp | BundleKind::Bundle => {
-            // 本地免凭据（无必填凭据）恒 Ready；有必填凭据则查系统凭据
-            let missing: Vec<&str> = bundle
-                .credentials
-                .iter()
-                .filter(|c| c.required && !credential_has(&c.key))
-                .map(|c| c.key.as_str())
-                .collect();
-            if missing.is_empty() {
-                Readiness::Ready
-            } else {
-                Readiness::NotReady("missing_credentials")
-            }
-        }
-        BundleKind::Skill => {
+        // MCP/组合/技能包同一规则：本地免凭据（无必填凭据）恒 Ready；
+        // 有必填凭据则查系统凭据。
+        _ => {
             let missing: Vec<&str> = bundle
                 .credentials
                 .iter()
@@ -615,15 +618,30 @@ mod tests {
                 provider: String::new(),
                 required: true,
             }],
-            secret_headers: vec![],
-            validate_on_install: false,
-            config_fields: vec![super::super::ConfigField {
-                key: "KEY".into(),
-                label: String::new(),
+            secret_headers: vec![super::super::SecretHeader {
+                header: "Authorization".into(),
+                scheme: "Bearer".into(),
+                source_key: "API_KEY".into(),
+                provider: String::new(),
                 required: true,
-                target: "env".into(),
-                secret: false,
             }],
+            validate_on_install: false,
+            config_fields: vec![
+                super::super::ConfigField {
+                    key: "KEY".into(),
+                    label: String::new(),
+                    required: true,
+                    target: "env".into(),
+                    secret: false,
+                },
+                super::super::ConfigField {
+                    key: "TOKEN".into(),
+                    label: String::new(),
+                    required: true,
+                    target: "bearer".into(),
+                    secret: true,
+                },
+            ],
             routing_rules: vec![],
             tool_table_entries: vec![],
             pip_dependencies: vec![],
@@ -631,11 +649,25 @@ mod tests {
             companion_skills: vec![],
         };
         let creds = tool_credentials(&tool);
-        assert_eq!(creds.len(), 2);
+        assert_eq!(creds.len(), 4);
         assert_eq!(creds[0].key, "KEY");
         assert_eq!(creds[0].target, CredentialTarget::Env);
         assert!(creds[0].required);
-        assert_eq!(creds[1].key, "SEC");
+        // config_field target="bearer" → Bearer；secret_headers → Bearer
+        assert_eq!(creds[1].key, "TOKEN");
+        assert_eq!(creds[1].target, CredentialTarget::Bearer);
+        assert_eq!(creds[2].key, "SEC");
+        assert_eq!(creds[3].key, "API_KEY");
+        assert_eq!(creds[3].target, CredentialTarget::Bearer);
+    }
+
+    /// 就绪态查询的 keyring target 必须与 install 存储对齐：bearer 落 "header"
+    /// （评审 BLOCKER 回归：查询 "bearer" 会永久 missing_credentials）。
+    #[test]
+    fn keyring_target_matches_install_storage() {
+        assert_eq!(keyring_target(CredentialTarget::Env), "env");
+        assert_eq!(keyring_target(CredentialTarget::Bearer), "header");
+        assert_eq!(keyring_target(CredentialTarget::Credential), "credential");
     }
 
     #[test]
@@ -706,8 +738,8 @@ mod tests {
             assert!(
                 ima.credentials
                     .iter()
-                    .any(|c| c.key == "IMA_API_KEY" && c.required),
-                "ima 应声明必填凭据"
+                    .any(|c| c.key == "api_key" && c.required),
+                "ima 应声明必填凭据（key 与 ima 专用凭据存储对齐）"
             );
             // ima-skills 不得再独立成包（被 ima 认领）
             assert!(

--- a/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/bundle.rs
@@ -126,10 +126,18 @@ impl BundleRegistry {
         let mut out: Vec<BundleInfo> = Vec::new();
         // 已被 MCP/凭据型包认领的技能 id（ima-skills 须在预置扫描前声明，避免先独立成包）
         let mut skill_claimed: Vec<String> = vec!["ima-skills".to_string()];
+        let installed_mcp_ids = self.mcp_manager.installed_ids();
 
         // 1) MCP 源（含组合包；凭据项从 manifest config_fields/secret_env 收敛）
         for tool in self.mcp_manager.available_tools() {
-            let companions = tool.companion_skills.clone();
+            // 修复方案 V5：companion 认领是「随包」语义——包本体已装才认领技能；
+            // 存量已单装技能的包未装时，技能保留独立纯技能包形态（不强制认领，
+            // 只影响新装路径），避免用户既有开关/技能消失。
+            let companions: Vec<String> = if installed_mcp_ids.contains(&tool.id) {
+                tool.companion_skills.clone()
+            } else {
+                Vec::new()
+            };
             skill_claimed.extend(companions.iter().cloned());
             let credentials = tool_credentials(&tool);
             out.push(BundleInfo {
@@ -144,7 +152,7 @@ impl BundleRegistry {
                 skills: companions,
                 cli: Vec::new(),
                 credentials,
-                installed: self.mcp_manager.installed_ids().contains(&tool.id),
+                installed: installed_mcp_ids.contains(&tool.id),
                 user_uploaded: false,
             });
         }
@@ -367,7 +375,8 @@ mod tests {
     }
 
     /// fixture：临时 home 下构造 mcp-servers manifest + 技能目录 + 上传标记。
-    fn seed_fixture(home: &std::path::Path) {
+    /// `install_gongwen=true` 时把 gongwen 写入 installed.json（V5 认领条件）。
+    fn seed_fixture(home: &std::path::Path, install_gongwen: bool) {
         let write = |rel: &str, content: &str| {
             let p = home.join(rel);
             std::fs::create_dir_all(p.parent().unwrap()).unwrap();
@@ -404,6 +413,10 @@ mod tests {
             "---\nname: my-upload\n---\n# hi",
         );
         write("bundle/skills/my-upload/.installed-from", "upload:pkg.zip");
+        // 安装态（V5 认领条件）
+        if install_gongwen {
+            write("marketplace/installed.json", r#"["gongwen"]"#);
+        }
     }
 
     #[test]
@@ -531,7 +544,7 @@ mod tests {
     fn registry_lists_all_source_kinds() {
         with_temp_home(|| {
             let home = std::env::var("PINVOU3_HOME").unwrap();
-            seed_fixture(std::path::Path::new(&home));
+            seed_fixture(std::path::Path::new(&home), true);
             let reg = BundleRegistry::new();
             let bundles = reg.list_bundles();
             // 四类源都存在
@@ -551,15 +564,17 @@ mod tests {
                 bundles.iter().any(|b| b.kind == BundleKind::Cli),
                 "应含 CLI 包"
             );
-            // gongwen 组合包应携带 government-writing 技能
+            // gongwen 已装 → 组合包，携带 government-writing
             let gongwen = bundles
                 .iter()
                 .find(|b| b.id == "gongwen")
                 .expect("gongwen 应存在");
+            assert_eq!(gongwen.kind, BundleKind::Bundle, "gongwen 已装应为组合包");
             assert!(
                 gongwen.skills.contains(&"government-writing".to_string()),
                 "gongwen 应携带 government-writing"
             );
+            assert!(gongwen.installed);
             // government-writing 不应再以独立技能包出现（已被认领）
             assert!(
                 !bundles
@@ -606,6 +621,32 @@ mod tests {
             ids.sort_unstable();
             ids.dedup();
             assert_eq!(ids.len(), bundles.len(), "包 id 必须唯一");
+        });
+    }
+
+    /// V5：包本体未装时 companion 技能保留独立纯技能包形态（存量单装兼容）。
+    #[test]
+    fn uninstalled_bundle_keeps_companion_skill_independent() {
+        with_temp_home(|| {
+            let home = std::env::var("PINVOU3_HOME").unwrap();
+            seed_fixture(std::path::Path::new(&home), false);
+            let reg = BundleRegistry::new();
+            let bundles = reg.list_bundles();
+            // gongwen 未装 → 纯 MCP 包（不认领）
+            let gongwen = bundles
+                .iter()
+                .find(|b| b.id == "gongwen")
+                .expect("gongwen 应存在");
+            assert_eq!(gongwen.kind, BundleKind::Mcp, "gongwen 未装应为纯 MCP 包");
+            assert!(gongwen.skills.is_empty(), "未装包不得认领技能");
+            assert!(!gongwen.installed);
+            // government-writing 保留独立技能包（存量单装可继续开关）
+            let skill = bundles
+                .iter()
+                .find(|b| b.id == "government-writing")
+                .expect("government-writing 应独立成包");
+            assert_eq!(skill.kind, BundleKind::Skill);
+            assert!(skill.installed, "存量单装技能保持已装态");
         });
     }
 }

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -605,7 +605,10 @@ fn manifest_secret_targets(manifest: &ToolManifest) -> Vec<(String, String)> {
         push("env", &s.key);
     }
     for s in &manifest.secret_headers {
-        push(bundle::keyring_target(bundle::CredentialTarget::Bearer), &s.source_key);
+        push(
+            bundle::keyring_target(bundle::CredentialTarget::Bearer),
+            &s.source_key,
+        );
     }
     for f in &manifest.config_fields {
         if f.secret {

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -1359,7 +1359,7 @@ impl<S: CredentialStore> MarketplaceManager<S> {
                             if field.secret {
                                 self.resolve_secret_placeholder(
                                     &manifest.id,
-                                    "header",
+                                    bundle::keyring_target(bundle::CredentialTarget::Bearer),
                                     &field.key,
                                     user_config,
                                     &manifest.env,
@@ -1385,7 +1385,7 @@ impl<S: CredentialStore> MarketplaceManager<S> {
                 for secret in &manifest.secret_headers {
                     self.resolve_secret_placeholder(
                         &manifest.id,
-                        "header",
+                        bundle::keyring_target(bundle::CredentialTarget::Bearer),
                         &secret.source_key,
                         user_config,
                         &manifest.env,
@@ -1405,7 +1405,7 @@ impl<S: CredentialStore> MarketplaceManager<S> {
                         if is_sensitive_key_name(k) {
                             let placeholder = self.resolve_secret_placeholder(
                                 &manifest.id,
-                                "header",
+                                bundle::keyring_target(bundle::CredentialTarget::Bearer),
                                 k,
                                 user_config,
                                 &manifest.env,

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -605,12 +605,12 @@ fn manifest_secret_targets(manifest: &ToolManifest) -> Vec<(String, String)> {
         push("env", &s.key);
     }
     for s in &manifest.secret_headers {
-        push("header", &s.source_key);
+        push(bundle::keyring_target(bundle::CredentialTarget::Bearer), &s.source_key);
     }
     for f in &manifest.config_fields {
         if f.secret {
             let target = if f.target == "bearer" {
-                "header"
+                bundle::keyring_target(bundle::CredentialTarget::Bearer)
             } else {
                 f.target.as_str()
             };

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -4,6 +4,7 @@
 //! 安装状态持久化在 `~/.pinvou3/marketplace/installed.json`。
 //! 安装/卸载时同步修改 `~/.pinvou3/bundle/mcp.json`。
 
+pub mod bundle;
 pub mod skill_marketplace;
 pub mod skill_scope;
 

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -971,6 +971,7 @@ pub fn run() {
             commands::marketplace::import_skill_package,
             commands::marketplace::import_skill_package_bytes,
             commands::marketplace::uninstall_marketplace_skill,
+            commands::marketplace::bundle_readiness,
             commands::files::verify_upload,
         ]);
 


### PR DESCRIPTION
## 背景

工具市场现状是三个异构真相源（MCP manifest + installed.json、技能清单 + 目录标记、CLI 连接器前端硬编码卡片），门禁侧靠命令层胶水对接（曾因此出现上传路径漏调 scope 同步的事故）。按已定设计决策（capability-governance §3，"一切外部能力统一建模为包"），落地第一步：只读包注册表。不改变任何现有行为。

## 变更

- 新增 `BundleRegistry` / `BundleInfo`：统一汇总 MCP manifest、预置技能、内置 CLI 连接器、已上传技能；`Bundle = { mcp_servers, skills, cli }` 三部分均可空
- `derive_bundle_kind` 内容现算（cli > bundle > mcp > skill），空包返回 `InvalidBundle` 在 schema 层拦截；类型不落存储
- `credentials` 凭据声明字段：收敛 manifest 的 config_fields/secret_env/secret_headers；ima 移出 CLI 包归凭据型技能包（无 CLI 二进制）
- `installed`（存储二态）与 `Readiness`（派生态现算）分离；新增统一命令 `bundle_readiness`（CLI 包按授权、凭据型按必填项、本地免凭据恒 Ready），命令层注入授权查询保持依赖方向
- V5：companion 技能条件认领（存量单装用户不强制并入包）
- V6：bundle 测试共享 ENV_LOCK 消除 PINVOU3_HOME 环境竞争

## 验证

- `cargo check --tests` 编译通过、`cargo fmt --check` 干净
- 架构守卫通过（无新增架构债）
- Rust 单测已编写（derive 优先级/空包/readiness 规则/凭据收敛/认领规则），本机 DLL 环境问题（0xc0000139，已知）无法执行，以 CI 为准

## 已知风险

- `bundle_readiness` 暂无前端消费（后续步骤接入），本次为纯增量、零行为变更
- 存储迁移（disabled_bundles.json）、投影层、统一失效入口为后续 PR，不在本范围
