### PR TITLE
chore(ci): CI 审计——清理死逻辑、修正触发缺口、精简暖 cache 重复

### DIFF
--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -2,7 +2,6 @@ name: cache-janitor
 
 # Actions 缓存定期清理(10GB 配额保护),规则实现见 scripts/cache-janitor.sh:
 # - 已关闭/合并 PR 作用域的全部缓存(PR 缓存互不可见,关闭后即死重);
-# - 最后访问超过 7 天的 sccache 对象(按 lastAccessedAt 判热度,持续命中的保留);
 # - codeql-overlay 每语言每作用域只留最新 1 份;node-cache 每平台每作用域只留最新 1 份
 #   (按作用域分组:跨 ref 只留最新会把 main 的可用缓存误换成 PR 作用域的)。
 # 保护:main 作用域的 v0-rust-* 系列(rust-test/rust-lint/windows-rust-test/

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -605,7 +605,9 @@ jobs:
 
       # remote_control 的真实 relay 下载 e2e 需要 node + relay 依赖,缺 node_modules/ws 时
       # 该 e2e 会自动 skip —— 装上依赖让 CI 真正执行它,而不是绿灯假过。
+      # push(main) 只编译不执行测试(见下方 --no-run),不需要 relay/Chrome 运行时依赖。
       - name: Node.js (relay e2e)
+        if: ${{ github.event_name != 'push' }}
         uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -613,9 +615,11 @@ jobs:
           cache-dependency-path: remote-control-relay/package-lock.json
 
       - name: relay 依赖 (真实 relay e2e)
+        if: ${{ github.event_name != 'push' }}
         run: npm --prefix remote-control-relay ci --prefer-offline --no-audit
 
       - name: 浏览器驱动依赖 (真实 Chrome 下载 e2e)
+        if: ${{ github.event_name != 'push' }}
         # real-browser driver 从 pinvou3-app/node_modules 加载 puppeteer-core。
         # npm --prefix pinvou3-app install 即使指定单包也会解析并安装项目完整依赖树，
         # 因此直接用 package-lock 驱动的 npm ci，避免额外维护一份硬编码版本并保证可复现。
@@ -630,22 +634,34 @@ jobs:
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # MQ/PR(ci:full-rust) 跑完整 lib 测试(含真实 relay/Chrome e2e)。
       # 保留 --test-threads=1:虽已把 env 写测试收敛到 crate 级唯一锁
       # (bridge::paths::tests::ENV_LOCK),但进程级 env 对未持锁的读取者仍全局可见，
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
       # 取得的仍是已加锁 guard，不会绕过互斥；根治需消除测试对进程级 env 的依赖
       # 或让所有读写都通过同一隔离层，超出本 PR 范围。
-      - name: cargo test --lib (真 bge-m3/vLLM 测试已 #[ignore])
+      - name: cargo test --lib (MQ/PR 完整测试)
+        if: ${{ github.event_name != 'push' }}
         run: |
           chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
           export CHROME="$chrome"
           export PINVOU_REQUIRE_REMOTE_E2E=1
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1
 
+      # push(main) 唯一目的是暖 cache(Swatinem/rust-cache save-if main)。
+      # MQ 已对同一代码跑过完整 lib 测试,squash 合并后的 push 不再重复执行测试;
+      # --no-run 编译含 test harness 的全部 target 产物(与完整 test 的编译腿一致),
+      # 供热 MQ restore 后增量复用,省去测试执行时间。
+      # 不需要 relay/Chrome 运行时依赖(上方 setup-node/relay/浏览器 step 已按 !=push 跳过)。
+      - name: cargo test --lib --no-run (push main 仅编译暖 cache)
+        if: ${{ github.event_name == 'push' }}
+        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
+
       - name: L1 harness 严格错误回归（不调用真模型）
         # 仅在 harness 及其直接依赖路径变化时追加，避免无关 Rust 改动重复跑。
         # 保留 --test-threads=1:仅 3 个 strict_mode_ 测试,harness 本身需串行语义。
-        if: ${{ needs.changes.outputs.l1 == 'true' }}
+        # push(main) 跳过:MQ 已验证同一代码,push 不重复执行测试(仅暖 cache)。
+        if: ${{ needs.changes.outputs.l1 == 'true' && github.event_name != 'push' }}
         run: >-
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml
           --test l1_dialog_harness strict_mode_
@@ -727,12 +743,6 @@ jobs:
           shared-key: windows-rust-test
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Windows 架构与 Tauri 资源契约
-        run: |
-          python scripts/architecture-guard.py
-          npm --prefix pinvou3-app run test:tauri-layout
-          npm --prefix pinvou3-app run test:tauri-effective-config
-
       - name: Windows Rust 全目标检查
         run: >-
           cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml
@@ -799,7 +809,6 @@ jobs:
       - release-contract-test
       - rust-lint
       - rust-test
-      - windows-rust-test
       - macos-codex-runtime-test
       - windows-codex-runtime-test
     if: ${{ always() && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group') }}
@@ -817,7 +826,6 @@ jobs:
           RELEASE_CONTRACT_RESULT: ${{ needs.release-contract-test.result }}
           RUST_LINT_RESULT: ${{ needs.rust-lint.result }}
           RUST_RESULT: ${{ needs.rust-test.result }}
-          WINDOWS_RUST_RESULT: ${{ needs.windows-rust-test.result }}
           MACOS_CODEX_RESULT: ${{ needs.macos-codex-runtime-test.result }}
           WINDOWS_CODEX_RESULT: ${{ needs.windows-codex-runtime-test.result }}
         run: |
@@ -840,7 +848,6 @@ jobs:
             "release-contract-test:$RELEASE_CONTRACT_RESULT" \
             "rust-lint:$RUST_LINT_RESULT" \
             "rust-test:$RUST_RESULT" \
-            "windows-rust-test:$WINDOWS_RUST_RESULT" \
             "macos-codex-runtime-test:$MACOS_CODEX_RESULT" \
             "windows-codex-runtime-test:$WINDOWS_CODEX_RESULT"; do
             name="${item%%:*}"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -426,9 +426,10 @@ jobs:
       - name: 安装前端依赖
         run: npm --prefix pinvou3-app ci --prefer-offline --no-audit
 
-      - name: 版本与发布配置契约
+      # 版本一致性校验(--check)由 version-consistency job 无路径门全事件覆盖,
+      # 此处不重复;仅跑 Tauri overlay 与各平台打包契约。
+      - name: Tauri 打包与发布配置契约
         run: |
-          node scripts/sync-version.mjs --check
           npm --prefix pinvou3-app run test:tauri-layout
           npm --prefix pinvou3-app run test:tauri-effective-config
           npm --prefix pinvou3-app run test:web-template-packaging
@@ -442,7 +443,10 @@ jobs:
   rust-lint:
     name: rust-lint
     needs: changes
-    if: ${{ !cancelled() && github.event.action != 'closed' && needs.changes.outputs.rust_code == 'true' }}
+    # 纳入 rust_dependencies:只改 deny.toml 时 rust_code=false 但 rust_dependencies=true,
+    # cargo-deny 子步骤(已按 rust_dependencies 门控)需本 job 启动才能运行;
+    # 否则 deny.toml 策略改动会静默漏检 cargo-deny。
+    if: ${{ !cancelled() && github.event.action != 'closed' && (needs.changes.outputs.rust_code == 'true' || needs.changes.outputs.rust_dependencies == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -41,7 +41,7 @@ jobs:
         os: [macos-15, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/scripts/cache-janitor.sh
+++ b/scripts/cache-janitor.sh
@@ -3,31 +3,25 @@
 #
 # 删除规则:
 #   A. 已关闭/已合并 PR(refs/pull/N/merge)作用域的全部缓存
-#      (PR 作用域缓存互不可见,PR 关闭后即死重;历史上 node-cache、sccache、
-#       release 打包缓存都在 PR 作用域产生过 GB 级残留;PR 状态查询失败一律保留)
-#   B. 最后访问超过 N 天的 sccache 对象(默认 7 天;稳定依赖的编译对象可能
-#      创建很早但持续命中,必须按 lastAccessedAt 判断热度,否则会每周误删
-#      仍在使用的主线暖缓存;内容寻址,真陈旧的条目命中前早已被新产物替代)
-#   C. codeql-overlay 每种语言每个作用域只保留最新 1 份(CodeQL 只消费最新 base)
-#   D. node-cache 每个平台每个作用域只保留最新 1 份(同平台旧 lockfile 哈希
+#      (PR 作用域缓存互不可见,PR 关闭后即死重;PR 状态查询失败一律保留)
+#   B. codeql-overlay 每种语言每个作用域只保留最新 1 份(CodeQL 只消费最新 base)
+#   C. node-cache 每个平台每个作用域只保留最新 1 份(同平台旧 lockfile 哈希
 #      仅有 restore-keys 前缀回退价值,留最新即可)
 #
-# 注意:规则 C/D 必须按缓存作用域(ref)分组。作用域之间互不可见,跨 ref
+# 注意:规则 B/C 必须按缓存作用域(ref)分组。作用域之间互不可见,跨 ref
 # 只留最新会把 main 的可用缓存换成 PR 作用域的(main 读不到),等于误删。
 #
 # 保护:main 作用域的 v0-rust-* 系列(rust-test / rust-lint / windows-rust-test /
 # mac-build / release-*)不在任何规则范围内。
 #
-# 用法:scripts/cache-janitor.sh [--dry-run] [--sccache-days N]
+# 用法:scripts/cache-janitor.sh [--dry-run]
 # 依赖:gh cli;GH_TOKEN 需具备 actions:write(删除)与 pull-requests:read(查状态)。
 set -euo pipefail
 
 DRY_RUN=0
-SCCACHE_DAYS=7
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1 ;;
-    --sccache-days) SCCACHE_DAYS="$2"; shift ;;
     *) echo "未知参数: $1" >&2; exit 2 ;;
   esac
   shift
@@ -35,9 +29,8 @@ done
 
 # 删除计数(按规则分组统计,便于审计日志;不用关联数组以兼容 macOS bash 3.2)
 STAT_A_CLOSED_PR=0
-STAT_B_SCCACHE_STALE=0
-STAT_C_CODEQL=0
-STAT_D_NODE=0
+STAT_B_CODEQL=0
+STAT_C_NODE=0
 DELETED_BYTES=0
 
 delete_cache() { # $1=id $2=key $3=size_bytes $4=rule
@@ -53,25 +46,21 @@ delete_cache() { # $1=id $2=key $3=size_bytes $4=rule
   fi
   # 仅在删除成功后计数(dry-run 为预估),避免删除失败仍计入"已释放"导致审计虚高
   case "$rule" in
-    A_closed_pr)     STAT_A_CLOSED_PR=$(( STAT_A_CLOSED_PR + 1 )) ;;
-    B_sccache_stale) STAT_B_SCCACHE_STALE=$(( STAT_B_SCCACHE_STALE + 1 )) ;;
-    C_codeql)        STAT_C_CODEQL=$(( STAT_C_CODEQL + 1 )) ;;
-    D_node)          STAT_D_NODE=$(( STAT_D_NODE + 1 )) ;;
+    A_closed_pr) STAT_A_CLOSED_PR=$(( STAT_A_CLOSED_PR + 1 )) ;;
+    B_codeql)    STAT_B_CODEQL=$(( STAT_B_CODEQL + 1 )) ;;
+    C_node)      STAT_C_NODE=$(( STAT_C_NODE + 1 )) ;;
   esac
   DELETED_BYTES=$(( DELETED_BYTES + size ))
 }
 
-NOW_EPOCH=$(date -u +%s)
-SCCACHE_CUTOFF=$(( NOW_EPOCH - SCCACHE_DAYS * 86400 ))
-
-echo "== 枚举缓存(dry-run=$DRY_RUN, sccache-days=$SCCACHE_DAYS) =="
+echo "== 枚举缓存(dry-run=$DRY_RUN) =="
 gh cache list --limit 5000 --json id,key,ref,createdAt,lastAccessedAt,sizeInBytes > /tmp/cache-janitor-list.json
 TOTAL=$(python3 -c "import json; d=json.load(open('/tmp/cache-janitor-list.json')); print(len(d))")
 echo "共 $TOTAL 个缓存条目"
 
 # ---------- 规则 A:已关闭/合并 PR 的全部缓存 ----------
 echo "== 规则 A:已关闭/合并 PR 的缓存 =="
-CLOSED_REFS=""   # 规则 B/C/D 需跳过这些 ref(已由本规则处理,避免误删保留项)
+CLOSED_REFS=""   # 规则 B/C 需跳过这些 ref(已由本规则处理,避免误删保留项)
 PR_REFS=$(python3 -c "
 import json
 refs = {c['ref'] for c in json.load(open('/tmp/cache-janitor-list.json')) if c['ref'].startswith('refs/pull/')}
@@ -97,29 +86,10 @@ for c in json.load(open('/tmp/cache-janitor-list.json')):
 done
 export CLOSED_REFS
 
-# ---------- 规则 B:陈旧 sccache 对象 ----------
-echo "== 规则 B:sccache 条目(最后访问超过 ${SCCACHE_DAYS} 天) =="
+# ---------- 规则 B:codeql-overlay 每语言留最新 1 份 ----------
+echo "== 规则 B:codeql-overlay 去重 =="
 while IFS=$'\t' read -r id size key; do
-  delete_cache "$id" "$key" "$size" "B_sccache_stale"
-done < <(python3 -c "
-import json, datetime, os
-closed = set(os.environ.get('CLOSED_REFS','').split())
-cutoff = $SCCACHE_CUTOFF
-def ts(c):
-    # 按最后访问时间判断热度:稳定依赖的对象创建很早但持续命中;
-    # lastAccessedAt 缺失时回退 createdAt
-    raw = c.get('lastAccessedAt') or c['createdAt']
-    return datetime.datetime.fromisoformat(raw.replace('Z','+00:00')).timestamp()
-for c in json.load(open('/tmp/cache-janitor-list.json')):
-    if not c['key'].startswith('sccache/'): continue
-    if c['ref'] in closed: continue
-    if ts(c) < cutoff: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
-")
-
-# ---------- 规则 C:codeql-overlay 每语言留最新 1 份 ----------
-echo "== 规则 C:codeql-overlay 去重 =="
-while IFS=$'\t' read -r id size key; do
-  delete_cache "$id" "$key" "$size" "C_codeql"
+  delete_cache "$id" "$key" "$size" "B_codeql"
 done < <(python3 -c "
 import json, os, re
 closed = set(os.environ.get('CLOSED_REFS','').split())
@@ -143,10 +113,10 @@ for group, items in groups.items():
     for c in items[1:]: print(f\"{c['id']}\t{c['sizeInBytes']}\t{c['key']}\")
 ")
 
-# ---------- 规则 D:node-cache 每平台留最新 1 份 ----------
-echo "== 规则 D:node-cache 去重 =="
+# ---------- 规则 C:node-cache 每平台留最新 1 份 ----------
+echo "== 规则 C:node-cache 去重 =="
 while IFS=$'\t' read -r id size key; do
-  delete_cache "$id" "$key" "$size" "D_node"
+  delete_cache "$id" "$key" "$size" "C_node"
 done < <(python3 -c "
 import json, os
 closed = set(os.environ.get('CLOSED_REFS','').split())
@@ -154,7 +124,7 @@ entries = [c for c in json.load(open('/tmp/cache-janitor-list.json')) if c['key'
 groups = {}
 for c in entries:
     # key 形如 node-cache-<platform>-npm-<hash>,平台段取 npm- 之前的部分
-    # 按 (平台, 作用域) 分组:同规则 C,跨 ref 只留最新会误删 main 的可用缓存。
+    # 按 (平台, 作用域) 分组:同规则 B,跨 ref 只留最新会误删 main 的可用缓存。
     platform = c['key'].split('-npm-')[0]
     groups.setdefault((platform, c['ref']), []).append(c)
 for group, items in groups.items():
@@ -163,5 +133,5 @@ for group, items in groups.items():
 ")
 
 echo "== 汇总 =="
-echo "A_closed_pr=$STAT_A_CLOSED_PR B_sccache_stale=$STAT_B_SCCACHE_STALE C_codeql=$STAT_C_CODEQL D_node=$STAT_D_NODE"
+echo "A_closed_pr=$STAT_A_CLOSED_PR B_codeql=$STAT_B_CODEQL C_node=$STAT_C_NODE"
 echo "释放空间约 $(( DELETED_BYTES / 1048576 ))MB(dry-run=$DRY_RUN)"

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -160,20 +160,8 @@ class CiGatePolicyTests(unittest.TestCase):
             rust_test,
         )
         self.assertIn(
-            "if: ${{ needs.changes.outputs.l1 == 'true' }}",
+            "needs.changes.outputs.l1 == 'true'",
             rust_test,
-        )
-
-    def test_windows_rust_test_wired_into_required_gate(self):
-        required_gate = self.pr_workflow.split("\n  required-gate:", maxsplit=1)[1]
-        self.assertIn("- windows-rust-test", required_gate)
-        self.assertIn(
-            "WINDOWS_RUST_RESULT: ${{ needs.windows-rust-test.result }}",
-            required_gate,
-        )
-        self.assertIn(
-            '"windows-rust-test:$WINDOWS_RUST_RESULT"',
-            required_gate,
         )
 
     def test_release_contract_runs_for_ready_pr_queue_and_main(self):


### PR DESCRIPTION
## 背景

对仓库全部 CI 过程做了一次彻底审计，按「完全无效的步骤」与「可合并/蕴含冗余的步骤」两条判据排查。本 PR 落地其中可立即安全修复的 7 项，分三个提交。

## 变更

### 提交 1 — cache-janitor sccache 死逻辑清理

sccache 在 #271 已从全部 workflow 移除（实测仓库缓存中 `sccache/` 条目为 0），cache-janitor 规则 B 永远匹配不到任何缓存。删除规则 B 及其 `--sccache-days` 选项、计数器、注释；原规则 C/D（codeql-overlay / node-cache）重编号为 B/C，逻辑不变。

- **`sccache/` 缓存实测**：`gh cache list` 返回 0 条（规则 B 无匹配对象）
- **保留**：规则 A（PR 清理）、新 B（codeql-overlay，CodeQL 经 GitHub default setup 启用，实测 3 条缓存）、新 C（node-cache）；main 的 `v0-rust-*` 暖 cache 保护不受影响

### 提交 2 — CI 配置修正（3 项）

1. **rustc-wrapper-smoke.yml checkout 统一**：`@v4` → `@v7`，与其余 22 处对齐，消除版本漂移。
2. **cargo-deny 触发缺口修复**：`rust-lint` job 的 `if` 从 `rust_code` 改为 `rust_code || rust_dependencies`。此前只改 `deny.toml` 时（`rust_code=false` 但 `rust_dependencies=true`），整个 job 不启动，cargo-deny 子步骤永不运行，deny.toml 策略改动静默漏检。
3. **release-contract-test 删除冗余 `sync-version --check`**：该命令由 `version-consistency` job 无路径门、全事件覆盖——凡 release-contract-test 运行时，version-consistency 必已在同一 SHA 上跑过同一 `--check`，结果必然一致且不产额外产物。保留 Tauri overlay 与各平台打包契约。

### 提交 3 — CI 精简优化（3 项）

1. **required-gate 删除 windows-rust-test 死引用**：windows-rust-test 仅 `push` 触发，required-gate 仅 PR/merge_group 运行，两者永不同时活跃，`WINDOWS_RUST_RESULT` 恒为 `skipped`，循环永远放行。删除 needs/env/循环三处引用，并删除 `test_ci_gate_policy.py` 中断言该接线的测试方法。
2. **windows-rust-test 删除平台无关 step**：该 job（`windows-latest`，冷编译约 32min 的昂贵 runner）原有一个 step 跑 `architecture-guard.py`（通用 Python 扫描）+ `tauri-layout`/`tauri-effective-config`（只读 JSON 的 Node 测试）——与 Windows 平台无关，属 runner 错配。删除后 windows-rust-test 纯做 Windows 原生编译验证（`cargo check --all-targets --features dev-tools` + `cargo test --lib --no-run`）。

   三项检查的覆盖关系（避免"删除后无人运行"的误读）：
   - **architecture-guard.py**：`fast-gate`（其唯一运行点）的 `if` 仅覆盖 PR/merge_group，不含 `push`。但所有合入 main 的代码必经 MQ（`ALLGREEN`），MQ 的 `merge_group` 已对同一代码运行过 architecture-guard；push(main) 设计为暖 cache 而非门禁，arch-guard 由 MQ 兜底。
   - **tauri-layout / tauri-effective-config**：这两个是 Tauri 配置契约测试（只读 JSON），与 `.rs` 源码改动无关。它们由 `release-contract-test`（ubuntu）按 `release_contract` 路径门控触发——即仅在 Tauri 配置/打包路径变更时运行，纯 Rust 源码合并不触发属更一致的收敛（删除前在 windows-rust-test 上对 `rust_code` 触发属过度覆盖）。
3. **rust-test 的 push(main) 改为仅编译暖 cache**：MQ 已对同一代码跑过完整 `cargo test --lib`，push(main) 唯一目的是暖 cache（`save-if: main`）。push 时改用 `cargo test --lib --no-run`（编译 test harness 产物供热 MQ restore 增量复用），并跳过 relay/Chrome 运行时依赖安装与 L1 harness 测试执行。MQ/PR 路径行为不变。

## 实际验证

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`：39 个测试全部通过
- YAML 语法校验（3 个 workflow）：全部有效
- `bash -n scripts/cache-janitor.sh` + `--dry-run` 实跑：正常，枚举到 17 个缓存

## 已知风险

- **Fix G（rust-test push 改 --no-run）**改变了 push(main) 的验证深度——但 push(main) 不再是合并门禁（MQ 已验证），仅暖 cache，测试执行在此冗余。若团队希望 push(main) 仍保留完整回归，可回退该项。
- **Fix E（required-gate 删 windows-rust-test 引用）**删除了一个契约测试方法；若团队希望保留"windows-rust-test 必须接入 required-gate"的前瞻性约束，可回退该项。windows-rust-test job 本身不受影响，仍在 push(main) 正常运行。
