### PR TITLE
fix(acp): 支持打开工作区资源并刷新文件树

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -313,6 +313,21 @@ pub async fn preview_codex_workspace_file(
 }
 
 #[tauri::command]
+pub async fn open_codex_workspace_resource(
+    session_id: String,
+    resource_path: String,
+    acp_pool: State<'_, AcpPool>,
+) -> Result<(), String> {
+    let root = codex_workspace_root(Some(&session_id), None, &acp_pool)?;
+    let path = workspace::resolve_workspace_resource(&root, &resource_path)
+        .map_err(|error| format!("打开 Codex 工作区资源失败: {error:#}"))?;
+    crate::platform::os::open_target(
+        crate::platform::os::external_application_path(&path),
+        "Codex 工作区资源",
+    )
+}
+
+#[tauri::command]
 pub async fn get_codex_workspace_changes(
     session_id: String,
     acp_pool: State<'_, AcpPool>,

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -257,6 +257,23 @@ pub fn preview_workspace_file(root: &Path, relative_path: &str) -> Result<Worksp
     })
 }
 
+pub fn resolve_workspace_resource(root: &Path, resource_path: &str) -> Result<PathBuf> {
+    let root = canonical_workspace(root)?;
+    let path = resource_path_from_uri(resource_path)?;
+    let candidate = if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    };
+    let canonical = fs::canonicalize(&candidate)
+        .with_context(|| format!("工作区资源不存在: {resource_path}"))?;
+    ensure_path_within_workspace(&root, &canonical)?;
+    if !canonical.is_file() {
+        bail!("工作区资源不是文件: {resource_path}");
+    }
+    Ok(canonical)
+}
+
 pub fn capture_baseline(session_id: &str, root: &Path) -> Result<()> {
     let root = canonical_workspace(root)?;
     let git = git_root(&root).is_some_and(|git_root| git_root == root);
@@ -634,6 +651,30 @@ fn normalize_relative_path(raw: &str) -> Result<String> {
         }
     }
     Ok(parts.join("/"))
+}
+
+fn resource_path_from_uri(raw: &str) -> Result<PathBuf> {
+    let value = raw.trim();
+    if value.is_empty() {
+        bail!("工作区资源路径不能为空");
+    }
+    if let Some(uri_path) = value.strip_prefix("file://") {
+        let bytes = uri_path.as_bytes();
+        let uri_path = if bytes.len() >= 3
+            && bytes[0] == b'/'
+            && bytes[1].is_ascii_alphabetic()
+            && bytes[2] == b':'
+        {
+            &uri_path[1..]
+        } else {
+            uri_path
+        };
+        return Ok(PathBuf::from(uri_path));
+    }
+    if value.contains("://") {
+        bail!("不支持的工作区资源链接");
+    }
+    Ok(PathBuf::from(value))
 }
 
 fn resolve_existing_path(root: &Path, relative: &str, directory: bool) -> Result<PathBuf> {
@@ -1226,6 +1267,28 @@ mod tests {
         let preview = preview_workspace_file(root.path(), "src/main.rs").unwrap();
         assert_eq!(preview.kind, "text");
         assert_eq!(preview.text.as_deref(), Some("fn main() {}"));
+    }
+
+    #[test]
+    fn resolves_workspace_resources_from_relative_absolute_and_file_uri_paths() {
+        let root = TestDir::new("resource-resolve");
+        let path = root.path().join("docs/report.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "# report\n").unwrap();
+
+        for resource in [
+            "docs/report.md".to_string(),
+            path.to_string_lossy().into_owned(),
+            format!("file://{}", path.to_string_lossy()),
+        ] {
+            assert_eq!(
+                resolve_workspace_resource(root.path(), &resource).unwrap(),
+                path
+            );
+        }
+        assert!(resolve_workspace_resource(root.path(), "https://example.com/report.md").is_err());
+        assert!(resolve_workspace_resource(root.path(), "../report.md").is_err());
+        assert!(resolve_workspace_resource(root.path(), "docs").is_err());
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -1275,6 +1275,7 @@ mod tests {
         let path = root.path().join("docs/report.md");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "# report\n").unwrap();
+        let path = fs::canonicalize(path).unwrap();
 
         for resource in [
             "docs/report.md".to_string(),

--- a/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/workspace.rs
@@ -658,18 +658,14 @@ fn resource_path_from_uri(raw: &str) -> Result<PathBuf> {
     if value.is_empty() {
         bail!("工作区资源路径不能为空");
     }
-    if let Some(uri_path) = value.strip_prefix("file://") {
-        let bytes = uri_path.as_bytes();
-        let uri_path = if bytes.len() >= 3
-            && bytes[0] == b'/'
-            && bytes[1].is_ascii_alphabetic()
-            && bytes[2] == b':'
-        {
-            &uri_path[1..]
-        } else {
-            uri_path
-        };
-        return Ok(PathBuf::from(uri_path));
+    if value
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("file://"))
+    {
+        let url = tauri::Url::parse(value).context("工作区资源文件链接无效")?;
+        return url
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("工作区资源文件链接无效"));
     }
     if value.contains("://") {
         bail!("不支持的工作区资源链接");
@@ -1272,15 +1268,15 @@ mod tests {
     #[test]
     fn resolves_workspace_resources_from_relative_absolute_and_file_uri_paths() {
         let root = TestDir::new("resource-resolve");
-        let path = root.path().join("docs/report.md");
+        let path = root.path().join("docs/report file.md");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "# report\n").unwrap();
         let path = fs::canonicalize(path).unwrap();
 
         for resource in [
-            "docs/report.md".to_string(),
+            "docs/report file.md".to_string(),
             path.to_string_lossy().into_owned(),
-            format!("file://{}", path.to_string_lossy()),
+            tauri::Url::from_file_path(&path).unwrap().to_string(),
         ] {
             assert_eq!(
                 resolve_workspace_resource(root.path(), &resource).unwrap(),

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -710,6 +710,7 @@ pub fn run() {
             commands::codex::list_codex_workspace,
             commands::codex::search_codex_workspace,
             commands::codex::preview_codex_workspace_file,
+            commands::codex::open_codex_workspace_resource,
             commands::codex::get_codex_workspace_changes,
             commands::codex::get_codex_workspace_diff,
             commands::codex::open_codex_workspace_file,

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -42,6 +42,7 @@ import {
   ConversationActivityIndicator,
   ConversationMarkdown,
   ConversationTurn,
+  WorkspaceResourceButtons,
 } from '../conversation/ConversationTimeline.jsx';
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 import { assistantResponseAvailable, assistantResponseText } from '../conversation/message-clipboard.js';
@@ -56,7 +57,11 @@ import {
 } from '../chat/composer-controls.jsx';
 import { visibleUserModels } from '../../shared/model-options.js';
 import { selectorMainLabel } from '../settings/model-catalog.js';
-import { isNearConversationBottom, toolWorkspaceResources } from '../conversation/conversation-model.js';
+import {
+  collectToolWorkspaceResources,
+  isNearConversationBottom,
+  toolWorkspaceResources,
+} from '../conversation/conversation-model.js';
 import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
 import { PlanLayer, cardBoxCls, cardBtnCls } from '../tools/tool-renderers.jsx';
 import { AttachmentChips } from '../attachments/AttachmentChips.jsx';
@@ -402,17 +407,7 @@ function GenericToolItem({ item, now, copy, cv, onOpenResource }) {
         meta={`${label} · ${state === 'running' ? `${copy.inProgress} · ${duration}` : state === 'failed' ? copy.failed : `${cv.ended} · ${duration}`}`}
         status={state} open={open} controlsId={detailsId}
         onToggle={() => setOpen(value => !value)} />
-      {resources.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
-          {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
-              disabled={!onOpenResource} title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
-              {resource.name}
-            </button>
-          ))}
-        </div>
-      )}
+      <WorkspaceResourceButtons resources={resources} onOpenResource={onOpenResource} />
       {open && (
         <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           <StructuredValue label={copy.arguments} value={tool.rawInput} />
@@ -433,14 +428,7 @@ function ToolGroup({ group, now, copy, cv, onOpenResource }) {
   const [open, setOpen] = useState(false);
   const detailsId = useId();
   const hasDetails = items.length > 0;
-  const resources = [];
-  const resourcePaths = new Set();
-  items.forEach(item => toolWorkspaceResources(item.tool).forEach(resource => {
-    if (!resourcePaths.has(resource.path)) {
-      resourcePaths.add(resource.path);
-      resources.push(resource);
-    }
-  }));
+  const resources = collectToolWorkspaceResources(items);
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
@@ -452,17 +440,7 @@ function ToolGroup({ group, now, copy, cv, onOpenResource }) {
         <span>{running ? copy.executing : failed ? cv.stepsFailed : copy.executionSteps} · {items.length}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
-      {resources.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
-          {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
-              disabled={!onOpenResource} title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
-              {resource.name}
-            </button>
-          ))}
-        </div>
-      )}
+      <WorkspaceResourceButtons resources={resources} onOpenResource={onOpenResource} />
       {open && hasDetails && (
         <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => item.type === 'command_execution'
@@ -2632,6 +2610,7 @@ export function CodexAcpView({
         <ConversationMarkdown
           text={item.legacyItem.text}
           onOpenExternal={(url) => invoke('open_user_external_url', { url }).catch(showError)}
+          onOpenResource={openWorkspaceResource}
         />
       );
     }

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -56,7 +56,7 @@ import {
 } from '../chat/composer-controls.jsx';
 import { visibleUserModels } from '../../shared/model-options.js';
 import { selectorMainLabel } from '../settings/model-catalog.js';
-import { isNearConversationBottom } from '../conversation/conversation-model.js';
+import { isNearConversationBottom, toolWorkspaceResources } from '../conversation/conversation-model.js';
 import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
 import { PlanLayer, cardBoxCls, cardBtnCls } from '../tools/tool-renderers.jsx';
 import { AttachmentChips } from '../attachments/AttachmentChips.jsx';
@@ -388,30 +388,33 @@ function CommandExecutionItem({ item, now, copy }) {
   );
 }
 
-function GenericToolItem({ item, now, copy, cv }) {
+function GenericToolItem({ item, now, copy, cv, onOpenResource }) {
   const tool = item.tool || {};
   const state = terminalStatus(item.status);
   const [open, setOpen] = useState(false);
   const detailsId = useId();
   const duration = copy.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const label = item.type === 'file_change' ? copy.fileChange : (tool.kind || cv.codexTool);
+  const resources = toolWorkspaceResources(tool);
   return (
     <div className="rounded-xl border border-black/[0.05] dark:border-white/[0.07] bg-white/45 dark:bg-white/[0.015]">
       <CompactItemRow icon={<Wrench size={13} />} title={tool.title || label}
         meta={`${label} · ${state === 'running' ? `${copy.inProgress} · ${duration}` : state === 'failed' ? copy.failed : `${cv.ended} · ${duration}`}`}
         status={state} open={open} controlsId={detailsId}
         onToggle={() => setOpen(value => !value)} />
+      {resources.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+          {resources.map(resource => (
+            <button type="button" key={resource.path} onClick={() => onOpenResource(resource.path)}
+              title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono hover:bg-blue-500/15">
+              {resource.name}
+            </button>
+          ))}
+        </div>
+      )}
       {open && (
         <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
-          {tool.locations && tool.locations.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {tool.locations.map((location, index) => (
-                <span key={index} className="px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono">
-                  {location.path || String(location)}
-                </span>
-              ))}
-            </div>
-          )}
           <StructuredValue label={copy.arguments} value={tool.rawInput} />
           <StructuredValue label={copy.result} value={tool.rawOutput != null ? tool.rawOutput : tool.content} />
         </div>
@@ -420,7 +423,7 @@ function GenericToolItem({ item, now, copy, cv }) {
   );
 }
 
-function ToolGroup({ group, now, copy, cv }) {
+function ToolGroup({ group, now, copy, cv, onOpenResource }) {
   const items = group.items || [];
   const running = items.some(item => terminalStatus(item.status) === 'running');
   const failed = items.some(item => terminalStatus(
@@ -430,6 +433,14 @@ function ToolGroup({ group, now, copy, cv }) {
   const [open, setOpen] = useState(false);
   const detailsId = useId();
   const hasDetails = items.length > 0;
+  const resources = [];
+  const resourcePaths = new Set();
+  items.forEach(item => toolWorkspaceResources(item.tool).forEach(resource => {
+    if (!resourcePaths.has(resource.path)) {
+      resourcePaths.add(resource.path);
+      resources.push(resource);
+    }
+  }));
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
@@ -441,11 +452,22 @@ function ToolGroup({ group, now, copy, cv }) {
         <span>{running ? copy.executing : failed ? cv.stepsFailed : copy.executionSteps} · {items.length}</span>
         <ChevronDown size={13} className={`ml-auto transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
+      {resources.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+          {resources.map(resource => (
+            <button type="button" key={resource.path} onClick={() => onOpenResource(resource.path)}
+              title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono hover:bg-blue-500/15">
+              {resource.name}
+            </button>
+          ))}
+        </div>
+      )}
       {open && hasDetails && (
         <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => item.type === 'command_execution'
             ? <CommandExecutionItem key={item.id} item={item} now={now} copy={copy} />
-            : <GenericToolItem key={item.id} item={item} now={now} copy={copy} cv={cv} />)}
+            : <GenericToolItem key={item.id} item={item} now={now} copy={copy} cv={cv} onOpenResource={onOpenResource} />)}
         </div>
       )}
     </div>
@@ -822,9 +844,10 @@ function TurnItem({
   onRespondElicitation,
   responding,
   onOpenExternal,
+  onOpenResource,
 }) {
   if (item.type === 'reasoning') return <ReasoningItem item={item} now={now} copy={copy} />;
-  if (item.type === 'tool_group') return <ToolGroup group={item} now={now} copy={copy} cv={cv} />;
+  if (item.type === 'tool_group') return <ToolGroup group={item} now={now} copy={copy} cv={cv} onOpenResource={onOpenResource} />;
   if (item.type === 'plan') return <PlanBlock plan={item.plan} copy={copy} />;
   if (item.type === 'permission') {
     return (
@@ -844,9 +867,9 @@ function TurnItem({
   if (item.type === 'agent_message') {
     const commentary = item.phase === 'commentary';
     return commentary
-      ? <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal}
+      ? <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} onOpenResource={onOpenResource}
           className="text-[13px] leading-6 text-gray-500 dark:text-gray-400" />
-      : <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} />;
+      : <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} onOpenResource={onOpenResource} />;
   }
   return null;
 }
@@ -864,6 +887,7 @@ function Turn({
   onRespondElicitation,
   responding,
   onOpenExternal,
+  onOpenResource,
 }) {
   const waitingPermission = turn.permissions.some(permission => !permission.resolved);
   const waitingInput = turn.elicitations.some(elicitation => !elicitation.resolved);
@@ -906,7 +930,7 @@ function Turn({
               agentName={agentName} copy={copy} cv={cv}
               pendingByTool={pendingByTool} pendingByElicitation={pendingByElicitation}
               onRespond={onRespond} onRespondElicitation={onRespondElicitation}
-              responding={responding} onOpenExternal={onOpenExternal} />
+              responding={responding} onOpenExternal={onOpenExternal} onOpenResource={onOpenResource} />
           ))}
           {!running && (assistantAvailable || turn.completedAt || turn.error) && <AssistantMessageFooter>
             {assistantAvailable && (
@@ -2663,6 +2687,18 @@ export function CodexAcpView({
     return undefined;
   }
 
+  async function openWorkspaceResource(resourcePath) {
+    if (!activeId || !resourcePath) return;
+    try {
+      await invoke('open_codex_workspace_resource', {
+        sessionId: activeId,
+        resourcePath: String(resourcePath),
+      });
+    } catch (err) {
+      showError(err);
+    }
+  }
+
   async function respond(toolCallId, optionId) {
     if (!activeId) return;
     setResponding(true); setError('');
@@ -2889,6 +2925,7 @@ export function CodexAcpView({
                         : undefined}
                     agentLabel={activeAgentName}
                     onOpenExternal={(url) => invoke('open_user_external_url', { url }).catch(showError)}
+                    onOpenResource={openWorkspaceResource}
                   />
                 )
               : (
@@ -2901,7 +2938,8 @@ export function CodexAcpView({
                     onRespond={respond}
                     onRespondElicitation={respondElicitation}
                     responding={responding}
-                    onOpenExternal={(url) => invoke('open_user_external_url', { url }).catch(showError)} />
+                    onOpenExternal={(url) => invoke('open_user_external_url', { url }).catch(showError)}
+                    onOpenResource={openWorkspaceResource} />
                 ))}
           </div>
         </div>

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -405,9 +405,9 @@ function GenericToolItem({ item, now, copy, cv, onOpenResource }) {
       {resources.length > 0 && (
         <div className="flex flex-wrap gap-1.5 px-3 pb-2">
           {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource(resource.path)}
-              title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono hover:bg-blue-500/15">
+            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
+              disabled={!onOpenResource} title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
               {resource.name}
             </button>
           ))}
@@ -455,9 +455,9 @@ function ToolGroup({ group, now, copy, cv, onOpenResource }) {
       {resources.length > 0 && (
         <div className="flex flex-wrap gap-1.5 px-3 pb-2">
           {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource(resource.path)}
-              title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono hover:bg-blue-500/15">
+            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
+              disabled={!onOpenResource} title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
               {resource.name}
             </button>
           ))}

--- a/pinvou3-app/src/features/codex/CodexWorkspacePanel.jsx
+++ b/pinvou3-app/src/features/codex/CodexWorkspacePanel.jsx
@@ -347,10 +347,29 @@ export function CodexWorkspacePanel({
     if (!sessionId || !refreshToken) return;
     const timer = window.setTimeout(() => {
       loadChanges();
-      if (visible && tab === 'files') loadDirectory('', { force: true });
+      if (visible && tab === 'files') {
+        const loadedDirectories = ['', ...expanded];
+        Promise.all(loadedDirectories.map(
+          path => loadDirectory(path, { force: true }),
+        ));
+      }
     }, 350);
     return () => window.clearTimeout(timer);
   }, [refreshToken, sessionId]);
+
+  useEffect(() => {
+    if (!visible || !browsable) return undefined;
+    const timer = window.setInterval(() => {
+      if (tab === 'files') {
+        const loadedDirectories = ['', ...expanded];
+        Promise.all(loadedDirectories.map(
+          path => loadDirectory(path, { force: true }),
+        ));
+      }
+      if (sessionId) loadChanges();
+    }, 2000);
+    return () => window.clearInterval(timer);
+  }, [visible, browsable, tab, sessionId, browsePath, expanded]);
 
   useEffect(() => {
     if (!browsable || !query.trim()) {

--- a/pinvou3-app/src/features/codex/CodexWorkspacePanel.jsx
+++ b/pinvou3-app/src/features/codex/CodexWorkspacePanel.jsx
@@ -355,18 +355,19 @@ export function CodexWorkspacePanel({
       }
     }, 350);
     return () => window.clearTimeout(timer);
-  }, [refreshToken, sessionId]);
+  }, [refreshToken, sessionId, visible, tab, expanded]);
 
   useEffect(() => {
     if (!visible || !browsable) return undefined;
     const timer = window.setInterval(() => {
+      if (document.visibilityState !== 'visible') return;
       if (tab === 'files') {
         const loadedDirectories = ['', ...expanded];
         Promise.all(loadedDirectories.map(
           path => loadDirectory(path, { force: true }),
         ));
       }
-      if (sessionId) loadChanges();
+      if (sessionId && tab === 'changes') loadChanges();
     }, 2000);
     return () => window.clearInterval(timer);
   }, [visible, browsable, tab, sessionId, browsePath, expanded]);

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -3,6 +3,10 @@ import {
   presentConversationItems,
   stripTerminalControlSequences,
 } from '../conversation/conversation-model.js';
+export {
+  toolWorkspaceResources,
+  workspaceMarkdownResource,
+} from '../conversation/conversation-model.js';
 
 function contentText(content) {
   if (!content) return '';

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -3,6 +3,7 @@ import {
   presentConversationItems,
   stripTerminalControlSequences,
 } from '../conversation/conversation-model.js';
+
 function contentText(content) {
   if (!content) return '';
   if (typeof content === 'string') return content;

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -3,11 +3,6 @@ import {
   presentConversationItems,
   stripTerminalControlSequences,
 } from '../conversation/conversation-model.js';
-export {
-  toolWorkspaceResources,
-  workspaceMarkdownResource,
-} from '../conversation/conversation-model.js';
-
 function contentText(content) {
   if (!content) return '';
   if (typeof content === 'string') return content;

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../components/icons.jsx';
 import {
   commandExecutionDetails,
+  collectToolWorkspaceResources,
   countsAsFailedOperation,
   elapsedMs,
   externalMarkdownUrl,
@@ -462,6 +463,21 @@ function FetchToolItem({ item, now, onOpenExternal, copy }) {
   );
 }
 
+export function WorkspaceResourceButtons({ resources, onOpenResource }) {
+  if (!resources.length) return null;
+  return (
+    <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+      {resources.map(resource => (
+        <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
+          disabled={!onOpenResource} title={resource.path}
+          className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
+          {resource.name}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 function GenericToolItem({ item, now, onOpenResource, copy }) {
   const c = conversationCopy(copy);
   const tool = item.tool || {};
@@ -477,17 +493,7 @@ function GenericToolItem({ item, now, onOpenResource, copy }) {
         meta={`${label} · ${state === 'running' ? `${c.inProgress} · ${duration}` : state === 'failed' ? c.failed : `${c.executionFinished} · ${duration}`}`}
         status={state} open={open} controlsId={detailsId}
         onToggle={() => setOpen(value => !value)} />
-      {resources.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
-          {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
-              disabled={!onOpenResource} title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
-              {resource.name}
-            </button>
-          ))}
-        </div>
-      )}
+      <WorkspaceResourceButtons resources={resources} onOpenResource={onOpenResource} />
       {open && (
         <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
           <StructuredValue label={c.arguments} value={tool.rawInput} />
@@ -538,14 +544,7 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, onOpenResource,
   const expanded = running || open;
   const detailsId = useId();
   const hasDetails = items.length > 0;
-  const resources = [];
-  const resourcePaths = new Set();
-  items.forEach(item => toolWorkspaceResources(item.tool).forEach(resource => {
-    if (!resourcePaths.has(resource.path)) {
-      resourcePaths.add(resource.path);
-      resources.push(resource);
-    }
-  }));
+  const resources = collectToolWorkspaceResources(items);
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
@@ -557,17 +556,7 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, onOpenResource,
         <span className="min-w-0 flex-1 truncate">{summary}</span>
         <ChevronDown size={13} className={`shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
       </button>
-      {resources.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
-          {resources.map(resource => (
-            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
-              disabled={!onOpenResource} title={resource.path}
-              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
-              {resource.name}
-            </button>
-          ))}
-        </div>
-      )}
+      <WorkspaceResourceButtons resources={resources} onOpenResource={onOpenResource} />
       {expanded && hasDetails && (
         <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => (

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -19,6 +19,8 @@ import {
   isSearchTool,
   searchToolDetails,
   terminalStatus,
+  toolWorkspaceResources,
+  workspaceMarkdownResource,
 } from './conversation-model.js';
 import { AssistantMessageActions, AssistantMessageFooter } from './AssistantMessageActions.jsx';
 import { assistantResponseAvailable, assistantResponseText } from './message-clipboard.js';
@@ -115,7 +117,7 @@ function localizedSemanticLabel(value, copy) {
   }[value] || value;
 }
 
-export function ConversationMarkdown({ text, className = '', onOpenExternal }) {
+export function ConversationMarkdown({ text, className = '', onOpenExternal, onOpenResource }) {
   const html = useMemo(() => renderMarkdown(text), [text]);
   const openLink = (event) => {
     const anchor = event.target && event.target.closest && event.target.closest('a[href]');
@@ -125,6 +127,10 @@ export function ConversationMarkdown({ text, className = '', onOpenExternal }) {
     event.preventDefault();
     const external = externalMarkdownUrl(href);
     if (external && onOpenExternal) onOpenExternal(external);
+    else {
+      const resource = workspaceMarkdownResource(href);
+      if (resource && onOpenResource) onOpenResource(resource);
+    }
   };
   return (
     <div
@@ -456,7 +462,7 @@ function FetchToolItem({ item, now, onOpenExternal, copy }) {
   );
 }
 
-function GenericToolItem({ item, now, copy }) {
+function GenericToolItem({ item, now, onOpenResource, copy }) {
   const c = conversationCopy(copy);
   const tool = item.tool || {};
   const state = terminalStatus(item.status);
@@ -464,23 +470,26 @@ function GenericToolItem({ item, now, copy }) {
   const detailsId = useId();
   const duration = c.elapsed(elapsedMs(item.startedAt, item.completedAt, now));
   const label = item.type === 'file_change' ? c.fileChange : (tool.kind || c.tool);
+  const resources = toolWorkspaceResources(tool);
   return (
     <div className="rounded-xl border border-black/[0.05] dark:border-white/[0.07] bg-white/45 dark:bg-white/[0.015]">
       <CompactItemRow icon={<Wrench size={13} />} title={localizedSemanticLabel(tool.title || label, c)}
         meta={`${label} · ${state === 'running' ? `${c.inProgress} · ${duration}` : state === 'failed' ? c.failed : `${c.executionFinished} · ${duration}`}`}
         status={state} open={open} controlsId={detailsId}
         onToggle={() => setOpen(value => !value)} />
+      {resources.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+          {resources.map(resource => (
+            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
+              disabled={!onOpenResource} title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
+              {resource.name}
+            </button>
+          ))}
+        </div>
+      )}
       {open && (
         <div id={detailsId} data-testid="conversation-compact-item-content" className="px-3 pb-3 border-t border-black/[0.05] dark:border-white/[0.06]">
-          {tool.locations && tool.locations.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {tool.locations.map((location, index) => (
-                <span key={index} className="px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono">
-                  {location.path || String(location)}
-                </span>
-              ))}
-            </div>
-          )}
           <StructuredValue label={c.arguments} value={tool.rawInput} />
           <StructuredValue label={c.result} value={tool.rawOutput != null ? tool.rawOutput : tool.content} />
         </div>
@@ -489,7 +498,7 @@ function GenericToolItem({ item, now, copy }) {
   );
 }
 
-function ToolItem({ item, now, renderToolItem, onOpenExternal, copy }) {
+function ToolItem({ item, now, renderToolItem, onOpenExternal, onOpenResource, copy }) {
   const custom = renderToolItem && renderToolItem(item);
   if (custom !== undefined) return custom;
   if (item.type === 'command_execution') {
@@ -501,7 +510,7 @@ function ToolItem({ item, now, renderToolItem, onOpenExternal, copy }) {
   if (isFetchTool(item.tool)) {
     return <FetchToolItem item={item} now={now} onOpenExternal={onOpenExternal} copy={copy} />;
   }
-  return <GenericToolItem item={item} now={now} copy={copy} />;
+  return <GenericToolItem item={item} now={now} onOpenResource={onOpenResource} copy={copy} />;
 }
 
 function runningToolLabel(item, copy) {
@@ -514,7 +523,7 @@ function runningToolLabel(item, copy) {
   return name || copy.tool;
 }
 
-function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
+function ToolGroup({ group, now, renderToolItem, onOpenExternal, onOpenResource, copy }) {
   const c = conversationCopy(copy);
   const items = group.items || [];
   const running = items.some(item => terminalStatus(item.status) === 'running');
@@ -529,6 +538,14 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
   const expanded = running || open;
   const detailsId = useId();
   const hasDetails = items.length > 0;
+  const resources = [];
+  const resourcePaths = new Set();
+  items.forEach(item => toolWorkspaceResources(item.tool).forEach(resource => {
+    if (!resourcePaths.has(resource.path)) {
+      resourcePaths.add(resource.path);
+      resources.push(resource);
+    }
+  }));
   return (
     <div className="min-w-0 max-w-full">
       <button type="button" onClick={() => setOpen(value => !value)}
@@ -540,6 +557,17 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
         <span className="min-w-0 flex-1 truncate">{summary}</span>
         <ChevronDown size={13} className={`shrink-0 transition-transform ${expanded ? 'rotate-180' : ''}`} />
       </button>
+      {resources.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-3 pb-2">
+          {resources.map(resource => (
+            <button type="button" key={resource.path} onClick={() => onOpenResource && onOpenResource(resource.path)}
+              disabled={!onOpenResource} title={resource.path}
+              className="max-w-full truncate px-2 py-1 rounded-lg bg-blue-500/8 text-[10px] text-blue-600 dark:text-blue-300 font-mono enabled:hover:bg-blue-500/15 disabled:cursor-default">
+              {resource.name}
+            </button>
+          ))}
+        </div>
+      )}
       {expanded && hasDetails && (
         <div id={detailsId} data-testid="conversation-tool-group-content" className="min-w-0 max-w-full ml-3 pl-3 border-l border-black/[0.06] dark:border-white/[0.08] space-y-1.5 pb-1">
           {items.map(item => (
@@ -549,6 +577,7 @@ function ToolGroup({ group, now, renderToolItem, onOpenExternal, copy }) {
               now={now}
               renderToolItem={renderToolItem}
               onOpenExternal={onOpenExternal}
+              onOpenResource={onOpenResource}
               copy={c}
             />
           ))}
@@ -659,6 +688,7 @@ function DefaultItem({
   responding,
   renderToolItem,
   onOpenExternal,
+  onOpenResource,
   agentLabel,
   copy,
 }) {
@@ -670,6 +700,7 @@ function DefaultItem({
         now={now}
         renderToolItem={renderToolItem}
         onOpenExternal={onOpenExternal}
+        onOpenResource={onOpenResource}
         copy={copy}
       />
     );
@@ -681,6 +712,7 @@ function DefaultItem({
         now={now}
         renderToolItem={renderToolItem}
         onOpenExternal={onOpenExternal}
+        onOpenResource={onOpenResource}
         copy={copy}
       />
     );
@@ -701,9 +733,9 @@ function DefaultItem({
   if (item.type === 'agent_message') {
     const commentary = item.phase === 'commentary';
     return commentary
-      ? <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal}
+      ? <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} onOpenResource={onOpenResource}
           className="text-[13px] leading-6 text-gray-500 dark:text-gray-400" />
-      : <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} />;
+      : <ConversationMarkdown text={item.text} onOpenExternal={onOpenExternal} onOpenResource={onOpenResource} />;
   }
   return null;
 }
@@ -718,6 +750,7 @@ export function ConversationTurn({
   renderItem,
   renderToolItem,
   onOpenExternal,
+  onOpenResource,
   agentLabel = 'Agent',
   assistantAvatar,
   copy,
@@ -799,6 +832,7 @@ export function ConversationTurn({
                 responding={responding}
                 renderToolItem={renderToolItem}
                 onOpenExternal={onOpenExternal}
+                onOpenResource={onOpenResource}
                 agentLabel={agentLabel}
                 copy={c}
               />

--- a/pinvou3-app/src/features/conversation/conversation-model.js
+++ b/pinvou3-app/src/features/conversation/conversation-model.js
@@ -105,6 +105,19 @@ export function toolWorkspaceResources(tool) {
   return resources;
 }
 
+export function collectToolWorkspaceResources(items) {
+  const resources = [];
+  const seen = new Set();
+  for (const item of items || []) {
+    for (const resource of toolWorkspaceResources(item.tool)) {
+      if (seen.has(resource.path)) continue;
+      seen.add(resource.path);
+      resources.push(resource);
+    }
+  }
+  return resources;
+}
+
 export function isNearConversationBottom(element, threshold = 96) {
   if (!element) return true;
   return (element.scrollHeight - element.scrollTop - element.clientHeight) < threshold;

--- a/pinvou3-app/src/features/conversation/conversation-model.js
+++ b/pinvou3-app/src/features/conversation/conversation-model.js
@@ -74,6 +74,37 @@ export function externalMarkdownUrl(value) {
   return /^https?:\/\/[^\s]+$/i.test(url) ? url : '';
 }
 
+export function workspaceMarkdownResource(value) {
+  const path = String(value || '').trim();
+  if (!path || path.startsWith('#') || /^(?:https?|mailto|tel|data|javascript):/i.test(path)) return '';
+  return path;
+}
+
+export function toolWorkspaceResources(tool) {
+  const resources = [];
+  const seen = new Set();
+  const add = (value, name = '') => {
+    const path = String(value || '').trim();
+    if (!path || seen.has(path)) return;
+    seen.add(path);
+    const basename = path.split(/[\\/]/).pop() || path;
+    const label = String(name || '').trim();
+    resources.push({ path, name: !label || label === path ? basename : label });
+  };
+  for (const location of tool && tool.locations || []) {
+    add(location && typeof location === 'object' ? location.path : location);
+  }
+  const visit = (value) => {
+    if (!value || typeof value !== 'object') return;
+    if (value.type === 'resource_link') add(value.uri, value.name);
+    if (value.type === 'diff') add(value.path);
+    if (Array.isArray(value)) value.forEach(visit);
+    else Object.values(value).forEach(visit);
+  };
+  visit(tool && tool.content);
+  return resources;
+}
+
 export function isNearConversationBottom(element, threshold = 96) {
   if (!element) return true;
   return (element.scrollHeight - element.scrollTop - element.clientHeight) < threshold;

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -37,6 +37,8 @@ try {
     projectAcpTimeline,
     resolveAcpSessionControls,
     stripTerminalControlSequences,
+    toolWorkspaceResources,
+    workspaceMarkdownResource,
   } = await import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`);
   const events = [
     event(1, 'user_message', {
@@ -193,6 +195,21 @@ try {
     'Unknown JSON field: \"baseRefOid\"\nworktree /workspace/pinvou3\n',
     'command output must not render ANSI colors or OSC hyperlinks as garbage',
   );
+
+  assert.equal(workspaceMarkdownResource('docs/report.md'), 'docs/report.md');
+  assert.equal(workspaceMarkdownResource('file:///workspace/report.md'), 'file:///workspace/report.md');
+  assert.equal(workspaceMarkdownResource('https://example.com/report.md'), '');
+  assert.deepEqual(toolWorkspaceResources({
+    locations: [{ path: '/workspace/docs/report.md' }],
+    content: [
+      { type: 'content', content: { type: 'resource_link', name: '/workspace/docs/diagram.svg', uri: '/workspace/docs/diagram.svg' } },
+      { type: 'diff', path: '/workspace/docs/generated.svg' },
+    ],
+  }), [
+    { path: '/workspace/docs/report.md', name: 'report.md' },
+    { path: '/workspace/docs/diagram.svg', name: 'diagram.svg' },
+    { path: '/workspace/docs/generated.svg', name: 'generated.svg' },
+  ]);
   assert.equal(
     stripTerminalControlSequences('\u009b32m✓ passed\u009b0m'),
     '✓ passed',
@@ -358,6 +375,11 @@ try {
     && conversationView.includes('max-h-80 max-w-full overflow-auto whitespace-pre'),
   'reasoning, plan, permission, and terminal content must stay within both timeline implementations');
   assert.ok(codexView.includes("directory: true"), 'new Codex sessions must expose a native directory picker');
+  assert.ok(codexView.includes("open_codex_workspace_resource")
+    && conversationView.includes('onOpenResource={onOpenResource}')
+    && codexWorkspace.includes("const loadedDirectories = ['', ...expanded]")
+    && codexWorkspace.includes('window.setInterval'),
+  'ACP workspace resources must open in the preview and event refreshes must reload expanded directories');
   assert.ok(codexView.includes('workspacePath'), 'selected project directory must reach the Tauri command');
   assert.ok(!codexView.includes('data-testid="acp-agent-selector"')
     && codexView.includes('onCodeAgentChange={selectDraftAgent}')

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -39,6 +39,7 @@ try {
     stripTerminalControlSequences,
   } = await import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`);
   const {
+    collectToolWorkspaceResources,
     toolWorkspaceResources,
     workspaceMarkdownResource,
   } = await import(`${pathToFileURL(path.join(conversationDir, 'conversation-model.js')).href}?t=${Date.now()}`);
@@ -211,6 +212,13 @@ try {
     { path: '/workspace/docs/report.md', name: 'report.md' },
     { path: '/workspace/docs/diagram.svg', name: 'diagram.svg' },
     { path: '/workspace/docs/generated.svg', name: 'generated.svg' },
+  ]);
+  assert.deepEqual(collectToolWorkspaceResources([
+    { tool: { locations: [{ path: '/workspace/docs/report.md' }] } },
+    { tool: { locations: [{ path: '/workspace/docs/report.md' }, { path: '/workspace/docs/diagram.svg' }] } },
+  ]), [
+    { path: '/workspace/docs/report.md', name: 'report.md' },
+    { path: '/workspace/docs/diagram.svg', name: 'diagram.svg' },
   ]);
   assert.equal(
     stripTerminalControlSequences('\u009b32m✓ passed\u009b0m'),

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -37,9 +37,11 @@ try {
     projectAcpTimeline,
     resolveAcpSessionControls,
     stripTerminalControlSequences,
+  } = await import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`);
+  const {
     toolWorkspaceResources,
     workspaceMarkdownResource,
-  } = await import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`);
+  } = await import(`${pathToFileURL(path.join(conversationDir, 'conversation-model.js')).href}?t=${Date.now()}`);
   const events = [
     event(1, 'user_message', {
       content: [{ type: 'text', text: '修改 README' }],
@@ -378,7 +380,8 @@ try {
   assert.ok(codexView.includes("open_codex_workspace_resource")
     && conversationView.includes('onOpenResource={onOpenResource}')
     && codexWorkspace.includes("const loadedDirectories = ['', ...expanded]")
-    && codexWorkspace.includes('window.setInterval'),
+    && codexWorkspace.includes("document.visibilityState !== 'visible'")
+    && codexWorkspace.includes("sessionId && tab === 'changes'"),
   'ACP workspace resources must open in the preview and event refreshes must reload expanded directories');
   assert.ok(codexView.includes('workspacePath'), 'selected project directory must reach the Tauri command');
   assert.ok(!codexView.includes('data-testid="acp-agent-selector"')


### PR DESCRIPTION
## 背景

ACP 工具事件中的本地资源此前只能显示路径，无法直接打开；同时工作区文件树只刷新根目录，Agent 修改已展开目录后可能仍显示旧内容。

## 变更

- 统一提取 `locations`、`resource_link`、`diff.path` 和本地 Markdown 链接，并在会话中提供资源按钮
- 后端校验资源真实存在、属于当前会话工作区且为文件，再交由系统默认应用打开
- ACP 事件触发时刷新根目录及已展开目录，并在面板可见时每 2 秒对账
- 后台窗口跳过轮询，仅在“变更”页签轮询 `git status`
- 补充资源提取、路径校验和刷新行为测试

## 验证

- `npm run test:codex-acp`
- `npm run lint:ui`
- `npm run build:ui`
- `python3 scripts/architecture-guard.py`
- `cargo fmt --all -- --check`
- `cargo test resolves_workspace_resources_from_relative_absolute_and_file_uri_paths --lib`
- `git diff --check origin/main...HEAD`

## 已知风险

- 文件面板前台可见期间会每 2 秒读取当前页签所需状态；未引入递归文件系统 watcher。