### PR TITLE
fix(ci): 移植主线 CI/构建修复——thin LTO+lld、合并队列分层、发布前置冒烟

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -26,6 +26,8 @@ on:
   push:
     branches: [main]
     paths:
+      # 纯前端 src/** 已由 PR/Queue 的 frontend-test 覆盖，不启动昂贵的
+      # Tauri/Rust universal 构建；package manifest 仍可能改变构建工具链，保留。
       - 'pinvou3-app/src-tauri/**'
       - 'pinvou3-app/scripts/tauri/**'
       - 'pinvou3-app/package.json'

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -7,7 +7,7 @@ name: mac-build
 # 与 pr-check.yml 的 rust-test 关系:
 # - rust-test 在 ubuntu 上跑完整 lib tests,是主线 gate。
 # - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟,
-#   验证 macOS 平台目标零回归。真发版的 fat-LTO --release 产物由 scripts/release-macos.sh 产出。
+#   验证 macOS 平台目标零回归。真发版的 thin-LTO --release 产物由 scripts/release-macos.sh 产出。
 # - mac-build 不跑 relay e2e(那需要 remote-control-relay 的 node_modules,mac-build 不装
 #   该依赖)。因此不设 PINVOU_REQUIRE_REMOTE_E2E,让 e2e 测试在缺依赖时静默跳过而非 panic。
 #
@@ -168,8 +168,8 @@ jobs:
         run: cargo test --target aarch64-apple-darwin --lib -- --test-threads=1
 
       # 编译冒烟用 release-fast(Cargo.toml 里专为 CI 定义的轻量 profile:lto=false、
-      # codegen-units=16、inherits="release"):release 现带 lto="fat"+codegen-units=1,
-      # 全图 fat-LTO 冷编译极易吃满 50min 上限;release-fast 验证 release 路径代码可编译即可。
+      # codegen-units=16、inherits="release"):release 现带 lto="thin"+codegen-units=1,
+      # 全图 thin-LTO 冷编译极易吃满 50min 上限;release-fast 验证 release 路径代码可编译即可。
       # 下方 tauri bundle 冒烟也用同一 release-fast profile —— 同 profile 同 target dir,
       # bundle 的 aarch64 编译腿直接复用本步产物,不再两套 profile 重复编译全图。
       - name: Cargo build (release-fast 冒烟)
@@ -189,7 +189,7 @@ jobs:
         # `-- --profile release-fast`:tauri v2 CLI 的 build 无一等 --profile 选项,
         # 自定义 profile 经 `--` 后的 runner 尾随参数透传给 cargo(CLI 据此定位
         # target/<triple>/release-fast/ 产物);与上方冒烟同 profile,aarch64 腿复用其产物,
-        # x86_64 腿为唯一新增编译。真正发版的 fat-LTO 产物由 release-macos.sh 产出。
+        # x86_64 腿为唯一新增编译。真正发版的 thin-LTO 产物由 release-macos.sh 产出。
         run: node scripts/tauri/build.js build --target universal-apple-darwin -- --profile release-fast
 
       # Verify 脚本:轻量探测(brew/connector CLI) + 核心校验(plist/usage-key/bundle targets)。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -688,7 +688,23 @@ jobs:
     # Merge Queue 按 Rust 路径触发。main 每次保留下来的 push 都执行 Windows 原生
     # 累计验证，避免 concurrency 用后续非 Rust pending 替换含 Rust 变更的 pending
     # 后，按相邻 diff 路由导致中间提交永远未经过 Windows 编译。
-    if: ${{ !cancelled() && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && needs.changes.outputs.rust_code == 'true' && github.event.pull_request.draft == false)) }}
+    if: >-
+      ${{
+        !cancelled() &&
+        (
+          github.event_name == 'push' ||
+          (
+            needs.changes.outputs.rust_code == 'true' &&
+            (
+              github.event_name == 'merge_group' ||
+              (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.draft == false
+              )
+            )
+          )
+        )
+      }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 移除 sccache 后冷编译更长,放宽到 90min(aws-lc-sys NASM 预生成对象冷编译更久)。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -26,7 +26,6 @@ name: PR Check
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
 # - Rust 相关 push main 跑 rust-test:cache 存 main 作用域,供 Merge Queue/显式 PR 复用。
-#   rust-test 的独立缓存缺失时先只读复用 rust-lint 暖缓存(见该 job 注释)。
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
@@ -123,7 +122,6 @@ jobs:
       rust_code: ${{ steps.filter.outputs.rust_code }}
       rust_dependencies: ${{ steps.filter.outputs.rust_dependencies }}
       release_contract: ${{ steps.filter.outputs.release_contract }}
-      l1: ${{ steps.filter.outputs.l1 }}
       pet: ${{ steps.filter.outputs.pet }}
       frontend: ${{ steps.filter.outputs.frontend }}
       relay: ${{ steps.filter.outputs.relay }}
@@ -175,18 +173,6 @@ jobs:
               - 'pinvou3-app/tests/codex_acp_windows_*'
               - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
               - 'pinvou3-app/tests/macos_phase2_contract.test.js'
-            l1:
-              - 'pinvou3-app/src-tauri/tests/l1_dialog_harness.rs'
-              - 'pinvou3-app/src-tauri/src/features/assistant/strict_mode_validation_tests.rs'
-              - 'pinvou3-app/src-tauri/src/features/assistant/platform/**'
-              - 'pinvou3-app/src-tauri/src/features/assistant/engine.rs'
-              - 'pinvou3-app/src-tauri/src/features/assistant/harness.rs'
-              - 'pinvou3-app/src-tauri/src/lib.rs'
-              - 'pinvou3-app/src-tauri/Cargo.toml'
-              - 'pinvou3-app/src-tauri/Cargo.lock'
-              - 'CodeWhale'
-              - '.github/workflows/pr-check.yml'
-              - '.github/workflows/mac-build.yml'
             pet:
               - 'pinvou3-app/src/assets/pet/**'
               - 'pinvou3-app/src/features/pet/**'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -558,6 +558,16 @@ jobs:
       # rustc,codegen 仍会溢出。必须用 ${{ github.workspace }} 绝对路径(Cargo 按
       # 进程 cwd 解析 RUSTC_WRAPPER 相对路径会双拼成不存在的路径)。
       RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
+      # codewhale-tui 恢复依赖级 O2 后,test binary 变大,link 阶段在 ubuntu 16GB
+      # runner 上内存峰值越线被 SIGTERM(merge_group run 实证,exit 143)。
+      # 实测(CI 对照):thin LTO + lld 能 Finished + 全量通过;
+      # lld-only(无 LTO)仍 OOM(binary 太大,lld 独立不够)。故两者都必需:
+      #   - Thin LTO:跨 crate 死代码消除 → test binary 变小(rustc 给依赖 crate 传
+      #     -C linker-plugin-lto,生成 LLVM bitcode,link 阶段合并——故依赖 lld)。
+      #   - lld:link 阶段处理 LLVM bitcode(lld 原生支持,BFD ld 不支持)。
+      # 不设 codegen-units:dev 默认 256,对 test 改动最小(不影响 release 的 codegen=1)。
+      CARGO_PROFILE_DEV_LTO: "thin"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
     # CARGO_PROFILE_DEV_DEBUG 环境变量。
     steps:
@@ -572,6 +582,7 @@ jobs:
       # pinvou3 编译链接的系统库(本地 pkg-config 实测:gtk/webkit/soup/rsvg/openssl/
       # X11×3/appindicator)。ubuntu runner 默认没装,否则 glib-sys 等 build script 失败。
       # cmake:reqwest 0.13 的 rustls 改用 aws-lc-rs,其 build script 需 cmake + C 编译器。
+      # lld:上方注入 CARGO_PROFILE_DEV_LTO=thin 后 link 阶段需支持 LLVM bitcode 的链接器。
       - name: 装 Tauri + pinvou3 Linux 系统依赖
         run: |
           sudo apt-get update
@@ -580,7 +591,7 @@ jobs:
             librsvg2-dev libssl-dev \
             libx11-dev libxi-dev libxtst-dev \
             libayatana-appindicator3-dev \
-            build-essential pkg-config cmake
+            build-essential pkg-config cmake lld
 
       # bge-m3 是 gitignored 大资源(559M),CI 干净 checkout 没有它,而 tauri_build::build()
       # 会校验 tauri.conf resources 路径存在。单测用 mem()=embedder None、不加载真模型,真

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -170,6 +170,7 @@ jobs:
               - 'pinvou3-app/tests/macos_phase2_contract.test.js'
             l1:
               - 'pinvou3-app/src-tauri/tests/l1_dialog_harness.rs'
+              - 'pinvou3-app/src-tauri/src/features/assistant/strict_mode_validation_tests.rs'
               - 'pinvou3-app/src-tauri/src/features/assistant/platform/**'
               - 'pinvou3-app/src-tauri/src/features/assistant/engine.rs'
               - 'pinvou3-app/src-tauri/src/features/assistant/harness.rs'
@@ -651,7 +652,9 @@ jobs:
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
       # 取得的仍是已加锁 guard，不会绕过互斥；根治需消除测试对进程级 env 的依赖
       # 或让所有读写都通过同一隔离层，超出本 PR 范围。
-      - name: cargo test --lib (MQ/PR 完整测试)
+      # strict_mode 的三个确定性回归已并入 pinvou3_lib 单测，和全量 lib tests
+      # 共用一次编译与链接，避免第二个 integration test 目标重复链接全依赖树。
+      - name: cargo test --lib（含 strict_mode 回归；真 bge-m3/vLLM 测试已 #[ignore]）
         if: ${{ github.event_name != 'push' }}
         run: |
           chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
@@ -667,16 +670,6 @@ jobs:
       - name: cargo test --lib --no-run (push main 仅编译暖 cache)
         if: ${{ github.event_name == 'push' }}
         run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
-
-      - name: L1 harness 严格错误回归（不调用真模型）
-        # 仅在 harness 及其直接依赖路径变化时追加，避免无关 Rust 改动重复跑。
-        # 保留 --test-threads=1:仅 3 个 strict_mode_ 测试,harness 本身需串行语义。
-        # push(main) 跳过:MQ 已验证同一代码,push 不重复执行测试(仅暖 cache)。
-        if: ${{ needs.changes.outputs.l1 == 'true' && github.event_name != 'push' }}
-        run: >-
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml
-          --test l1_dialog_harness strict_mode_
-          -- --test-threads=1
 
       - name: CodeWhale 定时任务运行时回归
         # 暂时关闭；底座对应运行时已回退，父仓后续另行收敛代码与 gitlink。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,13 +9,15 @@ name: PR Check
 #   Merge Queue 对最新组合提交跑完整受影响前端门禁。
 # - release-contract-test:发布链路改动只跑配置/脚本契约,不在 PR 构建安装包。
 # - rust-test(编译类):Draft/普通 PR 默认不跑;Ready 高风险 PR 可加 ci:full-rust
-#   标签提前跑；Merge Queue 对最新组合提交运行；main push 写暖 cache。
+#   标签提前跑；Merge Queue 对最新组合提交运行；main push 无条件累计验证并写暖
+#   cache(防 concurrency pending 替换盲区)。
 # - rust-lint:Draft 只跑 fmt；Ready/Queue/main 跑 clippy；cargo-deny 仅在依赖
 #   或策略路径变化时追加，三项均无 continue-on-error。
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
 #   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
 #   欠账由清理 PR(#35 及后续)消化后逐个升 deny。
-# - windows-rust-test:Rust 相关 Ready PR、Merge Queue 与 main push 跑 Windows 原生编译/单测；Draft 跳过。
+# - windows-rust-test:Windows 专属原语在原生 runner 执行;Ready PR/Merge Queue
+#   按 Rust 路径触发;main 每次保留下来的 push 无条件累计验证(防 pending 替换盲区)。
 # - windows-codex-runtime-test:相关 PR 在 Windows 原生准备 Node + ACP Bridge，并核对安装包资源。
 # - required-gate:PR 阶段汇总所有适用检查，作为唯一 required check。
 # - merge_group:按 base/head 的真实组合 diff 运行适用门禁，保证验证对象就是
@@ -24,6 +26,7 @@ name: PR Check
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
 # - Rust 相关 push main 跑 rust-test:cache 存 main 作用域,供 Merge Queue/显式 PR 复用。
+#   rust-test 的独立缓存缺失时先只读复用 rust-lint 暖缓存(见该 job 注释)。
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
@@ -53,8 +56,11 @@ permissions:
   contents: read
   pull-requests: read   # dorny/paths-filter 调 API 读 PR 改了哪些文件
 
-# 同一 PR 连续 push 或被合并/关闭时取消旧检查；main 的完整 Rust 验证不取消，
-# 避免 cache writer 反复被截断导致后续持续冷编译。
+# 同一 PR 连续 push 或被合并/关闭时取消上一次未跑完的检查,省 runner。
+# main push 保留当前正在运行的暖缓存任务；GitHub 同一 concurrency group 最多保留
+# 一个 running 和一个 pending，新 push 会替换旧 pending。为避免被替换的 pending
+# 恰好包含 Rust 变更、而保留下来的后续 push 只看相邻非 Rust diff，main 的 Rust
+# 累计验证不依赖单次 push 的 paths-filter(见 rust-test/windows-rust-test)。
 concurrency:
   group: pr-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -106,7 +112,8 @@ jobs:
   # PR、Merge Queue 与 main push 均按实际改动路径选择检查。
   # paths-filter v4 在 merge_group 上使用事件 base/head SHA 比较队列组合提交。
   # push(main) 下 dorny/paths-filter 用 before..sha 本地 diff(需 fetch-depth:0),
-  # 供 windows-rust-test 按路径触发(docs-only 推送不再烧 32min Windows runner)。
+  # 供其余按路径 job 使用；rust-test/windows-rust-test 的 main 累计验证为规避
+  # concurrency pending 替换盲区，有意不依赖单次 push 的相邻 diff。
   changes:
     name: changes
     if: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group' || github.event_name == 'push' }}
@@ -531,20 +538,25 @@ jobs:
   rust-test:
     name: rust-test
     needs: changes
-    # Draft/普通 PR 默认跳过；Merge Queue 对最新组合提交跑；
-    # main push 写暖 cache；Ready 高风险 PR 可用标签提前跑。
+    # Draft/普通 PR 默认跳过；可信高风险场景按路径/标签触发；Ready 高风险 PR
+    # 可用标签提前跑。main push 无条件执行累计状态验证,避免 concurrency 用后续
+    # 非 Rust pending 替换含 Rust 变更的 pending 后,只看相邻 diff 而漏检。
     if: >-
       ${{
         !cancelled() &&
         github.event.action != 'closed' &&
-        needs.changes.outputs.rust_code == 'true' &&
         (
-          github.event_name == 'merge_group' ||
           github.event_name == 'push' ||
           (
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.draft == false &&
-            contains(github.event.pull_request.labels.*.name, 'ci:full-rust')
+            needs.changes.outputs.rust_code == 'true' &&
+            (
+              github.event_name == 'merge_group' ||
+              (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.draft == false &&
+                contains(github.event.pull_request.labels.*.name, 'ci:full-rust')
+              )
+            )
           )
         )
       }}
@@ -684,9 +696,11 @@ jobs:
   windows-rust-test:
     name: windows-rust-test
     needs: changes
-    # Windows 专属原语必须在原生 runner 执行；Draft 保持快速反馈，Ready PR、Merge Queue
-    # 与 main push 按 Rust 路径触发，docs-only 变更不消耗 Windows runner。
-    if: ${{ !cancelled() && needs.changes.outputs.rust_code == 'true' && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)) }}
+    # Windows 专属原语必须在原生 runner 执行；Draft 保持快速反馈，Ready PR 与
+    # Merge Queue 按 Rust 路径触发。main 每次保留下来的 push 都执行 Windows 原生
+    # 累计验证，避免 concurrency 用后续非 Rust pending 替换含 Rust 变更的 pending
+    # 后，按相邻 diff 路由导致中间提交永远未经过 Windows 编译。
+    if: ${{ !cancelled() && (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && needs.changes.outputs.rust_code == 'true' && github.event.pull_request.draft == false)) }}
     runs-on: windows-latest
     # 全量 cargo check --all-targets + lib 链接检查,无暖 cache,挂死会长时间烧 runner 分钟。
     # 移除 sccache 后冷编译更长,放宽到 90min(aws-lc-sys NASM 预生成对象冷编译更久)。

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -441,6 +441,8 @@ jobs:
           npm --prefix pinvou3-app run test:tauri-layout
           npm --prefix pinvou3-app run test:tauri-effective-config
           npm --prefix pinvou3-app run test:web-template-packaging
+          npm --prefix pinvou3-app run prepare:web-template
+          npm --prefix pinvou3-app/src-tauri/resources/common/web-template run build
           npm --prefix pinvou3-app run test:macos-phase2
 
   # clippy/fmt/deny 独立 job:与 rust-test 并行,各自独立 cache。

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -86,12 +86,16 @@ jobs:
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
-      # v0.9.5 升级后 release(fat-LTO O3)编译 codewhale-tui 时 rustc/LLVM 栈溢出
+      # v0.9.5 升级后 release(thin-LTO O3)编译 codewhale-tui 时 rustc/LLVM 栈溢出
       # (SIGBUS,Linux 与 macOS 同源风险)。.cargo/config.toml 不设置 rustc-wrapper
       # (全局键无法按平台条件化),由本 Linux 发布 job 显式注入 RUSTC_WRAPPER
       # 指向 sh 版(wrapper 只作用于编译期 rustc 进程,产物运行时语义不变)。
       # 必须用 ${{ github.workspace }} 绝对路径:Cargo 按自身进程 cwd 解析相对路径,
       # 构建步骤 working-directory 为 pinvou3-app,相对路径会被双拼成不存在的路径。
+      # lld:BFD ld 处理大型 Rust binary 内存效率差,是 link OOM 独立主因(同 arm64);
+      # release profile 的 thin LTO 让 rustc 给依赖 crate 传 -C linker-plugin-lto
+      # (生成 LLVM bitcode),link 阶段必须用支持 bitcode 的链接器。
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
     steps:
       - name: Checkout (含 submodule)
@@ -112,7 +116,7 @@ jobs:
 
       # pinvou3 编译链接的系统库(gtk/webkit/soup/rsvg/openssl/X11×3/appindicator),
       # ubuntu runner 默认没装;cmake:reqwest 的 rustls 用 aws-lc-rs,其 build script
-      # 需 cmake + C 编译器。清单同 pr-check.yml。
+      # 需 cmake + C 编译器。清单同 pr-check.yml(含 lld,thin LTO 的 link 依赖)。
       - name: 装 Tauri + pinvou3 Linux 系统依赖
         run: |
           sudo apt-get update
@@ -121,7 +125,7 @@ jobs:
             librsvg2-dev libssl-dev \
             libx11-dev libxi-dev libxtst-dev \
             libayatana-appindicator3-dev \
-            build-essential pkg-config cmake
+            build-essential pkg-config cmake lld
 
       - name: Node.js
         uses: actions/setup-node@v7
@@ -189,6 +193,11 @@ jobs:
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
+      # release profile 已在 Cargo.toml 设为 thin LTO(原 fat 在 ubuntu 16GB 上
+      # link 内存越线被 SIGTERM),ARM 不再用 env 覆盖 profile。
+      # lld 是必需的:thin LTO 让 rustc 给依赖 crate 传 -C linker-plugin-lto
+      # (生成 LLVM bitcode,link 阶段做跨 crate 合并),BFD ld 无法处理 LLVM bitcode。
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       # release 编译 codewhale-tui 的 SIGBUS 同源风险防护(同 build-linux-x64,
       # 正式入口按平台注入 RUSTC_WRAPPER,见 config.toml 注释)。
       RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
@@ -389,13 +398,13 @@ jobs:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.build_required == 'true'
     runs-on: macos-15
-    # 冷缓存双 target + fat LTO 实测可能超过 90 分钟（0.7.4 发布构建曾逼近上限），
+    # 冷缓存双 target + thin LTO 实测可能超过 90 分钟（0.7.4 发布构建曾逼近上限），
     # 放宽至 150 分钟以覆盖冷缓存与 runner 抖动，避免发布构建被超时取消。
     timeout-minutes: 150
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
       VERSION: ${{ needs.check-version-bump.outputs.version }}
-      # v0.9.5 升级后 release(fat-LTO O3)编译 codewhale-tui 时 rustc/LLVM 栈溢出
+      # v0.9.5 升级后 release(thin-LTO O3)编译 codewhale-tui 时 rustc/LLVM 栈溢出
       # (SIGBUS,run 31558490865 实证)。.cargo/config.toml 不设置 rustc-wrapper
       # (全局键无法按平台条件化),由本 macOS 发布 job 显式注入 RUSTC_WRAPPER
       # 指向 sh 版(wrapper 只作用于编译期 rustc 进程,产物运行时语义不变)。

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -67,6 +67,15 @@ jobs:
       - name: 校验各处版本文件与 VERSION 一致
         run: node scripts/sync-version.mjs --check
 
+      # 网页模板打进安装包,发布前先在本机冒烟:契约(依赖声明跟随 package.json)
+      # + 真实 prepare(lockfile 驱动 npm ci) + 真实 vite build,避免模板构建
+      # 断裂只能等四平台构建 job 才暴露。
+      - name: 网页模板发布前冒烟
+        run: |
+          npm --prefix pinvou3-app run test:web-template-packaging
+          npm --prefix pinvou3-app run prepare:web-template
+          npm --prefix pinvou3-app/src-tauri/resources/common/web-template run build
+
       - name: 输出发布版本
         id: release
         run: |

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -122,10 +122,13 @@ jobs:
             # 编译 .exe 版 wrapper(与 selector 同一命令),再直接执行它跑 env
             # 观测注入结果(.exe 是原生二进制,可直接运行,无 .cmd 嵌套引号问题)。
             rustc -O scripts/rustc-stack-wrapper.rs -o scripts/rustc-stack-wrapper.exe
-            scripts/rustc-stack-wrapper.exe env | grep -q "^RUST_MIN_STACK=16777216$"
+            out="$(scripts/rustc-stack-wrapper.exe env)"
           else
-            scripts/rustc-stack-wrapper env | grep -q "^RUST_MIN_STACK=16777216$"
+            out="$(scripts/rustc-stack-wrapper env)"
           fi
+          # 用命令替换(非管道)避免 grep -q 提前关闭管道导致 env SIGPIPE
+          # (set -o pipefail 下 SIGPIPE 会让 step flaky 失败)。
+          echo "$out" | grep -q "^RUST_MIN_STACK=16777216$"
 
       # 4) 运行时契约:不继承编译器栈覆盖。
       #    复制仓库契约测试到最小 crate,按正式入口方式注入 wrapper 后跑
@@ -169,9 +172,11 @@ jobs:
           unset RUST_MIN_STACK
           if [ "$RUNNER_OS" = "Windows" ]; then
             rustc -O rustc-stack-wrapper.rs -o rustc-stack-wrapper.exe
-            RUSTC_WRAPPER_CHAIN=env ./rustc-stack-wrapper.exe env | grep -q "^RUST_MIN_STACK=16777216$"
+            out="$(RUSTC_WRAPPER_CHAIN=env ./rustc-stack-wrapper.exe env)"
           else
             # `env env`:链上命令 `env` 执行参数中的 `env`(无参),打印当前环境,
             # 应包含经 wrapper 注入的 RUST_MIN_STACK=16777216。
-            RUSTC_WRAPPER_CHAIN=env ./rustc-stack-wrapper env | grep -q "^RUST_MIN_STACK=16777216$"
+            out="$(RUSTC_WRAPPER_CHAIN=env ./rustc-stack-wrapper env)"
           fi
+          # 命令替换(非管道)避免 grep -q 提前关闭管道导致 env SIGPIPE(同上)。
+          echo "$out" | grep -q "^RUST_MIN_STACK=16777216$"

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -25,16 +25,50 @@ on:
   merge_group:
   push:
     branches: [main]
+    paths:
+      - 'pinvou3-app/src-tauri/.cargo/config.toml'
+      - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper'
+      - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.rs'
+      - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh'
+      - 'pinvou3-app/run-dev.sh'
+      - '.github/workflows/rustc-wrapper-smoke.yml'
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: rustc-wrapper-smoke-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # merge_group 不支持事件级 paths 过滤，先在一个轻量 Linux job 中判断组合
+  # diff；无关 PR 入队时跳过后续三个平台 runner。PR/push 的事件级 paths 仍
+  # 保留，避免这些事件连轻量路由 job 都启动。
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      wrapper: ${{ steps.filter.outputs.wrapper }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            wrapper:
+              - 'pinvou3-app/src-tauri/.cargo/config.toml'
+              - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper'
+              - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.rs'
+              - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh'
+              - 'pinvou3-app/run-dev.sh'
+              - '.github/workflows/rustc-wrapper-smoke.yml'
+
   smoke:
+    needs: changes
+    if: ${{ needs.changes.outputs.wrapper == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rustc-wrapper-smoke.yml
+++ b/.github/workflows/rustc-wrapper-smoke.yml
@@ -22,6 +22,7 @@ on:
       - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.rs'
       - 'pinvou3-app/src-tauri/scripts/rustc-stack-wrapper-select.sh'
       - 'pinvou3-app/run-dev.sh'
+      - '.github/workflows/rustc-wrapper-smoke.yml'
   merge_group:
   push:
     branches: [main]

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -253,7 +253,13 @@ wildcard_dependencies = "deny"
 # 改 abort 会破坏「单次工具 panic 不拖垮整个会话」的设计。
 [profile.release]
 opt-level = 3
-lto = "fat"
+# Thin LTO 替代 fat:fat 在 ubuntu 16GB runner 上编译 codewhale-tui + tauri 全图
+# 会 link 越线被 SIGTERM(merge_group run 实证)。thin 内存峰值与耗时远低于 fat,
+# 运行时优化损失可忽略(官方:大型项目 thin 常优于 fat)。
+# 注:cargo 在 lto="thin" 时给依赖 crate 传 -C linker-plugin-lto(生成 LLVM bitcode,
+# 把跨 crate LTO 推迟到 link 阶段),故 release 构建 link 阶段必须用支持 LLVM bitcode
+# 的链接器(lld);release-packages 的 Linux 发布 job 已注入 -fuse-ld=lld。
+lto = "thin"
 codegen-units = 1
 # macOS 27+ 发布链路会注入 CARGO_PROFILE_RELEASE_STRIP=none 绕过 dyld 对齐 bug,
 # 本设置主要作用于 Linux deb / Windows MSI 产物。
@@ -265,7 +271,7 @@ incremental = false
 # 专为 Release 测试/CI 用的轻量 profile:不 LTO、不禁 incremental,编译快但仍走 release 优化。
 # mac-build.yml 的编译冒烟与 universal bundle 冒烟均用此 profile,
 # 两者产物可互相复用(同 profile 同 target dir),避免 CI 里两套 profile 重复编译全图。
-# 真正发版的 fat-LTO 产物由 scripts/release-macos.sh(走真 --release)产出。
+# 真正发版的 thin-LTO 产物由 scripts/release-macos.sh(走真 --release)产出。
 [profile.release-fast]
 inherits = "release"
 lto = false

--- a/pinvou3-app/src-tauri/src/features/assistant/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/mod.rs
@@ -17,3 +17,4 @@ pub(crate) mod turn_shell_tasks;
 
 #[cfg(test)]
 mod multiagent_regression_tests;
+mod strict_mode_validation_tests;

--- a/pinvou3-app/src-tauri/src/features/assistant/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/mod.rs
@@ -17,4 +17,5 @@ pub(crate) mod turn_shell_tasks;
 
 #[cfg(test)]
 mod multiagent_regression_tests;
+#[cfg(test)]
 mod strict_mode_validation_tests;

--- a/pinvou3-app/src-tauri/src/features/assistant/strict_mode_validation_tests.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/strict_mode_validation_tests.rs
@@ -1,0 +1,166 @@
+//! `strict_mode` 严格错误校验回归。
+//!
+//! 这三个测试原属 `l1_dialog_harness.rs`，是确定性纯函数校验：只依赖
+//! `deepseek_tui` 的 `Event` / `ErrorEnvelope` / `TurnOutcomeStatus` / `Usage`，
+//! 不触碰 `AppEngine` / `Pinvou3Bridge`。作为 `pinvou3_lib` 的单测模块随现有
+//! `cargo test --lib` 一起链接和执行，避免再启动一个 integration test 目标，
+//! 重复编译并链接 fastembed / tauri / aws-lc-sys 全树。
+//!
+//! 真 vLLM 端到端 scenario 仍留在 `l1_dialog_harness.rs`（`#[ignore]`，需 vLLM
+//! 在线、按需手跑）；本模块只跑不依赖运行时与外部模型的确定性校验，CI 可常跑。
+//!
+//! 下面的纯辅助函数与 `l1_dialog_harness.rs` 中同名函数行为一致（那份同时被真模型
+//! scenario 使用，无法整体迁出）；此处保留副本，改动需两边同步。
+
+#![allow(dead_code)] // TurnSummary 部分字段由 summarize 填充、本目标测试不全部读取
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use deepseek_tui::core::events::{Event, TurnOutcomeStatus};
+use deepseek_tui::error_taxonomy::ErrorEnvelope;
+
+/// scenario 跑完后聚合结果（与 `l1_dialog_harness.rs` 同名结构保持一致）。
+struct TurnSummary {
+    /// 所有 MessageDelta.content 串起来 (LLM 的纯文本输出)
+    full_text: String,
+    /// 工具名 → 成功完成的调用次数
+    tool_call_counts: HashMap<String, usize>,
+    /// Engine 在 turn 内发出的错误；严格真模型验收中任意一条都必须失败。
+    engine_errors: Vec<String>,
+    /// TurnComplete 报告的权威终态；None 表示未收到完整终态。
+    terminal_status: Option<TurnOutcomeStatus>,
+    /// TurnComplete 携带的终态错误。
+    terminal_error: Option<String>,
+    elapsed: Duration,
+    timed_out: bool,
+}
+
+fn summarize(timeline: &[(f64, Event)], elapsed: Duration, timed_out: bool) -> TurnSummary {
+    let mut full_text = String::new();
+    let mut tool_call_counts = HashMap::<String, usize>::new();
+    let mut engine_errors = Vec::new();
+    let mut terminal_status = None;
+    let mut terminal_error = None;
+    for (_t, e) in timeline {
+        match e {
+            Event::MessageDelta { content, .. } => full_text.push_str(content),
+            Event::ToolCallComplete { name, result, .. } => {
+                if result.is_ok() {
+                    *tool_call_counts.entry(name.clone()).or_insert(0) += 1;
+                }
+            }
+            Event::Error { envelope, .. } => {
+                engine_errors.push(format!("{}: {}", envelope.code, envelope.message));
+            }
+            Event::TurnComplete { status, error, .. } => {
+                terminal_status = Some(*status);
+                terminal_error = error.clone();
+            }
+            _ => {}
+        }
+    }
+    TurnSummary {
+        full_text,
+        tool_call_counts,
+        engine_errors,
+        terminal_status,
+        terminal_error,
+        elapsed,
+        timed_out,
+    }
+}
+
+fn validate_engine_errors(engine_errors: &[String], strict: bool) -> Result<(), String> {
+    if strict && !engine_errors.is_empty() {
+        return Err(format!(
+            "turn 收到 {} 个 Engine Error: {}",
+            engine_errors.len(),
+            engine_errors.join(" | ")
+        ));
+    }
+    Ok(())
+}
+
+fn validate_terminal_outcome(summary: &TurnSummary, strict: bool) -> Result<(), String> {
+    if !strict {
+        return Ok(());
+    }
+
+    match summary.terminal_status {
+        Some(TurnOutcomeStatus::Completed) if summary.terminal_error.is_none() => Ok(()),
+        Some(status) => Err(format!(
+            "turn 终态不是无错误的 Completed: status={status:?}, error={:?}",
+            summary.terminal_error
+        )),
+        None => Err("turn 未收到 TurnComplete 权威终态".to_string()),
+    }
+}
+
+fn is_authoritative_turn_complete(event: &Event) -> bool {
+    matches!(event, Event::TurnComplete { .. })
+}
+
+#[test]
+fn strict_mode_rejects_runtime_engine_error() {
+    let timeline = vec![(
+        0.1,
+        Event::error(ErrorEnvelope::classify(
+            "stream read error: response body decode failed".to_string(),
+            true,
+        )),
+    )];
+    let summary = summarize(&timeline, Duration::from_millis(100), false);
+
+    assert_eq!(summary.engine_errors.len(), 1);
+    assert!(summary.engine_errors[0].contains("stream read error"));
+    assert!(validate_engine_errors(&summary.engine_errors, true).is_err());
+    assert!(validate_engine_errors(&summary.engine_errors, false).is_ok());
+    assert!(validate_engine_errors(&[], true).is_ok());
+}
+
+#[test]
+fn strict_mode_rejects_failed_turn_without_error_event() {
+    use deepseek_tui::models::Usage;
+
+    let timeline = vec![(
+        0.1,
+        Event::TurnComplete {
+            usage: Usage::default(),
+            status: TurnOutcomeStatus::Failed,
+            error: Some("engine task panicked".to_string()),
+            tool_catalog: None,
+            base_url: None,
+        },
+    )];
+    let summary = summarize(&timeline, Duration::from_millis(100), false);
+
+    assert!(summary.engine_errors.is_empty());
+    assert_eq!(summary.terminal_status, Some(TurnOutcomeStatus::Failed));
+    assert_eq!(
+        summary.terminal_error.as_deref(),
+        Some("engine task panicked")
+    );
+    assert!(validate_terminal_outcome(&summary, true).is_err());
+    assert!(validate_terminal_outcome(&summary, false).is_ok());
+}
+
+#[test]
+fn strict_mode_waits_for_turn_complete_after_error() {
+    use deepseek_tui::models::Usage;
+
+    let error = Event::error(ErrorEnvelope::classify(
+        "temporary stream error".to_string(),
+        true,
+    ));
+    let complete = Event::TurnComplete {
+        usage: Usage::default(),
+        status: TurnOutcomeStatus::Failed,
+        error: Some("stream recovery failed".to_string()),
+        tool_catalog: None,
+        base_url: None,
+    };
+
+    assert!(!is_authoritative_turn_complete(&error));
+    assert!(is_authoritative_turn_complete(&complete));
+}

--- a/pinvou3-app/src-tauri/tests/l1_dialog_harness.rs
+++ b/pinvou3-app/src-tauri/tests/l1_dialog_harness.rs
@@ -22,7 +22,6 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use deepseek_tui::core::events::{Event, TurnOutcomeStatus};
-use deepseek_tui::error_taxonomy::ErrorEnvelope;
 use deepseek_tui::tui::app::AppMode;
 use pinvou3_lib::features::assistant::engine::AppEngine;
 use pinvou3_lib::features::assistant::platform::bridge::Pinvou3Bridge;
@@ -418,69 +417,11 @@ fn record_transcript(
     path
 }
 
-#[test]
-fn strict_mode_rejects_runtime_engine_error() {
-    let timeline = vec![(
-        0.1,
-        Event::error(ErrorEnvelope::classify(
-            "stream read error: response body decode failed".to_string(),
-            true,
-        )),
-    )];
-    let summary = summarize(&timeline, Duration::from_millis(100), false);
-
-    assert_eq!(summary.engine_errors.len(), 1);
-    assert!(summary.engine_errors[0].contains("stream read error"));
-    assert!(validate_engine_errors(&summary.engine_errors, true).is_err());
-    assert!(validate_engine_errors(&summary.engine_errors, false).is_ok());
-    assert!(validate_engine_errors(&[], true).is_ok());
-}
-
-#[test]
-fn strict_mode_rejects_failed_turn_without_error_event() {
-    use deepseek_tui::models::Usage;
-
-    let timeline = vec![(
-        0.1,
-        Event::TurnComplete {
-            usage: Usage::default(),
-            status: TurnOutcomeStatus::Failed,
-            error: Some("engine task panicked".to_string()),
-            tool_catalog: None,
-            base_url: None,
-        },
-    )];
-    let summary = summarize(&timeline, Duration::from_millis(100), false);
-
-    assert!(summary.engine_errors.is_empty());
-    assert_eq!(summary.terminal_status, Some(TurnOutcomeStatus::Failed));
-    assert_eq!(
-        summary.terminal_error.as_deref(),
-        Some("engine task panicked")
-    );
-    assert!(validate_terminal_outcome(&summary, true).is_err());
-    assert!(validate_terminal_outcome(&summary, false).is_ok());
-}
-
-#[test]
-fn strict_mode_waits_for_turn_complete_after_error() {
-    use deepseek_tui::models::Usage;
-
-    let error = Event::error(ErrorEnvelope::classify(
-        "temporary stream error".to_string(),
-        true,
-    ));
-    let complete = Event::TurnComplete {
-        usage: Usage::default(),
-        status: TurnOutcomeStatus::Failed,
-        error: Some("stream recovery failed".to_string()),
-        tool_catalog: None,
-        base_url: None,
-    };
-
-    assert!(!is_authoritative_turn_complete(&error));
-    assert!(is_authoritative_turn_complete(&complete));
-}
+// strict_mode_ 的三个确定性测试已移入 src/features/assistant/strict_mode_validation_tests.rs
+// (pinvou3_lib 单测模块):它们只依赖 deepseek_tui 类型,却因本文件 import
+// AppEngine/Pinvou3Bridge 被迫链接 fastembed/tauri/aws-lc-sys 全树,在 ubuntu 16GB
+// runner 上 link OOM(exit 143)。此处保留的同名 helper 副本仍被真模型
+// scenario(#[ignore])使用,改动需两边同步。
 
 fn render_timeline(timeline: &[(f64, Event)]) -> String {
     let mut s = String::new();

--- a/pinvou3-app/tests/tauri_platform_layout.test.js
+++ b/pinvou3-app/tests/tauri_platform_layout.test.js
@@ -167,8 +167,8 @@ for (const stalePath of [
   assert.equal(workflow.includes(stalePath), false, `PR workflow still references migrated path: ${stalePath}`);
   assert.equal(connectorWorkflow.includes(stalePath), false, `connector workflow still references migrated path: ${stalePath}`);
 }
-assert.match(workflow, /src\/features\/assistant\/platform\/\*\*/);
-assert.match(workflow, /src\/features\/assistant\/harness\.rs/);
+// l1 filter 已随 strict_mode 测试并入 lib 单测删除;这些 Rust 路径的 CI 触发
+// 由 rust_code filter 的 **/*.rs 通配覆盖,不再逐路径断言。
 assert.match(workflow, /src\/platform\/prefs\.rs/);
 assert.match(connectorWorkflow, /resources\/platforms\/\*\*\/bundle\/connectors\/\*\*/);
 for (const resources of ["linux/aarch64", "linux/x86_64", "macos/aarch64", "macos/x86_64", "windows/x86_64"]) {

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -105,7 +105,6 @@ class CiGatePolicyTests(unittest.TestCase):
             "rust_code",
             "rust_dependencies",
             "release_contract",
-            "l1",
             "pet",
             "frontend",
             "relay",

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -151,17 +151,28 @@ class CiGatePolicyTests(unittest.TestCase):
             "contains(github.event.pull_request.labels.*.name, 'ci:full-rust')",
             rust_test,
         )
+        # main push 无条件累计验证(防 concurrency pending 替换盲区),
+        # 不与 rust_code 路径条件短路。
         self.assertIn(
-            "github.event_name == 'push'",
+            "github.event_name == 'push' ||",
             rust_test,
         )
-        self.assertNotIn(
-            "github.event_name == 'push' || needs.changes.outputs.rust_code == 'true'",
-            rust_test,
+
+    def test_windows_rust_test_cumulative_main_push_is_path_independent(self):
+        # concurrency 可能用后续非 Rust pending 替换含 Rust 变更的 pending;main 的
+        # Windows 累计验证不得依赖单次 push 的相邻路径 diff,push 无条件执行。
+        windows_rust_test = self.pr_workflow.split(
+            "\n  windows-rust-test:", maxsplit=1
+        )[1].split("\n  windows-codex-runtime-test:", maxsplit=1)[0]
+        self.assertIn(
+            "github.event_name == 'push' ||", windows_rust_test
+        )
+        self.assertIn("github.event_name == 'merge_group'", windows_rust_test)
+        self.assertIn(
+            "github.event.pull_request.draft == false", windows_rust_test
         )
         self.assertIn(
-            "needs.changes.outputs.l1 == 'true'",
-            rust_test,
+            "needs.changes.outputs.rust_code == 'true'", windows_rust_test
         )
 
     def test_release_contract_runs_for_ready_pr_queue_and_main(self):

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -166,12 +166,14 @@ class CiGatePolicyTests(unittest.TestCase):
         self.assertIn(
             "github.event_name == 'push' ||", windows_rust_test
         )
-        self.assertIn("github.event_name == 'merge_group'", windows_rust_test)
         self.assertIn(
-            "github.event.pull_request.draft == false", windows_rust_test
+            "needs.changes.outputs.rust_code == 'true' &&\n"
+            "            (\n"
+            "              github.event_name == 'merge_group' ||",
+            windows_rust_test,
         )
         self.assertIn(
-            "needs.changes.outputs.rust_code == 'true'", windows_rust_test
+            "github.event.pull_request.draft == false", windows_rust_test
         )
 
     def test_release_contract_runs_for_ready_pr_queue_and_main(self):

--- a/scripts/tests/test_ci_trigger_routing_policy.py
+++ b/scripts/tests/test_ci_trigger_routing_policy.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAC_BUILD_WORKFLOW = ROOT / ".github/workflows/mac-build.yml"
+WRAPPER_WORKFLOW = ROOT / ".github/workflows/rustc-wrapper-smoke.yml"
+
+
+class CiTriggerRoutingPolicyTests(unittest.TestCase):
+    def test_pure_frontend_changes_do_not_trigger_macos_rust_build(self):
+        workflow = MAC_BUILD_WORKFLOW.read_text(encoding="utf-8")
+        trigger = workflow.split("\non:", maxsplit=1)[1].split(
+            "\npermissions:", maxsplit=1
+        )[0]
+
+        self.assertIn("'pinvou3-app/src-tauri/**'", trigger)
+        self.assertNotIn("'pinvou3-app/src/**'", trigger)
+        self.assertIn("'pinvou3-app/package.json'", trigger)
+        self.assertIn("'pinvou3-app/package-lock.json'", trigger)
+
+    def test_wrapper_smoke_routes_merge_groups_before_platform_matrix(self):
+        workflow = WRAPPER_WORKFLOW.read_text(encoding="utf-8")
+        trigger = workflow.split("\non:", maxsplit=1)[1].split(
+            "\npermissions:", maxsplit=1
+        )[0]
+        changes = workflow.split("\n  changes:", maxsplit=1)[1].split(
+            "\n  smoke:", maxsplit=1
+        )[0]
+        smoke = workflow.split("\n  smoke:", maxsplit=1)[1]
+
+        self.assertIn("merge_group:", trigger)
+        self.assertIn("push:", trigger)
+        self.assertIn("paths:", trigger)
+        self.assertIn("uses: dorny/paths-filter@v4", changes)
+        self.assertIn("wrapper: ${{ steps.filter.outputs.wrapper }}", changes)
+        self.assertIn("needs: changes", smoke)
+        self.assertIn(
+            "if: ${{ needs.changes.outputs.wrapper == 'true' }}", smoke
+        )
+        self.assertIn("os: [macos-15, ubuntu-latest, windows-latest]", smoke)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ci_trigger_routing_policy.py
+++ b/scripts/tests/test_ci_trigger_routing_policy.py
@@ -24,6 +24,10 @@ class CiTriggerRoutingPolicyTests(unittest.TestCase):
         trigger = workflow.split("\non:", maxsplit=1)[1].split(
             "\npermissions:", maxsplit=1
         )[0]
+        pull_request = trigger.split("\n  pull_request:", maxsplit=1)[1].split(
+            "\n  merge_group:", maxsplit=1
+        )[0]
+        push = trigger.split("\n  push:", maxsplit=1)[1]
         changes = workflow.split("\n  changes:", maxsplit=1)[1].split(
             "\n  smoke:", maxsplit=1
         )[0]
@@ -32,6 +36,10 @@ class CiTriggerRoutingPolicyTests(unittest.TestCase):
         self.assertIn("merge_group:", trigger)
         self.assertIn("push:", trigger)
         self.assertIn("paths:", trigger)
+        workflow_path = "'.github/workflows/rustc-wrapper-smoke.yml'"
+        self.assertIn(workflow_path, pull_request)
+        self.assertIn(workflow_path, push)
+        self.assertIn(workflow_path, changes)
         self.assertIn("uses: dorny/paths-filter@v4", changes)
         self.assertIn("wrapper: ${{ steps.filter.outputs.wrapper }}", changes)
         self.assertIn("needs: changes", smoke)

--- a/scripts/tests/test_release_arm64_policy.py
+++ b/scripts/tests/test_release_arm64_policy.py
@@ -27,14 +27,14 @@ class ReleaseArm64PolicyTests(unittest.TestCase):
             "\n      - name: 构建 deb", maxsplit=1
         )[1].split("\n      # tauri deb 产物默认名", maxsplit=1)[0]
 
+        # release profile 已在 Cargo.toml 设 thin LTO(thin 替代 fat),ARM 不再需要
+        # env 覆盖;保留 lld(thin LTO 的 link 阶段需要支持 LLVM bitcode 的链接器)。
+        self.assertIn('RUSTFLAGS: "-C link-arg=-fuse-ld=lld"', job_env)
+        self.assertNotIn("CARGO_PROFILE_RELEASE_LTO", job_env)
+        self.assertNotIn("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", job_env)
+
         self.assertIn("build-essential pkg-config cmake lld", self.arm64_job)
-        for setting in (
-            "CARGO_PROFILE_RELEASE_LTO",
-            "CARGO_PROFILE_RELEASE_CODEGEN_UNITS",
-            "RUSTFLAGS",
-        ):
-            self.assertNotIn(setting, job_env)
-            self.assertNotIn(setting, build)
+        self.assertNotIn("RUSTFLAGS", build)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

Official 已验证并合入一组 CI/构建修复；Community 与其共用 CodeWhale r6 底座和同构发布链路，本 PR 只语义移植目标仓仍适用的部分。网页模板主体修复已由 Community #291 先行合入，本 PR 不再重复修改模板实现。

## 变更

1. **thin LTO + lld 解决 link OOM**（Official #627）
   - release profile 从 fat 改为 thin LTO；Linux Rust 测试和发布构建使用 lld。
   - 修复 rustc-wrapper smoke 中 `grep -q` 管道 SIGPIPE 波动。
2. **strict_mode 回归并入 lib 单测**（Official #675）
   - 三个确定性测试随现有 `cargo test --lib` 共用编译/链接，不再重复链接完整 integration test 目标。
3. **分层执行队列检查**（Official #674）
   - main push 无条件执行 Linux/Windows Rust 累计验证，避免 concurrency pending 替换盲区。
   - `rustc-wrapper-smoke` 对 PR/push 使用路径触发，对 Merge Queue 先做轻量 diff 路由。
   - 修正移植自检发现的两处路由缺口：工作流自身变更会触发 smoke；非 Rust Merge Queue 不启动 Windows 全量 Rust。
4. **发布前网页模板冒烟**（Official #677 的适用部分）
   - PR 发布契约和 release gate 执行模板契约、真实 prepare 与 Vite build。
   - 模板依赖/marker 的更完整实现已由 #291 合入，本 PR rebase 后无重复代码。

## 不移植项

- Official 回流专用门禁与 `rust-test-v2` 缓存改名：Community 无对应回流流程，且现有 Rust 缓存健康。
- #677 的 Windows `Get-Command` 修复：Community 直接调用 `git`，不存在该实现问题。
- rust-lint 缓存复用：clippy/check 与本 PR test profile 指纹不兼容，无有效复用收益。

## 实际验证

- `python3 -m unittest discover -s scripts/tests -p "test_*.py"`：42 项通过
- `node pinvou3-app/tests/tauri_platform_layout.test.js`
- `node pinvou3-app/tests/web_template_packaging_contract.test.js`
- `npm --prefix pinvou3-app run prepare:web-template`
- 网页模板 `vite build`：Vite 8.2.1，84 个模块构建成功
- `node scripts/sync-version.mjs --check`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `git diff --check`

## 风险

- thin LTO 和新增 Rust flags 会使既有 Rust 测试缓存首次失效；Merge Queue 将在最新 main 组合提交上运行完整适用门禁。
- main push 无条件累计 Rust 验证会增加非 Rust push 的 CI 分钟，这是堵住 pending 替换盲区的有意取舍。