### PR TITLE
fix(build): 修复 Vite 8 网页模板依赖校验

### DIFF
--- a/pinvou3-app/scripts/tauri/web-template.js
+++ b/pinvou3-app/scripts/tauri/web-template.js
@@ -12,6 +12,7 @@ const WEB_TEMPLATE_ROOT = path.join(
   "common",
   "web-template",
 );
+const PACKAGE_JSON_PATH = path.join(WEB_TEMPLATE_ROOT, "package.json");
 const LOCKFILE_PATH = path.join(WEB_TEMPLATE_ROOT, "package-lock.json");
 const MARKER_PATH = path.join(
   WEB_TEMPLATE_ROOT,
@@ -73,10 +74,20 @@ function expectedMarker({
   };
 }
 
+function declaredPackageNames(packageJsonPath = PACKAGE_JSON_PATH) {
+  const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  return [
+    ...new Set([
+      ...Object.keys(manifest.dependencies || {}),
+      ...Object.keys(manifest.devDependencies || {}),
+    ]),
+  ].sort();
+}
+
 function isPrepared(expected = expectedMarker()) {
   try {
     const actual = JSON.parse(fs.readFileSync(MARKER_PATH, "utf8"));
-    const requiredPackages = ["vite", "esbuild", "react", "react-dom"];
+    const requiredPackages = declaredPackageNames();
     return (
       JSON.stringify(actual) === JSON.stringify(expected) &&
       requiredPackages.every((packageName) =>
@@ -148,7 +159,9 @@ if (require.main === module) {
 module.exports = {
   LOCKFILE_PATH,
   MARKER_PATH,
+  PACKAGE_JSON_PATH,
   WEB_TEMPLATE_ROOT,
+  declaredPackageNames,
   expectedMarker,
   isPrepared,
   main,

--- a/pinvou3-app/scripts/tauri/web-template.js
+++ b/pinvou3-app/scripts/tauri/web-template.js
@@ -19,8 +19,10 @@ const MARKER_PATH = path.join(
   "node_modules",
   ".pinvou-prepared.json",
 );
-const PREPARE_FORMAT_VERSION = 1;
+const PREPARE_FORMAT_VERSION = 2;
 const NPM_CI_ARGS = ["ci", "--prefer-offline", "--no-audit", "--no-fund"];
+
+class InvalidDependencyFieldError extends TypeError {}
 
 function npmInstallInvocation({
   platform = process.platform,
@@ -64,37 +66,69 @@ function npmInvocation({ platform = process.platform, env = process.env } = {}) 
 function expectedMarker({
   platform = process.platform,
   architecture = process.arch,
+  webTemplateRoot = WEB_TEMPLATE_ROOT,
+  packageJsonPath = path.join(webTemplateRoot, "package.json"),
+  lockfilePath = path.join(webTemplateRoot, "package-lock.json"),
 } = {}) {
-  const lockfile = fs.readFileSync(LOCKFILE_PATH);
+  const packageJson = fs.readFileSync(packageJsonPath);
+  const lockfile = fs.readFileSync(lockfilePath);
   return {
     format: PREPARE_FORMAT_VERSION,
     platform,
     architecture,
+    packageJsonSha256: crypto
+      .createHash("sha256")
+      .update(packageJson)
+      .digest("hex"),
     lockfileSha256: crypto.createHash("sha256").update(lockfile).digest("hex"),
   };
 }
 
 function declaredPackageNames(packageJsonPath = PACKAGE_JSON_PATH) {
   const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const packageNames = (fieldName) => {
+    const field = manifest[fieldName];
+    if (field == null) return [];
+    if (typeof field !== "object" || Array.isArray(field)) {
+      throw new InvalidDependencyFieldError(
+        `package.json 的 ${fieldName} 必须是对象、null 或缺失`,
+      );
+    }
+    return Object.keys(field);
+  };
   return [
     ...new Set([
-      ...Object.keys(manifest.dependencies || {}),
-      ...Object.keys(manifest.devDependencies || {}),
+      ...packageNames("dependencies"),
+      ...packageNames("devDependencies"),
     ]),
   ].sort();
 }
 
-function isPrepared(expected = expectedMarker()) {
+function isPrepared(expected = expectedMarker(), {
+  webTemplateRoot = WEB_TEMPLATE_ROOT,
+  packageJsonPath = path.join(webTemplateRoot, "package.json"),
+  lockfilePath = path.join(webTemplateRoot, "package-lock.json"),
+  markerPath = path.join(webTemplateRoot, "node_modules", ".pinvou-prepared.json"),
+} = {}) {
   try {
-    const actual = JSON.parse(fs.readFileSync(MARKER_PATH, "utf8"));
-    const requiredPackages = declaredPackageNames();
+    const requiredPackages = declaredPackageNames(packageJsonPath);
+    const currentExpected = expectedMarker({
+      platform: expected?.platform,
+      architecture: expected?.architecture,
+      webTemplateRoot,
+      packageJsonPath,
+      lockfilePath,
+    });
+    const actual = JSON.parse(fs.readFileSync(markerPath, "utf8"));
     return (
+      JSON.stringify(expected) === JSON.stringify(currentExpected) &&
       JSON.stringify(actual) === JSON.stringify(expected) &&
       requiredPackages.every((packageName) =>
-        fs.existsSync(path.join(WEB_TEMPLATE_ROOT, "node_modules", packageName)),
+        fs.existsSync(path.join(webTemplateRoot, "node_modules", packageName)),
       )
     );
-  } catch {
+  } catch (error) {
+    if (error instanceof InvalidDependencyFieldError) throw error;
     return false;
   }
 }

--- a/pinvou3-app/tests/web_template_packaging_contract.test.js
+++ b/pinvou3-app/tests/web_template_packaging_contract.test.js
@@ -3,6 +3,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 const {
+  declaredPackageNames,
   npmInstallInvocation,
   npmInvocation,
 } = require("../scripts/tauri/web-template.js");
@@ -28,6 +29,22 @@ for (const required of ["package.json", "package-lock.json"]) {
     `网页模板必须保留 ${required}`,
   );
 }
+
+const templateManifest = JSON.parse(
+  fs.readFileSync(path.join(TEMPLATE_ROOT, "package.json"), "utf8"),
+);
+const declaredPackages = [
+  ...new Set([
+    ...Object.keys(templateManifest.dependencies || {}),
+    ...Object.keys(templateManifest.devDependencies || {}),
+  ]),
+].sort();
+assert.deepEqual(
+  declaredPackageNames(),
+  declaredPackages,
+  "网页模板准备校验必须跟随直接依赖，不能保留已移除依赖的硬编码",
+);
+assert.ok(!declaredPackages.includes("esbuild"), "Vite 8 模板不再直接依赖 esbuild");
 
 const trackedNodeModules = execFileSync(
   "git",

--- a/pinvou3-app/tests/web_template_packaging_contract.test.js
+++ b/pinvou3-app/tests/web_template_packaging_contract.test.js
@@ -1,9 +1,12 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 const {
   declaredPackageNames,
+  expectedMarker,
+  isPrepared,
   npmInstallInvocation,
   npmInvocation,
 } = require("../scripts/tauri/web-template.js");
@@ -45,6 +48,124 @@ assert.deepEqual(
   "网页模板准备校验必须跟随直接依赖，不能保留已移除依赖的硬编码",
 );
 assert.ok(!declaredPackages.includes("esbuild"), "Vite 8 模板不再直接依赖 esbuild");
+
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pinvou3-web-template-"));
+const fixturePackageJson = path.join(fixtureRoot, "package.json");
+const fixtureLockfile = path.join(fixtureRoot, "package-lock.json");
+const fixtureNodeModules = path.join(fixtureRoot, "node_modules");
+const fixtureMarker = path.join(fixtureNodeModules, ".pinvou-prepared.json");
+const fixturePaths = {
+  webTemplateRoot: fixtureRoot,
+  packageJsonPath: fixturePackageJson,
+  lockfilePath: fixtureLockfile,
+  markerPath: fixtureMarker,
+};
+const markerForFixture = () => expectedMarker({
+  platform: "test-platform",
+  architecture: "test-architecture",
+  ...fixturePaths,
+});
+const writeFixtureManifest = (manifest) => {
+  fs.writeFileSync(fixturePackageJson, `${JSON.stringify(manifest, null, 2)}\n`);
+};
+const writeFixtureMarker = (marker) => {
+  fs.mkdirSync(fixtureNodeModules, { recursive: true });
+  fs.writeFileSync(fixtureMarker, `${JSON.stringify(marker, null, 2)}\n`);
+};
+
+try {
+  fs.writeFileSync(fixtureLockfile, '{"lockfileVersion":3}\n');
+  writeFixtureManifest({
+    dependencies: {
+      "@scope/runtime": "1.0.0",
+      react: "19.0.0",
+    },
+    devDependencies: {
+      react: "19.0.0",
+      vite: "8.0.0",
+    },
+  });
+  assert.deepEqual(
+    declaredPackageNames(fixturePackageJson),
+    ["@scope/runtime", "react", "vite"],
+    "scoped 包和跨字段重复依赖必须正确解析并去重",
+  );
+  for (const packageName of declaredPackageNames(fixturePackageJson)) {
+    fs.mkdirSync(path.join(fixtureNodeModules, packageName), { recursive: true });
+  }
+  const originalMarker = markerForFixture();
+  assert.equal(originalMarker.format, 2, "package manifest 加入 marker 后必须提升格式版本");
+  assert.ok(!declaredPackageNames(fixturePackageJson).includes("esbuild"));
+  writeFixtureMarker(originalMarker);
+  assert.equal(
+    isPrepared(originalMarker, fixturePaths),
+    true,
+    "没有 esbuild 时，只要所有声明依赖目录存在就应判定为已准备",
+  );
+
+  fs.rmSync(path.join(fixtureNodeModules, "@scope", "runtime"), { recursive: true });
+  assert.equal(
+    isPrepared(originalMarker, fixturePaths),
+    false,
+    "缺少任一声明依赖目录时必须重新准备",
+  );
+  fs.mkdirSync(path.join(fixtureNodeModules, "@scope", "runtime"), { recursive: true });
+
+  writeFixtureManifest({
+    dependencies: {
+      "@scope/runtime": "1.0.1",
+      react: "19.0.0",
+    },
+    devDependencies: { vite: "8.0.0" },
+  });
+  assert.equal(
+    isPrepared(originalMarker, fixturePaths),
+    false,
+    "package.json 修改后旧 marker 必须失效",
+  );
+  const manifestMarker = markerForFixture();
+  writeFixtureMarker(manifestMarker);
+  assert.equal(isPrepared(manifestMarker, fixturePaths), true);
+
+  fs.writeFileSync(fixtureLockfile, '{"lockfileVersion":3,"changed":true}\n');
+  assert.equal(
+    isPrepared(manifestMarker, fixturePaths),
+    false,
+    "package-lock.json 修改后旧 marker 必须失效",
+  );
+
+  writeFixtureManifest({ dependencies: null });
+  assert.deepEqual(
+    declaredPackageNames(fixturePackageJson),
+    [],
+    "null dependencies 和缺失 devDependencies 必须按空字段处理",
+  );
+  writeFixtureManifest({ devDependencies: null });
+  assert.deepEqual(
+    declaredPackageNames(fixturePackageJson),
+    [],
+    "缺失 dependencies 和 null devDependencies 必须按空字段处理",
+  );
+
+  for (const fieldName of ["dependencies", "devDependencies"]) {
+    for (const invalidValue of [[], "react", 1]) {
+      writeFixtureManifest({ [fieldName]: invalidValue });
+      assert.throws(
+        () => declaredPackageNames(fixturePackageJson),
+        new RegExp(`${fieldName} 必须是对象`),
+        `${fieldName} 不得接受 ${typeof invalidValue} 类型`,
+      );
+    }
+  }
+  writeFixtureManifest({ dependencies: [] });
+  assert.throws(
+    () => isPrepared(originalMarker, fixturePaths),
+    /dependencies 必须是对象/,
+    "真实 isPrepared 路径必须明确报告非法 manifest 字段",
+  );
+} finally {
+  fs.rmSync(fixtureRoot, { recursive: true, force: true });
+}
 
 const trackedNodeModules = execFileSync(
   "git",


### PR DESCRIPTION
## 背景

干净 Windows 打包环境在为离线网页模板执行 `npm ci` 后报“网页模板依赖准备后校验失败”。模板已升级至 Vite 8，`esbuild` 不再是直接依赖，但准备逻辑仍硬编码要求其目录存在，导致干净环境稳定失败；旧工作区可能因残留依赖掩盖问题。

## 变更

- 网页模板准备校验改为从 `package.json` 的 `dependencies` 与 `devDependencies` 声明动态推导必需包
- 删除对 Vite 8 可选 peer `esbuild` 的隐式硬编码依赖
- marker 升级至 v2，同时绑定 `package.json` 与 lockfile 哈希，任一声明变化都会触发重新准备
- 对非法依赖字段类型给出明确错误，缺失或 `null` 字段按空依赖处理
- 增加真实 `isPrepared` fixture，覆盖成功、缺包、manifest/lockfile 变化、scoped/重复/空字段及非法字段

## 验证

- `node pinvou3-app/tests/web_template_packaging_contract.test.js`
- `npm --prefix pinvou3-app run prepare:web-template`：干净安装 44 个包成功，二次执行正确复用 marker
- 当前模板与无 `esbuild` 的隔离干净安装均执行 `vite build` 成功（84 个模块）
- `python scripts/architecture-guard.py`
- `git diff --check`

## 风险与关联

- 低风险：仅调整构建前依赖完整性校验，不改变模板运行时代码或依赖锁
- marker v1 会一次性失效并重新执行 `npm ci`，属于预期迁移
- 与 #290 中的网页模板修复部分重叠；本 PR 刻意保持聚焦，用于快速解除干净环境的打包阻塞，不包含 #290 的 ThinLTO、CI 分层等其他改动