### PR TITLE
fix(ci): Windows 导入诊断不阻断并消除 SxS 假阳性

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -881,14 +881,7 @@ jobs:
           "PINVOU3_TEST_EXE=$testExe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Windows Rust 测试 exe: $testExe"
 
-      # 测试 exe 曾在回归步骤启动即挂(exit code 0xc0000139,STATUS_ENTRYPOINT_NOT_FOUND),
-      # Windows 不指明缺哪个 DLL/符号。此步骤静态解析 PE 导入表作对照输出,纯诊断不阻断。
-      # 纯诊断不阻断:脚本异常(如解析到截断 PE)不得挂掉本 job,故 continue-on-error
-      - name: Windows 测试二进制导入诊断
-        continue-on-error: true
-        run: python scripts/ci-windows-imports-diagnose.py pinvou3-app/src-tauri/target/debug/deps
-
-      # 0xc0000139 根因(已由上述诊断定位):muda 静态导入 TaskDialogIndirect,该符号仅
+      # 0xc0000139 根因(已由诊断定位):muda 静态导入 TaskDialogIndirect,该符号仅
       # 存在于 Common-Controls v6 side-by-side 程序集;主 exe 由 tauri-build 嵌入声明该
       # 依赖的清单,而 cargo test 的 pinvou3_lib-*.exe 没有 v6 依赖声明。
       # link.exe 已给测试 exe 嵌入默认清单,Windows 会优先使用内嵌资源而忽略同目录
@@ -928,6 +921,17 @@ jobs:
             throw "FAIL: 无法向 $($testExe.Name) 嵌入 Common-Controls v6 清单"
           }
           Write-Host "已嵌入清单的测试 exe: $($testExe.FullName)"
+
+      # 测试 exe 曾在回归步骤启动即挂(exit code 0xc0000139,STATUS_ENTRYPOINT_NOT_FOUND),
+      # Windows 不指明缺哪个 DLL/符号。此步骤静态解析 PE 导入表作对照输出,纯诊断不阻断。
+      # 纯诊断不阻断:脚本异常(如解析到截断 PE)不得挂掉本 job,故 continue-on-error。
+      # 必须位于「嵌入 Common-Controls v6 清单」之后:脚本读 exe 已嵌入的清单来豁免
+      # SxS 程序集 DLL(如 comctl32)的缺符号假阳性,嵌入前读到的是无 v6 声明的默认清单;
+      # 直接传 $PINVOU3_TEST_EXE 保证诊断对象就是刚嵌入清单、回归将运行的那个 exe。
+      - name: Windows 测试二进制导入诊断
+        continue-on-error: true
+        shell: pwsh
+        run: python scripts/ci-windows-imports-diagnose.py "$env:PINVOU3_TEST_EXE"
 
       - name: Windows 原子替换状态机回归
         shell: bash

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -883,7 +883,9 @@ jobs:
 
       # 测试 exe 曾在回归步骤启动即挂(exit code 0xc0000139,STATUS_ENTRYPOINT_NOT_FOUND),
       # Windows 不指明缺哪个 DLL/符号。此步骤静态解析 PE 导入表作对照输出,纯诊断不阻断。
+      # 纯诊断不阻断:脚本异常(如解析到截断 PE)不得挂掉本 job,故 continue-on-error
       - name: Windows 测试二进制导入诊断
+        continue-on-error: true
         run: python scripts/ci-windows-imports-diagnose.py pinvou3-app/src-tauri/target/debug/deps
 
       # 0xc0000139 根因(已由上述诊断定位):muda 静态导入 TaskDialogIndirect,该符号仅

--- a/pinvou3-app/src-tauri/src/platform/filesystem.rs
+++ b/pinvou3-app/src-tauri/src/platform/filesystem.rs
@@ -613,11 +613,12 @@ pub(crate) mod tests {
     fn windows_failed_first_promotion_preserves_the_complete_replacement() {
         let (root, target, replacement, backup) = windows_replace_fixture("promotion-blocked");
         std::fs::write(&replacement, "complete-new-value").unwrap();
-        // 首写(target 尚无文件)时 promote 就是 std::fs::rename。让目标名被目录
-        // 占用,rename 必然失败(ERROR_ACCESS_DENIED)且 target.is_file() 为 false
-        // → RecoveryRequired。此前版本用 share_mode(0) 独占打开 replacement 期望
-        // rename 失败,但 NTFS 的 rename 只改目录项、不受源文件独占句柄影响,
-        // Windows CI 上 rename 直接成功,前提不成立(与 memory 侧
+        // 目标名被目录占用:target.exists() 为 true,走 ReplaceFileW(目标是目录,
+        // 必然失败)→ 收敛分支 promote_replacement,rename(文件→目录名)同样必然
+        // ERROR_ACCESS_DENIED,且 target.is_file() 为 false → RecoveryRequired。
+        // 此前版本用 share_mode(0) 独占打开 replacement 期望首写提升的 rename
+        // 失败,但 NTFS 的 rename 只改目录项、不受源文件独占句柄影响,Windows CI
+        // 上 rename 直接成功,前提不成立(与 memory 侧
         // memory_write_cleans_tmp_backup_on_permanently_occupied_target 同构)。
         std::fs::create_dir(&target).unwrap();
 

--- a/scripts/ci-windows-imports-diagnose.py
+++ b/scripts/ci-windows-imports-diagnose.py
@@ -11,7 +11,11 @@ Windows 不给出具体缺哪个 DLL/符号,只能静态解析导入表比对导
 定位每个被导入的 DLL,解析其导出表,报告:
   - 找不到的 DLL(MODULE_NOT_FOUND 类问题)
   - DLL 存在但缺失的导入符号(ENTRYPOINT_NOT_FOUND 类问题)
-仅做诊断,不修改任何文件;exit 0(纯信息输出,不阻断 CI 步骤)。
+exe 旁外部清单声明的 SxS 程序集所覆盖的 DLL(如 comctl32)缺符号时
+降级为预期提示:loader 按程序集版本解析,静态走文件系统只会看到
+System32 副本,其缺 v6 专属符号不构成问题。
+仅做诊断,不修改任何文件;exit 0(纯信息输出,不阻断 CI 步骤),
+脚本自身异常同样 exit 0 兜底。
 """
 import glob
 import io
@@ -121,6 +125,35 @@ def find_dll(name, exe_dir):
     return None
 
 
+# SxS 程序集名 → 其覆盖的 DLL。loader 见到清单声明的程序集依赖时,绑定程序集
+# 版本(如 WinSxS 里的 comctl32 v6)而非 System32 的 v5 副本;脚本静态走文件
+# 系统,只会找到 System32 副本,其缺 v6 专属符号(如 TaskDialogIndirect)属预期。
+SXS_ASSEMBLY_DLLS = {
+    'Microsoft.Windows.Common-Controls': {'comctl32.dll'},
+}
+
+
+def manifest_sxs_dlls(exe):
+    """返回 exe 清单声明的 SxS 程序集所覆盖的 DLL 名集合(小写)。
+
+    只读外部清单(<exe>.manifest,Windows loader 在无嵌入清单时的回退);
+    嵌入清单在 RT_MANIFEST 资源里,当前不解析。
+    """
+    mpath = exe + '.manifest'
+    if not os.path.isfile(mpath):
+        return set()
+    try:
+        with open(mpath, 'r', encoding='utf-8', errors='replace') as f:
+            text = f.read()
+    except OSError:
+        return set()
+    dlls = set()
+    for assembly, names in SXS_ASSEMBLY_DLLS.items():
+        if assembly in text:
+            dlls |= names
+    return dlls
+
+
 def main():
     deps_dir = sys.argv[1] if len(sys.argv) > 1 else '.'
     exes = sorted(glob.glob(os.path.join(deps_dir, 'pinvou3_lib-*.exe')), key=os.path.getmtime)
@@ -133,11 +166,12 @@ def main():
     print('DIAG dlls next to exe:', [f for f in os.listdir(exe_dir) if f.lower().endswith('.dll')])
 
     problems = []
+    sxs_dlls = manifest_sxs_dlls(exe)
     system_dirs = {os.path.normcase(os.path.abspath(p)) for p in (
         os.path.join(os.environ.get('SystemRoot', r'C:\Windows'), 'System32'),
         os.environ.get('SystemRoot', r'C:\Windows'),
     )}
-    # exe 直接导入 + 非系统 DLL 的一层递归(loader 递归解析,缺符号可能藏在依赖链)
+    # exe 直接导入 + 非系统 DLL 的传递递归(loader 递归解析,缺符号可能藏在依赖链)
     queue = [(dll, funcs, exe) for dll, funcs in imports_of(exe)]
     seen = set()
     while queue:
@@ -149,12 +183,16 @@ def main():
             problems.append(f'缺模块: {dll} (被 {os.path.basename(importer)} 导入,未在 loader 搜索路径找到)')
             continue
         missing = [f for f in funcs if not f.startswith('#') and f not in exports_of(path)]
-        status = f'缺 {len(missing)} 符号: {missing[:10]}' if missing else 'ok'
         indent = '' if importer == exe else '    ↳ '
-        print(f'  {indent}{dll} -> {path} ({len(funcs)} imports) {status}')
-        if missing:
-            problems.append(f'{path} 缺符号(被 {os.path.basename(importer)} 导入): {missing[:20]}')
-        # 非 System32 的 DLL(如 exe 旁拷贝的运行时 DLL)继续向下钻一层
+        if missing and dll.lower() in sxs_dlls:
+            print(f'  {indent}{dll} -> {path} ({len(funcs)} imports) '
+                  f'缺 {len(missing)} 符号(SxS 清单已声明,loader 按程序集版本解析,属预期)')
+        else:
+            status = f'缺 {len(missing)} 符号: {missing[:10]}' if missing else 'ok'
+            print(f'  {indent}{dll} -> {path} ({len(funcs)} imports) {status}')
+            if missing:
+                problems.append(f'{path} 缺符号(被 {os.path.basename(importer)} 导入): {missing[:20]}')
+        # 非 System32 的 DLL(如 exe 旁拷贝的运行时 DLL)继续传递向下钻
         key = os.path.normcase(path)
         if key not in seen and os.path.normcase(os.path.dirname(path)) not in system_dirs:
             seen.add(key)
@@ -171,4 +209,10 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception:  # 诊断自身异常只记录,兑现「纯诊断不阻断」的承诺
+        import traceback
+        traceback.print_exc()
+        sys.stderr.write('DIAG: 诊断自身异常,已忽略(不阻断 CI 步骤)\n')
+        sys.exit(0)

--- a/scripts/ci-windows-imports-diagnose.py
+++ b/scripts/ci-windows-imports-diagnose.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Windows 测试二进制 PE 导入诊断(定位 STATUS_ENTRYPOINT_NOT_FOUND / 0xc0000139)。
 
-用法:python scripts/ci-windows-imports-diagnose.py [deps 目录]
+用法:python scripts/ci-windows-imports-diagnose.py [deps 目录 | 测试 exe 路径]
 
 背景:windows-rust-test 的回归步骤首次真正执行测试 exe 时启动即挂
 (exit code 0xc0000139)。该错误是「DLL 找到了但导入的符号不存在」,
@@ -11,11 +11,12 @@ Windows 不给出具体缺哪个 DLL/符号,只能静态解析导入表比对导
 定位每个被导入的 DLL,解析其导出表,报告:
   - 找不到的 DLL(MODULE_NOT_FOUND 类问题)
   - DLL 存在但缺失的导入符号(ENTRYPOINT_NOT_FOUND 类问题)
-exe 旁外部清单声明的 SxS 程序集所覆盖的 DLL(如 comctl32)缺符号时
-降级为预期提示:loader 按程序集版本解析,静态走文件系统只会看到
-System32 副本,其缺 v6 专属符号不构成问题。
-仅做诊断,不修改任何文件;exit 0(纯信息输出,不阻断 CI 步骤),
-脚本自身异常同样 exit 0 兜底。
+清单声明的 SxS 程序集所覆盖的 DLL(如 comctl32)缺符号时降级为预期
+提示:loader 按程序集版本解析,静态走文件系统只会看到 System32 副本,
+其缺 v6 专属符号不构成问题。清单优先读 exe 的 RT_MANIFEST 嵌入资源
+(loader 优先级最高,CI 由 mt.exe 嵌入,故诊断步骤必须排在嵌入之后);
+无嵌入时回退 exe 旁外部清单。仅做诊断,不修改任何文件;
+exit 0(纯信息输出,不阻断 CI 步骤),脚本自身异常同样 exit 0 兜底。
 """
 import glob
 import io
@@ -125,6 +126,9 @@ def find_dll(name, exe_dir):
     return None
 
 
+# Windows 资源类型:RT_MANIFEST(清单嵌入在资源目录树的类型 24 下)
+RT_MANIFEST = 24
+
 # SxS 程序集名 → 其覆盖的 DLL。loader 见到清单声明的程序集依赖时,绑定程序集
 # 版本(如 WinSxS 里的 comctl32 v6)而非 System32 的 v5 副本;脚本静态走文件
 # 系统,只会找到 System32 副本,其缺 v6 专属符号(如 TaskDialogIndirect)属预期。
@@ -133,20 +137,60 @@ SXS_ASSEMBLY_DLLS = {
 }
 
 
+def embedded_manifest(exe):
+    """返回 exe RT_MANIFEST(资源类型 24)里的清单文本;无则 None。
+
+    CI 在回归前用 mt.exe 把 v6 清单嵌入 resource #1,loader 实际使用的
+    就是它,故豁免判定以嵌入清单为准。资源目录树三层:类型→名称→语言,
+    目录/条目偏移相对资源节起始,叶子 DATA_ENTRY 里的 OffsetToData 是 RVA。
+    """
+    pe = read_pe(exe)
+    if pe is None:
+        return None
+    data, data_dir, sections = pe
+    res_rva = struct.unpack_from('<I', data, data_dir + 16)[0]
+    if not res_rva:
+        return None
+    base = rva_off(res_rva, sections)
+
+    def walk(dir_off, want_type):
+        n_named, n_id = struct.unpack_from('<HH', data, dir_off + 12)
+        for i in range(n_named + n_id):
+            name, off = struct.unpack_from('<II', data, dir_off + 16 + i * 8)
+            if want_type is not None and name != want_type:
+                continue
+            if off >> 31:  # 高位为 1 → 子目录
+                found = walk(base + (off & 0x7FFFFFFF), None)
+                if found is not None:
+                    return found
+            else:  # 叶子 → IMAGE_RESOURCE_DATA_ENTRY
+                rva, size = struct.unpack_from('<II', data, base + off)
+                fo = rva_off(rva, sections)
+                return data[fo:fo + size].decode('utf-8', errors='replace')
+        return None
+
+    return walk(base, RT_MANIFEST)
+
+
 def manifest_sxs_dlls(exe):
     """返回 exe 清单声明的 SxS 程序集所覆盖的 DLL 名集合(小写)。
 
-    只读外部清单(<exe>.manifest,Windows loader 在无嵌入清单时的回退);
-    嵌入清单在 RT_MANIFEST 资源里,当前不解析。
+    优先读嵌入 RT_MANIFEST;无嵌入时回退外部清单(<exe>.manifest,
+    loader 在无嵌入清单时才使用它,两者并存时外部清单被忽略)。
     """
-    mpath = exe + '.manifest'
-    if not os.path.isfile(mpath):
-        return set()
     try:
-        with open(mpath, 'r', encoding='utf-8', errors='replace') as f:
-            text = f.read()
-    except OSError:
-        return set()
+        text = embedded_manifest(exe)
+    except Exception:  # 资源树解析异常只损失豁免,不拖垮整个诊断
+        text = None
+    if text is None:
+        mpath = exe + '.manifest'
+        if not os.path.isfile(mpath):
+            return set()
+        try:
+            with open(mpath, 'r', encoding='utf-8', errors='replace') as f:
+                text = f.read()
+        except OSError:
+            return set()
     dlls = set()
     for assembly, names in SXS_ASSEMBLY_DLLS.items():
         if assembly in text:
@@ -155,10 +199,15 @@ def manifest_sxs_dlls(exe):
 
 
 def main():
-    deps_dir = sys.argv[1] if len(sys.argv) > 1 else '.'
-    exes = sorted(glob.glob(os.path.join(deps_dir, 'pinvou3_lib-*.exe')), key=os.path.getmtime)
+    arg = sys.argv[1] if len(sys.argv) > 1 else '.'
+    if os.path.isfile(arg):
+        # CI 直接传入待诊断的测试 exe:即回归步骤要运行、刚由 mt.exe 嵌入
+        # v6 清单的那个,避免多产物并存时按 mtime 猜错对象。
+        exes = [os.path.abspath(arg)]
+    else:
+        exes = sorted(glob.glob(os.path.join(arg, 'pinvou3_lib-*.exe')), key=os.path.getmtime)
     if not exes:
-        print('DIAG: no pinvou3_lib-*.exe found in', deps_dir)
+        print('DIAG: no pinvou3_lib-*.exe found in', arg)
         return 0
     exe = exes[-1]
     exe_dir = os.path.dirname(exe)
@@ -167,6 +216,8 @@ def main():
 
     problems = []
     sxs_dlls = manifest_sxs_dlls(exe)
+    if sxs_dlls:
+        print('DIAG SxS 清单豁免 DLL(缺符号属预期):', ', '.join(sorted(sxs_dlls)))
     system_dirs = {os.path.normcase(os.path.abspath(p)) for p in (
         os.path.join(os.environ.get('SystemRoot', r'C:\Windows'), 'System32'),
         os.environ.get('SystemRoot', r'C:\Windows'),

--- a/scripts/tests/test_windows_imports_diagnose.py
+++ b/scripts/tests/test_windows_imports_diagnose.py
@@ -143,10 +143,14 @@ class ManifestSxsDllsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             exe = Path(tmp) / "pinvou3_lib-test.exe"
             exe.write_bytes(build_pe_with_manifest(COMMON_CONTROLS_MANIFEST))
+            # 脚本自身把 stdout/stderr 强制为 UTF-8(见其模块头);父进程必须
+            # 用同编码解码,否则在默认编码非 UTF-8 的 Windows(GBK/cp1252)上
+            # 严格解码抛 UnicodeDecodeError 或产出乱码,断言必然失败。
             proc = subprocess.run(
                 [sys.executable, str(SCRIPT), str(exe)],
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
+                errors="replace",
             )
             self.assertEqual(proc.returncode, 0)
             self.assertIn("SxS 清单豁免", proc.stdout)

--- a/scripts/tests/test_windows_imports_diagnose.py
+++ b/scripts/tests/test_windows_imports_diagnose.py
@@ -1,0 +1,182 @@
+"""ci-windows-imports-diagnose.py 的行为契约。
+
+覆盖两类回归:
+- SxS 清单豁免必须真实生效:嵌入 RT_MANIFEST 优先,外部清单回退
+  (CI 先由 mt.exe 嵌入清单、诊断步骤读嵌入结果,才能消除 comctl32 假阳性);
+- pr-check.yml 的步骤顺序契约:诊断必须排在嵌入清单之后,否则豁免必然落空
+  (诊断读到的是无 v6 声明的默认清单,TaskDialogIndirect 仍计入根因结论)。
+"""
+import importlib.util
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "ci-windows-imports-diagnose.py"
+SPEC = importlib.util.spec_from_file_location("ci_windows_imports_diagnose", SCRIPT)
+DIAG = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(DIAG)
+
+ROOT = Path(__file__).resolve().parents[2]
+PR_WORKFLOW = ROOT / ".github/workflows/pr-check.yml"
+
+COMMON_CONTROLS_MANIFEST = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+    '<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">'
+    '<dependency><dependentAssembly>'
+    '<assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" '
+    'version="6.0.0.0" processorArchitecture="*" '
+    'publicKeyToken="6595b64144ccf1df" language="*"/>'
+    '</dependentAssembly></dependency></assembly>'
+)
+
+PLAIN_MANIFEST = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"/>'
+)
+
+SECTION_VA = 0x1000
+SECTION_RAW = 0x200
+
+
+def build_pe_with_manifest(manifest_text):
+    """构造仅含资源目录(RT_MANIFEST)的最小 PE32。
+
+    布局:资源目录树 类型(24)→名称(1)→语言(0x409)→DATA_ENTRY,
+    全部落在唯一节内;导入表 RVA 为 0(诊断脚本据此跳过导入解析)。
+    """
+    manifest_bytes = manifest_text.encode("utf-8")
+
+    # 节内偏移:类型目录 0x00,名称目录 0x40,语言目录 0x80,
+    # DATA_ENTRY 0xC0,清单内容 0x100。
+    def resource_dir(entry_name, entry_off):
+        # Characteristics/TimeStamp/Versions 共 12 字节,然后条目数与条目
+        return struct.pack("<IIHHHH", 0, 0, 0, 0, 0, 1) + struct.pack(
+            "<II", entry_name, entry_off
+        )
+
+    type_dir = resource_dir(24, 0x80000040)  # RT_MANIFEST → 子目录(名称层)
+    name_dir = resource_dir(1, 0x80000080)  # 清单 ID 1 → 子目录(语言层)
+    lang_dir = resource_dir(0x409, 0xC0)  # 语言 → 叶子 DATA_ENTRY
+    data_entry = struct.pack(
+        "<IIII", SECTION_VA + 0x100, len(manifest_bytes), 0, 0
+    )
+
+    section = bytearray(0x100)
+    section[0x00 : 0x00 + len(type_dir)] = type_dir
+    section[0x40 : 0x40 + len(name_dir)] = name_dir
+    section[0x80 : 0x80 + len(lang_dir)] = lang_dir
+    section[0xC0 : 0xC0 + len(data_entry)] = data_entry
+    section += manifest_bytes
+
+    pe = 0x40
+    opt_off = pe + 24
+    opt_size = 224  # PE32
+    data_dir_off = opt_off + 96  # 数据目录起始于可选头 +96
+    res_rva_entry = data_dir_off + 16  # 索引 2:资源表
+
+    buf = bytearray(SECTION_RAW + len(section))
+    buf[0:2] = b"MZ"
+    struct.pack_into("<I", buf, 0x3C, pe)
+    buf[pe : pe + 4] = b"PE\0\0"
+    # COFF:Machine(i386) 1 节,可选头 224 字节
+    struct.pack_into("<HHIIIHH", buf, pe + 4, 0x14C, 1, 0, 0, 0, opt_size, 0x102)
+    struct.pack_into("<H", buf, opt_off, 0x10B)  # PE32 magic
+    struct.pack_into("<I", buf, res_rva_entry, SECTION_VA)
+    struct.pack_into("<I", buf, res_rva_entry + 4, len(section))
+
+    sec_off = opt_off + opt_size
+    buf[sec_off : sec_off + 8] = b".rsrc\0\0\0"
+    struct.pack_into(
+        "<IIII", buf, sec_off + 8, len(section), SECTION_VA, len(section), SECTION_RAW
+    )
+    buf[SECTION_RAW:] = section
+    return bytes(buf)
+
+
+class ManifestSxsDllsTests(unittest.TestCase):
+    def test_no_manifest_yields_no_exemption(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "pinvou3_lib-test.exe"
+            exe.write_bytes(build_pe_with_manifest(PLAIN_MANIFEST))
+            self.assertEqual(DIAG.manifest_sxs_dlls(str(exe)), set())
+
+    def test_external_manifest_declares_sxs_dll(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "pinvou3_lib-test.exe"
+            # 无嵌入清单的 PE:资源表存在但为空目录树,embedded_manifest 返回 None
+            exe.write_bytes(build_pe_with_manifest(PLAIN_MANIFEST)[:SECTION_RAW])
+            (Path(tmp) / "pinvou3_lib-test.exe.manifest").write_text(
+                COMMON_CONTROLS_MANIFEST, encoding="utf-8"
+            )
+            self.assertEqual(
+                DIAG.manifest_sxs_dlls(str(exe)), {"comctl32.dll"}
+            )
+
+    def test_embedded_manifest_declares_sxs_dll(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "pinvou3_lib-test.exe"
+            exe.write_bytes(build_pe_with_manifest(COMMON_CONTROLS_MANIFEST))
+            self.assertEqual(
+                DIAG.manifest_sxs_dlls(str(exe)), {"comctl32.dll"}
+            )
+
+    def test_embedded_manifest_takes_priority_over_external(self):
+        # loader 优先嵌入清单;豁免判定必须同序,否则嵌入 v6 清单后
+        # 旁边残留的旧外部清单仍会把 System32 comctl32 缺符号误报为根因。
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "pinvou3_lib-test.exe"
+            exe.write_bytes(build_pe_with_manifest(COMMON_CONTROLS_MANIFEST))
+            (Path(tmp) / "pinvou3_lib-test.exe.manifest").write_text(
+                PLAIN_MANIFEST, encoding="utf-8"
+            )
+            self.assertEqual(
+                DIAG.manifest_sxs_dlls(str(exe)), {"comctl32.dll"}
+            )
+
+    def test_script_diagnoses_explicit_exe_and_exempts_sxs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / "pinvou3_lib-test.exe"
+            exe.write_bytes(build_pe_with_manifest(COMMON_CONTROLS_MANIFEST))
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(exe)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0)
+            self.assertIn("SxS 清单豁免", proc.stdout)
+            self.assertNotIn("可能即 0xc0000139 根因", proc.stdout)
+
+
+class WorkflowStepOrderContractTests(unittest.TestCase):
+    """诊断步骤必须在「嵌入 Common-Controls v6 清单」之后运行(见类 docstring)。"""
+
+    def setUp(self):
+        self.workflow = PR_WORKFLOW.read_text(encoding="utf-8")
+
+    def _step_block(self, step_name):
+        start = self.workflow.index(f"- name: {step_name}")
+        next_step = self.workflow.find("\n      - name:", start + 1)
+        return start, self.workflow[start:next_step]
+
+    def test_diagnose_runs_after_manifest_embedding(self):
+        embed_start, _ = self._step_block("Windows 测试 exe 嵌入 Common-Controls v6 清单")
+        diagnose_start, _ = self._step_block("Windows 测试二进制导入诊断")
+        self.assertGreater(diagnose_start, embed_start)
+
+    def test_diagnose_step_contract(self):
+        _, block = self._step_block("Windows 测试二进制导入诊断")
+        self.assertIn("continue-on-error: true", block)
+        # 显式传入回归将运行的测试 exe(mt.exe 刚嵌入清单的那个),
+        # 避免多产物并存时按 mtime 猜错诊断对象。
+        self.assertIn("ci-windows-imports-diagnose.py", block)
+        self.assertIn("PINVOU3_TEST_EXE", block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

#288(已合并)审阅发现三点遗留,本 PR 收尾:

1. **诊断步骤「纯诊断不阻断」承诺无机制兜底**:pr-check.yml 的导入诊断步骤无 `continue-on-error`,脚本对截断/非 PE 输入存在多条 `struct.error`/`TypeError` 裸抛路径,异常时会以非零退出挂掉 23 分钟的 Windows job,与设计意图相反。
2. **修复后诊断常驻假阳性**:脚本不感知 exe 清单声明的 SxS 程序集,#288 的 manifest 修复生效后,每次绿跑仍打印 `comctl32.dll 缺 1 符号: ['TaskDialogIndirect']` 并列入「DIAG 结论(可能即 0xc0000139 根因)」——绿跑日志里天天喊根因,长期稀释诊断信号。
3. **filesystem.rs 测试注释与实际路径不符**:注释称目录占用下走「首写分支」,实际 `target.exists()`(目录也为 true)使其走 ReplaceFileW 失败→收敛分支的 `promote_replacement`;契约覆盖未变,仅注释误导。

zhuowp 评审指出初版「读外部清单」的豁免在实际步骤顺序下不会生效(诊断先于清单创建),核实成立;且同步 main 后 #276 已改为 mt.exe 嵌入 RT_MANIFEST,外部清单在 CI 里已不存在。已按评论 a451f7f6 重做:诊断步骤移到嵌入清单之后并显式传入 `PINVOU3_TEST_EXE`,脚本解析嵌入 RT_MANIFEST(外部清单回退),并新增脚本单测与步骤顺序契约测试。

## 变更

- `pr-check.yml`:诊断步骤补 `continue-on-error: true`,移至「嵌入 Common-Controls v6 清单」之后,显式传入 `"$env:PINVOU3_TEST_EXE"` 并声明 `shell: pwsh`。
- `ci-windows-imports-diagnose.py`:
  - `__main__` 包顶层异常兜底 exit 0,与 continue-on-error 双保险兑现「不阻断」;
  - 新增 `embedded_manifest()`:解析 exe 资源目录树中的 RT_MANIFEST(类型 24,loader 优先级最高,CI 由 mt.exe 嵌入),无嵌入时回退 `<exe>.manifest` 外部清单;SxS 程序集(当前登记 `Microsoft.Windows.Common-Controls` → comctl32.dll)覆盖的 DLL 缺符号时降级为「属预期」提示并在 DIAG 头部打印豁免清单,不计入根因结论;
  - 支持直接传测试 exe 路径(CI 用途),目录模式保留;修正注释:依赖钻取是传递递归而非「一层」。
- `scripts/tests/test_windows_imports_diagnose.py`(新增,随 fast-gate 必跑):最小 PE 构造验证嵌入豁免/外部回退/嵌入优先/显式 exe 端到端,及 pr-check.yml 步骤顺序契约(诊断在嵌入之后、continue-on-error、传 PINVOU3_TEST_EXE)。
- `filesystem.rs`:仅按真实执行路径改写 `windows_failed_first_promotion_preserves_the_complete_replacement` 的注释,代码零改动。
- 同步 origin/main 至 f9900a81/#310(干净合并)。

## 验证

- `python3 -m py_compile` 通过;截断 PE、空目录、非 PE 随机文件均正常诊断 exit 0;<0x40 字节随机文件强制触发 `struct.error`,实测兜底生效 exit 0。
- 新测试 7/7、`scripts/tests` 全量 50/50 通过;PyYAML 语义断言步骤顺序 嵌入(10)→诊断(11)→回归(12)。
- `cargo check --lib` 0 error;`cargo test --lib platform::filesystem` 通过(codewale-tui 19 条警告为既有)。
- CI 上诊断步骤对嵌入清单的实际降级输出由 windows-rust-test 直接验证。

## 已知风险

- 嵌入清单解析按资源目录树首叶子读取,不校验清单 ID/语言(当前 mt.exe 固定写 resource #1,足够)。
- SxS 程序集→DLL 映射为手工登记表,新程序集依赖需人工补充(当前仅 Common-Controls 一项)。