### PR TITLE
fix(settings): 模型目录拼写对齐底座规范并兼容存量配置大小写

### DIFF
--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -16,7 +16,7 @@ import {
   MODEL_CATALOG_SECTIONS, MODEL_CATALOG, CLOUD_MODEL_PROVIDERS,
   BRAND_ICON_BY_PRESET, BRAND_ICON_BY_VENDOR,
   presetOptionsI18n, presetProviderLabel,
-  normalizedProviderBaseUrl, findCloudProviderForModel, providerLabelForModel, isCodingPlanModel,
+  normalizedProviderBaseUrl, findCloudProviderForModel, providerLabelForModel, isCodingPlanModel, catalogItemMatchesModel,
   groupModelsForSelector, selectorMainLabel, selectorSubLabel,
   reasoningEffortTiersForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort,
 } from './model-catalog.js';
@@ -1269,7 +1269,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       const initialCatalogMatch = initialCatalogGroups.some(group =>
         group.preset === initial.preset
         && (!initialProvider || group.key === initialProvider.key)
-        && group.items.some(item => !item.custom && item.model === initial.model)
+        && group.items.some(item => !item.custom && catalogItemMatchesModel(item, initial.model))
       );
       const canSetUpLocalModel = can('localModelSetup');
       const [name, setName] = useState(initial.name || '');
@@ -1616,8 +1616,8 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
       const formDivider = 'border-black/[0.10] dark:border-white/[0.10]';
       const renderProviderModelField = () => {
         const items = activeProvider ? activeProvider.items : [];
-        const known = items.some(item => !item.custom && item.model === model);
-        const selectedItem = known ? items.find(item => !item.custom && item.model === model) : null;
+        const known = items.some(item => !item.custom && catalogItemMatchesModel(item, model));
+        const selectedItem = known ? items.find(item => !item.custom && catalogItemMatchesModel(item, model)) : null;
         const selectedLabel = customModel || !known ? `${settingsCopy.customModel} ID` : ((selectedItem && selectedItem.title) || model);
         const chooseModel = (item) => {
           const nextModel = (!item || item.custom) ? '' : item.model;
@@ -1652,7 +1652,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
             {providerModelPickerOpen && (
               <div className={`border-b last:border-b-0 ${formDivider}`}>
                 {items.map(item => {
-                  const active = item.custom ? (customModel || !known) : (!customModel && item.model === model);
+                  const active = item.custom ? (customModel || !known) : (!customModel && catalogItemMatchesModel(item, model));
                   return (
                     <button
                       type="button"

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -1738,7 +1738,7 @@ const SCard = React.forwardRef(({ title, titleAdornment, children, id, style }, 
               <div className={catalogSectionTitleClass}>{group.providerKind === PROVIDER_KIND_CODING_PLAN ? group.title : presetProviderLabel(group.preset, t)}</div>
               <div className={catalogGroupClass}>
                 {group.items.map(item => {
-                  const active = preset === group.preset && model === item.model && !item.custom;
+                  const active = preset === group.preset && !item.custom && catalogItemMatchesModel(item, model);
                   const itemTitle = item.custom ? (settingsCopy.customModelTitles[group.key] || settingsCopy.customModelTitle(presetProviderLabel(group.preset, t))) : item.title;
                   const itemDescription = item.custom
                     ? (group.providerKind === PROVIDER_KIND_CODING_PLAN ? settingsCopy.customCodingPlanDesc : (group.preset === 'local_vllm' ? settingsCopy.customLocalDesc : (group.preset === 'openai_compatible' ? settingsCopy.customCompatibleDesc : settingsCopy.customModelDesc)))

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -887,6 +887,7 @@ export {
   findCloudProviderForModel,
   providerLabelForModel,
   isCodingPlanModel,
+  catalogItemMatchesModel,
   isPresetModel,
   groupModelsForSelector,
   localUserNamed,

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -38,6 +38,12 @@ const MODEL_PRESET_DEFS = {
 const PROVIDER_KIND_CODING_PLAN = 'coding_plan';
 const PROVIDER_KIND_OFFICIAL_API = 'official_api';
 const PROVIDER_KIND_CUSTOM = 'custom';
+// 模型拼写约定：凡底座（CodeWhale）route 目录收录的模型，列表项 `model` 一律
+// 使用底座目录的规范拼写——z.ai 直连（GLM Coding Plan 国际版）的目录行是
+// `GLM-5.2` / `GLM-5-Turbo`（`glm-5.1` 为小写）；自定义兼容端点（bigmodel.cn
+// Coding Plan、开放平台）与 modelstudio 目录（qwen_token_plan）保持各自的小写
+// wire id。底座 resolver 对严格直连 provider 已做大小写不敏感回退，但新保存
+// 配置仍以规范拼写进入底座，避免依赖回退路径。
 const MODEL_CATALOG_SECTIONS = {
   coding_plan: 'Coding Plan',
   official_api: '官方 API',
@@ -119,6 +125,8 @@ const MODEL_CATALOG = {
       vendor: 'glm',
       baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
       endpointAliases: ['https://open.bigmodel.cn/api/coding/paas/v4/chat/completions'],
+      // bigmodel 是底座 zai kind 的自定义端点：模型名原样透传，必须用厂商
+      // 文档的小写 wire id（glm-5.2），不要对齐 z.ai 直连目录的大写拼写。
       items: [
         { model: 'glm-5.2', title: 'GLM-5.2', desc: '旗舰编码模型' },
         { model: 'glm-5-turbo', title: 'GLM-5-Turbo', desc: '高性能编码模型' },
@@ -138,8 +146,8 @@ const MODEL_CATALOG = {
       baseUrl: 'https://api.z.ai/api/coding/paas/v4',
       endpointAliases: ['https://api.z.ai/api/coding/paas/v4/chat/completions'],
       items: [
-        { model: 'glm-5.2', title: 'GLM-5.2', desc: '旗舰编码模型' },
-        { model: 'glm-5-turbo', title: 'GLM-5-Turbo', desc: '高性能编码模型' },
+        { model: 'GLM-5.2', title: 'GLM-5.2', desc: '旗舰编码模型' },
+        { model: 'GLM-5-Turbo', title: 'GLM-5-Turbo', desc: '高性能编码模型' },
         { model: 'glm-4.7', title: 'GLM-4.7', desc: '日常编码模型' },
         { model: '', title: '自定义 GLM Coding Plan 模型', desc: '手动填写 Coding Plan 模型 ID', custom: true },
       ],
@@ -507,7 +515,7 @@ function findCloudProviderForModel(model) {
       .map(url => provider.endpointMode === 'full_chat_completions' ? normalizeEndpointUrl(url) : normalizeOpenAiBaseUrl(url));
     const compareBase = provider.endpointMode === 'full_chat_completions' ? base : normalizeOpenAiBaseUrl(base);
     if (compareBase && urls.includes(compareBase)) return true;
-    return !providerKind && !vendor && provider.preset === model.preset && provider.items.some(item => !item.custom && item.model === model.model);
+    return !providerKind && !vendor && provider.preset === model.preset && provider.items.some(item => !item.custom && catalogItemMatchesModel(item, model.model));
   }) || null;
 }
 function providerLabelForModel(model, t) {
@@ -527,17 +535,24 @@ function isCodingPlanModel(model) {
 // ── 模型选择器:预设/自定义分组与可区分标注(纯函数,显示期计算) ─────
 // 分类判据:模型是否命中其实际 provider 的非 custom 目录项。自定义兼容接口即使
 // 使用目录中已有的模型 ID,也必须保持为自定义,避免多个聚合服务模型再次同名。
+// 目录命中比较大小写不敏感:目录拼写以底座(CodeWhale)为准,存量配置可能保存
+// 旧拼写(如 z.ai 直连的 glm-5.2 vs 目录行 GLM-5.2),不得因此误判为自定义。
+function catalogItemMatchesModel(item, model) {
+  return typeof item.model === 'string' && typeof model === 'string'
+    && item.model.toLowerCase() === model.toLowerCase();
+}
+
 function isPresetModel(m) {
   if (!m || !m.model) return false;
   if (m.preset === 'local_vllm') {
     return (MODEL_CATALOG.local || []).some(group =>
-      (group.items || []).some(item => !item.custom && item.model === m.model));
+      (group.items || []).some(item => !item.custom && catalogItemMatchesModel(item, m.model)));
   }
   const providerKind = m.provider_kind || m.providerKind;
   if (providerKind === PROVIDER_KIND_CUSTOM) return false;
   const provider = findCloudProviderForModel(m);
   return !!provider && provider.providerKind !== PROVIDER_KIND_CUSTOM
-    && (provider.items || []).some(item => !item.custom && item.model === m.model);
+    && (provider.items || []).some(item => !item.custom && catalogItemMatchesModel(item, m.model));
 }
 
 // 保留各组在入参中的原顺序。

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -39,11 +39,14 @@ const PROVIDER_KIND_CODING_PLAN = 'coding_plan';
 const PROVIDER_KIND_OFFICIAL_API = 'official_api';
 const PROVIDER_KIND_CUSTOM = 'custom';
 // 模型拼写约定：凡底座（CodeWhale）route 目录收录的模型，列表项 `model` 一律
-// 使用底座目录的规范拼写——z.ai 直连（GLM Coding Plan 国际版）的目录行是
-// `GLM-5.2` / `GLM-5-Turbo`（`glm-5.1` 为小写）；自定义兼容端点（bigmodel.cn
-// Coding Plan、开放平台）与 modelstudio 目录（qwen_token_plan）保持各自的小写
-// wire id。底座 resolver 对严格直连 provider 已做大小写不敏感回退，但新保存
-// 配置仍以规范拼写进入底座，避免依赖回退路径。
+// 使用底座 models_dev.bundled.json 目录行的原样拼写——z.ai 直连（GLM Coding
+// Plan 国际版）当前为 `GLM-5.2` / `GLM-5-Turbo` / `glm-5.1`，资产自身大小写
+// 不统一（agent 层 ModelInfo 目录行则统一大写），新增条目须逐行核对资产行拼写，
+// 不可套用大小写规律；自定义兼容端点（bigmodel.cn Coding Plan、开放平台）与
+// modelstudio 目录（qwen_token_plan）保持各自的小写 wire id。resolver 目录匹配
+// 是精确比较，拼写偏离目录行的 id（如小写 glm-5.2）会命中其他 provider 的裸
+// wire id 而被严格直连误拒——大小写不敏感回退已回馈上游审核、未随当前 gitlink
+// 发布，故新保存配置必须用目录行原样拼写。
 const MODEL_CATALOG_SECTIONS = {
   coding_plan: 'Coding Plan',
   official_api: '官方 API',

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -20,6 +20,7 @@ vm.createContext(ctx);
 vm.runInContext(
   `${code}\n` +
   `this.isPresetModel = isPresetModel;\n` +
+  `this.catalogItemMatchesModel = catalogItemMatchesModel;\n` +
   `this.groupModelsForSelector = groupModelsForSelector;\n` +
   `this.localUserNamed = localUserNamed;\n` +
   `this.selectorMainLabel = selectorMainLabel;\n` +
@@ -35,7 +36,7 @@ vm.runInContext(
   { filename: srcPath },
 );
 
-const { isPresetModel, groupModelsForSelector, localUserNamed, selectorMainLabel, selectorSubLabel, providerLabelForModel, reasoningEffortTiersForModel, defaultReasoningEffortForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort } = ctx;
+const { isPresetModel, catalogItemMatchesModel, MODEL_CATALOG, groupModelsForSelector, localUserNamed, selectorMainLabel, selectorSubLabel, providerLabelForModel, reasoningEffortTiersForModel, defaultReasoningEffortForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort } = ctx;
 
 // i18n 测试替身:复刻实际字典里会用到的字段
 const t = {
@@ -73,6 +74,17 @@ test('z.ai 直连存量小写配置仍命中大写目录行 -> 预设', () => {
   // 目录拼写以底座为准（GLM-5.2），存量配置可能保存旧小写 glm-5.2。
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'glm-5.2' })), true);
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'GLM-5.2' })), true);
+});
+test('catalogItemMatchesModel 大小写不敏感(编辑弹窗存量小写命中目录行)', () => {
+  // SettingsView 编辑弹窗的 initialCatalogMatch/known/active 均复用此比较:
+  // 存量小写 glm-5.2 必须命中 z.ai 直连目录行 GLM-5.2,不得误判为自定义。
+  const zaiGroup = MODEL_CATALOG.cloud.find(group => group.key === 'glm_coding_plan_global');
+  const glm52 = zaiGroup.items.find(item => item.model === 'GLM-5.2');
+  assert.ok(glm52, 'z.ai 直连目录应含 GLM-5.2 规范拼写行');
+  assert.strictEqual(catalogItemMatchesModel(glm52, 'glm-5.2'), true);
+  assert.strictEqual(catalogItemMatchesModel(glm52, 'GLM-5.2'), true);
+  assert.strictEqual(catalogItemMatchesModel(glm52, 'glm-5.3'), false);
+  assert.strictEqual(catalogItemMatchesModel(glm52, undefined), false);
 });
 test('Coding Plan 手填 ID -> 自定义', () => {
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://open.bigmodel.cn/api/coding/paas/v4', model: 'my-custom-glm' })), false);

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -69,6 +69,11 @@ test('OpenAI Compatible 命中目录 ID 仍为自定义', () => {
 test('Coding Plan 命中目录(glm-5.2) -> 预设', () => {
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://open.bigmodel.cn/api/coding/paas/v4', model: 'glm-5.2' })), true);
 });
+test('z.ai 直连存量小写配置仍命中大写目录行 -> 预设', () => {
+  // 目录拼写以底座为准（GLM-5.2），存量配置可能保存旧小写 glm-5.2。
+  assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'glm-5.2' })), true);
+  assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'GLM-5.2' })), true);
+});
 test('Coding Plan 手填 ID -> 自定义', () => {
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://open.bigmodel.cn/api/coding/paas/v4', model: 'my-custom-glm' })), false);
 });


### PR DESCRIPTION
> 本 PR 原为「底座修复 + 目录拼写」混合提交，已按要求拆分：本 PR 仅保留**设置页目录拼写对齐**（直接解决选模型不生效的保存侧问题）；底座 gitlink/r7 登记/guard 指纹/bridge 端到端回归见配套 PR #295。

## 背景

0.8.1 macOS 版用 GLM Coding Plan 国际版，选了列表里的 `glm-5.2`，访问时报：

```
send_user_message failed: model "glm-5.2" is not served by direct provider zai
```

自定义模型名 `glm-5.3` 正常（且上游实际把 glm-5.2 路由到 glm-5.3，服务端本可接受）。

## 根因（保存侧）

设置页目录项拼写与底座（CodeWhale）route 目录不一致：z.ai 直连的底座目录行是市场拼写 `GLM-5.2` / `GLM-5-Turbo`，而目录列表保存的是小写 `glm-5.2`。用户从列表选择后，小写选择器进入底座严格路由，精确比较匹配不到自身目录行。底座侧的大小写不敏感回退修复（resolver）走 `Pinvou/CodeWhale#14` + 配套 gitlink PR（#295）；本 PR 让**新保存配置直接以规范拼写进入底座**，不依赖回退路径。

## 拼写约定（本 PR 确立）

**凡底座（CodeWhale）route 目录收录的模型，设置页目录项一律以底座目录拼写为准**；自定义端点按厂商 wire id：

- **z.ai 直连**（GLM Coding Plan 国际版，严格直连路由）：列表项 `GLM-5.2` / `GLM-5-Turbo`（`glm-5.1` 底座即小写）
- **bigmodel.cn Coding Plan / 开放平台 / qwen_token_plan**：自定义/聚合端点，模型名原样透传，保持厂商小写 wire id（`glm-5.2` 等）

## 变更

- `model-catalog.js`：仅 z.ai 直连两组列表改规范拼写 + 约定注释；bigmodel 组补防回归注释说明不得对齐大写
- `isPresetModel` / `findCloudProviderForModel` 目录命中改大小写不敏感（`catalogItemMatchesModel`），**存量小写配置**仍识别为预设行，不误判为自定义
- node 测试：新增「z.ai 直连存量小写配置仍命中大写目录行 → 预设」

## 验证

- `node --test tests/model_catalog_grouping.test.js`：35 全通过（main 基线 34 + 新增 1）
- `python3 scripts/architecture-guard.py` 通过
- 不涉及 CodeWhale 与 Rust 侧，`fork-guard.sh` 不受影响

## 已知风险

- 无行为风险：目录命中大小写不敏感只会放宽匹配，存量精确匹配行为不变
- 若底座侧修复 PR（#295）未合入，仅靠本 PR 新保存的大写 `GLM-5.2` 在当前底座上本就精确匹配成功，可独立生效