### PR TITLE
fix(scheduled): 重选已选中的模型选项时重新提交绑定

### DIFF
--- a/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
+++ b/pinvou3-app/src/features/scheduled/ScheduledTasksView.jsx
@@ -114,7 +114,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
     const ScheduledSelect = ({
       value, options, onChange, testId, ariaLabel, theme, minWidth = 180,
       multiple = false, minSelected = 0, onClose, emptyLabel = '—', separator = '、',
-      footerAction,
+      footerAction, alwaysCommit = false,
     }) => {
       const [open, setOpen] = useState(false);
       const [menuStyle, setMenuStyle] = useState(null);
@@ -208,7 +208,9 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
                 onClick={() => {
                   if (!multiple) {
                     closeMenu();
-                    if (!active) onChange(option.value);
+                    // 模型配置可被原地编辑（wire name 变化但配置 id 不变），
+                    // 重选同一选项也要重新提交，治愈 EnginePool 的过期绑定快照。
+                    if (alwaysCommit || !active) onChange(option.value);
                     return;
                   }
                   const nextValues = new Set(selectedValues);
@@ -1357,7 +1359,7 @@ import weeklyReviewImage from '../../assets/scheduled/weekly-review.jpg';
                     <span className={`ml-1 text-[15px] font-normal ${bodyText}`}>{scheduledCopy.aiModel}</span>
                     <div className="flex items-center gap-1.5">
                       <ScheduledSelect value={detailForm.modelId || ''} options={modelOptions}
-                        onChange={value => editModel(value)}
+                        onChange={value => editModel(value)} alwaysCommit
                         testId="scheduled-live-model" ariaLabel={scheduledCopy.chooseModel} theme={theme} minWidth={220} emptyLabel={scheduledCopy.choose} footerAction={modelManageAction} />
                       <ChevronRight className={`h-3.5 w-3.5 text-[#C5C5C7] dark:text-[#EBEBF5]/30`} />
                     </div>

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -403,6 +403,15 @@ assert.ok(
   'scheduled model selection should display the wire model instead of stale display names'
 );
 assert.ok(
+  /footerAction, alwaysCommit = false,/.test(indexHtml) &&
+    /if \(alwaysCommit \|\| !active\) onChange\(option\.value\);/.test(indexHtml) &&
+    /onChange=\{value => editModel\(value\)\} alwaysCommit/.test(indexHtml) &&
+    (indexHtml.match(/alwaysCommit/g) || []).length === 3,
+  're-selecting the already-active model option must re-commit the binding: ' +
+    'an in-place edited model config keeps its id while its wire name changes, ' +
+    'and the engine rejects the stale binding snapshot until the task is re-saved'
+);
+assert.ok(
   !/data-testid="scheduled-task-pin"/.test(indexHtml) &&
     !/data-testid="scheduled-task-actions"/.test(indexHtml) &&
     !/data-testid="scheduled-task-action-menu"/.test(indexHtml) &&


### PR DESCRIPTION
## 背景

定时任务绑定模型配置后,若在设置页把该配置的模型原地改掉(配置 id 不变、wire name 从 glm-5.2 改为 glm-5.3),任务运行会被 `resolve_scheduled_model`(engine_pool.rs)拒绝:

> 此任务绑定的 AI 模型配置已变更,请重新选择 AI 模型并保存任务

提示用户「重新选择 AI 模型」,但详情页模型下拉的选中值是**配置 id**——原地改配置后下拉已显示新模型名,点回该选项是「已激活选项」,被 `ScheduledSelect` 的 `if (!active)` 守卫静默吞掉,`editModel` 不触发、什么都不保存,任务永远无法按提示自愈。

## 变更

- `ScheduledTasksView.jsx`:为 `ScheduledSelect` 增加 `alwaysCommit` prop,点击已激活选项也调用 `onChange`;仅详情页模型下拉启用。
- `tests/scheduled_tasks_unit.test.js`:新增断言,锁住「重选已激活模型选项必须重新提交绑定」的行为(组件 prop、守卫、启用点三处)。

修复机制:`editModel` 按配置 id 读取**当前** wire name 并连同 `modelId` 重新提交,后端 `update_task` 会重写 automation 记录与 model-bindings,过期绑定快照即被治愈;重复提交幂等,其余下拉(重复频率/星期/小时)行为不变。

## 验证

- `node --test tests/scheduled_tasks_unit.test.js` 通过(含新断言)
- `npm test` 前端全量 136 项通过
- `eslint` 改动文件无告警
- `python3 scripts/architecture-guard.py` 通过

## 已知风险

仅前端交互层改动,不触碰后端校验防线(该防线防止任务绑定的模型被静默偷换,保留原样);Rust 侧无变更。