### PR TITLE
feat(i18n): 初始语言跟随系统设置

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -184,7 +184,7 @@ objc2-speech = { version = "0.3", default-features = false, features = [
 ] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Performance", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Storage_FileSystem", "Win32_System_Performance", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_WindowsAndMessaging"] }
 webview2-com = "0.38.2"
 windows = "0.61.3"
 

--- a/pinvou3-app/src-tauri/src/app/commands/voice.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/voice.rs
@@ -317,8 +317,8 @@ pub async fn transcribe_voice_audio(
         // 平台选择封装在 `features::voice::recognize_native`（platform/ 适配器），
         // 此处只按返回值分发，不出现 cfg(target_os)。
         let result = {
-            // 识别语言跟随 UI 语言偏好（默认 zh-Hans → zh-CN）：系统默认 locale
-            // 可能是 en-US，会把中文音频当英文解析 → 无意义英文字母。
+            // 识别语言跟随 UI 语言偏好（首次启动时由系统 locale 决定）：避免 UI 与
+            // 识别模型语言错配，例如中文 UI 却把中文音频当英文解析。
             let locale_tag = crate::platform::prefs::UserPrefs::load()
                 .language
                 .speech_recognition_locale();

--- a/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
@@ -14,10 +14,10 @@ pub use permission::{
 };
 pub use system::{
     archive_dependency_packages, archive_tool_exists, archive_tool_path, command_exists,
-    email_dependency_packages, email_manual_hint, email_tool_exists, libreoffice_missing_message,
-    libreoffice_open_fallback_needed, libreoffice_tool_path, msg_converter_required,
-    msg_native_supported, nvidia_smi_candidates, ocr_dependency_packages, ocr_tessdata_dir,
-    ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
+    current_system_locale, email_dependency_packages, email_manual_hint, email_tool_exists,
+    libreoffice_missing_message, libreoffice_open_fallback_needed, libreoffice_tool_path,
+    msg_converter_required, msg_native_supported, nvidia_smi_candidates, ocr_dependency_packages,
+    ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
     pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path, pdf_dependency_packages,
     pdf_ocr_missing_message, pdf_render_missing_message, pdf_text_missing_message, pdf_tool_exists,
     pdf_tool_path, presentation_pdf_missing_message, reveal_target, show_archive_dependency_check,

--- a/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
@@ -14,6 +14,10 @@ pub fn command_exists(command: &str) -> bool {
     super::super::platform::command_exists(command)
 }
 
+pub fn current_system_locale() -> Option<String> {
+    super::super::platform::current_system_locale()
+}
+
 #[cfg(target_os = "windows")]
 pub fn bios_serial_number() -> Result<String, String> {
     super::super::platform::bios_serial_number()

--- a/pinvou3-app/src-tauri/src/platform/os/linux/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/mod.rs
@@ -2,6 +2,8 @@ mod linux_path;
 mod linux_permission;
 mod linux_system;
 
+pub(crate) use super::locale::current_system_locale;
+
 pub use linux_path::{
     apply_user_npm_prefix, configure_onnxruntime_dylib, connector_cli_command,
     filesystem_path_identity_key, kill_pid_tree, obsidian_config_path, path_component_eq,

--- a/pinvou3-app/src-tauri/src/platform/os/locale.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/locale.rs
@@ -1,0 +1,161 @@
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn language_preference(value: Option<&str>) -> Option<&str> {
+    value?
+        .split(':')
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+}
+
+fn is_portable_locale(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    value.eq_ignore_ascii_case("C")
+        || value.eq_ignore_ascii_case("POSIX")
+        || (bytes.len() > 2 && bytes[0].eq_ignore_ascii_case(&b'c') && bytes[1] == b'.')
+}
+
+/// Selects the locale used for GNU-style translated messages.
+///
+/// `LANGUAGE` overrides an explicitly configured category locale, except when
+/// the effective base locale is the untranslated `C`/`POSIX` locale. A missing
+/// base locale also means the portable default and therefore ignores
+/// `LANGUAGE`. Keeping this logic pure makes the environment precedence
+/// testable without mutating process-global state.
+fn select_message_locale(
+    language: Option<&str>,
+    lc_all: Option<&str>,
+    lc_messages: Option<&str>,
+    lang: Option<&str>,
+) -> Option<String> {
+    let base_locale = [lc_all, lc_messages, lang]
+        .into_iter()
+        .find_map(non_empty)?;
+
+    if is_portable_locale(base_locale) {
+        return Some(base_locale.to_owned());
+    }
+
+    language_preference(language)
+        .or(Some(base_locale))
+        .map(str::to_owned)
+}
+
+pub(crate) fn current_system_locale() -> Option<String> {
+    let language = std::env::var("LANGUAGE").ok();
+    let lc_all = std::env::var("LC_ALL").ok();
+    let lc_messages = std::env::var("LC_MESSAGES").ok();
+    let lang = std::env::var("LANG").ok();
+
+    select_message_locale(
+        language.as_deref(),
+        lc_all.as_deref(),
+        lc_messages.as_deref(),
+        lang.as_deref(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_precedes_non_portable_base_locale() {
+        assert_eq!(
+            select_message_locale(
+                Some("ja_JP"),
+                Some("en_US.UTF-8"),
+                Some("zh_CN.UTF-8"),
+                Some("de_DE.UTF-8"),
+            ),
+            Some("ja_JP".to_string())
+        );
+    }
+
+    #[test]
+    fn base_locale_uses_category_precedence_without_language() {
+        assert_eq!(
+            select_message_locale(
+                Some("  "),
+                Some("en_US.UTF-8"),
+                Some("ja_JP.UTF-8"),
+                Some("zh_CN.UTF-8"),
+            ),
+            Some("en_US.UTF-8".to_string())
+        );
+        assert_eq!(
+            select_message_locale(None, Some(""), Some("ja_JP.UTF-8"), Some("zh_CN.UTF-8")),
+            Some("ja_JP.UTF-8".to_string())
+        );
+        assert_eq!(
+            select_message_locale(None, None, None, Some("zh_CN.UTF-8")),
+            Some("zh_CN.UTF-8".to_string())
+        );
+    }
+
+    #[test]
+    fn language_uses_first_non_empty_colon_list_entry() {
+        assert_eq!(
+            select_message_locale(Some(" : ja_JP : zh_CN "), None, None, Some("en_US.UTF-8")),
+            Some("ja_JP".to_string())
+        );
+    }
+
+    #[test]
+    fn c_base_locale_ignores_language() {
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), Some(" c "), Some("zh_CN"), Some("en_US")),
+            Some("c".to_string())
+        );
+    }
+
+    #[test]
+    fn c_encoding_base_locales_ignore_language() {
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), Some("C.UTF-8"), None, None),
+            Some("C.UTF-8".to_string())
+        );
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), None, Some("C.utf8"), None),
+            Some("C.utf8".to_string())
+        );
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), None, None, Some("c.UtF-8")),
+            Some("c.UtF-8".to_string())
+        );
+    }
+
+    #[test]
+    fn locale_starting_with_c_is_not_automatically_portable() {
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), Some("ca_ES.UTF-8"), None, None),
+            Some("ja_JP".to_string())
+        );
+    }
+
+    #[test]
+    fn posix_base_locale_ignores_language() {
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), None, Some("POSIX"), Some("zh_CN")),
+            Some("POSIX".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_values_do_not_select_a_locale() {
+        assert_eq!(
+            select_message_locale(Some(" :  : "), Some(" "), Some(""), None),
+            None
+        );
+    }
+
+    #[test]
+    fn language_without_an_explicit_base_locale_is_ignored() {
+        assert_eq!(select_message_locale(Some("ja_JP"), None, None, None), None);
+        assert_eq!(
+            select_message_locale(Some("ja_JP"), Some(" "), Some(""), Some("  ")),
+            None
+        );
+    }
+}

--- a/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
@@ -3,6 +3,14 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::macos_path;
+use objc2_foundation::NSLocale;
+
+pub fn current_system_locale() -> Option<String> {
+    NSLocale::preferredLanguages()
+        .firstObject()
+        .map(|locale| locale.to_string())
+        .filter(|locale| !locale.trim().is_empty())
+}
 
 /// 校验路径存在且至少有一个可执行位(owner/group/other 任一有 x bit)。
 /// 与 Linux 侧 `which` 自带的可执行性校验对齐:`command_exists` 此前只调

--- a/pinvou3-app/src-tauri/src/platform/os/macos/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/macos/mod.rs
@@ -21,10 +21,10 @@ pub use macos_permission::{
 };
 pub use macos_system::{
     archive_dependency_packages, archive_tool_exists, archive_tool_path, command_exists,
-    email_dependency_packages, email_manual_hint, email_tool_exists, libreoffice_missing_message,
-    libreoffice_open_fallback_needed, libreoffice_tool_path, msg_converter_required,
-    msg_native_supported, nvidia_smi_candidates, ocr_dependency_packages, ocr_tessdata_dir,
-    ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
+    current_system_locale, email_dependency_packages, email_manual_hint, email_tool_exists,
+    libreoffice_missing_message, libreoffice_open_fallback_needed, libreoffice_tool_path,
+    msg_converter_required, msg_native_supported, nvidia_smi_candidates, ocr_dependency_packages,
+    ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
     pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path, pdf_dependency_packages,
     pdf_ocr_missing_message, pdf_render_missing_message, pdf_text_missing_message, pdf_tool_exists,
     pdf_tool_path, presentation_pdf_missing_message, reveal_target, show_archive_dependency_check,

--- a/pinvou3-app/src-tauri/src/platform/os/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/mod.rs
@@ -15,8 +15,13 @@ pub(crate) mod posix;
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
 pub(crate) mod unsupported;
 
-mod interface;
+// GNU 消息 locale 语义的环境变量探测，仅 linux 与 unsupported 平台消费
+// (windows/macos 各有原生实现)，按 posix.rs 先例门控到消费平台并集，
+// 避免在非消费平台累积 dead_code(见 [lints] 中 dead_code 升 deny 计划)。
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 mod locale;
+
+mod interface;
 
 #[cfg(target_os = "linux")]
 pub(crate) use linux as platform;

--- a/pinvou3-app/src-tauri/src/platform/os/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod posix;
 pub(crate) mod unsupported;
 
 mod interface;
+mod locale;
 
 #[cfg(target_os = "linux")]
 pub(crate) use linux as platform;
@@ -28,17 +29,18 @@ pub(crate) use windows as platform;
 
 pub use interface::{
     apply_user_npm_prefix, archive_dependency_packages, archive_tool_exists, archive_tool_path,
-    command_exists, configure_onnxruntime_dylib, connector_cli_command, disable_super_permission,
-    email_dependency_packages, email_manual_hint, email_tool_exists, enable_super_permission,
-    external_application_path, file_url_from_path, filesystem_path_identity_key, kill_pid_tree,
-    libreoffice_missing_message, libreoffice_open_fallback_needed, libreoffice_tool_path,
-    msg_converter_required, msg_native_supported, nvidia_smi_candidates, obsidian_config_path,
-    ocr_dependency_packages, ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target,
-    pandoc_dependency_packages, pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path,
-    path_component_eq, pdf_dependency_packages, pdf_ocr_missing_message,
-    pdf_render_missing_message, pdf_text_missing_message, pdf_tool_exists, pdf_tool_path,
-    platform_compat_path, presentation_pdf_missing_message, python_command, reveal_target,
-    show_archive_dependency_check, show_ocr_dependency_check, show_pandoc_dependency_check,
-    show_pdf_dependency_check, super_permission_is_enabled, super_permission_turn_reminder,
-    system_default_open_supported, user_home_dir, validate_upload_location,
+    command_exists, configure_onnxruntime_dylib, connector_cli_command, current_system_locale,
+    disable_super_permission, email_dependency_packages, email_manual_hint, email_tool_exists,
+    enable_super_permission, external_application_path, file_url_from_path,
+    filesystem_path_identity_key, kill_pid_tree, libreoffice_missing_message,
+    libreoffice_open_fallback_needed, libreoffice_tool_path, msg_converter_required,
+    msg_native_supported, nvidia_smi_candidates, obsidian_config_path, ocr_dependency_packages,
+    ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
+    pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path, path_component_eq,
+    pdf_dependency_packages, pdf_ocr_missing_message, pdf_render_missing_message,
+    pdf_text_missing_message, pdf_tool_exists, pdf_tool_path, platform_compat_path,
+    presentation_pdf_missing_message, python_command, reveal_target, show_archive_dependency_check,
+    show_ocr_dependency_check, show_pandoc_dependency_check, show_pdf_dependency_check,
+    super_permission_is_enabled, super_permission_turn_reminder, system_default_open_supported,
+    user_home_dir, validate_upload_location,
 };

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -10,6 +10,9 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+// macOS 侧由 `macos_system::current_system_locale` 显式实现阴影本符号,该目标下
+// unused(unused_imports=deny 会拦);其余 unsupported 平台它是唯一来源,保留。
+#[cfg(not(target_os = "macos"))]
 pub(crate) use super::locale::current_system_locale;
 
 pub fn open_target(_target: impl AsRef<OsStr>, label: &str) -> Result<(), String> {

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -9,6 +9,9 @@
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+pub(crate) use super::locale::current_system_locale;
+
 pub fn open_target(_target: impl AsRef<OsStr>, label: &str) -> Result<(), String> {
     Err(format!("当前平台不支持系统打开: {label}"))
 }

--- a/pinvou3-app/src-tauri/src/platform/os/windows/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/windows/mod.rs
@@ -14,13 +14,13 @@ pub use windows_permission::{
 };
 pub use windows_system::{
     archive_dependency_packages, archive_tool_exists, archive_tool_path, bios_serial_number,
-    command_exists, email_dependency_packages, email_manual_hint, email_tool_exists,
-    libreoffice_missing_message, libreoffice_open_fallback_needed, libreoffice_tool_path,
-    msg_converter_required, msg_native_supported, nvidia_smi_candidates, ocr_dependency_packages,
-    ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target, pandoc_dependency_packages,
-    pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path, pdf_dependency_packages,
-    pdf_ocr_missing_message, pdf_render_missing_message, pdf_text_missing_message, pdf_tool_exists,
-    pdf_tool_path, presentation_pdf_missing_message, reveal_target, show_archive_dependency_check,
-    show_ocr_dependency_check, show_pandoc_dependency_check, show_pdf_dependency_check,
-    system_default_open_supported,
+    command_exists, current_system_locale, email_dependency_packages, email_manual_hint,
+    email_tool_exists, libreoffice_missing_message, libreoffice_open_fallback_needed,
+    libreoffice_tool_path, msg_converter_required, msg_native_supported, nvidia_smi_candidates,
+    ocr_dependency_packages, ocr_tessdata_dir, ocr_tool_exists, ocr_tool_path, open_target,
+    pandoc_dependency_packages, pandoc_missing_message, pandoc_tool_exists, pandoc_tool_path,
+    pdf_dependency_packages, pdf_ocr_missing_message, pdf_render_missing_message,
+    pdf_text_missing_message, pdf_tool_exists, pdf_tool_path, presentation_pdf_missing_message,
+    reveal_target, show_archive_dependency_check, show_ocr_dependency_check,
+    show_pandoc_dependency_check, show_pdf_dependency_check, system_default_open_supported,
 };

--- a/pinvou3-app/src-tauri/src/platform/os/windows/windows_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/windows/windows_system.rs
@@ -5,10 +5,42 @@ use std::path::{Path, PathBuf};
 
 use super::windows_path;
 use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Globalization::{GetUserPreferredUILanguages, MUI_LANGUAGE_NAME};
 use windows_sys::Win32::System::Registry::{
     RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_CLASSES_ROOT, HKEY_CURRENT_USER,
     KEY_READ, REG_EXPAND_SZ, REG_SZ,
 };
+
+pub fn current_system_locale() -> Option<String> {
+    let mut language_count = 0;
+    let mut buffer_len = 0;
+    // The sizing call is expected to return false with an insufficient-buffer error.
+    unsafe {
+        GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            &mut language_count,
+            std::ptr::null_mut(),
+            &mut buffer_len,
+        );
+    }
+    if buffer_len <= 1 {
+        return None;
+    }
+    let mut locale_names = vec![0u16; buffer_len as usize];
+    let ok = unsafe {
+        GetUserPreferredUILanguages(
+            MUI_LANGUAGE_NAME,
+            &mut language_count,
+            locale_names.as_mut_ptr(),
+            &mut buffer_len,
+        )
+    };
+    if ok == 0 || language_count == 0 {
+        return None;
+    }
+    let first_len = locale_names.iter().position(|unit| *unit == 0)?;
+    String::from_utf16(&locale_names[..first_len]).ok()
+}
 
 pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String> {
     HiddenCommand::new("cmd")

--- a/pinvou3-app/src-tauri/src/platform/os/windows/windows_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/windows/windows_system.rs
@@ -14,16 +14,19 @@ use windows_sys::Win32::System::Registry::{
 pub fn current_system_locale() -> Option<String> {
     let mut language_count = 0;
     let mut buffer_len = 0;
-    // The sizing call is expected to return false with an insufficient-buffer error.
-    unsafe {
+    // MSDN sizing call: null buffer with *pcchLanguagesBuffer = 0 returns TRUE
+    // and stores the required size (trailing double NUL included). Still check
+    // the return value so a failed call leaving buffer_len undefined cannot
+    // trigger a bogus large allocation below.
+    let sized = unsafe {
         GetUserPreferredUILanguages(
             MUI_LANGUAGE_NAME,
             &mut language_count,
             std::ptr::null_mut(),
             &mut buffer_len,
-        );
-    }
-    if buffer_len <= 1 {
+        )
+    };
+    if sized == 0 || buffer_len <= 1 {
         return None;
     }
     let mut locale_names = vec![0u16; buffer_len as usize];

--- a/pinvou3-app/src-tauri/src/platform/prefs/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs/mod.rs
@@ -61,6 +61,24 @@ pub enum Language {
     Ja,
 }
 impl Language {
+    fn from_system_locale(locale: Option<&str>) -> Self {
+        let Some(locale) = locale.map(str::trim).filter(|locale| !locale.is_empty()) else {
+            return Language::En;
+        };
+        let primary = locale
+            .split(|ch: char| matches!(ch, '-' | '_' | '.' | '@' | ':'))
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        match primary.as_str() {
+            "zh" => Language::ZhHans,
+            "ja" => Language::Ja,
+            "en" => Language::En,
+            // 品悟当前只提供中、英、日；其它系统语言使用英文，而不是误显示中文。
+            _ => Language::En,
+        }
+    }
+
     pub fn locale_tag(self) -> &'static str {
         match self {
             Language::ZhHans => "zh-Hans",
@@ -462,22 +480,84 @@ pub struct UserPrefs {
     pub advanced: AdvancedPrefs,
 }
 
+struct ParsedSettings {
+    prefs: UserPrefs,
+    allow_normalization_persist: bool,
+}
+
+fn should_persist_normalization(allow_persist: bool, requested: bool, changed: bool) -> bool {
+    requested && changed && allow_persist
+}
+
 impl UserPrefs {
-    /// 从 `~/.pinvou3/settings.json` 读。文件不存在或 JSON 解析失败时返回默认。
+    /// 从 `~/.pinvou3/settings.json` 读。没有有效语言配置时跟随当前系统语言。
     pub fn load() -> Self {
         let _guard = lock_user_prefs();
         Self::load_unlocked(true)
     }
 
+    fn defaults_for_system_locale(locale: Option<&str>) -> Self {
+        Self {
+            language: Language::from_system_locale(locale),
+            ..Self::default()
+        }
+    }
+
+    fn parse_settings_with_state(raw: Option<&str>, system_locale: Option<&str>) -> ParsedSettings {
+        let Some(raw) = raw else {
+            return ParsedSettings {
+                prefs: Self::defaults_for_system_locale(system_locale),
+                allow_normalization_persist: false,
+            };
+        };
+        let value: serde_json::Value = match serde_json::from_str(raw) {
+            Ok(value) => value,
+            Err(error) => {
+                eprintln!(
+                    "[pinvou3-app] settings.json parse failed ({error}), using system-language defaults"
+                );
+                return ParsedSettings {
+                    prefs: Self::defaults_for_system_locale(system_locale),
+                    allow_normalization_persist: false,
+                };
+            }
+        };
+        let has_language = value
+            .as_object()
+            .is_some_and(|settings| settings.contains_key("language"));
+        let mut prefs: Self = match serde_json::from_value(value) {
+            Ok(prefs) => prefs,
+            Err(error) => {
+                eprintln!(
+                    "[pinvou3-app] settings.json parse failed ({error}), using system-language defaults"
+                );
+                return ParsedSettings {
+                    prefs: Self::defaults_for_system_locale(system_locale),
+                    allow_normalization_persist: false,
+                };
+            }
+        };
+        if !has_language {
+            prefs.language = Language::from_system_locale(system_locale);
+        }
+        ParsedSettings {
+            prefs,
+            allow_normalization_persist: true,
+        }
+    }
+
+    #[cfg(test)]
+    fn parse_settings(raw: Option<&str>, system_locale: Option<&str>) -> Self {
+        Self::parse_settings_with_state(raw, system_locale).prefs
+    }
+
     fn load_unlocked(persist_normalized: bool) -> Self {
         let path = super::paths::settings_path();
-        let mut prefs = match std::fs::read_to_string(&path) {
-            Ok(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
-                eprintln!("[pinvou3-app] settings.json parse failed ({e}), using defaults");
-                Self::default()
-            }),
-            Err(_) => Self::default(),
-        };
+        let raw = std::fs::read_to_string(&path).ok();
+        let system_locale = crate::platform::os::current_system_locale();
+        let mut parsed = Self::parse_settings_with_state(raw.as_deref(), system_locale.as_deref());
+        let allow_normalization_persist = parsed.allow_normalization_persist;
+        let prefs = &mut parsed.prefs;
         // 必须在 migrate_models/normalize 改写前记录；否则只能修正本次运行的内存值，
         // save gate 看不到变化，旧域名会永久留在 settings.json 中、每次启动重复迁移。
         let minimax_endpoint_changed = prefs
@@ -494,15 +574,19 @@ impl UserPrefs {
         prefs.normalize_saved_model_metadata();
         let migration = prefs.migrate_plaintext_api_keys_with_store(&SystemCredentialStore::new());
         let memory_policy_changed = prefs.enforce_memory_locale_policy();
-        if persist_normalized
-            && (minimax_endpoint_changed || migration.settings_sanitized || memory_policy_changed)
-        {
+        let normalization_changed =
+            minimax_endpoint_changed || migration.settings_sanitized || memory_policy_changed;
+        if should_persist_normalization(
+            allow_normalization_persist,
+            persist_normalized,
+            normalization_changed,
+        ) {
             if let Err(e) = prefs.save_unlocked() {
                 eprintln!("[pinvou3-app] settings normalization save failed: {e:#}");
             }
         }
         prefs.sanitize_plaintext_api_keys();
-        prefs
+        parsed.prefs
     }
 
     pub fn save(&self) -> std::io::Result<()> {
@@ -1366,6 +1450,94 @@ mod tests {
             assert!(prefs.notifications.task_completed);
         }
         assert!(prefs.advanced.allow_shell.is_none());
+    }
+
+    #[test]
+    fn system_locale_maps_to_supported_language() {
+        assert_eq!(
+            Language::from_system_locale(Some("zh_CN.UTF-8")),
+            Language::ZhHans
+        );
+        assert_eq!(
+            Language::from_system_locale(Some("zh-Hant-TW")),
+            Language::ZhHans
+        );
+        assert_eq!(Language::from_system_locale(Some("ja-JP")), Language::Ja);
+        assert_eq!(Language::from_system_locale(Some("en-US")), Language::En);
+        assert_eq!(Language::from_system_locale(Some("fr-FR")), Language::En);
+        assert_eq!(Language::from_system_locale(None), Language::En);
+    }
+
+    #[test]
+    fn missing_settings_uses_system_language() {
+        let prefs = UserPrefs::parse_settings(None, Some("ja-JP"));
+        assert_eq!(prefs.language, Language::Ja);
+    }
+
+    #[test]
+    fn invalid_settings_uses_system_language() {
+        let prefs = UserPrefs::parse_settings(Some("{broken"), Some("en-US"));
+        assert_eq!(prefs.language, Language::En);
+    }
+
+    #[test]
+    fn invalid_settings_never_allow_normalization_persist() {
+        for (raw, locale, expected_language) in [
+            ("{broken", "en-US", Language::En),
+            (r#"{"language":42}"#, "ja-JP", Language::Ja),
+        ] {
+            let mut parsed = UserPrefs::parse_settings_with_state(Some(raw), Some(locale));
+            assert_eq!(parsed.prefs.language, expected_language);
+            assert!(!parsed.allow_normalization_persist);
+            parsed.prefs.memory_enabled = true;
+            let normalization_changed = parsed.prefs.enforce_memory_locale_policy();
+            assert!(normalization_changed);
+            assert!(!should_persist_normalization(
+                parsed.allow_normalization_persist,
+                true,
+                normalization_changed,
+            ));
+        }
+    }
+
+    #[test]
+    fn missing_settings_do_not_allow_normalization_persist() {
+        let parsed = UserPrefs::parse_settings_with_state(None, Some("en-US"));
+        assert!(!parsed.allow_normalization_persist);
+        assert!(!should_persist_normalization(
+            parsed.allow_normalization_persist,
+            true,
+            true,
+        ));
+    }
+
+    #[test]
+    fn valid_settings_allow_existing_normalization_persist() {
+        let mut parsed = UserPrefs::parse_settings_with_state(
+            Some(r#"{"language":"en","memory_enabled":true}"#),
+            Some("ja-JP"),
+        );
+        assert!(parsed.allow_normalization_persist);
+        let normalization_changed = parsed.prefs.enforce_memory_locale_policy();
+        assert!(normalization_changed);
+        assert!(should_persist_normalization(
+            parsed.allow_normalization_persist,
+            true,
+            normalization_changed,
+        ));
+    }
+
+    #[test]
+    fn settings_without_language_uses_system_language() {
+        let prefs = UserPrefs::parse_settings(Some(r#"{"theme":"genesis"}"#), Some("ja-JP"));
+        assert_eq!(prefs.theme, Theme::Genesis);
+        assert_eq!(prefs.language, Language::Ja);
+    }
+
+    #[test]
+    fn explicit_language_overrides_system_language() {
+        let prefs = UserPrefs::parse_settings(Some(r#"{"language":"zh-Hans"}"#), Some("en-US"));
+        assert_eq!(prefs.language, Language::ZhHans);
     }
 
     #[test]

--- a/pinvou3-app/src/app/DetachedShell.jsx
+++ b/pinvou3-app/src/app/DetachedShell.jsx
@@ -7,14 +7,14 @@ import { CardPoolView } from '../features/personas/Personas.jsx';
 import { CodexAcpView } from '../features/codex/CodexAcpView.jsx';
 import { useBridgeState } from '../hooks/useBridge.js';
 import { emitTauri, invokeTauri, isTauriAvailable, listenTauri } from '../platform/tauri/client.js';
-import { dict, TAG_TO_LANG } from '../shared/i18n.js';
+import { dict, initialSystemLanguage, TAG_TO_LANG } from '../shared/i18n.js';
 
 function useDetachedBase() {
   const bs = useBridgeState([
     'platform', 'sessions', 'chat', 'voice', 'knowledge', 'scheduled', 'monitor',
     'settings', 'personas',
   ]);
-  const [language, setLanguage] = useState('zh');
+  const [language, setLanguage] = useState(initialSystemLanguage);
   const [activeTheme, setActiveTheme] = useState('dark');
   const initRef = useRef(false);
 

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -10,7 +10,7 @@ import { MobileMoreSheet, MobileTabBar, MobileTopBar } from '../components/layou
 import { VllmSetupProgress } from '../components/VllmSetupProgress.jsx';
 import { bridge, useBridgeState, activeModelIsLocal, shouldShowApiKeyGate } from '../hooks/useBridge.js';
 import { useCompactViewport, useVisualViewportHeight } from '../hooks/useViewport.js';
-import { dict, LANG_TO_TAG, languageFromLocaleTags, SEARCH_KEY_PROVIDERS, TAG_TO_LANG } from '../shared/i18n.js';
+import { dict, LANG_TO_TAG, initialSystemLanguage, SEARCH_KEY_PROVIDERS, TAG_TO_LANG } from '../shared/i18n.js';
 import { formatSessionDate, localDateKey, formatDateGroupLabel } from '../shared/date-utils.js';
 import { runSessionBatch } from '../shared/session-management.js';
 import { can, isWeb } from '../shared/platform.js';
@@ -309,11 +309,7 @@ function workspaceDisplayName(path) {
       }, [platformCapabilities.localVllmSupported]);
       const [vllmDeclineConfirm, setVllmDeclineConfirm] = useState(false); // 引导框「不再提醒」二次确认子态
       const [language, setLanguage] = useState(() => {
-        const systemLanguage = languageFromLocaleTags(
-          typeof navigator === 'undefined'
-            ? []
-            : (navigator.languages?.length ? navigator.languages : navigator.language),
-        );
+        const systemLanguage = initialSystemLanguage();
         if (!isWeb) return systemLanguage;
         try {
           const value = window.localStorage.getItem('pinvou.web.language');

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -10,7 +10,7 @@ import { MobileMoreSheet, MobileTabBar, MobileTopBar } from '../components/layou
 import { VllmSetupProgress } from '../components/VllmSetupProgress.jsx';
 import { bridge, useBridgeState, activeModelIsLocal, shouldShowApiKeyGate } from '../hooks/useBridge.js';
 import { useCompactViewport, useVisualViewportHeight } from '../hooks/useViewport.js';
-import { dict, LANG_TO_TAG, SEARCH_KEY_PROVIDERS, TAG_TO_LANG } from '../shared/i18n.js';
+import { dict, LANG_TO_TAG, languageFromLocaleTags, SEARCH_KEY_PROVIDERS, TAG_TO_LANG } from '../shared/i18n.js';
 import { formatSessionDate, localDateKey, formatDateGroupLabel } from '../shared/date-utils.js';
 import { runSessionBatch } from '../shared/session-management.js';
 import { can, isWeb } from '../shared/platform.js';
@@ -309,11 +309,16 @@ function workspaceDisplayName(path) {
       }, [platformCapabilities.localVllmSupported]);
       const [vllmDeclineConfirm, setVllmDeclineConfirm] = useState(false); // 引导框「不再提醒」二次确认子态
       const [language, setLanguage] = useState(() => {
-        if (!isWeb) return 'zh';
+        const systemLanguage = languageFromLocaleTags(
+          typeof navigator === 'undefined'
+            ? []
+            : (navigator.languages?.length ? navigator.languages : navigator.language),
+        );
+        if (!isWeb) return systemLanguage;
         try {
           const value = window.localStorage.getItem('pinvou.web.language');
-          return value && dict[value] ? value : 'zh';
-        } catch (_) { return 'zh'; }
+          return value && dict[value] ? value : systemLanguage;
+        } catch (_) { return systemLanguage; }
       });
       const [superPerm, setSuperPerm] = useState(false);
       const defaultTaskCompletedNotif = platformCapabilities.taskCompletionNotificationsDefault !== false;
@@ -533,7 +538,7 @@ function workspaceDisplayName(path) {
           scheduledTaskAutoOpenSeenRef.current = bs.scheduledTaskAutoOpenId;
           setCurrentView('scheduled');
         }
-        // UI 语言/主题:启动时从落盘 settings 恢复一次(此前只写不读,重启即回中文+深色)
+        // UI 语言/主题:启动时从落盘 settings 恢复一次；无语言配置时后端已按系统 locale 补齐。
         if (!uiPrefsInitRef.current && bs.settings) {
           if (isWeb) {
             bootedLanguageRef.current = language;
@@ -541,7 +546,7 @@ function workspaceDisplayName(path) {
             const lang = TAG_TO_LANG[bs.settings.language];
             if (lang && lang !== language) setLanguage(lang);
             // engine 已用此语言启动,作为「需重启」基线(切语言不重启 engine,见 commands.rs)
-            bootedLanguageRef.current = lang || 'zh';
+            bootedLanguageRef.current = lang || language;
             // 后端 Theme 枚举(prefs.rs)只认 genesis/liquid-light/liquid-dark;深色=genesis,浅色=liquid-light
             const th = bs.settings.theme === 'liquid-light' ? 'light' : 'dark';
             if (th !== activeTheme) setActiveTheme(th);
@@ -1714,6 +1719,7 @@ function workspaceDisplayName(path) {
           {isWeb && isSidebarOpen && (
             <button
               type="button"
+              data-testid="mobile-navigation-close"
               aria-label={t.uiMainApp.closeNavigation}
               onClick={() => setIsSidebarOpen(false)}
               className="fixed inset-0 z-30 hidden bg-black/40 max-sm:block"

--- a/pinvou3-app/src/components/layout/MobileShell.jsx
+++ b/pinvou3-app/src/components/layout/MobileShell.jsx
@@ -11,7 +11,8 @@ const MobileTopBar = ({ theme, t, title, onMenu, onNewChat }) => {
   const btnCls = 'w-10 h-10 shrink-0 rounded-full flex items-center justify-center transition-colors text-[#444746] hover:bg-[#E1E5EA] dark:text-[#E3E3E3] dark:hover:bg-[#333537]';
   return (
     <div data-testid="mobile-top-bar" className="h-12 shrink-0 flex items-center gap-1 px-2 bg-[#F0F4F9] dark:bg-[#1E1F20]">
-      <button type="button" aria-label={t.uiComponents.openNavigation} onClick={onMenu} className={btnCls}>
+      <button type="button" data-testid="mobile-navigation-open"
+        aria-label={t.uiComponents.openNavigation} onClick={onMenu} className={btnCls}>
         <Menu size={20} />
       </button>
       <span className="flex-1 min-w-0 truncate text-center text-[15px] font-medium px-1">{title}</span>

--- a/pinvou3-app/src/features/pet/PetWindow.jsx
+++ b/pinvou3-app/src/features/pet/PetWindow.jsx
@@ -71,7 +71,7 @@ import {
   resolvePet,
 } from './pet-registry.js';
 import { useReducedMotion } from '../../hooks/useReducedMotion.js';
-import { dict, TAG_TO_LANG } from '../../shared/i18n.js';
+import { dict, initialSystemLanguage, TAG_TO_LANG } from '../../shared/i18n.js';
 import './pet.css';
 
 const TICK_MS = 600;
@@ -157,7 +157,7 @@ export default function PetWindow({
     ? Math.min(MAX_SCALE, Math.max(DEFAULT_SCALE, configuredScale))
     : DEFAULT_SCALE;
   const stateRef = useRef(createPetState());
-  const [language, setLanguage] = useState('zh');
+  const [language, setLanguage] = useState(initialSystemLanguage);
   const t = dict[language] || dict.zh;
   const petCopy = t.uiPet;
   // pet.html 的 <title>/<html lang> 是静态中文,按当前语言同步一次。
@@ -282,7 +282,7 @@ export default function PetWindow({
     let disposed = false;
     let unlisten = null;
     invokeTauri('get_settings').then((settings) => {
-      if (!disposed) setLanguage(TAG_TO_LANG[settings?.language] || 'zh');
+      if (!disposed) setLanguage(TAG_TO_LANG[settings?.language] || initialSystemLanguage());
     }).catch(() => {});
     tauriEvents.listen('ui:language_changed', (event) => {
       const next = event.payload?.language;

--- a/pinvou3-app/src/features/reader/ReaderApp.jsx
+++ b/pinvou3-app/src/features/reader/ReaderApp.jsx
@@ -4,7 +4,7 @@ import {
 } from '../../components/icons.jsx';
 import { FileColoredIcon } from '../../components/files/FileColoredIcon.jsx';
 import { invokeTauri, listenTauri, tauriEvents } from '../../platform/tauri/client.js';
-import { dict, TAG_TO_LANG } from '../../shared/i18n.js';
+import { dict, initialSystemLanguage, TAG_TO_LANG } from '../../shared/i18n.js';
 import {
   CodeViewerContent,
   clampViewerFontSize,
@@ -43,7 +43,7 @@ function ReaderTabContent({ tab, state, fontSize, copy }) {
 }
 
 export function ReaderApp() {
-  const [language, setLanguage] = useState('zh');
+  const [language, setLanguage] = useState(initialSystemLanguage);
   const copy = (dict[language] || dict.zh).uiCodexWorkspace;
   const [tabs, setTabs] = useState([]);
   const [activeKey, setActiveKey] = useState('');
@@ -59,7 +59,7 @@ export function ReaderApp() {
     let unlisten = null;
     invokeTauri('get_settings').then((settings) => {
       if (disposed) return;
-      setLanguage(TAG_TO_LANG[settings?.language] || 'zh');
+      setLanguage(TAG_TO_LANG[settings?.language] || initialSystemLanguage());
       // 后端 Theme 枚举只认 genesis/liquid-light/liquid-dark；深色=genesis，浅色=liquid-light。
       document.documentElement.classList.toggle('dark', settings?.theme !== 'liquid-light');
     }).catch(() => {});

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -1570,6 +1570,14 @@ const dict = {
       // 当前只提供中、英、日；系统首选语言不受支持时使用英文。
       return 'en';
     }
+    // 首帧系统语言探测:主窗口与各辅助窗口(桌宠/阅读器/分离窗口)在落盘
+    // settings 到达前共用;之后仍以 get_settings/bs.settings 的显式配置为准。
+    function initialSystemLanguage() {
+      if (typeof navigator === 'undefined') return 'en';
+      return languageFromLocaleTags(
+        navigator.languages?.length ? navigator.languages : navigator.language,
+      );
+    }
     const SEARCH_KEY_PROVIDERS = ['metaso', 'bocha', 'baidu', 'tavily'];
 
     /* ==========================================
@@ -2485,4 +2493,4 @@ dict.ja.uiSettingsDetail.memoryTopicCleanupRequired = 'メモリは更新され�
 
 if (typeof window !== 'undefined') window.__PINVOU_SHARED_I18N__ = dict;
 
-export { dict, LANG_TO_TAG, TAG_TO_LANG, languageFromLocaleTags, SEARCH_KEY_PROVIDERS };
+export { dict, LANG_TO_TAG, TAG_TO_LANG, languageFromLocaleTags, initialSystemLanguage, SEARCH_KEY_PROVIDERS };

--- a/pinvou3-app/src/shared/i18n.js
+++ b/pinvou3-app/src/shared/i18n.js
@@ -1559,6 +1559,17 @@ const dict = {
     // 这里 / dict / Rust prefs.rs Language 枚举
     const LANG_TO_TAG = { zh: 'zh-Hans', en: 'en', ja: 'ja' };
     const TAG_TO_LANG = { 'zh-Hans': 'zh', 'en': 'en', 'ja': 'ja' };
+    function languageFromLocaleTags(localeTags, fallback = 'en') {
+      const locales = Array.isArray(localeTags) ? localeTags : [localeTags];
+      const locale = locales.find((value) => typeof value === 'string' && value.trim());
+      if (!locale) return fallback;
+      const primary = locale.trim().split(/[-_.@:]/, 1)[0].toLowerCase();
+      if (primary === 'zh') return 'zh';
+      if (primary === 'ja') return 'ja';
+      if (primary === 'en') return 'en';
+      // 当前只提供中、英、日；系统首选语言不受支持时使用英文。
+      return 'en';
+    }
     const SEARCH_KEY_PROVIDERS = ['metaso', 'bocha', 'baidu', 'tavily'];
 
     /* ==========================================
@@ -2474,4 +2485,4 @@ dict.ja.uiSettingsDetail.memoryTopicCleanupRequired = 'メモリは更新され�
 
 if (typeof window !== 'undefined') window.__PINVOU_SHARED_I18N__ = dict;
 
-export { dict, LANG_TO_TAG, TAG_TO_LANG, SEARCH_KEY_PROVIDERS };
+export { dict, LANG_TO_TAG, TAG_TO_LANG, languageFromLocaleTags, SEARCH_KEY_PROVIDERS };

--- a/pinvou3-app/tests/fixtures/reader_app_diff_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/reader_app_diff_smoke.jsx
@@ -7,6 +7,12 @@ import { ReaderApp } from '../../src/features/reader/ReaderApp.jsx';
 window.__invokeLog = [];
 window.__readerOpenHandler = null;
 
+// 标签/工具栏断言依赖中文文案：把系统语言固定为中文，使初始语言即 zh，
+// get_settings 解析后 setLanguage 同值短路，拉取 pending 的 effect 不会因
+// 语言状态变化而重跑（重跑会触发第二次 take_code_reader_pending）。
+Object.defineProperty(window.navigator, 'languages', { get: () => ['zh-CN'] });
+Object.defineProperty(window.navigator, 'language', { get: () => 'zh-CN' });
+
 const PENDING = [
   { kind: 'diff', sessionId: 's-1', workspacePath: null, relativePath: 'src/main.py' },
 ];

--- a/pinvou3-app/tests/fixtures/reader_app_diff_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/reader_app_diff_smoke.jsx
@@ -17,7 +17,8 @@ window.__TAURI__ = {
       window.__invokeLog.push({ command, args });
       switch (command) {
         case 'get_settings':
-          throw new Error('fixture: 无设置后端，回退默认语言');
+          // 固定中文，断言不随运行环境系统语言漂移（与 ui_smoke.js 惯例一致）。
+          return { theme: 'liquid-light', language: 'zh-Hans' };
         case 'take_code_reader_pending':
           return PENDING;
         case 'get_codex_workspace_diff':

--- a/pinvou3-app/tests/fixtures/reader_app_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/reader_app_smoke.jsx
@@ -16,7 +16,8 @@ window.__TAURI__ = {
       window.__invokeLog.push({ command, args });
       switch (command) {
         case 'get_settings':
-          throw new Error('fixture: 无设置后端，回退默认语言');
+          // 固定中文，断言不随运行环境系统语言漂移（与 ui_smoke.js 惯例一致）。
+          return { theme: 'liquid-light', language: 'zh-Hans' };
         case 'take_code_reader_pending':
           return PENDING;
         case 'preview_codex_workspace_file':

--- a/pinvou3-app/tests/fixtures/reader_app_smoke.jsx
+++ b/pinvou3-app/tests/fixtures/reader_app_smoke.jsx
@@ -6,6 +6,12 @@ import { ReaderApp } from '../../src/features/reader/ReaderApp.jsx';
 window.__invokeLog = [];
 window.__readerOpenHandler = null;
 
+// 标签/工具栏断言依赖中文文案：把系统语言固定为中文，使初始语言即 zh，
+// get_settings 解析后 setLanguage 同值短路，拉取 pending 的 effect 不会因
+// 语言状态变化而重跑（重跑会触发第二次 take_code_reader_pending）。
+Object.defineProperty(window.navigator, 'languages', { get: () => ['zh-CN'] });
+Object.defineProperty(window.navigator, 'language', { get: () => 'zh-CN' });
+
 const PENDING = [
   { sessionId: null, workspacePath: 'D:/proj/demo', relativePath: 'main.py' },
 ];

--- a/pinvou3-app/tests/system_language_default.test.mjs
+++ b/pinvou3-app/tests/system_language_default.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { languageFromLocaleTags } from '../src/shared/i18n.js';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('system locale maps to a supported initial language', () => {
+  assert.equal(languageFromLocaleTags(['zh-CN']), 'zh');
+  assert.equal(languageFromLocaleTags(['zh-Hant-TW']), 'zh');
+  assert.equal(languageFromLocaleTags(['ja-JP']), 'ja');
+  assert.equal(languageFromLocaleTags(['en-US']), 'en');
+  assert.equal(languageFromLocaleTags(['fr-FR']), 'en');
+});
+
+test('missing system locale falls back to English', () => {
+  assert.equal(languageFromLocaleTags([]), 'en');
+  assert.equal(languageFromLocaleTags([undefined, '']), 'en');
+});
+
+test('mobile web smoke uses locale-independent navigation selectors', () => {
+  const mobileShell = fs.readFileSync(
+    path.join(appRoot, 'src', 'components', 'layout', 'MobileShell.jsx'),
+    'utf8',
+  );
+  const main = fs.readFileSync(path.join(appRoot, 'src', 'app', 'main.jsx'), 'utf8');
+  const webUiSmoke = fs.readFileSync(
+    path.join(appRoot, '..', 'remote-control-relay', 'test', 'web-ui.smoke.cjs'),
+    'utf8',
+  );
+
+  assert.match(mobileShell, /data-testid="mobile-navigation-open"/u);
+  assert.match(main, /data-testid="mobile-navigation-close"/u);
+  assert.match(webUiSmoke, /click\('\[data-testid="mobile-navigation-open"\]'\)/u);
+  assert.match(
+    webUiSmoke,
+    /evaluate\(\(\) => document\.querySelector\('\[data-testid="mobile-navigation-close"\]'\)\.click\(\)\)/u,
+    'the sidebar covers the overlay center, so closing must use a DOM click instead of coordinates',
+  );
+  assert.doesNotMatch(webUiSmoke, /button\[aria-label="(?:打开|关闭)导航"\]/u);
+});

--- a/remote-control-relay/test/web-ui.smoke.cjs
+++ b/remote-control-relay/test/web-ui.smoke.cjs
@@ -744,7 +744,7 @@ async function main() {
     { timeout: 5_000 },
   );
 
-  await mobilePage.click('[data-testid="mobile-top-bar"] button[aria-label="打开导航"]');
+  await mobilePage.click('[data-testid="mobile-navigation-open"]');
   await mobilePage.waitForFunction(
     () => document.querySelector('[data-testid="app-sidebar"]')?.getBoundingClientRect().width > 0,
     { timeout: 5_000 },
@@ -776,7 +776,10 @@ async function main() {
       && mobileSidebarLayout.primaryBottom <= 400
       && mobileSidebarLayout.recentsTop <= 405,
     JSON.stringify(mobileSidebarLayout));
-  await mobilePage.evaluate(() => document.querySelector('button[aria-label="关闭导航"]').click());
+  // The z-40 sidebar covers the center of the z-30 full-screen overlay. A
+  // Puppeteer coordinate click would hit a sidebar session instead of closing
+  // the drawer, so invoke the overlay's click handler directly.
+  await mobilePage.evaluate(() => document.querySelector('[data-testid="mobile-navigation-close"]').click());
   await mobilePage.waitForFunction(
     () => document.querySelector('[data-testid="app-sidebar"]')?.getBoundingClientRect().width === 0,
     { timeout: 5_000 },


### PR DESCRIPTION
## 背景
首次启动或语言配置不可用时，品悟此前固定使用中文，未跟随用户的系统语言。

## 变更
- Windows、macOS、Linux 分别读取系统首选语言，并映射到中、英、日三种已支持语言
- `settings.json` 不存在、解析失败或缺少 `language` 时使用系统语言；系统语言无法读取或不受支持时回退英文
- 已有显式语言配置保持最高优先级
- Web 首次访问同步使用浏览器系统语言，避免首屏语言不一致
- Linux 按 GNU 消息 locale 语义处理 `LANGUAGE`、`LC_ALL`、`LC_MESSAGES`、`LANG`，覆盖 `C`/`POSIX`/`C.<encoding>`
- 配置损坏或缺失时禁止启动期 normalization 回写，避免覆盖可能可恢复的原文件

## 审核闭环
使用相互独立的审核者与修复者角色交替完成 7 轮审修：
1. 修正 GNU `LANGUAGE` 优先级与冒号列表
2. 修正无基础 locale 时错误采用 `LANGUAGE`
3. 补齐 `C.UTF-8` / `C.utf8` portable locale
4. 修复损坏配置可能被 normalization 覆盖的数据安全问题
5. 全量复审通过，无阻塞或非阻塞发现
6. 修复系统语言变化暴露的 WebUI 烟测中文 selector 依赖
7. 修复侧栏覆盖遮罩中心导致的坐标误点，复审通过

## 验证
- `node --test tests/system_language_default.test.mjs`
- `node tests/tauri_platform_layout.test.js`
- `node tests/ui_language_coverage.test.mjs`
- `node --check remote-control-relay/test/web-ui.smoke.cjs`
- locale 共享纯函数独立 Rust 测试：9/9 通过
- `python scripts/architecture-guard.py`
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `cargo metadata --manifest-path pinvou3-app/src-tauri/Cargo.toml --locked --no-deps --format-version 1`
- `git diff --check`

## 已知验证边界
- 当前 Windows 环境中完整 Cargo 定向测试持续阻塞于 CodeWhale TUI 大型依赖编译，未进入测试执行；交由 PR CI 继续验证。
- macOS/Linux 平台 API 未在对应实体平台运行验证。