### PR TITLE
fix(settings): 目录命中兼容限定到显式 legacyAliases，其余恢复精确比较

### DIFF
--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -46,7 +46,8 @@ const PROVIDER_KIND_CUSTOM = 'custom';
 // modelstudio 目录（qwen_token_plan）保持各自的小写 wire id。resolver 目录匹配
 // 是精确比较，拼写偏离目录行的 id（如小写 glm-5.2）会命中其他 provider 的裸
 // wire id 而被严格直连误拒——大小写不敏感回退已回馈上游审核、未随当前 gitlink
-// 发布，故新保存配置必须用目录行原样拼写。
+// 发布，故新保存配置必须用目录行原样拼写；凡目录行拼写发生变更（含大小写），
+// 旧拼写须登记到该项 legacyAliases 以兼容存量配置，其余情况保持精确比较。
 const MODEL_CATALOG_SECTIONS = {
   coding_plan: 'Coding Plan',
   official_api: '官方 API',
@@ -148,9 +149,11 @@ const MODEL_CATALOG = {
       vendor: 'glm',
       baseUrl: 'https://api.z.ai/api/coding/paas/v4',
       endpointAliases: ['https://api.z.ai/api/coding/paas/v4/chat/completions'],
+      // legacyAliases：本组目录行曾是旧小写拼写（glm-5.2 / glm-5-turbo），存量
+      // 配置可能保存旧值，目录命中时兼容识别；其余目录项一律精确比较。
       items: [
-        { model: 'GLM-5.2', title: 'GLM-5.2', desc: '旗舰编码模型' },
-        { model: 'GLM-5-Turbo', title: 'GLM-5-Turbo', desc: '高性能编码模型' },
+        { model: 'GLM-5.2', legacyAliases: ['glm-5.2'], title: 'GLM-5.2', desc: '旗舰编码模型' },
+        { model: 'GLM-5-Turbo', legacyAliases: ['glm-5-turbo'], title: 'GLM-5-Turbo', desc: '高性能编码模型' },
         { model: 'glm-4.7', title: 'GLM-4.7', desc: '日常编码模型' },
         { model: '', title: '自定义 GLM Coding Plan 模型', desc: '手动填写 Coding Plan 模型 ID', custom: true },
       ],
@@ -538,11 +541,13 @@ function isCodingPlanModel(model) {
 // ── 模型选择器:预设/自定义分组与可区分标注(纯函数,显示期计算) ─────
 // 分类判据:模型是否命中其实际 provider 的非 custom 目录项。自定义兼容接口即使
 // 使用目录中已有的模型 ID,也必须保持为自定义,避免多个聚合服务模型再次同名。
-// 目录命中比较大小写不敏感:目录拼写以底座(CodeWhale)为准,存量配置可能保存
-// 旧拼写(如 z.ai 直连的 glm-5.2 vs 目录行 GLM-5.2),不得因此误判为自定义。
+// 目录命中默认精确比较:本地 vLLM 等服务的模型 ID 是不透明字符串、可能区分
+// 大小写,case-only 的自定义 ID 必须保持自定义。大小写兼容只对发生过「目录
+// 拼写迁移」的目录项生效,且以 legacyAliases 显式列出历史拼写(存量值只能
+// 来自旧目录行的精确值,精确别名即可覆盖),不做全量 case-insensitive。
 function catalogItemMatchesModel(item, model) {
-  return typeof item.model === 'string' && typeof model === 'string'
-    && item.model.toLowerCase() === model.toLowerCase();
+  if (typeof item.model !== 'string' || typeof model !== 'string') return false;
+  return item.model === model || (item.legacyAliases || []).includes(model);
 }
 
 function isPresetModel(m) {

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -74,17 +74,33 @@ test('z.ai 直连存量小写配置仍命中大写目录行 -> 预设', () => {
   // 目录拼写以底座为准（GLM-5.2），存量配置可能保存旧小写 glm-5.2。
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'glm-5.2' })), true);
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'GLM-5.2' })), true);
+  // 另一迁移项 GLM-5-Turbo（旧拼写 glm-5-turbo）同样兼容。
+  assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://api.z.ai/api/coding/paas/v4', model: 'glm-5-turbo' })), true);
 });
-test('catalogItemMatchesModel 大小写不敏感(编辑弹窗存量小写命中目录行)', () => {
+test('catalogItemMatchesModel 精确比较+legacyAliases 兼容迁移拼写', () => {
   // SettingsView 编辑弹窗的 initialCatalogMatch/known/active 均复用此比较:
-  // 存量小写 glm-5.2 必须命中 z.ai 直连目录行 GLM-5.2,不得误判为自定义。
+  // 存量小写 glm-5.2 必须命中 z.ai 直连目录行 GLM-5.2(经 legacyAliases),
+  // 不得误判为自定义;除显式登记的历史拼写外一律精确比较。
   const zaiGroup = MODEL_CATALOG.cloud.find(group => group.key === 'glm_coding_plan_global');
   const glm52 = zaiGroup.items.find(item => item.model === 'GLM-5.2');
   assert.ok(glm52, 'z.ai 直连目录应含 GLM-5.2 规范拼写行');
   assert.strictEqual(catalogItemMatchesModel(glm52, 'glm-5.2'), true);
   assert.strictEqual(catalogItemMatchesModel(glm52, 'GLM-5.2'), true);
+  assert.strictEqual(catalogItemMatchesModel(glm52, 'Glm-5.2'), false);
   assert.strictEqual(catalogItemMatchesModel(glm52, 'glm-5.3'), false);
   assert.strictEqual(catalogItemMatchesModel(glm52, undefined), false);
+});
+test('本地 case-only 模型 ID 仍为自定义(vLLM ID 大小写敏感)', () => {
+  // 本地 OpenAI-compatible 服务的模型 ID 是不透明字符串、可能区分大小写:
+  // 与目录默认项 qwen36_35b_256k 仅大小写不同的 ID 是另一个模型,必须保持自定义。
+  assert.strictEqual(isPresetModel(mk({ preset: 'local_vllm', model: 'QWEN36_35B_256K' })), false);
+  assert.strictEqual(isPresetModel(mk({ preset: 'local_vllm', model: 'qwen36_35b_256k' })), true);
+});
+test('云端 case-only 模型 ID 仍为自定义(无拼写迁移的目录精确比较)', () => {
+  // minimax 目录行 MiniMax-M3 从未变更过拼写,case-only 变体不是存量迁移值,
+  // 不得命中预设;同 provider 未收录 ID 也保持自定义。
+  assert.strictEqual(isPresetModel(mk({ preset: 'minimax', provider_kind: 'official_api', vendor: 'minimax', base_url: 'https://api.minimaxi.com/v1', model: 'minimax-m3' })), false);
+  assert.strictEqual(isPresetModel(mk({ preset: 'minimax', provider_kind: 'official_api', vendor: 'minimax', base_url: 'https://api.minimaxi.com/v1', model: 'MiniMax-M3' })), true);
 });
 test('Coding Plan 手填 ID -> 自定义', () => {
   assert.strictEqual(isPresetModel(mk({ preset: 'openai_compatible', provider_kind: 'coding_plan', vendor: 'glm', base_url: 'https://open.bigmodel.cn/api/coding/paas/v4', model: 'my-custom-glm' })), false);


### PR DESCRIPTION
## 背景

#293（模型目录拼写对齐底座规范）合入前的最后一轮复审中，zhuowp 指出其 `catalogItemMatchesModel` 全量大小写不敏感**作用域过宽**，但该 PR 在修复落地前已合并（squash 449fbc36 内容止于 0d9414c8）。本 PR 补上该修复，意见原文见 #293 行内评论（model-catalog.js:545）。

## 问题

#293 将目录命中改为全量 case-insensitive，而该比较器被 `isPresetModel` 的 `local_vllm` 分支、所有云 provider 分支及 `findCloudProviderForModel` 复用：

- 本地 vLLM 等 OpenAI-compatible 服务的模型 ID 是不透明字符串、可能区分大小写。local_vllm 目录唯一非 custom 项即 `qwen36_35b_256k`，用户配置的 `QWEN36_35B_256K` 会被误分为预设并错误高亮。
- 云端同理：minimax 目录行 `MiniMax-M3` 从未变更过拼写，case-only 变体 `minimax-m3` 不是存量迁移值，不得命中预设。

## 修复

- `catalogItemMatchesModel` 恢复**精确比较**，仅命中目录项显式登记的 `legacyAliases` 时兼容。
- git 历史核实：z.ai 直连组从首次引入（179ea7bc）至 #293 前目录行始终为小写 `glm-5.2`/`glm-5-turbo`，#293 是唯一一次拼写迁移；存量值只能来自旧目录行的精确拼写，故两个迁移项分别登记 `['glm-5.2']`/`['glm-5-turbo']` 即可完整覆盖，其余目录项无历史迁移，恢复精确比较。
- 顶部拼写约定注释补充登记规则：凡目录行拼写变更（含大小写），旧拼写须登记到 `legacyAliases`。

## 验证

- `node --test tests/model_catalog_grouping.test.js`：38 全过（main 基线 36 + 新增 2 个反向测试：本地 case-only ID `QWEN36_35B_256K` 仍为自定义、云端无迁移目录 case-only ID `minimax-m3` 仍为自定义；另补 `glm-5-turbo` 存量别名正例与 `Glm-5.2` 混合大小写不命中边界断言）
- `node --test tests/acp_providers_contract.test.js` 通过
- `python3 scripts/architecture-guard.py` 通过

## 已知风险

- 无保存数据风险：`doSave` 只写表单值，误分类仅影响分组/弹窗高亮，且本 PR 将其收窄回精确比较。
- z.ai 存量小写配置的运行时兜底仍依赖底座大小写不敏感回退（Pinvou/CodeWhale#14，gitlink PR #295），与 #293 声明一致。