### PR TITLE
ci(release): macOS 发布构建超时放宽至 240 分钟

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -398,9 +398,12 @@ jobs:
     needs: check-version-bump
     if: needs.check-version-bump.outputs.build_required == 'true'
     runs-on: macos-15
-    # 冷缓存双 target + thin LTO 实测可能超过 90 分钟（0.7.4 发布构建曾逼近上限），
-    # 放宽至 150 分钟以覆盖冷缓存与 runner 抖动，避免发布构建被超时取消。
-    timeout-minutes: 150
+    # 冷缓存双 target + thin LTO 的临界路径持续增长：0.8.3 冷缓存全程约 110 分钟，
+    # 0.8.4 依赖面扩大(+72 crate)后冷缓存估算超 160 分钟，150 分钟上限在 pass2 链接
+    # 阶段将构建杀掉(run 32093220066，pass1 90m13s + pass2 被杀于 pinvou3-tauri 链接)。
+    # release-macos 缓存又因仓库缓存总量顶满 10GB LRU 上限基本不可能跨发布存活，
+    # 每次发布都按冷缓存规划。放宽至 240 分钟覆盖依赖增长与 runner 抖动。
+    timeout-minutes: 240
     env:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
       VERSION: ${{ needs.check-version-bump.outputs.version }}


### PR DESCRIPTION
## 背景

0.8.4 发布构建（run 32093220066，commit `fb759253`）中 macOS universal dmg job 在 150 分钟 `timeout-minutes` 上限被杀：pass1（aarch64）以 90m13s 正常完成，pass2（x86_64）完成依赖编译与 codewhale-tui 编译（05:06）后被杀于 pinvou3-tauri 链接阶段（05:19），估算全程需 160 分钟以上。Linux×2 与 Windows 产物正常产出。

## 审计结论（无可疑步骤，纯构建时间增长）

对照 0.8.3 成功构建（run 31890181554，全程约 110 分钟）逐阶段核对：

- rustc 同为 1.97.1（rust-toolchain.toml 锁定）、runner 镜像/版本相同、macOS job 配置零改动。
- 两遍 cargo 编译串行是 Tauri universal 构建固有行为（aarch64 → x86_64 → lipo），并行度即 runner 核数，无配置缺陷。
- CodeWhale 两次 gitlink 间 tui 代码净删 846 行，排除上游变慢。
- 增长来源：依赖面 +72 crate（#276 共享知识库引入 age 加密栈 / fluent i18n / rust-embed / mdns-sd / pinvou-knowledge，#283 notify 6→8），两遍依赖编译各 +3~4.5m，pass1 codewhale-tui lib 38.6m→60m、应用编译+链接 11m→19m。
- 缓存确实未复用，但非回归：0.8.3 自己也是冷缓存跑完的（`No cache found`）。release-macos 缓存（2.1GB）保存三天内即被逐出——仓库缓存总量 9.67GB 顶满 10GB LRU 上限，pr-check/mac-build/CodeQL/npm 缓存随每次 main push 持续挤占，跨发布（间隔 ≥3 天）必然逐出。发布构建按冷缓存规划。

## 变更

`.github/workflows/release-packages.yml` macOS job `timeout-minutes` 150 → 240，注释同步更新为 0.8.4 实测数据。

## 实际验证

- 纯 CI 配置改动，无代码行为变化；yaml 缩进与上下文对齐。
- 工作基于合并前的最新 `origin/main`（`9f3390a3`），提交带有效 Signed-off-by（DCO）。

## 已知风险

超时放宽仅影响被杀时机，无行为风险；Linux/Windows job 上限（90 分钟）不动，本次实测 40m/70m 余量充足。
