### PR TITLE
chore(deps): 升级 h2 修复 RUSTSEC-2026-0258

### DIFF
--- a/pinvou-knowledge/Cargo.lock
+++ b/pinvou-knowledge/Cargo.lock
@@ -1611,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -3523,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## 背景

RustSec 新增 `RUSTSEC-2026-0258`：`h2` 在处理无上限空 DATA frame 时可能造成内存无界增长或 panic。当前应用与知识库两套锁文件分别固定在受影响的 `0.4.14` 和 `0.4.15`，并已被 CI 的 `cargo-deny` 阻断；官方修复版本为 `0.4.16` 及以上。

## 变更

- 将两个 Rust 锁文件中的传递依赖 `h2` 统一精确锁定至 `0.4.16`：
  - `pinvou3-app/src-tauri/Cargo.lock`：`0.4.14` → `0.4.16`。
  - `pinvou-knowledge/Cargo.lock`：`0.4.15` → `0.4.16`。
- 两个锁文件均仅更新 version/checksum，依赖边保持不变。

## 验证

- `cargo metadata --manifest-path pinvou3-app/src-tauri/Cargo.toml --locked --format-version 1 --no-deps`：通过。
- `cargo tree --manifest-path pinvou3-app/src-tauri/Cargo.toml --locked -i h2@0.4.16`：通过。
- `cargo metadata --manifest-path pinvou-knowledge/Cargo.toml --locked --format-version 1 --no-deps`：通过。
- `cargo tree --manifest-path pinvou-knowledge/Cargo.toml --locked -i h2@0.4.16`：通过。
- 应用与知识库的 `cargo fmt --check`：通过。
- `git diff --check`：通过。
- 更新后的 `cargo-deny` 等待本 PR CI 验证，本地不声明已通过。

## 风险

两套锁文件均为传递依赖的补丁级锁定升级，不涉及应用 API 或依赖边变化；风险限于上游补丁版本的行为差异。