### PR TITLE
perf(streaming): 避免流式事件深拷贝完整会话

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1239,24 +1239,64 @@
     for (var i = 0; i < domains.length; i++) Object.assign(result, snapshotStateSlice(domains[i]));
     return result;
   }
-  // Subscription snapshots are internal, read-only render inputs. Deep-cloning
-  // the entire transcript for every streamed token retained hundreds of MB in
-  // React's update queue on long sessions. Keep get/getMany defensive and
-  // detached, while subscriptions copy only the top-level containers needed to
-  // trigger React. Nested message/tool objects stay structurally shared.
-  function subscriptionStateValue(value) {
-    if (Array.isArray(value)) return Object.freeze(value.slice());
-    if (value && typeof value === "object") return Object.freeze(Object.assign({}, value));
-    return value;
+  // Subscription snapshots are immutable persistent projections. The first
+  // projection detaches nested state; later notifications reconcile against it
+  // and allocate only changed paths. Long transcripts therefore stay shared
+  // between snapshots while an in-place streaming item mutation still produces
+  // a stable new item for subscribers. get/getMany retain their deep-copy API.
+  function subscriptionStateValue(value, previous) {
+    if (!value || typeof value !== "object") return value;
+    if (Array.isArray(value)) {
+      var previousArray = Array.isArray(previous) ? previous : null;
+      if (!previousArray) {
+        return Object.freeze(value.map(function (item) {
+          return subscriptionStateValue(item, undefined);
+        }));
+      }
+      var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
+      for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
+        var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex]);
+        if (nextItem !== previousArray[arrayIndex]) {
+          if (!nextArray) nextArray = previousArray.slice();
+          nextArray[arrayIndex] = nextItem;
+        }
+      }
+      return nextArray ? Object.freeze(nextArray) : previousArray;
+    }
+
+    var keys = Object.keys(value);
+    var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
+      ? previous
+      : null;
+    var previousKeys = previousObject ? Object.keys(previousObject) : [];
+    var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
+      return Object.prototype.hasOwnProperty.call(previousObject, key);
+    });
+    var nextObject = sameShape ? null : {};
+    for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
+      var key = keys[objectIndex];
+      var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key]);
+      if (!sameShape || nextValue !== previousObject[key]) {
+        if (!nextObject) nextObject = Object.assign({}, previousObject);
+        nextObject[key] = nextValue;
+      }
+    }
+    return nextObject ? Object.freeze(nextObject) : previousObject;
   }
+  var subscriptionSliceRevision = 0;
+  var subscriptionSliceCache = Object.create(null);
   function subscriptionStateSlice(domain) {
     var fields = STATE_SLICE_FIELDS[domain];
     if (!fields) throw new Error("Unknown Tauri bridge state slice: " + domain);
-    var slice = {};
+    var cached = subscriptionSliceCache[domain];
+    if (cached && cached.revision === subscriptionSliceRevision) return cached.snapshot;
+    var current = {};
     for (var i = 0; i < fields.length; i++) {
-      slice[fields[i]] = subscriptionStateValue(state[fields[i]]);
+      current[fields[i]] = state[fields[i]];
     }
-    return Object.freeze(slice);
+    var snapshot = subscriptionStateValue(current, cached && cached.snapshot);
+    subscriptionSliceCache[domain] = { revision: subscriptionSliceRevision, snapshot: snapshot };
+    return snapshot;
   }
   function subscriptionStateSlices(domains) {
     if (!Array.isArray(domains) || domains.length === 0) {
@@ -1347,6 +1387,7 @@
     state.sessionBusy = {};
     for (var id in sessionStates) state.sessionBusy[id] = !!sessionStates[id].busy;
     if (state.activeSessionId) state.sessionBusy[state.activeSessionId] = !!state.busy;
+    subscriptionSliceRevision += 1;
     for (var i = 0; i < subscribers.length; i++) subscribers[i]();
   }
   function subscribe(fn) {

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -290,7 +290,7 @@
     mountedRemoteCollections: [],
     mountedCollectionsRevision: 0,
     // personaPool 只放轻量元信息(loadState),1078 张卡放模块级 personaPoolCache,
-    // 不进 notify() 的 JSON 深拷贝(否则每个流式 token 都克隆 ~950KB,卡顿)。
+    // 不进 state/订阅快照，避免每个流式 token 都复制完整卡池。
     personaPool: { loadState: "idle" }, // idle | loading | ready | error
     // 应用内升级: updateInfo = check_for_update 返回值(available=true 才有意义)
     appVersion: null,
@@ -1203,12 +1203,6 @@
 
   // ── Pub/Sub ──────────────────────────────────────────────────────
   var subscribers = [];
-  function snapshotState() {
-    if (typeof structuredClone === "function") {
-      try { return structuredClone(state); } catch (_) {}
-    }
-    return JSON.parse(JSON.stringify(state));
-  }
   var STATE_SLICE_FIELDS = {
     platform: ["appVersion", "backendOnline", "platformCapabilities"],
     sessions: ["sessions", "archivedSessions", "activeSessionId", "sessionBusy", "draftEpoch"],
@@ -1244,6 +1238,35 @@
     var result = {};
     for (var i = 0; i < domains.length; i++) Object.assign(result, snapshotStateSlice(domains[i]));
     return result;
+  }
+  // Subscription snapshots are internal, read-only render inputs. Deep-cloning
+  // the entire transcript for every streamed token retained hundreds of MB in
+  // React's update queue on long sessions. Keep get/getMany defensive and
+  // detached, while subscriptions copy only the top-level containers needed to
+  // trigger React. Nested message/tool objects stay structurally shared.
+  function subscriptionStateValue(value) {
+    if (Array.isArray(value)) return Object.freeze(value.slice());
+    if (value && typeof value === "object") return Object.freeze(Object.assign({}, value));
+    return value;
+  }
+  function subscriptionStateSlice(domain) {
+    var fields = STATE_SLICE_FIELDS[domain];
+    if (!fields) throw new Error("Unknown Tauri bridge state slice: " + domain);
+    var slice = {};
+    for (var i = 0; i < fields.length; i++) {
+      slice[fields[i]] = subscriptionStateValue(state[fields[i]]);
+    }
+    return Object.freeze(slice);
+  }
+  function subscriptionStateSlices(domains) {
+    if (!Array.isArray(domains) || domains.length === 0) {
+      throw new Error("Tauri bridge state.subscribeMany requires at least one domain");
+    }
+    var result = {};
+    for (var i = 0; i < domains.length; i++) {
+      Object.assign(result, subscriptionStateSlice(domains[i]));
+    }
+    return Object.freeze(result);
   }
   function cloneJson(value, fallback) {
     try { return JSON.parse(JSON.stringify(value == null ? fallback : value)); }
@@ -1324,8 +1347,7 @@
     state.sessionBusy = {};
     for (var id in sessionStates) state.sessionBusy[id] = !!sessionStates[id].busy;
     if (state.activeSessionId) state.sessionBusy[state.activeSessionId] = !!state.busy;
-    var snapshot = snapshotState();
-    for (var i = 0; i < subscribers.length; i++) subscribers[i](snapshot);
+    for (var i = 0; i < subscribers.length; i++) subscribers[i]();
   }
   function subscribe(fn) {
     subscribers.push(fn);
@@ -1334,11 +1356,12 @@
     };
   }
   function subscribeStateSlice(domain, fn) {
-    return subscribe(function () { fn(snapshotStateSlice(domain)); });
+    subscriptionStateSlice(domain);
+    return subscribe(function () { fn(subscriptionStateSlice(domain)); });
   }
   function subscribeStateSlices(domains, fn) {
-    snapshotStateSlices(domains);
-    return subscribe(function () { fn(snapshotStateSlices(domains)); });
+    subscriptionStateSlices(domains);
+    return subscribe(function () { fn(subscriptionStateSlices(domains)); });
   }
 
   var scheduledFeature = installBridgeFeature("scheduled", { state: state, notify: notify, invoke: invoke, bt: bt, runSyncOnSession: runSyncOnSession, addSystemItem: addSystemItem, rememberScheduledRunOwner: rememberScheduledRunOwner, isScheduledRunTerminal: isScheduledRunTerminal, purgeSessionBuffer: purgeSessionBuffer, createNewSession: createNewSession, prefillComposer: prefillComposer, sessionStates: sessionStates });

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1244,44 +1244,84 @@
   // and allocate only changed paths. Long transcripts therefore stay shared
   // between snapshots while an in-place streaming item mutation still produces
   // a stable new item for subscribers. get/getMany retain their deep-copy API.
-  function subscriptionStateValue(value, previous) {
-    if (!value || typeof value !== "object") return value;
-    if (Array.isArray(value)) {
-      var previousArray = Array.isArray(previous) ? previous : null;
-      if (!previousArray) {
-        return Object.freeze(value.map(function (item) {
-          return subscriptionStateValue(item, undefined);
-        }));
+  function defineSubscriptionStateProperty(target, key, value) {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value: value,
+      writable: true,
+    });
+  }
+  function copySubscriptionStateObject(source) {
+    var result = {};
+    Object.keys(source).forEach(function (key) {
+      defineSubscriptionStateProperty(result, key, source[key]);
+    });
+    return result;
+  }
+  function subscriptionStateValue(value, previous, ancestors) {
+    var valueType = typeof value;
+    if (!value || valueType !== "object") {
+      if (valueType === "function" || valueType === "symbol" || valueType === "bigint") {
+        throw new TypeError("Subscription state only supports JSON-like scalar values");
       }
-      var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
-      for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
-        var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex]);
-        if (nextItem !== previousArray[arrayIndex]) {
-          if (!nextArray) nextArray = previousArray.slice();
-          nextArray[arrayIndex] = nextItem;
+      return value;
+    }
+    var isArray = Array.isArray(value);
+    if (!isArray) {
+      var prototype = Object.getPrototypeOf(value);
+      var isPlainObject = prototype === null || (
+        Object.getPrototypeOf(prototype) === null &&
+        Object.prototype.hasOwnProperty.call(prototype, "constructor") &&
+        prototype.constructor && prototype.constructor.name === "Object"
+      );
+      if (!isPlainObject) {
+        throw new TypeError("Subscription state only supports arrays and plain objects");
+      }
+    }
+    ancestors = ancestors || new WeakSet();
+    if (ancestors.has(value)) throw new TypeError("Subscription state must not contain cycles");
+    ancestors.add(value);
+    try {
+      if (isArray) {
+        var previousArray = Array.isArray(previous) ? previous : null;
+        if (!previousArray) {
+          return Object.freeze(value.map(function (item) {
+            return subscriptionStateValue(item, undefined, ancestors);
+          }));
+        }
+        var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
+        for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
+          var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex], ancestors);
+          if (!Object.is(nextItem, previousArray[arrayIndex])) {
+            if (!nextArray) nextArray = previousArray.slice();
+            nextArray[arrayIndex] = nextItem;
+          }
+        }
+        return nextArray ? Object.freeze(nextArray) : previousArray;
+      }
+
+      var keys = Object.keys(value);
+      var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
+        ? previous
+        : null;
+      var previousKeys = previousObject ? Object.keys(previousObject) : [];
+      var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
+        return Object.prototype.hasOwnProperty.call(previousObject, key);
+      });
+      var nextObject = sameShape ? null : {};
+      for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
+        var key = keys[objectIndex];
+        var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key], ancestors);
+        if (!sameShape || !Object.is(nextValue, previousObject[key])) {
+          if (!nextObject) nextObject = copySubscriptionStateObject(previousObject);
+          defineSubscriptionStateProperty(nextObject, key, nextValue);
         }
       }
-      return nextArray ? Object.freeze(nextArray) : previousArray;
+      return nextObject ? Object.freeze(nextObject) : previousObject;
+    } finally {
+      ancestors.delete(value);
     }
-
-    var keys = Object.keys(value);
-    var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
-      ? previous
-      : null;
-    var previousKeys = previousObject ? Object.keys(previousObject) : [];
-    var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
-      return Object.prototype.hasOwnProperty.call(previousObject, key);
-    });
-    var nextObject = sameShape ? null : {};
-    for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
-      var key = keys[objectIndex];
-      var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key]);
-      if (!sameShape || nextValue !== previousObject[key]) {
-        if (!nextObject) nextObject = Object.assign({}, previousObject);
-        nextObject[key] = nextValue;
-      }
-    }
-    return nextObject ? Object.freeze(nextObject) : previousObject;
   }
   var subscriptionSliceRevision = 0;
   var subscriptionSliceCache = Object.create(null);
@@ -1381,6 +1421,8 @@
     });
     return true;
   }
+  var notificationQueue = [];
+  var notificationDispatching = false;
   function notify() {
     if (suppressNotify) return;
     // 会话列表「工作中」指示:active 取活动工作集 state.busy,其余取各自 buffer.busy
@@ -1388,21 +1430,43 @@
     for (var id in sessionStates) state.sessionBusy[id] = !!sessionStates[id].busy;
     if (state.activeSessionId) state.sessionBusy[state.activeSessionId] = !!state.busy;
     subscriptionSliceRevision += 1;
-    for (var i = 0; i < subscribers.length; i++) subscribers[i]();
+    // Membership and state are fixed when a round is queued. Subscribe or
+    // unsubscribe during a callback affects only rounds queued afterwards.
+    var members = subscribers.slice();
+    notificationQueue.push(members.map(function (subscriber) {
+      return { callback: subscriber.callback, snapshot: subscriber.snapshot() };
+    }));
+    if (notificationDispatching) return;
+    notificationDispatching = true;
+    try {
+      while (notificationQueue.length) {
+        var round = notificationQueue.shift();
+        for (var i = 0; i < round.length; i++) round[i].callback(round[i].snapshot);
+      }
+    } catch (error) {
+      // Preserve synchronous callback error propagation. Later queued rounds may
+      // depend on the interrupted callback, so discard them instead of replaying
+      // stale work on the next notification.
+      notificationQueue = [];
+      throw error;
+    } finally {
+      notificationDispatching = false;
+    }
   }
-  function subscribe(fn) {
-    subscribers.push(fn);
+  function subscribe(snapshot, callback) {
+    var subscriber = { snapshot: snapshot, callback: callback };
+    subscribers.push(subscriber);
     return function () {
-      subscribers = subscribers.filter(function (f) { return f !== fn; });
+      subscribers = subscribers.filter(function (candidate) { return candidate !== subscriber; });
     };
   }
   function subscribeStateSlice(domain, fn) {
     subscriptionStateSlice(domain);
-    return subscribe(function () { fn(subscriptionStateSlice(domain)); });
+    return subscribe(function () { return subscriptionStateSlice(domain); }, fn);
   }
   function subscribeStateSlices(domains, fn) {
     subscriptionStateSlices(domains);
-    return subscribe(function () { fn(subscriptionStateSlices(domains)); });
+    return subscribe(function () { return subscriptionStateSlices(domains); }, fn);
   }
 
   var scheduledFeature = installBridgeFeature("scheduled", { state: state, notify: notify, invoke: invoke, bt: bt, runSyncOnSession: runSyncOnSession, addSystemItem: addSystemItem, rememberScheduledRunOwner: rememberScheduledRunOwner, isScheduledRunTerminal: isScheduledRunTerminal, purgeSessionBuffer: purgeSessionBuffer, createNewSession: createNewSession, prefillComposer: prefillComposer, sessionStates: sessionStates });

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1434,15 +1434,52 @@
     }
     return JSON.parse(JSON.stringify(state));
   }
-  function subscriptionState() {
-    var result = {};
-    Object.keys(state).forEach(function (key) {
-      var value = state[key];
-      if (Array.isArray(value)) result[key] = Object.freeze(value.slice());
-      else if (value && typeof value === "object") result[key] = Object.freeze(Object.assign({}, value));
-      else result[key] = value;
+  // Build immutable persistent subscription snapshots. Reconcile nested values
+  // so unchanged transcript history is shared across notifications, while each
+  // in-place streaming mutation gets a detached changed path.
+  function subscriptionStateValue(value, previous) {
+    if (!value || typeof value !== "object") return value;
+    if (Array.isArray(value)) {
+      var previousArray = Array.isArray(previous) ? previous : null;
+      if (!previousArray) {
+        return Object.freeze(value.map(function (item) {
+          return subscriptionStateValue(item, undefined);
+        }));
+      }
+      var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
+      for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
+        var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex]);
+        if (nextItem !== previousArray[arrayIndex]) {
+          if (!nextArray) nextArray = previousArray.slice();
+          nextArray[arrayIndex] = nextItem;
+        }
+      }
+      return nextArray ? Object.freeze(nextArray) : previousArray;
+    }
+
+    var keys = Object.keys(value);
+    var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
+      ? previous
+      : null;
+    var previousKeys = previousObject ? Object.keys(previousObject) : [];
+    var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
+      return Object.prototype.hasOwnProperty.call(previousObject, key);
     });
-    return Object.freeze(result);
+    var nextObject = sameShape ? null : {};
+    for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
+      var key = keys[objectIndex];
+      var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key]);
+      if (!sameShape || nextValue !== previousObject[key]) {
+        if (!nextObject) nextObject = Object.assign({}, previousObject);
+        nextObject[key] = nextValue;
+      }
+    }
+    return nextObject ? Object.freeze(nextObject) : previousObject;
+  }
+  var subscriptionSnapshot = null;
+  function subscriptionState() {
+    subscriptionSnapshot = subscriptionStateValue(state, subscriptionSnapshot);
+    return subscriptionSnapshot;
   }
   function notify() {
     if (suppressNotify) return;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1437,50 +1437,92 @@
   // Build immutable persistent subscription snapshots. Reconcile nested values
   // so unchanged transcript history is shared across notifications, while each
   // in-place streaming mutation gets a detached changed path.
-  function subscriptionStateValue(value, previous) {
-    if (!value || typeof value !== "object") return value;
-    if (Array.isArray(value)) {
-      var previousArray = Array.isArray(previous) ? previous : null;
-      if (!previousArray) {
-        return Object.freeze(value.map(function (item) {
-          return subscriptionStateValue(item, undefined);
-        }));
+  function defineSubscriptionStateProperty(target, key, value) {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value: value,
+      writable: true,
+    });
+  }
+  function copySubscriptionStateObject(source) {
+    var result = {};
+    Object.keys(source).forEach(function (key) {
+      defineSubscriptionStateProperty(result, key, source[key]);
+    });
+    return result;
+  }
+  function subscriptionStateValue(value, previous, ancestors) {
+    var valueType = typeof value;
+    if (!value || valueType !== "object") {
+      if (valueType === "function" || valueType === "symbol" || valueType === "bigint") {
+        throw new TypeError("Subscription state only supports JSON-like scalar values");
       }
-      var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
-      for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
-        var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex]);
-        if (nextItem !== previousArray[arrayIndex]) {
-          if (!nextArray) nextArray = previousArray.slice();
-          nextArray[arrayIndex] = nextItem;
+      return value;
+    }
+    var isArray = Array.isArray(value);
+    if (!isArray) {
+      var prototype = Object.getPrototypeOf(value);
+      var isPlainObject = prototype === null || (
+        Object.getPrototypeOf(prototype) === null &&
+        Object.prototype.hasOwnProperty.call(prototype, "constructor") &&
+        prototype.constructor && prototype.constructor.name === "Object"
+      );
+      if (!isPlainObject) {
+        throw new TypeError("Subscription state only supports arrays and plain objects");
+      }
+    }
+    ancestors = ancestors || new WeakSet();
+    if (ancestors.has(value)) throw new TypeError("Subscription state must not contain cycles");
+    ancestors.add(value);
+    try {
+      if (isArray) {
+        var previousArray = Array.isArray(previous) ? previous : null;
+        if (!previousArray) {
+          return Object.freeze(value.map(function (item) {
+            return subscriptionStateValue(item, undefined, ancestors);
+          }));
+        }
+        var nextArray = value.length === previousArray.length ? null : previousArray.slice(0, value.length);
+        for (var arrayIndex = 0; arrayIndex < value.length; arrayIndex++) {
+          var nextItem = subscriptionStateValue(value[arrayIndex], previousArray[arrayIndex], ancestors);
+          if (!Object.is(nextItem, previousArray[arrayIndex])) {
+            if (!nextArray) nextArray = previousArray.slice();
+            nextArray[arrayIndex] = nextItem;
+          }
+        }
+        return nextArray ? Object.freeze(nextArray) : previousArray;
+      }
+
+      var keys = Object.keys(value);
+      var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
+        ? previous
+        : null;
+      var previousKeys = previousObject ? Object.keys(previousObject) : [];
+      var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
+        return Object.prototype.hasOwnProperty.call(previousObject, key);
+      });
+      var nextObject = sameShape ? null : {};
+      for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
+        var key = keys[objectIndex];
+        var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key], ancestors);
+        if (!sameShape || !Object.is(nextValue, previousObject[key])) {
+          if (!nextObject) nextObject = copySubscriptionStateObject(previousObject);
+          defineSubscriptionStateProperty(nextObject, key, nextValue);
         }
       }
-      return nextArray ? Object.freeze(nextArray) : previousArray;
+      return nextObject ? Object.freeze(nextObject) : previousObject;
+    } finally {
+      ancestors.delete(value);
     }
-
-    var keys = Object.keys(value);
-    var previousObject = previous && typeof previous === "object" && !Array.isArray(previous)
-      ? previous
-      : null;
-    var previousKeys = previousObject ? Object.keys(previousObject) : [];
-    var sameShape = !!previousObject && keys.length === previousKeys.length && keys.every(function (key) {
-      return Object.prototype.hasOwnProperty.call(previousObject, key);
-    });
-    var nextObject = sameShape ? null : {};
-    for (var objectIndex = 0; objectIndex < keys.length; objectIndex++) {
-      var key = keys[objectIndex];
-      var nextValue = subscriptionStateValue(value[key], previousObject && previousObject[key]);
-      if (!sameShape || nextValue !== previousObject[key]) {
-        if (!nextObject) nextObject = Object.assign({}, previousObject);
-        nextObject[key] = nextValue;
-      }
-    }
-    return nextObject ? Object.freeze(nextObject) : previousObject;
   }
   var subscriptionSnapshot = null;
   function subscriptionState() {
     subscriptionSnapshot = subscriptionStateValue(state, subscriptionSnapshot);
     return subscriptionSnapshot;
   }
+  var notificationQueue = [];
+  var notificationDispatching = false;
   function notify() {
     if (suppressNotify) return;
     // 会话列表「工作中」指示:active 取活动工作集 state.busy,其余取各自 buffer.busy
@@ -1488,7 +1530,25 @@
     for (var id in sessionStates) state.sessionBusy[id] = !!sessionStates[id].busy;
     if (state.activeSessionId) state.sessionBusy[state.activeSessionId] = !!state.busy;
     var snapshot = subscriptionState();
-    for (var i = 0; i < subscribers.length; i++) subscribers[i](snapshot);
+    // Each queued round fixes both state and membership. Callback-time
+    // subscription changes apply only to rounds queued afterwards.
+    notificationQueue.push({ snapshot: snapshot, subscribers: subscribers.slice() });
+    if (notificationDispatching) return;
+    notificationDispatching = true;
+    try {
+      while (notificationQueue.length) {
+        var round = notificationQueue.shift();
+        for (var i = 0; i < round.subscribers.length; i++) round.subscribers[i](round.snapshot);
+      }
+    } catch (error) {
+      // Preserve synchronous callback error propagation. Later queued rounds may
+      // depend on the interrupted callback, so discard them instead of replaying
+      // stale work on the next notification.
+      notificationQueue = [];
+      throw error;
+    } finally {
+      notificationDispatching = false;
+    }
   }
   function subscribe(fn) {
     subscribers.push(fn);

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -186,7 +186,7 @@
     mountedCollections: [],
     mountedCollectionsRevision: 0,
     // personaPool 只放轻量元信息(loadState),1078 张卡放模块级 personaPoolCache,
-    // 不进 notify() 的 JSON 深拷贝(否则每个流式 token 都克隆 ~950KB,卡顿)。
+    // 不进 state/订阅快照，避免每个流式 token 都复制完整卡池。
     personaPool: { loadState: "idle" }, // idle | loading | ready | error
     // 应用内升级: updateInfo = check_for_update 返回值(available=true 才有意义)
     appVersion: null,
@@ -1434,13 +1434,23 @@
     }
     return JSON.parse(JSON.stringify(state));
   }
+  function subscriptionState() {
+    var result = {};
+    Object.keys(state).forEach(function (key) {
+      var value = state[key];
+      if (Array.isArray(value)) result[key] = Object.freeze(value.slice());
+      else if (value && typeof value === "object") result[key] = Object.freeze(Object.assign({}, value));
+      else result[key] = value;
+    });
+    return Object.freeze(result);
+  }
   function notify() {
     if (suppressNotify) return;
     // 会话列表「工作中」指示:active 取活动工作集 state.busy,其余取各自 buffer.busy
     state.sessionBusy = {};
     for (var id in sessionStates) state.sessionBusy[id] = !!sessionStates[id].busy;
     if (state.activeSessionId) state.sessionBusy[state.activeSessionId] = !!state.busy;
-    var snapshot = snapshotState();
+    var snapshot = subscriptionState();
     for (var i = 0; i < subscribers.length; i++) subscribers[i](snapshot);
   }
   function subscribe(fn) {

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -59,12 +59,18 @@
 
   function subscribe(domainName, callback) {
     get(domainName);
-    return flat.subscribe(function () { callback(get(domainName)); });
+    return flat.subscribe(function (full) {
+      callback(Object.freeze(pick(full, domainName)));
+    });
   }
 
   function subscribeMany(domains, callback) {
     getMany(domains);
-    return flat.subscribe(function () { callback(getMany(domains)); });
+    return flat.subscribe(function (full) {
+      var result = {};
+      domains.forEach(function (domainName) { Object.assign(result, pick(full, domainName)); });
+      callback(Object.freeze(result));
+    });
   }
 
   function domain(names, aliases) {

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -618,6 +618,7 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
   var dialogCalls = [];
   var dialogResult = null;
   var createdSession = 0;
+  var structuredCloneCalls = 0;
   var storageData = sharedStorage || Object.create(null);
   var storage = {
     getItem: function (key) { return Object.prototype.hasOwnProperty.call(storageData, key) ? storageData[key] : null; },
@@ -738,7 +739,10 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
     clearTimeout: runtimeOptions.clearTimeout || clearTimeout,
     setInterval: function () { return 0; },
     clearInterval: function () {},
-    structuredClone: function (value) { return JSON.parse(JSON.stringify(value)); },
+    structuredClone: function (value) {
+      structuredCloneCalls += 1;
+      return JSON.parse(JSON.stringify(value));
+    },
     TextDecoder: TextDecoder,
     Uint8Array: Uint8Array,
   };
@@ -768,6 +772,7 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
     calls: calls,
     storageData: storageData,
     dialogCalls: dialogCalls,
+    getStructuredCloneCalls: function () { return structuredCloneCalls; },
     setDialogResult: function (value) { dialogResult = value; },
     emit: function (name, payload) {
       assert.ok(listeners[name] && listeners[name].length, "expected listener " + name);
@@ -775,6 +780,89 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
       return Promise.all(listeners[name].map(function (listener) { return listener(event); }));
     },
   };
+}
+
+async function subscriptionSnapshotsAvoidTranscriptDeepClone() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var chatUpdates = [];
+  var combinedUpdates = [];
+  var unsubscribeChat = bridge.state.subscribe("chat", function (snapshot) {
+    chatUpdates.push(snapshot);
+  });
+  var unsubscribeCombined = bridge.state.subscribeMany(["sessions", "chat"], function (snapshot) {
+    combinedUpdates.push(snapshot);
+  });
+  var cloneCallsBeforeNotify = harness.getStructuredCloneCalls();
+
+  await bridge.sessions.createNewSession();
+
+  assert.strictEqual(chatUpdates.length, 1, "one bridge notification should publish one chat subscription update");
+  assert.strictEqual(combinedUpdates.length, 1, "one bridge notification should publish one combined subscription update");
+  assert.strictEqual(
+    harness.getStructuredCloneCalls(),
+    cloneCallsBeforeNotify,
+    "subscription notifications must not deep-clone the transcript"
+  );
+  assert.ok(Object.isFrozen(chatUpdates[0]) && Object.isFrozen(combinedUpdates[0]),
+    "subscription envelopes should be read-only");
+
+  assert.throws(function () {
+    chatUpdates[0].chatItems.push({ type: "system", text: "subscriber-only" });
+  }, /not extensible|read only|frozen/i, "subscription array containers should be read-only");
+  assert.strictEqual(bridge.state.get("chat").chatItems.length, 0,
+    "subscription array containers must not mutate bridge state");
+  var detached = bridge.state.get("chat");
+  detached.thinking.active = true;
+  assert.strictEqual(bridge.state.get("chat").thinking.active, false,
+    "get/getMany must retain their defensive deep-copy contract");
+
+  unsubscribeChat();
+  unsubscribeCombined();
+}
+
+async function longSessionStreamingAvoidsPerDeltaDeepClone() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var sessionId = "chat-long-stream";
+  var messages = [];
+  for (var index = 0; index < 469; index++) {
+    messages.push({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: [{ type: "text", text: "history-" + index + "-" + "x".repeat(1024) }],
+    });
+  }
+  harness.handlers.load_session = function () {
+    return {
+      metadata: { id: sessionId, title: "Long stream", message_count: messages.length },
+      messages: messages,
+      artifacts: [],
+    };
+  };
+  assert.strictEqual(await bridge.sessions.switchToSession(sessionId), true);
+
+  var updates = 0;
+  var unsubscribe = bridge.state.subscribeMany(["sessions", "chat"], function () {
+    updates += 1;
+  });
+  var cloneCallsBeforeStream = harness.getStructuredCloneCalls();
+  harness.emit("chat:turn_started", { session_id: sessionId });
+  for (var delta = 0; delta < 1000; delta++) {
+    harness.emit("chat:delta", { session_id: sessionId, text: "abcd" });
+  }
+  await tick();
+
+  assert.strictEqual(updates, 1001, "stream boundaries and deltas should remain immediately observable");
+  assert.strictEqual(
+    harness.getStructuredCloneCalls(),
+    cloneCallsBeforeStream,
+    "a long transcript must not be deep-cloned for each streamed delta"
+  );
+  var finalAssistant = bridge.state.get("chat").chatItems.filter(function (item) {
+    return item.type === "assistant" && item.streaming;
+  }).pop();
+  assert.strictEqual(finalAssistant.text.length, 4000, "subscription snapshot optimization must not lose text");
+  unsubscribe();
 }
 
 async function deepSeekTurnTimelineLifecycleBehavior() {
@@ -4550,6 +4638,8 @@ async function draftKnowledgeQueueStaysOnMaterializedSessionAfterSwitch() {
 }
 
 Promise.resolve()
+  .then(subscriptionSnapshotsAvoidTranscriptDeepClone)
+  .then(longSessionStreamingAvoidsPerDeltaDeepClone)
   .then(multipleKnowledgeMountBehavior)
   .then(queuedKnowledgeMountKeepsOriginalSession)
   .then(staleKnowledgeSnapshotDoesNotCrossSessions)

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -842,20 +842,56 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   assert.strictEqual(await bridge.sessions.switchToSession(sessionId), true);
 
   var updates = 0;
-  var unsubscribe = bridge.state.subscribeMany(["sessions", "chat"], function () {
+  var secondSubscriberUpdates = 0;
+  var snapshots = [];
+  var secondSubscriberSnapshots = [];
+  var unsubscribe = bridge.state.subscribeMany(["sessions", "chat"], function (snapshot) {
     updates += 1;
+    if (snapshots.length < 3) snapshots.push(snapshot);
+  });
+  var unsubscribeSecond = bridge.state.subscribe("chat", function (snapshot) {
+    secondSubscriberUpdates += 1;
+    if (secondSubscriberSnapshots.length < 3) secondSubscriberSnapshots.push(snapshot);
   });
   var cloneCallsBeforeStream = harness.getStructuredCloneCalls();
   harness.emit("chat:turn_started", { session_id: sessionId });
-  for (var delta = 0; delta < 1000; delta++) {
+  harness.emit("chat:delta", { session_id: sessionId, text: "abcd" });
+
+  var firstDeltaSnapshot = snapshots[1];
+  var firstDeltaItem = firstDeltaSnapshot.chatItems.filter(function (item) {
+    return item.type === "assistant" && item.streaming;
+  }).pop();
+  assert.strictEqual(firstDeltaItem.text, "abcd", "the first delta snapshot should capture its own text");
+  assert.ok(Object.isFrozen(firstDeltaItem), "nested subscription items should be immutable");
+  assert.strictEqual(Reflect.set(firstDeltaItem, "text", "subscriber-only"), false,
+    "a subscriber must not mutate a nested item");
+  assert.strictEqual(secondSubscriberSnapshots[1].chatItems.filter(function (item) {
+    return item.type === "assistant" && item.streaming;
+  }).pop().text, "abcd", "one subscriber must not affect a second subscriber");
+  assert.strictEqual(bridge.state.get("chat").chatItems.filter(function (item) {
+    return item.type === "assistant" && item.streaming;
+  }).pop().text, "abcd", "one subscriber must not affect bridge state");
+  assert.strictEqual(harness.getStructuredCloneCalls(), cloneCallsBeforeStream + 1,
+    "the explicit state.get isolation check should retain its defensive deep copy");
+  var cloneCallsAfterDefensiveRead = harness.getStructuredCloneCalls();
+
+  harness.emit("chat:delta", { session_id: sessionId, text: "abcd" });
+  assert.strictEqual(firstDeltaItem.text, "abcd", "an older subscription snapshot must remain stable");
+  assert.strictEqual(snapshots[2].chatItems.filter(function (item) {
+    return item.type === "assistant" && item.streaming;
+  }).pop().text, "abcdabcd", "the next snapshot should observe the next delta");
+
+  for (var delta = 2; delta < 1000; delta++) {
     harness.emit("chat:delta", { session_id: sessionId, text: "abcd" });
   }
   await tick();
 
   assert.strictEqual(updates, 1001, "stream boundaries and deltas should remain immediately observable");
+  assert.strictEqual(secondSubscriberUpdates, 1001,
+    "all subscribers should receive one immediate update per stream boundary and delta");
   assert.strictEqual(
     harness.getStructuredCloneCalls(),
-    cloneCallsBeforeStream,
+    cloneCallsAfterDefensiveRead,
     "a long transcript must not be deep-cloned for each streamed delta"
   );
   var finalAssistant = bridge.state.get("chat").chatItems.filter(function (item) {
@@ -863,6 +899,7 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   }).pop();
   assert.strictEqual(finalAssistant.text.length, 4000, "subscription snapshot optimization must not lose text");
   unsubscribe();
+  unsubscribeSecond();
 }
 
 async function deepSeekTurnTimelineLifecycleBehavior() {

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -821,6 +821,141 @@ async function subscriptionSnapshotsAvoidTranscriptDeepClone() {
   unsubscribeCombined();
 }
 
+async function reentrantSubscriptionNotificationsStayOrdered() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var firstOrder = [];
+  var secondOrder = [];
+  var unsubscribeFirst = bridge.state.subscribe("chat", function (snapshot) {
+    var text = snapshot.composerPrefill.text;
+    firstOrder.push(text);
+    if (text === "outer") bridge.chat.prefillComposer("nested");
+  });
+  var unsubscribeSecond = bridge.state.subscribe("chat", function (snapshot) {
+    secondOrder.push(snapshot.composerPrefill.text);
+  });
+
+  bridge.chat.prefillComposer("outer");
+  assert.deepStrictEqual(firstOrder, ["outer", "nested"], "the first subscriber should receive queued revisions in order");
+  assert.deepStrictEqual(secondOrder, ["outer", "nested"], "a later subscriber must not observe nested before outer");
+  assert.strictEqual(bridge.state.get("chat").composerPrefill.text, "nested");
+  unsubscribeFirst();
+  unsubscribeSecond();
+
+  var membershipHarness = createBridgeHarness();
+  var membershipBridge = membershipHarness.bridge;
+  var membershipFirst = [];
+  var membershipSecond = [];
+  var membershipAdded = [];
+  var unsubscribeMembershipSecond;
+  var unsubscribeAdded = function () {};
+  var unsubscribeMembershipFirst = membershipBridge.state.subscribe("chat", function (snapshot) {
+    var text = snapshot.composerPrefill.text;
+    membershipFirst.push(text);
+    if (text === "membership-outer") {
+      unsubscribeMembershipSecond();
+      unsubscribeAdded = membershipBridge.state.subscribe("chat", function (next) {
+        membershipAdded.push(next.composerPrefill.text);
+      });
+      membershipBridge.chat.prefillComposer("membership-nested");
+    }
+  });
+  unsubscribeMembershipSecond = membershipBridge.state.subscribe("chat", function (snapshot) {
+    membershipSecond.push(snapshot.composerPrefill.text);
+  });
+
+  membershipBridge.chat.prefillComposer("membership-outer");
+  assert.deepStrictEqual(membershipFirst, ["membership-outer", "membership-nested"]);
+  assert.deepStrictEqual(membershipSecond, ["membership-outer"],
+    "unsubscribe during a round should apply only to rounds queued afterwards");
+  assert.deepStrictEqual(membershipAdded, ["membership-nested"],
+    "subscribe during a round should apply only to rounds queued afterwards");
+  unsubscribeMembershipFirst();
+  unsubscribeAdded();
+
+  var errorHarness = createBridgeHarness();
+  var errorBridge = errorHarness.bridge;
+  var interruptedSecond = [];
+  var unsubscribeThrowing = errorBridge.state.subscribe("chat", function (snapshot) {
+    if (snapshot.composerPrefill.text === "error-outer") {
+      errorBridge.chat.prefillComposer("discarded-nested");
+      throw new Error("subscriber failed");
+    }
+  });
+  var unsubscribeInterruptedSecond = errorBridge.state.subscribe("chat", function (snapshot) {
+    interruptedSecond.push(snapshot.composerPrefill.text);
+  });
+  assert.throws(function () { errorBridge.chat.prefillComposer("error-outer"); }, /subscriber failed/,
+    "subscriber errors should retain their synchronous propagation behavior");
+  assert.deepStrictEqual(interruptedSecond, [], "a callback error should interrupt the current subscriber round");
+  unsubscribeThrowing();
+  unsubscribeInterruptedSecond();
+
+  var recovered = [];
+  var unsubscribeRecovered = errorBridge.state.subscribe("chat", function (snapshot) {
+    recovered.push(snapshot.composerPrefill.text);
+  });
+  errorBridge.chat.prefillComposer("recovered");
+  assert.deepStrictEqual(recovered, ["recovered"],
+    "queued revisions from an interrupted callback must be discarded before the next notification");
+  unsubscribeRecovered();
+}
+
+async function persistentSubscriptionSnapshotsPreserveJsonEdges() {
+  var harness = createBridgeHarness();
+  var bridge = harness.bridge;
+  var snapshots = [];
+  var negativeZero = true;
+  function settingsResult() {
+    var result = JSON.parse('{"language":"en","__proto__":{"marker":"own-value"}}');
+    Object.defineProperty(result, "nan", { enumerable: true, value: NaN, writable: true });
+    result.zero = negativeZero ? -0 : 0;
+    return result;
+  }
+  harness.handlers.update_settings = settingsResult;
+  harness.handlers.get_effective_model_config = function () { return null; };
+  var unsubscribe = bridge.state.subscribe("settings", function (snapshot) { snapshots.push(snapshot); });
+
+  assert.strictEqual(await bridge.settings.saveSettings({ language: "en" }), true);
+  assert.ok(snapshots.length >= 2, "settings save should publish its effective-model and saved revisions");
+  var first = snapshots[0];
+  var repeated = snapshots[1];
+  assert.ok(Object.prototype.hasOwnProperty.call(first.settings, "__proto__"));
+  assert.strictEqual(first.settings["__proto__"].marker, "own-value");
+  assert.strictEqual(Object.getPrototypeOf(first.settings), Object.getPrototypeOf(first),
+    "snapshots with own __proto__ data must retain the default object prototype");
+  assert.strictEqual(Object.getPrototypeOf(first.settings).marker, undefined, "snapshot prototypes must not be polluted");
+  assert.strictEqual(first.settings, repeated.settings, "Object.is should reuse an unchanged subtree containing NaN");
+  assert.ok(Number.isNaN(first.settings.nan));
+  assert.ok(Object.is(first.settings.zero, -0));
+
+  negativeZero = false;
+  assert.strictEqual(await bridge.settings.saveSettings({ language: "en" }), true);
+  var changed = snapshots[snapshots.length - 1];
+  assert.notStrictEqual(changed.settings, repeated.settings, "Object.is should distinguish -0 from +0");
+  assert.ok(Object.is(changed.settings.zero, 0));
+  assert.ok(Object.prototype.hasOwnProperty.call(changed.settings, "__proto__"),
+    "copy-on-write updates must retain an existing own __proto__ value");
+  assert.strictEqual(changed.settings["__proto__"].marker, "own-value");
+  assert.strictEqual(Object.getPrototypeOf(changed.settings).marker, undefined,
+    "copy-on-write updates must not route __proto__ through the prototype setter");
+  unsubscribe();
+}
+
+async function persistentSubscriptionSnapshotsRejectUnsupportedValues() {
+  async function rejects(result, pattern) {
+    var harness = createBridgeHarness();
+    harness.handlers.ingest_file = function () { return result; };
+    var unsubscribe = harness.bridge.state.subscribe("chat", function () {});
+    await assert.rejects(harness.bridge.attachments.addAttachmentByPath("C:\\snapshot-edge.txt"), pattern);
+    unsubscribe();
+  }
+  await rejects(new Date(0), /only supports arrays and plain objects/);
+  var cyclic = { value: "cycle" };
+  cyclic.self = cyclic;
+  await rejects(cyclic, /must not contain cycles/);
+}
+
 async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
@@ -4676,6 +4811,9 @@ async function draftKnowledgeQueueStaysOnMaterializedSessionAfterSwitch() {
 
 Promise.resolve()
   .then(subscriptionSnapshotsAvoidTranscriptDeepClone)
+  .then(reentrantSubscriptionNotificationsStayOrdered)
+  .then(persistentSubscriptionSnapshotsPreserveJsonEdges)
+  .then(persistentSubscriptionSnapshotsRejectUnsupportedValues)
   .then(longSessionStreamingAvoidsPerDeltaDeepClone)
   .then(multipleKnowledgeMountBehavior)
   .then(queuedKnowledgeMountKeepsOriginalSession)

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -960,8 +960,22 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   var harness = createBridgeHarness();
   var bridge = harness.bridge;
   var sessionId = "chat-long-stream";
-  var messages = [];
-  for (var index = 0; index < 469; index++) {
+  var messages = [
+    {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: "tool-stable-history",
+        name: "shell",
+        input: { command: "echo stable", options: { cwd: "history", environment: { MODE: "test" } } },
+      }],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "tool-stable-history", content: "stable output" }],
+    },
+  ];
+  for (var index = messages.length; index < 469; index++) {
     messages.push({
       role: index % 2 === 0 ? "user" : "assistant",
       content: [{ type: "text", text: "history-" + index + "-" + "x".repeat(1024) }],
@@ -982,11 +996,11 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   var secondSubscriberSnapshots = [];
   var unsubscribe = bridge.state.subscribeMany(["sessions", "chat"], function (snapshot) {
     updates += 1;
-    if (snapshots.length < 3) snapshots.push(snapshot);
+    snapshots.push(snapshot);
   });
   var unsubscribeSecond = bridge.state.subscribe("chat", function (snapshot) {
     secondSubscriberUpdates += 1;
-    if (secondSubscriberSnapshots.length < 3) secondSubscriberSnapshots.push(snapshot);
+    secondSubscriberSnapshots.push(snapshot);
   });
   var cloneCallsBeforeStream = harness.getStructuredCloneCalls();
   harness.emit("chat:turn_started", { session_id: sessionId });
@@ -1024,11 +1038,63 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   assert.strictEqual(updates, 1001, "stream boundaries and deltas should remain immediately observable");
   assert.strictEqual(secondSubscriberUpdates, 1001,
     "all subscribers should receive one immediate update per stream boundary and delta");
+  assert.strictEqual(snapshots.length, 1001, "the regression must retain every persistent snapshot");
+  assert.strictEqual(secondSubscriberSnapshots.length, 1001,
+    "the second subscriber must retain every same-round snapshot for identity checks");
   assert.strictEqual(
     harness.getStructuredCloneCalls(),
     cloneCallsAfterDefensiveRead,
     "a long transcript must not be deep-cloned for each streamed delta"
   );
+
+  var representativeFrames = [0, 1, 499, 500, 999, 1000];
+  var stableMessages = snapshots[0].messages;
+  var stableHistoryMessage = stableMessages[0];
+  var stableHistoryContent = stableHistoryMessage.content;
+  var stableHistoryBlock = stableHistoryContent[0];
+  var stableToolItem = snapshots[0].chatItems.find(function (item) {
+    return item.type === "tool" && item.toolId === "tool-stable-history";
+  });
+  assert.ok(stableToolItem, "the fixture should expose a historical tool chat item");
+  assert.strictEqual(stableToolItem.args.options.environment.MODE, "test");
+  representativeFrames.forEach(function (frame) {
+    var snapshot = snapshots[frame];
+    var secondSnapshot = secondSubscriberSnapshots[frame];
+    var toolItem = snapshot.chatItems.find(function (item) {
+      return item.type === "tool" && item.toolId === "tool-stable-history";
+    });
+    assert.strictEqual(snapshot.messages, stableMessages,
+      "unchanged history messages arrays must be shared across first/middle/last and adjacent frames");
+    assert.strictEqual(snapshot.messages[0], stableHistoryMessage,
+      "unchanged history message objects must be structurally shared");
+    assert.strictEqual(snapshot.messages[0].content, stableHistoryContent,
+      "unchanged history content arrays must be structurally shared");
+    assert.strictEqual(snapshot.messages[0].content[0], stableHistoryBlock,
+      "unchanged history content blocks must be structurally shared");
+    assert.strictEqual(toolItem, stableToolItem,
+      "unchanged historical tool chat items must be structurally shared");
+    assert.strictEqual(toolItem.args, stableToolItem.args,
+      "unchanged historical tool args must be structurally shared");
+    assert.strictEqual(toolItem.args.options.environment, stableToolItem.args.options.environment,
+      "unchanged historical tool deep subtrees must be structurally shared");
+    assert.strictEqual(secondSnapshot.messages, snapshot.messages,
+      "two subscribers in the same revision must share the messages domain subtree");
+    assert.strictEqual(secondSnapshot.chatItems, snapshot.chatItems,
+      "two subscribers in the same revision must share the chatItems domain subtree");
+  });
+
+  function streamingItemAt(frame) {
+    return snapshots[frame].chatItems.filter(function (item) {
+      return item.type === "assistant" && item.streaming;
+    }).pop();
+  }
+  for (var frame = 1; frame < snapshots.length; frame++) {
+    assert.notStrictEqual(streamingItemAt(frame - 1), streamingItemAt(frame),
+      "the changed streaming item must receive a new reference in every adjacent revision");
+  }
+  assert.strictEqual(streamingItemAt(1).text, "abcd", "the first retained delta must remain stable");
+  assert.strictEqual(streamingItemAt(500).text.length, 2000, "the middle retained delta must remain stable");
+  assert.strictEqual(streamingItemAt(1000).text.length, 4000, "the final retained delta must be complete");
   var finalAssistant = bridge.state.get("chat").chatItems.filter(function (item) {
     return item.type === "assistant" && item.streaming;
   }).pop();

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -119,6 +119,18 @@ assert.equal(deepCloneCalls, 0, 'subscription notifications must not deep-clone 
 assert.equal(flatSnapshots.length, 2, 'Web flat subscribers should observe parsing and ready updates');
 assert.equal(chatSnapshots.length, 2, 'Web domain subscribers should observe parsing and ready updates');
 assert.equal(combinedSnapshots.length, 2, 'Web multi-domain subscribers should observe parsing and ready updates');
+assert.equal(flatSnapshots[0], secondFlatSnapshots[0],
+  'Web flat subscribers in one revision should receive the exact same immutable snapshot');
+assert.equal(flatSnapshots[1], secondFlatSnapshots[1],
+  'Web flat subscribers should continue sharing the same snapshot in later revisions');
+assert.equal(flatSnapshots[1].attachments, chatSnapshots[1].attachments,
+  'Web flat and domain subscribers should share the same changed domain subtree in one revision');
+assert.equal(flatSnapshots[1].attachments, combinedSnapshots[1].attachments,
+  'Web flat and multi-domain subscribers should share the same domain subtree in one revision');
+assert.equal(flatSnapshots[0].messages, flatSnapshots[1].messages,
+  'unchanged Web transcript subtrees should be structurally shared across revisions');
+assert.equal(flatSnapshots[1].messages, chatSnapshots[1].messages,
+  'Web flat and domain subscribers should share unchanged transcript subtrees in one revision');
 assert.equal(flatSnapshots[0].attachments[0].status, 'parsing');
 assert.equal(flatSnapshots[1].attachments[0].status, 'ready');
 assert.equal(chatSnapshots[0].attachments[0].status, 'parsing');

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -45,6 +45,8 @@ const windowObject = {
   setTimeout,
   clearTimeout,
 };
+const nativeStructuredClone = globalThis.structuredClone;
+let deepCloneCalls = 0;
 const context = vm.createContext({
   window: windowObject,
   document: documentObject,
@@ -55,7 +57,10 @@ const context = vm.createContext({
   clearTimeout,
   setInterval,
   clearInterval,
-  structuredClone,
+  structuredClone(value) {
+    deepCloneCalls += 1;
+    return nativeStructuredClone(value);
+  },
   URL,
   URLSearchParams,
   Blob,
@@ -94,6 +99,24 @@ assert.ok(Object.hasOwn(state, 'sessions'));
 assert.ok(Object.hasOwn(state, 'settings'));
 assert.equal(Object.hasOwn(state, 'messages'), false);
 assert.throws(() => api.state.get('unknown'), /Unknown Tauri bridge state slice/);
+
+let subscribedChat;
+let subscribedCombined;
+const unsubscribeChat = api.state.subscribe('chat', snapshot => { subscribedChat = snapshot; });
+const unsubscribeCombined = api.state.subscribeMany(['sessions', 'chat'], snapshot => { subscribedCombined = snapshot; });
+snapshotReads = 0;
+deepCloneCalls = 0;
+await api.sessions.createNewSession();
+assert.equal(snapshotReads, 0, 'subscription notifications must use the supplied transport snapshot');
+assert.equal(deepCloneCalls, 0, 'subscription notifications must not deep-clone the transcript');
+assert.ok(Object.isFrozen(subscribedChat) && Object.isFrozen(subscribedCombined));
+assert.throws(
+  () => subscribedChat.chatItems.push({ type: 'system', text: 'subscriber-only' }),
+  /not extensible|read only|frozen/i,
+);
+assert.equal(api.state.get('chat').chatItems.length, 0, 'subscription arrays must not mutate Web bridge state');
+unsubscribeChat();
+unsubscribeCombined();
 
 const memorySources = {
   profile: { available: true }, preferences: { available: true }, work_context: { available: true },

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -100,21 +100,45 @@ assert.ok(Object.hasOwn(state, 'settings'));
 assert.equal(Object.hasOwn(state, 'messages'), false);
 assert.throws(() => api.state.get('unknown'), /Unknown Tauri bridge state slice/);
 
-let subscribedChat;
-let subscribedCombined;
-const unsubscribeChat = api.state.subscribe('chat', snapshot => { subscribedChat = snapshot; });
-const unsubscribeCombined = api.state.subscribeMany(['sessions', 'chat'], snapshot => { subscribedCombined = snapshot; });
+const flatSnapshots = [];
+const secondFlatSnapshots = [];
+const chatSnapshots = [];
+const combinedSnapshots = [];
+const unsubscribeFlat = flat.subscribe(snapshot => { flatSnapshots.push(snapshot); });
+const unsubscribeSecondFlat = flat.subscribe(snapshot => { secondFlatSnapshots.push(snapshot); });
+const unsubscribeChat = api.state.subscribe('chat', snapshot => { chatSnapshots.push(snapshot); });
+const unsubscribeCombined = api.state.subscribeMany(['sessions', 'chat'], snapshot => { combinedSnapshots.push(snapshot); });
 snapshotReads = 0;
 deepCloneCalls = 0;
-await api.sessions.createNewSession();
+invokeResponse = async command => command === 'web_access_ingest_file'
+  ? { basename: 'stable-snapshot.txt', handle: 'attachment-handle' }
+  : null;
+await api.attachments.addAttachmentByPath('/tmp/stable-snapshot.txt');
 assert.equal(snapshotReads, 0, 'subscription notifications must use the supplied transport snapshot');
 assert.equal(deepCloneCalls, 0, 'subscription notifications must not deep-clone the transcript');
-assert.ok(Object.isFrozen(subscribedChat) && Object.isFrozen(subscribedCombined));
-assert.throws(
-  () => subscribedChat.chatItems.push({ type: 'system', text: 'subscriber-only' }),
-  /not extensible|read only|frozen/i,
-);
-assert.equal(api.state.get('chat').chatItems.length, 0, 'subscription arrays must not mutate Web bridge state');
+assert.equal(flatSnapshots.length, 2, 'Web flat subscribers should observe parsing and ready updates');
+assert.equal(chatSnapshots.length, 2, 'Web domain subscribers should observe parsing and ready updates');
+assert.equal(combinedSnapshots.length, 2, 'Web multi-domain subscribers should observe parsing and ready updates');
+assert.equal(flatSnapshots[0].attachments[0].status, 'parsing');
+assert.equal(flatSnapshots[1].attachments[0].status, 'ready');
+assert.equal(chatSnapshots[0].attachments[0].status, 'parsing');
+assert.equal(chatSnapshots[1].attachments[0].status, 'ready');
+assert.ok(Object.isFrozen(flatSnapshots[0].attachments[0]));
+assert.ok(Object.isFrozen(chatSnapshots[0].attachments[0]));
+assert.equal(Reflect.set(flatSnapshots[0].attachments[0], 'status', 'subscriber-only'), false,
+  'a flat subscriber must not mutate a nested item');
+assert.equal(Reflect.set(chatSnapshots[1].attachments[0].result, 'handle', 'subscriber-only'), false,
+  'a domain subscriber must not mutate a nested result');
+assert.equal(flatSnapshots[0].attachments[0].status, 'parsing', 'an older flat snapshot must remain stable');
+assert.equal(chatSnapshots[0].attachments[0].status, 'parsing', 'an older domain snapshot must remain stable');
+assert.equal(secondFlatSnapshots[0].attachments[0].status, 'parsing',
+  'one flat subscriber must not affect a second subscriber');
+assert.equal(combinedSnapshots[1].attachments[0].result.handle, 'attachment-handle',
+  'one domain subscriber must not affect another domain subscriber');
+assert.equal(api.state.get('chat').attachments[0].result.handle, 'attachment-handle',
+  'subscription writes must not mutate Web bridge state');
+unsubscribeFlat();
+unsubscribeSecondFlat();
 unsubscribeChat();
 unsubscribeCombined();
 

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -142,6 +142,92 @@ unsubscribeSecondFlat();
 unsubscribeChat();
 unsubscribeCombined();
 
+const flatReentrantFirst = [];
+const flatReentrantSecond = [];
+const domainReentrantFirst = [];
+const domainReentrantSecond = [];
+const unsubscribeFlatReentrantFirst = flat.subscribe(snapshot => {
+  const text = snapshot.composerPrefill.text;
+  flatReentrantFirst.push(text);
+  if (text === 'outer') api.chat.prefillComposer('nested');
+});
+const unsubscribeFlatReentrantSecond = flat.subscribe(snapshot => {
+  flatReentrantSecond.push(snapshot.composerPrefill.text);
+});
+const unsubscribeDomainReentrantFirst = api.state.subscribe('chat', snapshot => {
+  domainReentrantFirst.push(snapshot.composerPrefill.text);
+});
+const unsubscribeDomainReentrantSecond = api.state.subscribe('chat', snapshot => {
+  domainReentrantSecond.push(snapshot.composerPrefill.text);
+});
+api.chat.prefillComposer('outer');
+assert.deepEqual(flatReentrantFirst, ['outer', 'nested']);
+assert.deepEqual(flatReentrantSecond, ['outer', 'nested'], 'Web flat subscribers must receive outer before nested');
+assert.deepEqual(domainReentrantFirst, ['outer', 'nested']);
+assert.deepEqual(domainReentrantSecond, ['outer', 'nested'], 'Web domain subscribers must receive outer before nested');
+assert.equal(api.state.get('chat').composerPrefill.text, 'nested');
+unsubscribeFlatReentrantFirst();
+unsubscribeFlatReentrantSecond();
+unsubscribeDomainReentrantFirst();
+unsubscribeDomainReentrantSecond();
+
+const membershipFirst = [];
+const membershipSecond = [];
+const membershipAdded = [];
+let unsubscribeMembershipSecond;
+let unsubscribeMembershipAdded = () => {};
+const unsubscribeMembershipFirst = flat.subscribe(snapshot => {
+  const text = snapshot.composerPrefill.text;
+  membershipFirst.push(text);
+  if (text === 'membership-outer') {
+    unsubscribeMembershipSecond();
+    unsubscribeMembershipAdded = flat.subscribe(next => { membershipAdded.push(next.composerPrefill.text); });
+    api.chat.prefillComposer('membership-nested');
+  }
+});
+unsubscribeMembershipSecond = flat.subscribe(snapshot => { membershipSecond.push(snapshot.composerPrefill.text); });
+api.chat.prefillComposer('membership-outer');
+assert.deepEqual(membershipFirst, ['membership-outer', 'membership-nested']);
+assert.deepEqual(membershipSecond, ['membership-outer'],
+  'Web unsubscribe during a round should affect only later queued rounds');
+assert.deepEqual(membershipAdded, ['membership-nested'],
+  'Web subscribe during a round should affect only later queued rounds');
+unsubscribeMembershipFirst();
+unsubscribeMembershipAdded();
+
+const settingsSnapshots = [];
+let negativeZero = true;
+const settingsResult = () => {
+  const result = JSON.parse('{"language":"en","__proto__":{"marker":"own-value"}}');
+  Object.defineProperty(result, 'nan', { enumerable: true, value: NaN, writable: true });
+  result.zero = negativeZero ? -0 : 0;
+  return result;
+};
+const unsubscribeSettings = api.state.subscribe('settings', snapshot => { settingsSnapshots.push(snapshot); });
+invokeResponse = async command => command === 'web_access_update_settings' ? settingsResult() : null;
+assert.equal(await api.settings.saveSettings({ language: 'en' }), true);
+api.chat.prefillComposer('same-settings-revision');
+const firstSettings = settingsSnapshots[0];
+const repeatedSettings = settingsSnapshots[1];
+assert.ok(Object.hasOwn(firstSettings.settings, '__proto__'));
+assert.equal(firstSettings.settings.__proto__.marker, 'own-value');
+assert.equal(Object.getPrototypeOf(firstSettings.settings), Object.getPrototypeOf(firstSettings));
+assert.equal(Object.getPrototypeOf(firstSettings.settings).marker, undefined);
+assert.equal(firstSettings.settings, repeatedSettings.settings, 'Object.is should reuse a subtree containing NaN');
+assert.ok(Number.isNaN(firstSettings.settings.nan));
+assert.ok(Object.is(firstSettings.settings.zero, -0));
+negativeZero = false;
+assert.equal(await api.settings.saveSettings({ language: 'en' }), true);
+const changedSettings = settingsSnapshots.at(-1);
+assert.notEqual(changedSettings.settings, repeatedSettings.settings, 'Object.is should distinguish -0 from +0');
+assert.ok(Object.is(changedSettings.settings.zero, 0));
+assert.ok(Object.prototype.hasOwnProperty.call(changedSettings.settings, '__proto__'),
+  'web copy-on-write updates should retain an existing own __proto__ value');
+assert.equal(changedSettings.settings['__proto__'].marker, 'own-value');
+assert.equal(Object.getPrototypeOf(changedSettings.settings).marker, undefined,
+  'web copy-on-write updates must not route __proto__ through the prototype setter');
+unsubscribeSettings();
+
 const memorySources = {
   profile: { available: true }, preferences: { available: true }, work_context: { available: true },
   current_focus: { available: true }, recent_activity: { available: true }, recent_work: { available: true },
@@ -195,5 +281,14 @@ assert.ok(
   indexSource.indexOf('platform/web/bridge.js') < indexSource.indexOf('platform/web/bridge/domain-adapter.js'),
   'Web domain adapter must load after the flat transport',
 );
+
+invokeResponse = async command => command === 'web_access_ingest_file' ? new Date(0) : null;
+await assert.rejects(api.attachments.addAttachmentByPath('/tmp/non-plain.txt'), /only supports arrays and plain objects/);
+const nonPlainAttachment = flat.getState().attachments.at(-1);
+api.attachments.removeAttachment(nonPlainAttachment.id);
+const cyclic = { value: 'cycle' };
+cyclic.self = cyclic;
+invokeResponse = async command => command === 'web_access_ingest_file' ? cyclic : null;
+await assert.rejects(api.attachments.addAttachmentByPath('/tmp/cyclic.txt'), /must not contain cycles/);
 
 console.log('web bridge domain contract passed');


### PR DESCRIPTION
## 背景

长对话持续生成时，应用偶发 WebView Out of Memory，界面表现为白屏。问题只在较长 session 的连续流式输出中明显，单次打开同一 session 时内存仍处于可控范围。

## 排查与根因

排查先确认 session 数据结构合法、单次加载占用可控；随后对连续流式事件采样，发现 retained heap 随事件数量近似线性增长。进一步定位到 bridge 的 `notify`：每个流式 delta 都会为订阅者深拷贝包含完整 transcript 的 session state，React 更新队列会在处理期间保留这些大快照。

因此，问题不在 session Schema 或单条消息，而在“高频事件 × 完整会话深拷贝”的组合。

## 变更

- Tauri bridge 按订阅 domain 维护深冻结的 persistent snapshot；Web flat bridge 每轮只生成一份同语义快照，domain adapter 从该快照取字段。后续通知递归 reconcile 当前 state 与上一快照，复用未变化子树，仅为变化路径做 COW 分配。
- 每次 `notify` 在调用当场构造不可变快照并保存到 FIFO revision queue；当前轮次固定订阅者集合和快照，同步重入产生的通知只能在当前轮结束后派发，所有订阅者严格观察相同的 outer → nested 顺序。
- 回调内 subscribe/unsubscribe 仅影响之后排入的轮次；回调异常保持同步抛出，并丢弃依赖该中断回调的待处理轮次，避免下次通知重放陈旧工作。
- 使用安全属性定义构造和复制快照，保留 JSON 对象自有的 `__proto__` 数据属性而不触发原型 setter；比较改用 `Object.is`，正确区分 `NaN` 与 `-0/+0`。
- 订阅快照只接受数组、普通对象和 JSON-like 标量；非普通对象、循环引用及不支持的标量显式 fail closed，避免静默 `{}` 或递归溢出。
- `state.get` / `state.getMany` 继续保持原有防御性深拷贝契约。
- 回归覆盖 Tauri、Web flat direct subscribe、Web domain adapter 与 subscribeMany：旧快照稳定、嵌套写隔离、双订阅同步重入顺序、订阅增删轮次、异常队列语义、`__proto__`/`NaN`/`-0`、非普通对象/循环拒绝。长会话用例保留全部 1001 帧，并确定性断言未变的 messages/content/tool 深层子树跨首/中/尾及相邻帧复用、同轮双订阅者共享 domain 子树、变化 streaming item 每帧使用新引用且旧文本稳定。

本 PR 仅处理流式订阅快照的内存放大和由此引出的快照/通知正确性，不包含事件节流、虚拟列表、Schema 调整或新增依赖，也不改变正常流式事件的频率与即时可见性。

## 实测对比

场景：469 条历史消息（每条约 1 KiB），连续 1000 个 `abcd` delta，并保留全部 1001 份订阅快照。

| 实现 | GC 后堆内存 | 1000 delta 总耗时 |
|---|---:|---:|
| 原完整深拷贝 | 约 319.2 MiB | 约 6.26 s |
| 第一版顶层浅拷贝 | 约 22.5 MiB | 约 3.35 s |
| 当前稳定快照 + 串行轮次 | 约 16.55 MiB（基线 9.24 MiB，增量 7.31 MiB） | 5.06–5.23 s |

当前实现两次 `node --expose-gc` 复测稳定，后 400 个 delta 用时 2.03–2.09 s。1000 个 delta 仍产生 1001 次即时通知，最终流式文本为 4000 字符；没有恢复逐 delta 的完整 transcript `structuredClone`/JSON 深拷贝。

## 验证

- `npm run test:scheduled`（保留全部 1001 帧并校验结构共享 identity）
- `node tests/web_bridge_domain_contract.test.mjs`
- `npm run test:node`（165 通过、1 跳过、0 失败）
- `npm run lint:ui`
- `npm run build:ui`
- `python scripts/architecture-guard.py`
- `git diff --check`

## 风险

persistent snapshot 每轮仍会递归遍历已订阅 state，以可靠识别原地 mutation、循环和非普通对象；安全校验增加常数 CPU 开销，但实测仍低于原完整深拷贝，并将 retained heap 从约 319.2 MiB 降至约 16.55 MiB。订阅结果现在是深层只读快照；需要可变副本的调用方应继续使用 `state.get` / `state.getMany`。

同步重入通知改为严格 FIFO，回调异常会中断当前轮并清空之后排入的轮次；这是为保持既有同步异常传播并避免陈旧重放而明确的语义。若内部 state 出现非普通对象、循环或 function/symbol/bigint，订阅通知会显式失败，从而暴露对 JSON state 边界的违反。本次不改变持久化数据、桥协议或正常事件频率。