### PR TITLE
ci(release): pin Linux builds to Ubuntu 22.04

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -170,10 +170,12 @@ jobs:
             release_contract:
               - 'VERSION'
               - 'scripts/sync-version.mjs'
+              - 'scripts/check-linux-glibc-floor.sh'
               - 'scripts/tests/sync-version.test.mjs'
               - 'scripts/tests/test_ci_gate_policy.py'
               - 'scripts/tests/test_ci_trigger_routing_policy.py'
               - 'scripts/tests/test_release_arm64_policy.py'
+              - 'scripts/tests/test_release_linux_floor_policy.py'
               - 'scripts/tests/test_release_manifest_probe.py'
               - '.github/workflows/release-packages.yml'
               - '.github/workflows/pr-check.yml'

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -183,7 +183,8 @@ jobs:
       # glibc 下限守护:解包 deb,对每个 ELF 断言 GLIBC_ 符号版本 ≤ 2.35
       # (Ubuntu 22.04 基线)。runner 被误升或依赖引入新符号时在此挡下,
       # 而不是等 22.04 用户启动崩溃。deb 内 ELF = 主二进制 + codex-bridge
-      # 的 node(asr 是 python、knowledge-host 是 shell、连接器 CLI 首用下载)。
+      # 的 node + knowledge-host 的 pinvou-knowledge-server(asr 是 python、
+      # knowledge-host 的 helper 是 shell、连接器 CLI 首用下载)。
       - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
         run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-x64.deb"
 

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -82,7 +82,11 @@ jobs:
     name: 构建 Linux x86_64 deb
     needs: check-version-bump
     if: needs.check-version-bump.outputs.build_required == 'true'
-    runs-on: ubuntu-latest
+    # Linux 发布基线是 Ubuntu 22.04 (glibc 2.35)。发布二进制链接构建机的 glibc,
+    # 在更新的 Ubuntu runner(当前 latest 指向 24.04/glibc 2.39)上构建会引入
+    # 22.04 没有的 GLIBC_2.3x+ 符号引用,导致 22.04 用户启动即崩。runner 必须钉在
+    # ubuntu-22.04,升级前先确认新基线决策(配套 glibc 下限守护步骤见构建尾部)。
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
@@ -110,7 +114,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: pinvou3-app/src-tauri
-          shared-key: release-linux-x64
+          # jammy 后缀:runner 从 24.04 降到 22.04 时必须换 key,防止 24.04
+          # glibc 环境编译的 target 产物被复用进 22.04 构建混入新符号引用。
+          shared-key: release-linux-x64-jammy
           # 手动分支验证只读，main 正式发布保存。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -174,6 +180,13 @@ jobs:
           echo "$SHA  $DST" > "$DST.sha256"
           ls -lh "$DST"
 
+      # glibc 下限守护:解包 deb,对每个 ELF 断言 GLIBC_ 符号版本 ≤ 2.35
+      # (Ubuntu 22.04 基线)。runner 被误升或依赖引入新符号时在此挡下,
+      # 而不是等 22.04 用户启动崩溃。deb 内 ELF = 主二进制 + codex-bridge
+      # 的 node(asr 是 python、knowledge-host 是 shell、连接器 CLI 首用下载)。
+      - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
+        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-x64.deb"
+
       - name: 上传 deb artifact
         uses: actions/upload-artifact@v7
         with:
@@ -189,7 +202,9 @@ jobs:
     name: 构建 Linux arm64 deb
     needs: check-version-bump
     if: needs.check-version-bump.outputs.build_required == 'true'
-    runs-on: ubuntu-24.04-arm
+    # 与 build-linux-x64 同理:Linux 发布基线是 Ubuntu 22.04 (glibc 2.35),
+    # runner 钉在 ubuntu-22.04-arm,升级前先确认新基线决策。
+    runs-on: ubuntu-22.04-arm
     timeout-minutes: 90
     env:
       VERSION: ${{ needs.check-version-bump.outputs.version }}
@@ -214,7 +229,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: pinvou3-app/src-tauri
-          shared-key: release-linux-arm64
+          # jammy 后缀:同 x64,换 runner 基座后必须换 key 防止旧 glibc 产物混链。
+          shared-key: release-linux-arm64-jammy
           # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
@@ -271,6 +287,10 @@ jobs:
           echo "deb sha256: $SHA"
           echo "$SHA  $DEB" > "$DEB.sha256"
           ls -lh "$DEB"
+
+      # glibc 下限守护(同 build-linux-x64,断言全部 ELF 的 GLIBC_ 符号 ≤ 2.35)。
+      - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
+        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-arm64.deb"
 
       - name: 上传 deb artifact
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Endpoints, model names, and API keys can also be managed directly in the applica
 - The [Tauri 2 system dependencies](https://v2.tauri.app/start/prerequisites/) for your platform
 - An accessible OpenAI-compatible model endpoint
 
-The source tree supports **Linux, Windows, and macOS**. The initial macOS target is Apple Silicon on macOS 11 or later.
+The source tree supports **Linux, Windows, and macOS**. Linux release packages target Ubuntu 22.04 or newer (glibc 2.35+) on x86_64 and arm64. The initial macOS target is Apple Silicon on macOS 11 or later.
 
 ### Run from source
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Endpoints, model names, and API keys can also be managed directly in the applica
 - The [Tauri 2 system dependencies](https://v2.tauri.app/start/prerequisites/) for your platform
 - An accessible OpenAI-compatible model endpoint
 
-The source tree supports **Linux, Windows, and macOS**. Linux release packages target Ubuntu 22.04 or newer (glibc 2.35+) on x86_64 and arm64. The initial macOS target is Apple Silicon on macOS 11 or later.
+The source tree supports **Linux, Windows, and macOS**. Linux release packages target Ubuntu 22.04 or newer (glibc 2.35+) on x86_64 and arm64; the deb also requires WebKitGTK 2.40+ (any 22.04 system with the standard updates pocket applied satisfies this). The initial macOS target is Apple Silicon on macOS 11 or later.
 
 ### Run from source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,7 +124,7 @@ export DEEPSEEK_MODEL="qwen36_35b_256k"
 - [Tauri 2 系统依赖](https://v2.tauri.app/start/prerequisites/)
 - 一个可访问的 OpenAI-compatible 模型端点
 
-源码树支持 **Linux、Windows 和 macOS**；Linux 发布包的目标基线为 Ubuntu 22.04 及以上（glibc 2.35+，x86_64 与 arm64），macOS 当前目标为 Apple Silicon (arm64) + macOS 11.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
+源码树支持 **Linux、Windows 和 macOS**；Linux 发布包的目标基线为 Ubuntu 22.04 及以上（glibc 2.35+，x86_64 与 arm64；deb 另要求 WebKitGTK 2.40+，已应用标准更新源的 22.04 系统均满足），macOS 当前目标为 Apple Silicon (arm64) + macOS 11.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
 
 ### 启动应用
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,7 +124,7 @@ export DEEPSEEK_MODEL="qwen36_35b_256k"
 - [Tauri 2 系统依赖](https://v2.tauri.app/start/prerequisites/)
 - 一个可访问的 OpenAI-compatible 模型端点
 
-源码树支持 **Linux、Windows 和 macOS**；macOS 当前目标为 Apple Silicon (arm64) + macOS 11.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
+源码树支持 **Linux、Windows 和 macOS**；Linux 发布包的目标基线为 Ubuntu 22.04 及以上（glibc 2.35+，x86_64 与 arm64），macOS 当前目标为 Apple Silicon (arm64) + macOS 11.0+。语音识别引擎可按构建配置打包；文件解析（PDF / Office / OCR / 压缩包等）依赖可选外部工具，可通过 Homebrew 或各工具官网安装。
 
 ### 启动应用
 

--- a/pinvou3-app/src-tauri/config/platforms/linux/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/linux/tauri.conf.json
@@ -12,7 +12,9 @@
         "desktopTemplate": "packaging/linux/deb/pinvou3.desktop",
         "postInstallScript": "packaging/linux/deb/scripts/postinst.sh",
         "preRemoveScript": "packaging/linux/deb/scripts/prerm.sh",
-        "depends": [],
+        "depends": [
+          "libwebkit2gtk-4.1-0 (>= 2.40)"
+        ],
         "recommends": [
           "poppler-utils",
           "tesseract-ocr",

--- a/scripts/check-linux-glibc-floor.sh
+++ b/scripts/check-linux-glibc-floor.sh
@@ -31,15 +31,28 @@ extract_dir="$(mktemp -d)"
 trap 'rm -rf -- "$extract_dir"' EXIT
 dpkg-deb -x "$deb_path" "$extract_dir"
 
-# 从 objdump -T 动态符号表提取某前缀的最大符号版本(如 GLIBC_2.38);无引用输出空。
+# 每个 ELF 的动态符号表只解析一次。objdump 自身失败(异架构 ELF/文件损坏/
+# 未来 binutils 不识别的新特性)必须硬失败——静默当成「无符号引用」会把该
+# ELF 的三个前缀全部放行,只有 grep 无匹配才是合法的「无引用」。
+dump_dynamic_symbols() {
+  local elf="$1" out
+  out="$(objdump -T "$elf" 2>&1)" || {
+    echo "FAIL: objdump 无法解析 ${elf#"$extract_dir"}(异架构或损坏?):" >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  }
+  printf '%s\n' "$out"
+}
+
+# 从动态符号表文本提取某前缀的最大符号版本(如 GLIBC_2.38);无引用输出空。
 max_symbol_version() {
-  local elf="$1" prefix="$2"
-  objdump -T "$elf" 2>/dev/null | grep -o "${prefix}[0-9][0-9.]*" | sort -Vu | tail -n 1 || true
+  local dynsyms="$1" prefix="$2"
+  printf '%s\n' "$dynsyms" | grep -o "${prefix}[0-9][0-9.]*" | sort -Vu | tail -n 1 || true
 }
 
 check_prefix() {
-  local elf="$1" prefix="$2" floor="$3" highest version
-  highest="$(max_symbol_version "$elf" "$prefix")"
+  local dynsyms="$1" elf="$2" prefix="$3" floor="$4" highest version
+  highest="$(max_symbol_version "$dynsyms" "$prefix")"
   [ -n "$highest" ] || return 0
   version="${highest#"$prefix"}"
   if dpkg --compare-versions "$version" gt "$floor"; then
@@ -55,14 +68,16 @@ failed=0
 while IFS= read -r -d '' elf; do
   file -b "$elf" | grep -q '^ELF' || continue
   elf_count=$((elf_count + 1))
+  dynsyms="$(dump_dynamic_symbols "$elf")" || { failed=1; continue; }
   ok=0
-  check_prefix "$elf" 'GLIBC_' "$glibc_floor" || ok=1
-  check_prefix "$elf" 'GLIBCXX_' "$glibcxx_floor" || ok=1
-  check_prefix "$elf" 'CXXABI_' "$cxxabi_floor" || ok=1
+  check_prefix "$dynsyms" "$elf" 'GLIBC_' "$glibc_floor" || ok=1
+  check_prefix "$dynsyms" "$elf" 'GLIBCXX_' "$glibcxx_floor" || ok=1
+  check_prefix "$dynsyms" "$elf" 'CXXABI_' "$cxxabi_floor" || ok=1
   [ "$ok" -eq 0 ] || failed=1
 done < <(find "$extract_dir" -type f -print0)
 
-# deb 至少含主二进制与 codex-bridge 的 node;一个 ELF 都没有说明解包或打包异常。
+# deb 至少含主二进制、codex-bridge 的 node、knowledge-host 的
+# pinvou-knowledge-server;一个 ELF 都没有说明解包或打包异常。
 [ "$elf_count" -gt 0 ] || {
   echo "FAIL: deb 内未发现任何 ELF(解包或打包异常): $deb_path" >&2
   exit 1

--- a/scripts/check-linux-glibc-floor.sh
+++ b/scripts/check-linux-glibc-floor.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# 校验发布 deb 内全部 ELF 的动态符号版本不超过 Ubuntu 22.04 基线:
+#   GLIBC_   ≤ 2.35   (jammy glibc 2.35)
+#   GLIBCXX_ ≤ 3.4.30 (jammy libstdc++,gcc 12)
+#   CXXABI_  ≤ 1.3.13 (同上)
+# 在 release runner 的 deb 产物上运行(见 release-packages.yml 的「glibc 下限守护」
+# 步骤);任一 ELF 超线即非零退出,把「22.04 用户启动即崩」提前挡在 CI,防 runner
+# 被误升级或依赖引入新符号时静默抬高基线。依赖 dpkg-deb/dpkg/file/objdump,
+# 均为 ubuntu runner 自带;脚本本身只在 Linux 上有意义,本地语法检查用 bash -n。
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <deb> [glibc-floor]" >&2
+  exit 2
+}
+
+deb_path="${1:-}"
+[ -n "$deb_path" ] && [ -f "$deb_path" ] || usage
+glibc_floor="${2:-2.35}"
+glibcxx_floor="3.4.30"
+cxxabi_floor="1.3.13"
+
+for command_name in dpkg-deb dpkg file objdump; do
+  command -v "$command_name" >/dev/null || {
+    echo "missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+extract_dir="$(mktemp -d)"
+trap 'rm -rf -- "$extract_dir"' EXIT
+dpkg-deb -x "$deb_path" "$extract_dir"
+
+# 从 objdump -T 动态符号表提取某前缀的最大符号版本(如 GLIBC_2.38);无引用输出空。
+max_symbol_version() {
+  local elf="$1" prefix="$2"
+  objdump -T "$elf" 2>/dev/null | grep -o "${prefix}[0-9][0-9.]*" | sort -Vu | tail -n 1 || true
+}
+
+check_prefix() {
+  local elf="$1" prefix="$2" floor="$3" highest version
+  highest="$(max_symbol_version "$elf" "$prefix")"
+  [ -n "$highest" ] || return 0
+  version="${highest#"$prefix"}"
+  if dpkg --compare-versions "$version" gt "$floor"; then
+    echo "FAIL: ${elf#"$extract_dir"} requires $highest > baseline $prefix$floor" >&2
+    return 1
+  fi
+  echo "ok: ${elf#"$extract_dir"} $highest ≤ $prefix$floor"
+  return 0
+}
+
+elf_count=0
+failed=0
+while IFS= read -r -d '' elf; do
+  file -b "$elf" | grep -q '^ELF' || continue
+  elf_count=$((elf_count + 1))
+  ok=0
+  check_prefix "$elf" 'GLIBC_' "$glibc_floor" || ok=1
+  check_prefix "$elf" 'GLIBCXX_' "$glibcxx_floor" || ok=1
+  check_prefix "$elf" 'CXXABI_' "$cxxabi_floor" || ok=1
+  [ "$ok" -eq 0 ] || failed=1
+done < <(find "$extract_dir" -type f -print0)
+
+# deb 至少含主二进制与 codex-bridge 的 node;一个 ELF 都没有说明解包或打包异常。
+[ "$elf_count" -gt 0 ] || {
+  echo "FAIL: deb 内未发现任何 ELF(解包或打包异常): $deb_path" >&2
+  exit 1
+}
+[ "$failed" -eq 0 ] || {
+  echo "FAIL: 存在超出 Ubuntu 22.04 基线的符号版本引用(见上)" >&2
+  exit 1
+}
+echo "PASS: $elf_count 个 ELF 满足 GLIBC_ ≤ $glibc_floor / GLIBCXX_ ≤ $glibcxx_floor / CXXABI_ ≤ $cxxabi_floor(基线 Ubuntu 22.04)"

--- a/scripts/tests/test_release_linux_floor_policy.py
+++ b/scripts/tests/test_release_linux_floor_policy.py
@@ -1,0 +1,60 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
+GUARD_SCRIPT = ROOT / "scripts" / "check-linux-glibc-floor.sh"
+LINUX_OVERLAY = ROOT / "pinvou3-app/src-tauri/config/platforms/linux/tauri.conf.json"
+
+# Linux 发布基线是 Ubuntu 22.04 (glibc 2.35) x86_64/arm64。发布二进制链接
+# 构建机 glibc,runner 升级会静默抬高基线,因此 runner 标签与 glibc 守护
+# 都是有意决策,本测试防止无意的基线漂移。
+
+
+class ReleaseLinuxFloorPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        self.x64_job = self.workflow.split("\n  build-linux-x64:", maxsplit=1)[1].split(
+            "\n  build-linux-arm64:", maxsplit=1
+        )[0]
+        self.arm64_job = self.workflow.split("\n  build-linux-arm64:", maxsplit=1)[1].split(
+            "\n  build-windows-x64:", maxsplit=1
+        )[0]
+
+    def test_linux_builds_pin_ubuntu_22_04_runners(self):
+        # 带换行断言,避免 x64 段误匹配 ubuntu-22.04-arm 这类更长标签。
+        self.assertIn("runs-on: ubuntu-22.04\n", self.x64_job)
+        self.assertIn("runs-on: ubuntu-22.04-arm\n", self.arm64_job)
+        self.assertNotIn("ubuntu-latest", self.x64_job.split("\n    steps:")[0])
+        self.assertNotIn("ubuntu-24.04", self.arm64_job.split("\n    steps:")[0])
+
+    def test_linux_builds_run_glibc_floor_guard_before_upload(self):
+        # 守护必须覆盖两个 Linux job,且位于产物上传之前(失败即阻断发布)。
+        for job in (self.x64_job, self.arm64_job):
+            guard = job.find("check-linux-glibc-floor.sh")
+            upload = job.find("uses: actions/upload-artifact@")
+            self.assertGreater(guard, 0, "missing glibc floor guard step")
+            self.assertGreater(upload, guard, "glibc floor guard must run before upload")
+        self.assertEqual(self.workflow.count("check-linux-glibc-floor.sh"), 2)
+
+    def test_guard_script_defaults_to_2204_glibc_floor(self):
+        # 脚本默认 glibc 下限必须与基线一致;workflow 不传参即用默认值。
+        source = GUARD_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('glibc_floor="${2:-2.35}"', source)
+        self.assertIn('"3.4.30"', source)  # GLIBCXX_ (jammy gcc 12)
+        self.assertIn('"1.3.13"', source)  # CXXABI_ (jammy gcc 12)
+
+    def test_guard_script_is_valid_bash(self):
+        subprocess.run(["bash", "-n", str(GUARD_SCRIPT)], check=True)
+
+    def test_deb_declares_webkit_floor(self):
+        # tauri-runtime-wry 启用 webkit2gtk v2_40,运行时需要 WebKitGTK ≥ 2.40;
+        # jammy 原始 pocket 只有 2.36.0,显式 depends 让 apt 给出明确错误而非启动崩溃。
+        overlay = LINUX_OVERLAY.read_text(encoding="utf-8")
+        self.assertIn("libwebkit2gtk-4.1-0 (>= 2.40)", overlay)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_linux_floor_policy.py
+++ b/scripts/tests/test_release_linux_floor_policy.py
@@ -39,6 +39,48 @@ class ReleaseLinuxFloorPolicyTests(unittest.TestCase):
             self.assertGreater(upload, guard, "glibc floor guard must run before upload")
         self.assertEqual(self.workflow.count("check-linux-glibc-floor.sh"), 2)
 
+    def test_linux_builds_rotate_rust_cache_key_per_runner_baseline(self):
+        # 换 runner 基座必须换 rust-cache key:24.04 glibc 环境编译的缓存产物
+        # 复用进 22.04 构建会把高版本符号引用混进发布二进制,-jammy 后缀把
+        # 两个基座的缓存隔离。runner 标签与 cache key 必须绑定变更。
+        self.assertIn("shared-key: release-linux-x64-jammy", self.x64_job)
+        self.assertIn("shared-key: release-linux-arm64-jammy", self.arm64_job)
+
+    def _step_block(self, job, needle):
+        # 提取含 needle 的步骤块(步骤以 6 空格 + '- ' 开始),供单步骤断言。
+        at = job.find(needle)
+        self.assertGreater(at, 0, f"missing step containing {needle!r}")
+        start = job.rfind("\n      - ", 0, at)
+        self.assertGreater(start, 0, f"{needle!r} must live inside a step")
+        end = job.find("\n      - ", at)
+        return job[start:] if end == -1 else job[start:end]
+
+    def test_glibc_floor_guard_step_cannot_be_neutralized(self):
+        # continue-on-error 或步骤级 if: 会让超基线产物绿着通过守护,把启动
+        # 崩溃留给 22.04 用户;守护步骤必须无条件执行且直接调用脚本。
+        for job in (self.x64_job, self.arm64_job):
+            step = self._step_block(job, "check-linux-glibc-floor.sh")
+            self.assertIn("run: ./scripts/check-linux-glibc-floor.sh", step)
+            self.assertNotIn("continue-on-error", step)
+            self.assertNotIn("\n        if:", step)
+
+    def test_linux_deb_unified_name_consistent_across_rename_guard_upload(self):
+        # deb 统一名横跨 重命名→守护→上传 手工同步(重命名/守护用 ${VERSION},
+        # 上传用 needs 输出表达式);失配只能在 90 分钟构建后的发布 run 末尾
+        # 暴露(guard usage exit 2 或 upload 找不到文件),契约层直接钉住。
+        for job, arch in ((self.x64_job, "x64"), (self.arm64_job, "arm64")):
+            local_name = "pinvou-agent_${VERSION}-linux-" + arch + ".deb"
+            upload_name = (
+                "pinvou-agent_${{ needs.check-version-bump.outputs.version }}"
+                "-linux-" + arch + ".deb"
+            )
+            self.assertEqual(
+                job.count(local_name), 2, f"{arch}: unified deb name must appear in rename and guard"
+            )
+            self.assertEqual(
+                job.count(upload_name), 2, f"{arch}: unified deb name must appear in both upload paths"
+            )
+
     def test_guard_script_defaults_to_2204_glibc_floor(self):
         # 脚本默认 glibc 下限必须与基线一致;workflow 不传参即用默认值。
         source = GUARD_SCRIPT.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Lower the Linux release floor to **Ubuntu 22.04 (glibc 2.35)** on both **x86_64 and arm64**.

Linux release binaries link against the build runner's glibc. Both Linux release jobs currently build on 24.04-based runners (`ubuntu-latest` and `ubuntu-24.04-arm`, glibc 2.39), so the shipped debs reference `GLIBC_2.3x+` symbols that do not exist on 22.04 and crash on launch there. Pinning the runners to the 22.04 baseline makes the produced binaries run on 22.04 and newer.

Verified feasibility before implementation:

- `ubuntu-22.04` and `ubuntu-22.04-arm` hosted runners are both GA and not yet in deprecation (26.04 is still preview).
- jammy provides all build dependencies (`libwebkit2gtk-4.1-dev`, `libsoup-3.0-dev`, `libayatana-appindicator3-dev`); WebKitGTK in jammy-updates is 2.50.4.
- Every runtime ELF shipped in the deb satisfies the baseline: the bundled Node 22 official binary requires glibc ≥ 2.28 only; `asr` is a Python script, `knowledge-host` is a shell script; connector CLIs (static Go / static-pie / no versioned glibc symbols) are downloaded on first use and not embedded in the deb.

## Changes

- **`.github/workflows/release-packages.yml`**
  - Pin `build-linux-x64` to `ubuntu-22.04` and `build-linux-arm64` to `ubuntu-22.04-arm`, with comments explaining the baseline decision.
  - Rotate rust-cache `shared-key` to a `-jammy` suffix for both jobs so cached artifacts built on 24.04 can never be reused into a 22.04 build.
  - Add a **glibc floor guard** step in each Linux job (after packaging, before artifact upload): unpack the deb and assert every ELF keeps `GLIBC_` ≤ 2.35, `GLIBCXX_` ≤ 3.4.30, `CXXABI_` ≤ 1.3.13. A future runner bump or dependency change that silently raises the floor now fails CI instead of crashing users on 22.04.
- **`scripts/check-linux-glibc-floor.sh`** (new): the guard script above (uses `dpkg-deb`/`objdump`, both present on ubuntu runners).
- **`pinvou3-app/src-tauri/config/platforms/linux/tauri.conf.json`**: deb `depends` now declares `libwebkit2gtk-4.1-0 (>= 2.40)`. `tauri-runtime-wry` 2.11.1 enables webkit2gtk `v2_40` APIs, while jammy's original pocket ships 2.36.0 — without this constraint apt would install an incompatible WebKit and the app would crash on launch. (tauri-bundler's `depends` is passed through verbatim, so this cannot shadow any auto-computed dependency.)
- **`scripts/tests/test_release_linux_floor_policy.py`** (new): contract test pinning the runner labels, guard-before-upload placement, script floor defaults, and the deb depends entry, so the baseline cannot drift unintentionally.
- **`.github/workflows/pr-check.yml`**: register the new script and test in the `release_contract` paths filter (the test also runs in `fast-gate` via unittest discovery on every PR).
- **`README.md` / `README.zh-CN.md`**: document the Ubuntu 22.04+ (glibc 2.35+, x86_64/arm64) baseline.

## Testing

- [x] `python3 -m unittest discover -s scripts/tests` — 68 tests pass (including the 4 new ones)
- [x] Both workflows parse as valid YAML; overlay JSON validated (`depends = ["libwebkit2gtk-4.1-0 (>= 2.40)"]`)
- [x] `npm run test:tauri-layout` and `npm run test:tauri-effective-config` pass (after `npm ci`; an earlier local failure was a pre-existing missing `@tauri-apps/cli` in local `node_modules`, reproduced on the unmodified tree via stash)
- [x] `python3 scripts/architecture-guard.py` passes
- [x] Commit message validated by `scripts/validate-commit-msg.py`
- [ ] First real run of `check-linux-glibc-floor.sh` happens in CI (needs GNU `objdump` on an ELF deb; macOS llvm-objdump output differs, only `bash -n` and the contract test run locally)

## Known risks / notes

- The 0.8.5 release (built before this PR merges) still uses the 24.04 runners; the 22.04 baseline takes effect from the next release or a manual `workflow_dispatch`.
- jammy build-dependency versions differ from 24.04 (e.g. GTK 3.24.33 vs 3.24.41): compile behavior is expected to be identical, but the first post-merge release build is the real proof — the glibc guard plus the existing artifact checksum steps will catch any surprise.
- Runtime WebKit on a 22.04 machine comes from jammy-updates (2.50.4, satisfying ≥ 2.40); the deb `depends` enforces this explicitly.
