### PR TITLE
fix(web-acp): harden web code mode follow-ups

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/files.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/files.rs
@@ -45,13 +45,20 @@ pub async fn ingest_draft_file_chunk(
     total: usize,
     data_base64: String,
     commit: bool,
+    sha256: Option<String>,
 ) -> Result<Option<crate::features::files::file_ingest::IngestResult>, String> {
     let result = async {
         let data = base64::engine::general_purpose::STANDARD
             .decode(data_base64)
             .map_err(|error| format!("解码附件分块失败：{error}"))?;
         crate::features::files::attachment_upload::append_draft_chunk(
-            &upload_id, &filename, offset, total, &data, commit,
+            &upload_id,
+            &filename,
+            offset,
+            total,
+            &data,
+            commit,
+            sha256.as_deref(),
         )
         .await
     }
@@ -89,6 +96,7 @@ pub async fn ingest_dropped_file_chunk(
     total: usize,
     data_base64: String,
     commit: bool,
+    sha256: Option<String>,
     store: State<'_, SessionStore>,
 ) -> Result<Option<crate::features::files::file_ingest::IngestResult>, String> {
     let (workspace, _) = conversation_attachment_context(&store, &session_id)?;
@@ -97,7 +105,14 @@ pub async fn ingest_dropped_file_chunk(
             .decode(data_base64)
             .map_err(|error| format!("解码附件分块失败：{error}"))?;
         crate::features::files::attachment_upload::append_chunk(
-            &workspace, &upload_id, &filename, offset, total, &data, commit,
+            &workspace,
+            &upload_id,
+            &filename,
+            offset,
+            total,
+            &data,
+            commit,
+            sha256.as_deref(),
         )
         .await
     }

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -39,23 +39,133 @@ fn web_acp_agent_id(agent_id: Option<String>) -> Result<String, String> {
         .ok_or_else(|| "Web code sessions support ACP agents only".to_string())
 }
 
-fn web_workspace_result<T, E: std::fmt::Display>(
-    operation: &str,
+/// Stable error-code operations for `web_access_*` ACP commands. The wire
+/// format `web_acp_{operation}_failed` is consumed by `acpErrors.js`;
+/// `stable_web_error_codes_are_locked` pins the full list in Rust so a
+/// rename fails on the Rust side instead of only in source-text regexes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebAcpOperation {
+    SessionCreate,
+    Cancel,
+    Prompt,
+    Timeline,
+    SessionInfo,
+    SetModel,
+    SetMode,
+    SetConfigOption,
+    PendingPermissions,
+    RespondPermission,
+    PendingElicitations,
+    RespondElicitation,
+    ListSessions,
+    ListAgents,
+    AgentStatus,
+}
+
+impl WebAcpOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionCreate => "session_create",
+            Self::Cancel => "cancel",
+            Self::Prompt => "prompt",
+            Self::Timeline => "timeline",
+            Self::SessionInfo => "session_info",
+            Self::SetModel => "set_model",
+            Self::SetMode => "set_mode",
+            Self::SetConfigOption => "set_config_option",
+            Self::PendingPermissions => "pending_permissions",
+            Self::RespondPermission => "respond_permission",
+            Self::PendingElicitations => "pending_elicitations",
+            Self::RespondElicitation => "respond_elicitation",
+            Self::ListSessions => "list_sessions",
+            Self::ListAgents => "list_agents",
+            Self::AgentStatus => "agent_status",
+        }
+    }
+}
+
+/// Stable error-code operations for `web_access_*` workspace commands, wire
+/// format `web_workspace_{operation}_failed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebWorkspaceOperation {
+    Listing,
+    Search,
+    Preview,
+    Changes,
+    Diff,
+}
+
+impl WebWorkspaceOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Listing => "listing",
+            Self::Search => "search",
+            Self::Preview => "preview",
+            Self::Changes => "changes",
+            Self::Diff => "diff",
+        }
+    }
+}
+
+/// Stable error-code operations for generic `web_access_*` session commands,
+/// wire format `web_session_{operation}_failed`. Native errors from the
+/// session store may embed host paths; folding them keeps Relay responses
+/// controlled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WebSessionOperation {
+    ListSessions,
+    ListArchivedSessions,
+    CreateSession,
+    LoadSessionChunk,
+}
+
+impl WebSessionOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ListSessions => "list_sessions",
+            Self::ListArchivedSessions => "list_archived_sessions",
+            Self::CreateSession => "create_session",
+            Self::LoadSessionChunk => "load_session_chunk",
+        }
+    }
+}
+
+fn web_session_result<T, E: std::fmt::Display>(
+    operation: WebSessionOperation,
     result: Result<T, E>,
 ) -> Result<T, String> {
     result.map_err(|error| {
-        log::warn!("[remote_control] Web code workspace {operation} failed: {error}");
-        format!("web_workspace_{operation}_failed")
+        log::warn!(
+            "[remote_control] Web session {} failed: {error}",
+            operation.as_str()
+        );
+        format!("web_session_{}_failed", operation.as_str())
+    })
+}
+
+fn web_workspace_result<T, E: std::fmt::Display>(
+    operation: WebWorkspaceOperation,
+    result: Result<T, E>,
+) -> Result<T, String> {
+    result.map_err(|error| {
+        log::warn!(
+            "[remote_control] Web code workspace {} failed: {error}",
+            operation.as_str()
+        );
+        format!("web_workspace_{}_failed", operation.as_str())
     })
 }
 
 fn web_acp_result<T, E: std::fmt::Display>(
-    operation: &str,
+    operation: WebAcpOperation,
     result: Result<T, E>,
 ) -> Result<T, String> {
     result.map_err(|error| {
-        log::warn!("[remote_control] Web ACP {operation} failed: {error:#}");
-        format!("web_acp_{operation}_failed")
+        log::warn!(
+            "[remote_control] Web ACP {} failed: {error:#}",
+            operation.as_str()
+        );
+        format!("web_acp_{}_failed", operation.as_str())
     })
 }
 
@@ -207,7 +317,10 @@ pub async fn web_access_list_sessions(
     store: State<'_, SessionStore>,
     acp_pool: State<'_, AcpPool>,
 ) -> Result<Vec<super::sessions::SessionListItem>, String> {
-    let mut sessions = super::sessions::list_sessions(store, acp_pool).await?;
+    let mut sessions = web_session_result(
+        WebSessionOperation::ListSessions,
+        super::sessions::list_sessions(store, acp_pool).await,
+    )?;
     for session in &mut sessions {
         session.metadata = super::codex::redact_session_metadata_for_web(session.metadata.clone());
     }
@@ -218,7 +331,10 @@ pub async fn web_access_list_sessions(
 pub async fn web_access_list_archived_sessions(
     store: State<'_, SessionStore>,
 ) -> Result<Vec<super::sessions::HiddenSessionListItem>, String> {
-    let mut sessions = super::sessions::list_archived_sessions(store).await?;
+    let mut sessions = web_session_result(
+        WebSessionOperation::ListArchivedSessions,
+        super::sessions::list_archived_sessions(store).await,
+    )?;
     for session in &mut sessions {
         session.metadata = super::codex::redact_session_metadata_for_web(session.metadata.clone());
     }
@@ -234,7 +350,10 @@ pub async fn web_access_create_session(
     store: State<'_, SessionStore>,
     pool: State<'_, EnginePool>,
 ) -> Result<WebSessionMetadata, String> {
-    let metadata = super::sessions::create_session(Some(false), app, store, pool).await?;
+    let metadata = web_session_result(
+        WebSessionOperation::CreateSession,
+        super::sessions::create_session(Some(false), app, store, pool).await,
+    )?;
     let transcript_revision = crate::features::sessions::transcript_revision(&[])
         .map_err(|error| format!("create empty transcript revision: {error:#}"))?;
     Ok(WebSessionMetadata::project(metadata, transcript_revision))
@@ -395,8 +514,36 @@ pub struct SessionDataChunk {
 
 /// Serialize a Session on the desktop and transfer it in bounded chunks. A
 /// full SavedSession can exceed Relay's frame ceiling after a long history.
+///
+/// Every error path folds into the stable `web_session_load_session_chunk_failed`
+/// code: the native chain (store errors embed host paths, e.g. the sessions
+/// directory) goes to the desktop log only.
 #[tauri::command]
 pub async fn web_access_load_session_chunk(
+    id: String,
+    download_id: Option<String>,
+    requested_download_id: Option<String>,
+    offset: u64,
+    limit: Option<usize>,
+    manager: State<'_, RemoteControlManager>,
+    store: State<'_, SessionStore>,
+) -> Result<SessionDataChunk, String> {
+    web_session_result(
+        WebSessionOperation::LoadSessionChunk,
+        load_session_chunk_inner(
+            id,
+            download_id,
+            requested_download_id,
+            offset,
+            limit,
+            manager,
+            store,
+        )
+        .await,
+    )
+}
+
+async fn load_session_chunk_inner(
     id: String,
     download_id: Option<String>,
     requested_download_id: Option<String>,
@@ -447,9 +594,9 @@ pub async fn web_access_load_session_chunk(
                         format!("compute Session {session_id} transcript revision: {error:#}")
                     })?;
                 let artifact_roots = [
-                    store.ledger_root(&session_id).map_err(|error| {
-                        format!("resolve Session {session_id} workspace: {error:#}")
-                    })?,
+                    store
+                        .ledger_root(&session_id)
+                        .map_err(|error| format!("resolve Session workspace ledger: {error:#}"))?,
                     crate::platform::paths::session_artifacts_dir(&session_id),
                 ];
                 let mut writer = BufWriter::new(output_file);
@@ -541,6 +688,7 @@ pub async fn web_access_upload_attachment_chunk(
     total: usize,
     data_base64: String,
     commit: bool,
+    sha256: Option<String>,
     manager: State<'_, RemoteControlManager>,
 ) -> Result<Option<manager::WebAttachmentSummary>, String> {
     let data = base64::engine::general_purpose::STANDARD
@@ -549,8 +697,15 @@ pub async fn web_access_upload_attachment_chunk(
     if data.len() > MAX_TRANSFER_CHUNK_BYTES {
         return Err("attachment upload chunk exceeds 256 KiB".into());
     }
-    let Some((file_name, bytes)) = manager
-        .append_web_attachment_upload(&upload_id, &file_name, offset, total, &data, commit)?
+    let Some((file_name, bytes)) = manager.append_web_attachment_upload(
+        &upload_id,
+        &file_name,
+        offset,
+        total,
+        &data,
+        commit,
+        sha256.as_deref(),
+    )?
     else {
         return Ok(None);
     };
@@ -766,7 +921,7 @@ pub async fn web_access_create_codex_acp_session(
         Ok(super::codex::redact_session_metadata_for_web(metadata))
     }
     .await;
-    web_acp_result("session_create", outcome)
+    web_acp_result(WebAcpOperation::SessionCreate, outcome)
 }
 
 /// Session-bound Web workspace reads. Draft browsing is intentionally owned
@@ -780,7 +935,7 @@ pub async fn web_access_list_codex_workspace(
 ) -> Result<WorkspaceListing, String> {
     let result =
         super::codex::list_codex_workspace(Some(session_id), relative_path, None, acp_pool).await;
-    web_workspace_result("listing", result)
+    web_workspace_result(WebWorkspaceOperation::Listing, result)
 }
 
 #[tauri::command]
@@ -791,7 +946,7 @@ pub async fn web_access_search_codex_workspace(
 ) -> Result<Vec<WorkspaceEntry>, String> {
     let result =
         super::codex::search_codex_workspace(Some(session_id), query, None, acp_pool).await;
-    web_workspace_result("search", result)
+    web_workspace_result(WebWorkspaceOperation::Search, result)
 }
 
 #[tauri::command]
@@ -803,7 +958,7 @@ pub async fn web_access_preview_codex_workspace_file(
     let result =
         super::codex::preview_codex_workspace_file(Some(session_id), relative_path, None, acp_pool)
             .await;
-    web_workspace_result("preview", result)
+    web_workspace_result(WebWorkspaceOperation::Preview, result)
 }
 
 #[tauri::command]
@@ -812,7 +967,7 @@ pub async fn web_access_get_codex_workspace_changes(
     acp_pool: State<'_, AcpPool>,
 ) -> Result<WorkspaceChanges, String> {
     let result = super::codex::get_codex_workspace_changes(session_id, acp_pool).await;
-    web_workspace_result("changes", result)
+    web_workspace_result(WebWorkspaceOperation::Changes, result)
 }
 
 #[tauri::command]
@@ -822,7 +977,7 @@ pub async fn web_access_get_codex_workspace_diff(
     acp_pool: State<'_, AcpPool>,
 ) -> Result<WorkspaceDiff, String> {
     let result = super::codex::get_codex_workspace_diff(session_id, relative_path, acp_pool).await;
-    web_workspace_result("diff", result)
+    web_workspace_result(WebWorkspaceOperation::Diff, result)
 }
 
 #[tauri::command]
@@ -831,7 +986,7 @@ pub async fn web_access_cancel_codex_acp(
     acp_pool: State<'_, AcpPool>,
 ) -> Result<(), String> {
     let result = super::codex::cancel_codex_acp(session_id, acp_pool).await;
-    web_acp_result("cancel", result)
+    web_acp_result(WebAcpOperation::Cancel, result)
 }
 
 /// Web-safe ACP prompt entry point. Browser and host-picked attachments are
@@ -911,7 +1066,7 @@ pub async fn web_access_codex_acp_prompt(
         result
     }
     .await;
-    web_acp_result("prompt", outcome)
+    web_acp_result(WebAcpOperation::Prompt, outcome)
 }
 
 #[derive(Debug, Serialize)]
@@ -957,7 +1112,7 @@ pub fn web_access_get_codex_acp_timeline(
             events: page.events,
         })
     })();
-    web_acp_result("timeline", outcome)
+    web_acp_result(WebAcpOperation::Timeline, outcome)
 }
 
 fn project_acp_pending_permission_for_web(
@@ -997,7 +1152,7 @@ pub async fn web_access_get_codex_acp_session_info(
         .session_info(&session_id)
         .await
         .and_then(project_acp_session_info_for_web);
-    web_acp_result("session_info", outcome)
+    web_acp_result(WebAcpOperation::SessionInfo, outcome)
 }
 
 #[tauri::command]
@@ -1010,7 +1165,7 @@ pub async fn web_access_set_codex_acp_model(
         .set_model(&session_id, &model_id)
         .await
         .and_then(project_acp_session_info_for_web);
-    web_acp_result("set_model", outcome)
+    web_acp_result(WebAcpOperation::SetModel, outcome)
 }
 
 #[tauri::command]
@@ -1023,7 +1178,7 @@ pub async fn web_access_set_codex_acp_mode(
         .set_mode(&session_id, &mode_id)
         .await
         .and_then(project_acp_session_info_for_web);
-    web_acp_result("set_mode", outcome)
+    web_acp_result(WebAcpOperation::SetMode, outcome)
 }
 
 #[tauri::command]
@@ -1037,7 +1192,7 @@ pub async fn web_access_set_codex_acp_config_option(
         .set_config_option(&session_id, &config_id, &value_id)
         .await
         .and_then(project_acp_session_info_for_web);
-    web_acp_result("set_config_option", outcome)
+    web_acp_result(WebAcpOperation::SetConfigOption, outcome)
 }
 
 #[tauri::command]
@@ -1057,7 +1212,7 @@ pub async fn web_access_get_codex_acp_pending_permissions(
             .collect())
     }
     .await;
-    web_acp_result("pending_permissions", outcome)
+    web_acp_result(WebAcpOperation::PendingPermissions, outcome)
 }
 
 #[tauri::command]
@@ -1070,7 +1225,7 @@ pub async fn web_access_respond_codex_acp_permission(
     let outcome = acp_pool
         .respond_permission(&session_id, &tool_call_id, &option_id)
         .await;
-    web_acp_result("respond_permission", outcome)
+    web_acp_result(WebAcpOperation::RespondPermission, outcome)
 }
 
 #[tauri::command]
@@ -1090,7 +1245,7 @@ pub async fn web_access_get_codex_acp_pending_elicitations(
             .collect())
     }
     .await;
-    web_acp_result("pending_elicitations", outcome)
+    web_acp_result(WebAcpOperation::PendingElicitations, outcome)
 }
 
 #[tauri::command]
@@ -1104,7 +1259,7 @@ pub async fn web_access_respond_codex_acp_elicitation(
     let outcome = acp_pool
         .respond_elicitation(&session_id, &elicitation_id, &action, content)
         .await;
-    web_acp_result("respond_elicitation", outcome)
+    web_acp_result(WebAcpOperation::RespondElicitation, outcome)
 }
 
 fn project_acp_status_for_web(
@@ -1127,7 +1282,7 @@ pub async fn web_access_list_codex_acp_sessions(
     acp_pool: State<'_, AcpPool>,
 ) -> Result<Vec<crate::app::commands::codex::CodexAcpSessionListItem>, String> {
     let outcome = super::codex::list_codex_acp_sessions_for_web(&store, &acp_pool).await;
-    web_acp_result("list_sessions", outcome)
+    web_acp_result(WebAcpOperation::ListSessions, outcome)
 }
 
 #[tauri::command]
@@ -1135,7 +1290,7 @@ pub async fn web_access_list_acp_agents(
     acp_pool: State<'_, AcpPool>,
 ) -> Result<Vec<crate::features::codex_acp::AcpAgentDescriptor>, String> {
     let outcome = super::codex::list_acp_agents_for_pool(&acp_pool).await;
-    web_acp_result("list_agents", outcome)
+    web_acp_result(WebAcpOperation::ListAgents, outcome)
 }
 
 #[tauri::command]
@@ -1147,7 +1302,7 @@ pub async fn web_access_get_acp_agent_status(
     let outcome = super::codex::get_acp_agent_status_for_pool(agent_id, recheck, &acp_pool)
         .await
         .map(project_acp_status_for_web);
-    web_acp_result("agent_status", outcome)
+    web_acp_result(WebAcpOperation::AgentStatus, outcome)
 }
 
 async fn web_access_chat_for_session(
@@ -1511,11 +1666,109 @@ pub async fn web_access_render_artifact_visual(
 mod tests {
     use super::{
         ensure_web_chat_session_supported, web_acp_agent_id, web_acp_result,
-        web_artifact_storage_path, web_workspace_result, WebSavedSession, WebSessionMetadata,
+        web_artifact_storage_path, web_session_result, web_workspace_result, WebAcpOperation,
+        WebSavedSession, WebSessionMetadata, WebSessionOperation, WebWorkspaceOperation,
     };
     use deepseek_tui::session_manager::{create_saved_session, SavedSession};
     use serde_json::{json, Value};
     use std::path::Path;
+
+    #[test]
+    fn stable_web_error_codes_are_locked() {
+        // `acpErrors.js` treats every code below as a controlled Web failure;
+        // `web_access_contract.test.mjs` additionally pins the mapping from
+        // each web_access_* command to its operation. Renaming an operation
+        // must change this list and the JS regex in the same PR.
+        let acp_codes: Vec<String> = [
+            WebAcpOperation::SessionCreate,
+            WebAcpOperation::Cancel,
+            WebAcpOperation::Prompt,
+            WebAcpOperation::Timeline,
+            WebAcpOperation::SessionInfo,
+            WebAcpOperation::SetModel,
+            WebAcpOperation::SetMode,
+            WebAcpOperation::SetConfigOption,
+            WebAcpOperation::PendingPermissions,
+            WebAcpOperation::RespondPermission,
+            WebAcpOperation::PendingElicitations,
+            WebAcpOperation::RespondElicitation,
+            WebAcpOperation::ListSessions,
+            WebAcpOperation::ListAgents,
+            WebAcpOperation::AgentStatus,
+        ]
+        .iter()
+        .map(|operation| format!("web_acp_{}_failed", operation.as_str()))
+        .collect();
+        let expected_acp = [
+            "web_acp_session_create_failed",
+            "web_acp_cancel_failed",
+            "web_acp_prompt_failed",
+            "web_acp_timeline_failed",
+            "web_acp_session_info_failed",
+            "web_acp_set_model_failed",
+            "web_acp_set_mode_failed",
+            "web_acp_set_config_option_failed",
+            "web_acp_pending_permissions_failed",
+            "web_acp_respond_permission_failed",
+            "web_acp_pending_elicitations_failed",
+            "web_acp_respond_elicitation_failed",
+            "web_acp_list_sessions_failed",
+            "web_acp_list_agents_failed",
+            "web_acp_agent_status_failed",
+        ];
+        assert_eq!(acp_codes, expected_acp);
+
+        let workspace_codes: Vec<String> = [
+            WebWorkspaceOperation::Listing,
+            WebWorkspaceOperation::Search,
+            WebWorkspaceOperation::Preview,
+            WebWorkspaceOperation::Changes,
+            WebWorkspaceOperation::Diff,
+        ]
+        .iter()
+        .map(|operation| format!("web_workspace_{}_failed", operation.as_str()))
+        .collect();
+        assert_eq!(
+            workspace_codes,
+            [
+                "web_workspace_listing_failed",
+                "web_workspace_search_failed",
+                "web_workspace_preview_failed",
+                "web_workspace_changes_failed",
+                "web_workspace_diff_failed",
+            ]
+        );
+
+        // The mapping helper itself must keep the wire format stable and must
+        // never leak host details from the underlying native error.
+        let error: Result<(), &str> = Err("host detail /Users/alice/.pinvou3 must not cross");
+        assert_eq!(
+            web_acp_result(WebAcpOperation::Timeline, error).unwrap_err(),
+            "web_acp_timeline_failed"
+        );
+        let error: Result<(), &str> = Err("host detail C:\\Users\\alice must not cross");
+        assert_eq!(
+            web_workspace_result(WebWorkspaceOperation::Diff, error).unwrap_err(),
+            "web_workspace_diff_failed"
+        );
+        assert_eq!(
+            web_session_result(WebSessionOperation::ListSessions, error.clone()).unwrap_err(),
+            "web_session_list_sessions_failed"
+        );
+        assert_eq!(
+            web_session_result(WebSessionOperation::ListArchivedSessions, error.clone())
+                .unwrap_err(),
+            "web_session_list_archived_sessions_failed"
+        );
+        assert_eq!(
+            web_session_result(WebSessionOperation::CreateSession, error.clone()).unwrap_err(),
+            "web_session_create_session_failed"
+        );
+        assert_eq!(
+            web_session_result(WebSessionOperation::LoadSessionChunk, error).unwrap_err(),
+            "web_session_load_session_chunk_failed"
+        );
+    }
 
     fn saved_session_with_private_paths(
         workspace: &str,
@@ -1599,36 +1852,36 @@ mod tests {
             "/home/alice/secret-project",
         ] {
             let error = web_workspace_result::<(), _>(
-                "preview",
+                WebWorkspaceOperation::Preview,
                 Err(format!("workspace unavailable: {private_path}")),
             )
             .unwrap_err();
             assert_eq!(error, "web_workspace_preview_failed");
             assert!(!error.contains(private_path));
 
-            for operation in [
-                "timeline",
-                "session_create",
-                "prompt",
-                "session_info",
-                "set_model",
-                "set_mode",
-                "set_config_option",
-                "pending_permissions",
-                "pending_elicitations",
-                "respond_permission",
-                "respond_elicitation",
-                "list_sessions",
-                "list_agents",
-                "agent_status",
-                "cancel",
+            for (operation, code) in [
+                (WebAcpOperation::Timeline, "timeline"),
+                (WebAcpOperation::SessionCreate, "session_create"),
+                (WebAcpOperation::Prompt, "prompt"),
+                (WebAcpOperation::SessionInfo, "session_info"),
+                (WebAcpOperation::SetModel, "set_model"),
+                (WebAcpOperation::SetMode, "set_mode"),
+                (WebAcpOperation::SetConfigOption, "set_config_option"),
+                (WebAcpOperation::PendingPermissions, "pending_permissions"),
+                (WebAcpOperation::PendingElicitations, "pending_elicitations"),
+                (WebAcpOperation::RespondPermission, "respond_permission"),
+                (WebAcpOperation::RespondElicitation, "respond_elicitation"),
+                (WebAcpOperation::ListSessions, "list_sessions"),
+                (WebAcpOperation::ListAgents, "list_agents"),
+                (WebAcpOperation::AgentStatus, "agent_status"),
+                (WebAcpOperation::Cancel, "cancel"),
             ] {
                 let acp_error = web_acp_result::<(), _>(
                     operation,
                     Err(format!("ACP unavailable: {private_path}")),
                 )
                 .unwrap_err();
-                assert_eq!(acp_error, format!("web_acp_{operation}_failed"));
+                assert_eq!(acp_error, format!("web_acp_{code}_failed"));
                 assert!(!acp_error.contains(private_path));
             }
         }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/agent_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/agent_probe.rs
@@ -56,7 +56,7 @@ impl CliProbeCache {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ResolvedCli {
     pub(super) path: PathBuf,
     /// `--version` 原始输出；版本门禁单独校验，解析失败一律不合规。
@@ -121,5 +121,43 @@ impl AcpPool {
         let slot = probe.slot_mut(backend);
         slot.generation = slot.generation.wrapping_add(1);
         slot.value = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_probe_slots_are_independent_and_invalidation_resets_only_one() {
+        let mut cache = CliProbeCache::default();
+
+        cache.slot_mut(AgentBackend::ClaudeAcp).value = Some(Some(ResolvedCli {
+            path: PathBuf::from("/opt/claude"),
+            version: Some("1.0.0".into()),
+            install_source: Some("script"),
+        }));
+        cache.slot_mut(AgentBackend::KimiAcp).value = Some(None);
+
+        // Slots start at generation 0 with their cached values visible.
+        assert_eq!(
+            cache.slot(AgentBackend::ClaudeAcp).value,
+            Some(Some(ResolvedCli {
+                path: PathBuf::from("/opt/claude"),
+                version: Some("1.0.0".into()),
+                install_source: Some("script"),
+            }))
+        );
+        assert_eq!(cache.slot(AgentBackend::KimiAcp).value, Some(None));
+        assert_eq!(cache.slot(AgentBackend::ClaudeAcp).generation, 0);
+
+        // Bumping the Claude slot's generation is what `invalidate_cli_probe`
+        // does; the Kimi slot must keep its cached value and generation.
+        let claude_slot = cache.slot_mut(AgentBackend::ClaudeAcp);
+        claude_slot.generation = claude_slot.generation.wrapping_add(1);
+        claude_slot.value = None;
+        assert_eq!(cache.slot(AgentBackend::ClaudeAcp).value, None);
+        assert_eq!(cache.slot(AgentBackend::KimiAcp).value, Some(None));
+        assert_eq!(cache.slot(AgentBackend::KimiAcp).generation, 0);
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/auth_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/auth_probe.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -35,6 +36,22 @@ impl AgentAuthProbeState {
             AgentBackend::KimiAcp => &self.kimi,
             AgentBackend::Deepseek => unreachable!("Deepseek does not use ACP authentication"),
         }
+    }
+
+    /// Cache validity rule, kept as pure logic for unit testing: the entry is
+    /// usable only when the seqlock generation, executable path, and TTL all
+    /// match the probe that wants to reuse it.
+    pub(super) fn cached_auth_valid(
+        cache: &HashMap<AgentBackend, CachedAuthStatus>,
+        backend: AgentBackend,
+        executable: &Path,
+        generation: u64,
+    ) -> Option<bool> {
+        let cached = cache.get(&backend).cloned()?;
+        (cached.generation == generation
+            && cached.executable == executable
+            && cached.checked_at.elapsed() < AUTH_STATUS_TTL)
+            .then_some(cached.authenticated)
     }
 }
 
@@ -102,11 +119,12 @@ impl AcpPool {
         executable: &Path,
         generation: u64,
     ) -> Option<bool> {
-        let cached = self.auth_cache.read().get(&backend).cloned()?;
-        (cached.generation == generation
-            && cached.executable == executable
-            && cached.checked_at.elapsed() < AUTH_STATUS_TTL)
-            .then_some(cached.authenticated)
+        AgentAuthProbeState::cached_auth_valid(
+            &self.auth_cache.read(),
+            backend,
+            executable,
+            generation,
+        )
     }
 
     fn store_auth_cache_if_current(
@@ -147,5 +165,56 @@ impl AcpPool {
             .generation
             .fetch_add(1, Ordering::AcqRel);
         self.auth_cache.write().remove(&backend);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn auth_cache_validity_follows_generation_executable_and_ttl() {
+        let backend = AgentBackend::ClaudeAcp;
+        let executable = PathBuf::from("/opt/cli/agent");
+        let mut cache = HashMap::new();
+
+        let entry = |generation: u64, authenticated: bool, age: Duration| CachedAuthStatus {
+            executable: executable.clone(),
+            authenticated,
+            checked_at: Instant::now() - age,
+            generation,
+        };
+
+        // Nothing cached yet.
+        assert!(AgentAuthProbeState::cached_auth_valid(&cache, backend, &executable, 0).is_none());
+
+        // Matching generation/executable/fresh entry is valid.
+        cache.insert(backend, entry(0, true, Duration::ZERO));
+        assert_eq!(
+            AgentAuthProbeState::cached_auth_valid(&cache, backend, &executable, 0),
+            Some(true)
+        );
+
+        // A bumped generation (invalidate) must reject the cached entry.
+        assert!(AgentAuthProbeState::cached_auth_valid(&cache, backend, &executable, 1).is_none());
+
+        // A different executable path must not reuse the cached verdict.
+        let other = PathBuf::from("/opt/cli/other");
+        assert!(AgentAuthProbeState::cached_auth_valid(&cache, backend, &other, 0).is_none());
+
+        // An expired TTL must invalidate even a matching entry.
+        cache.insert(
+            backend,
+            entry(0, true, AUTH_STATUS_TTL + Duration::from_secs(1)),
+        );
+        assert!(AgentAuthProbeState::cached_auth_valid(&cache, backend, &executable, 0).is_none());
+
+        // A false verdict with a fresh matching entry round-trips as false.
+        cache.insert(backend, entry(0, false, Duration::ZERO));
+        assert_eq!(
+            AgentAuthProbeState::cached_auth_valid(&cache, backend, &executable, 0),
+            Some(false)
+        );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -710,8 +710,10 @@ impl OrderedWebDelivery {
             if remaining.is_zero() {
                 // A producer that dies between sequence allocation and
                 // delivery must not block the session pipeline forever.
-                // The browser client detects the sequence gap and recovers
-                // from the durable timeline on its next reconnect.
+                // The skipped envelope leaves a seq hole in the live stream
+                // (the browser has no envelope-seq gap detection); it is
+                // healed only by the next reconnect or session reopen,
+                // which refetches the durable timeline.
                 eprintln!(
                     "[acp] Web event delivery for sequence {seq} timed out waiting for sequence {}; skipping the gap",
                     last_seq.saturating_add(1)

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -4,6 +4,7 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use agent_client_protocol::schema::v1::{
     SessionNotification, SessionUpdate, ToolCall, ToolCallStatus, ToolCallUpdate,
@@ -23,6 +24,9 @@ const STATE_FILE: &str = "acp-state.json";
 /// Leaves headroom for the remote event/RPC envelope below the 2 MiB Relay cap.
 const MAX_WEB_ACP_EVENT_BYTES: usize = 1_750_000;
 const HOST_PATH_REDACTION: &str = "[host path omitted]";
+/// Upper bound for waiting on a missing predecessor sequence before ordered
+/// Web delivery skips the gap and keeps the session pipeline responsive.
+const WEB_DELIVERY_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Codex ACP 页面唯一消费的事件合同。
 ///
@@ -682,20 +686,39 @@ pub struct EventBridge {
 struct OrderedWebDelivery {
     last_seq: Arc<Mutex<u64>>,
     ready: Arc<Condvar>,
+    wait_timeout: Arc<Duration>,
 }
 
 impl OrderedWebDelivery {
     fn new(last_seq: u64) -> Self {
+        Self::with_wait_timeout(last_seq, WEB_DELIVERY_WAIT_TIMEOUT)
+    }
+
+    fn with_wait_timeout(last_seq: u64, wait_timeout: Duration) -> Self {
         Self {
             last_seq: Arc::new(Mutex::new(last_seq)),
             ready: Arc::new(Condvar::new()),
+            wait_timeout: Arc::new(wait_timeout),
         }
     }
 
     fn deliver(&self, seq: u64, delivery: impl FnOnce()) {
         let mut last_seq = self.last_seq.lock();
+        let deadline = Instant::now() + *self.wait_timeout;
         while seq > last_seq.saturating_add(1) {
-            self.ready.wait(&mut last_seq);
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                // A producer that dies between sequence allocation and
+                // delivery must not block the session pipeline forever.
+                // The browser client detects the sequence gap and recovers
+                // from the durable timeline on its next reconnect.
+                eprintln!(
+                    "[acp] Web event delivery for sequence {seq} timed out waiting for sequence {}; skipping the gap",
+                    last_seq.saturating_add(1)
+                );
+                break;
+            }
+            self.ready.wait_for(&mut last_seq, remaining);
         }
         if seq <= *last_seq {
             return;
@@ -903,8 +926,12 @@ impl EventBridge {
         event_type: &str,
         data: Value,
     ) -> AcpEventEnvelope {
-        let has_web_subscriber =
-            crate::platform::app_events::has_active_app_event_subscriber(&self.app, "acp:event");
+        // While the remote endpoint is active the projection must be built
+        // even if the browser is momentarily disconnected: the journal
+        // replays disconnect-window events on reconnect. Without an endpoint
+        // at all, both projection cost and journal are skipped.
+        let web_transport_active =
+            crate::platform::app_events::has_active_app_event_transport(&self.app);
         let envelope = {
             // Sequence allocation, persistence, and native publication remain
             // one ordered unit. Potentially large Web projection and Relay
@@ -955,7 +982,7 @@ impl EventBridge {
             envelope
         };
 
-        let web_payload = has_web_subscriber.then(|| {
+        let web_payload = web_transport_active.then(|| {
             serde_json::to_value(project_acp_event_for_web_bounded(
                 &envelope,
                 MAX_WEB_ACP_EVENT_BYTES,
@@ -1491,6 +1518,42 @@ mod tests {
             thread.join().unwrap();
         }
 
+        assert_eq!(*seen.lock(), vec![1, 2]);
+    }
+
+    #[test]
+    fn ordered_web_delivery_skips_gap_after_bounded_wait() {
+        let delivery = OrderedWebDelivery::with_wait_timeout(0, Duration::from_millis(20));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+
+        // Sequence 1 never arrives (its producer died before delivering).
+        delivery.deliver(2, || seen.lock().push(2));
+
+        assert_eq!(*seen.lock(), vec![2], "delivery must skip the dead gap");
+
+        // A late predecessor must not double-deliver or regress the cursor.
+        delivery.deliver(1, || seen.lock().push(1));
+        assert_eq!(*seen.lock(), vec![2]);
+
+        // Later sequences continue in order without re-blocking.
+        delivery.deliver(3, || seen.lock().push(3));
+        assert_eq!(*seen.lock(), vec![2, 3]);
+    }
+
+    #[test]
+    fn ordered_web_delivery_timeout_does_not_lose_arriving_predecessor() {
+        let delivery = OrderedWebDelivery::with_wait_timeout(0, Duration::from_secs(30));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let later = {
+            let delivery = delivery.clone();
+            let seen = Arc::clone(&seen);
+            std::thread::spawn(move || delivery.deliver(2, || seen.lock().push(2)))
+        };
+        std::thread::sleep(Duration::from_millis(50));
+        delivery.deliver(1, || seen.lock().push(1));
+        later.join().unwrap();
+
+        // The predecessor arrived inside the wait window, so strict order holds.
         assert_eq!(*seen.lock(), vec![1, 2]);
     }
 

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -710,10 +710,10 @@ impl OrderedWebDelivery {
             if remaining.is_zero() {
                 // A producer that dies between sequence allocation and
                 // delivery must not block the session pipeline forever.
-                // The skipped envelope leaves a seq hole in the live stream
-                // (the browser has no envelope-seq gap detection); it is
-                // healed only by the next reconnect or session reopen,
-                // which refetches the durable timeline.
+                // The skipped envelope leaves a seq hole in the live stream;
+                // the Web client's envelope-seq gap detection heals it with a
+                // debounced authoritative timeline resync, and the next
+                // reconnect or session reopen refetches it as well.
                 eprintln!(
                     "[acp] Web event delivery for sequence {seq} timed out waiting for sequence {}; skipping the gap",
                     last_seq.saturating_add(1)

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -2564,7 +2564,8 @@ impl AcpPool {
     }
 
     /// 会话级 Provider 覆盖（F11）：写入 per-session 配置的 "provider" 键并重启该
-    /// 会话 runtime；`provider_id=None` 恢复该会话官方登录。解析优先级：
+    /// Agent 的全部会话 runtime（配置按 Agent 生效，无法只重启一个）；
+    /// `provider_id=None` 恢复该 Agent 官方登录。解析优先级：
     /// 会话 option > 全局 current_provider。
     pub async fn set_acp_session_provider(
         &self,

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -2575,6 +2575,15 @@ impl AcpPool {
             bail!("当前会话不是 ACP 会话");
         }
         let backend = self.backend(session_id);
+        // Provider 切换会重启该 Agent 的全部会话 runtime，不只是当前会话；
+        // 该 Agent 任一会话正在生成时必须先拒绝（与 set_model/set_mode 的
+        // busy 语义一致），而不是硬杀进行中的 turn。
+        if self.sessions.lock().await.iter().any(|(id, runtime)| {
+            self.agents.backend(id) == backend
+                && runtime.busy.load(std::sync::atomic::Ordering::Acquire)
+        }) {
+            bail!("该 Agent 的 ACP 会话仍在生成，本轮结束后才能切换 Provider");
+        }
         let agent = backend.agent_id().context("非 ACP 会话")?;
         match provider_id {
             Some(provider_id) => {

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -2563,10 +2563,11 @@ impl AcpPool {
         self.providers.import(agent, json)
     }
 
-    /// 会话级 Provider 覆盖（F11）：写入 per-session 配置的 "provider" 键并重启该
-    /// Agent 的全部会话 runtime（配置按 Agent 生效，无法只重启一个）；
-    /// `provider_id=None` 恢复该 Agent 官方登录。解析优先级：
-    /// 会话 option > 全局 current_provider。
+    /// Per-session provider override (F11): writes the "provider" key into the
+    /// per-session config and restarts every session runtime of that agent
+    /// (the config applies per agent, so one runtime cannot restart alone);
+    /// `provider_id=None` restores the agent's official login. Resolution
+    /// order: session option > global current_provider.
     pub async fn set_acp_session_provider(
         &self,
         session_id: &str,
@@ -2576,9 +2577,10 @@ impl AcpPool {
             bail!("当前会话不是 ACP 会话");
         }
         let backend = self.backend(session_id);
-        // Provider 切换会重启该 Agent 的全部会话 runtime，不只是当前会话；
-        // 该 Agent 任一会话正在生成时必须先拒绝（与 set_model/set_mode 的
-        // busy 语义一致），而不是硬杀进行中的 turn。
+        // Switching providers restarts every session runtime of that agent,
+        // not just the current one; reject while any of its sessions is
+        // generating (same busy semantics as set_model/set_mode) instead of
+        // hard-killing an in-flight turn.
         if self.sessions.lock().await.iter().any(|(id, runtime)| {
             self.agents.backend(id) == backend
                 && runtime.busy.load(std::sync::atomic::Ordering::Acquire)

--- a/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
+++ b/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
@@ -1,4 +1,3 @@
-use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -278,28 +277,15 @@ async fn append_draft_chunk_in_workspace(
 /// whole-file digest. A mismatch aborts the commit (staging stays for the
 /// client's cleanup path) instead of letting corrupted bytes reach ingest.
 async fn verify_staging_sha256(staging_path: &Path, expected: &str) -> Result<(), String> {
-    let expected = expected.trim().to_ascii_lowercase();
-    if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+    let Some(expected) = crate::platform::encoding::normalize_sha256_hex(expected) else {
         return Err("附件完整性校验值无效".into());
-    }
+    };
     let staging_path = staging_path.to_path_buf();
-    let actual = tokio::task::spawn_blocking(move || -> std::io::Result<String> {
-        use sha2::{Digest, Sha256};
-        let mut file = std::fs::File::open(&staging_path)?;
-        let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let read = file.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        Ok(crate::platform::encoding::hex_lower(&hasher.finalize()))
-    })
-    .await
-    .map_err(|error| format!("附件完整性校验任务失败：{error}"))?
-    .map_err(|error| format!("读取附件暂存文件失败：{error}"))?;
+    let actual =
+        tokio::task::spawn_blocking(move || crate::platform::hashing::sha256_file(&staging_path))
+            .await
+            .map_err(|error| format!("附件完整性校验任务失败：{error}"))?
+            .map_err(|error| format!("读取附件暂存文件失败：{error}"))?;
     if actual != expected {
         return Err("附件完整性校验失败，上传内容在传输中损坏".into());
     }

--- a/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
+++ b/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
@@ -274,8 +274,9 @@ async fn append_draft_chunk_in_workspace(
 }
 
 /// Re-hash the assembled staging file and compare it with the client-provided
-/// whole-file digest. A mismatch aborts the commit (staging stays for the
-/// client's cleanup path) instead of letting corrupted bytes reach ingest.
+/// whole-file digest. A mismatch aborts the commit; the command layer's abort
+/// path then removes the staging upload, so corrupted bytes never reach
+/// ingest.
 async fn verify_staging_sha256(staging_path: &Path, expected: &str) -> Result<(), String> {
     let Some(expected) = crate::platform::encoding::normalize_sha256_hex(expected) else {
         return Err("附件完整性校验值无效".into());

--- a/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
+++ b/pinvou3-app/src-tauri/src/features/files/attachment_upload.rs
@@ -1,3 +1,4 @@
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
@@ -248,10 +249,13 @@ pub async fn append_draft_chunk(
     total: usize,
     data: &[u8],
     commit: bool,
+    sha256: Option<&str>,
 ) -> Result<Option<IngestResult>, String> {
     let workspace = draft_attachment_workspace();
-    append_draft_chunk_in_workspace(&workspace, upload_id, filename, offset, total, data, commit)
-        .await
+    append_draft_chunk_in_workspace(
+        &workspace, upload_id, filename, offset, total, data, commit, sha256,
+    )
+    .await
 }
 
 async fn append_draft_chunk_in_workspace(
@@ -262,8 +266,44 @@ async fn append_draft_chunk_in_workspace(
     total: usize,
     data: &[u8],
     commit: bool,
+    sha256: Option<&str>,
 ) -> Result<Option<IngestResult>, String> {
-    append_chunk(workspace, upload_id, filename, offset, total, data, commit).await
+    append_chunk(
+        workspace, upload_id, filename, offset, total, data, commit, sha256,
+    )
+    .await
+}
+
+/// Re-hash the assembled staging file and compare it with the client-provided
+/// whole-file digest. A mismatch aborts the commit (staging stays for the
+/// client's cleanup path) instead of letting corrupted bytes reach ingest.
+async fn verify_staging_sha256(staging_path: &Path, expected: &str) -> Result<(), String> {
+    let expected = expected.trim().to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err("附件完整性校验值无效".into());
+    }
+    let staging_path = staging_path.to_path_buf();
+    let actual = tokio::task::spawn_blocking(move || -> std::io::Result<String> {
+        use sha2::{Digest, Sha256};
+        let mut file = std::fs::File::open(&staging_path)?;
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(crate::platform::encoding::hex_lower(&hasher.finalize()))
+    })
+    .await
+    .map_err(|error| format!("附件完整性校验任务失败：{error}"))?
+    .map_err(|error| format!("读取附件暂存文件失败：{error}"))?;
+    if actual != expected {
+        return Err("附件完整性校验失败，上传内容在传输中损坏".into());
+    }
+    Ok(())
 }
 
 pub async fn abort_draft_upload(upload_id: &str) -> Result<(), String> {
@@ -372,6 +412,9 @@ async fn adopt_upload(
 /// Incomplete bytes live below `.pinvou3/attachment-drop-staging/`. Commit is
 /// an atomic rename into `attachments/<upload_id>/`, so the application keeps
 /// exactly one managed copy and session deletion owns its final lifecycle.
+/// When the client provides a whole-file SHA-256 on the committing chunk the
+/// assembled staging file is re-hashed before the rename, so corrupted bytes
+/// from the transport never reach the ingest pipeline.
 pub async fn append_chunk(
     workspace: &Path,
     upload_id: &str,
@@ -380,6 +423,7 @@ pub async fn append_chunk(
     total: usize,
     data: &[u8],
     commit: bool,
+    sha256: Option<&str>,
 ) -> Result<Option<IngestResult>, String> {
     let upload_id = validate_upload_id(upload_id)?;
     let filename = validate_filename(filename)?;
@@ -436,6 +480,9 @@ pub async fn append_chunk(
     }
     if end != total {
         return Err(format!("附件提交大小不完整：应为 {total}，实际为 {end}"));
+    }
+    if let Some(expected) = sha256 {
+        verify_staging_sha256(&staging_path, expected).await?;
     }
 
     let completed_dir = upload_completed_dir(workspace, upload_id);
@@ -673,6 +720,7 @@ mod tests {
             new_bytes.len(),
             new_bytes,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -697,6 +745,7 @@ mod tests {
             bytes.len(),
             bytes,
             true,
+            None,
         )
         .await
         .unwrap()
@@ -732,6 +781,7 @@ mod tests {
             bytes.len(),
             &bytes,
             true,
+            None,
         )
         .await
         .is_err());
@@ -750,6 +800,7 @@ mod tests {
             8,
             b"original",
             true,
+            None,
         )
         .await
         .unwrap()
@@ -763,6 +814,7 @@ mod tests {
             11,
             b"replacement",
             true,
+            None,
         )
         .await
         .is_err());
@@ -787,6 +839,7 @@ mod tests {
             bytes.len(),
             bytes,
             true,
+            None,
         )
         .await
         .unwrap()
@@ -808,6 +861,69 @@ mod tests {
             std::fs::remove_dir_all(source_workspace).unwrap();
         }
         std::fs::remove_dir_all(target_workspace).unwrap();
+    }
+
+    #[tokio::test]
+    async fn commit_verifies_client_provided_sha256() {
+        use sha2::{Digest, Sha256};
+
+        let workspace = test_workspace("sha256-commit");
+        let upload_id = "desktop_attach_sha256";
+        let bytes = b"integrity checked payload";
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let good = crate::platform::encoding::hex_lower(&hasher.finalize());
+
+        let committed = append_chunk(
+            &workspace,
+            upload_id,
+            "notes.txt",
+            0,
+            bytes.len(),
+            bytes,
+            true,
+            Some(&good),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(std::fs::read(&committed.path).unwrap(), bytes);
+
+        // A digest that does not match the assembled staging file must abort
+        // the commit and leave no completed upload behind.
+        assert!(append_chunk(
+            &workspace,
+            "desktop_attach_sha256_bad",
+            "notes.txt",
+            0,
+            bytes.len(),
+            bytes,
+            true,
+            Some(&"a".repeat(64)),
+        )
+        .await
+        .is_err());
+        assert!(!workspace
+            .join("attachments")
+            .join("desktop_attach_sha256_bad")
+            .exists());
+
+        // Malformed digests are rejected before hashing.
+        assert!(append_chunk(
+            &workspace,
+            "desktop_attach_sha256_invalid",
+            "notes.txt",
+            0,
+            bytes.len(),
+            bytes,
+            true,
+            Some("not-hex"),
+        )
+        .await
+        .is_err());
+
+        std::fs::remove_dir_all(workspace).unwrap();
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
@@ -3059,7 +3059,11 @@ mod tests {
             Some(&"b".repeat(64)),
         )
         .expect_err("digest mismatch must abort the commit");
-        assert!(error.contains("完整性校验失败"));
+        assert_eq!(
+            error,
+            transfer::WEB_ATTACHMENT_INTEGRITY_MISMATCH,
+            "the mismatch failure must surface as a stable wire code for localized client copy"
+        );
 
         // Malformed digests are rejected before hashing and keep the upload
         // resumable (the entry is not consumed).
@@ -3085,7 +3089,11 @@ mod tests {
             Some("not-hex"),
         )
         .expect_err("malformed digest must be rejected");
-        assert!(error.contains("校验值无效"));
+        assert_eq!(
+            error,
+            transfer::WEB_ATTACHMENT_DIGEST_INVALID,
+            "the malformed-digest failure must surface as a stable wire code for localized client copy"
+        );
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
@@ -1674,17 +1674,6 @@ impl RemoteControlManager {
         }
     }
 
-    /// Cheap, read-only projection gate for optional event transports.
-    /// Delivery revalidates the same state in `publish_event_inner`.
-    pub(crate) fn has_active_subscription(&self, event: &str) -> bool {
-        let inner = self.inner.lock();
-        let web_client_connected = inner
-            .endpoint
-            .as_ref()
-            .is_some_and(|endpoint| endpoint.web_client_connected);
-        has_active_event_subscription(web_client_connected, &inner.subscriptions, event)
-    }
-
     /// Whether the remote-control endpoint is active at all. Producers use
     /// this as the journal gate: while the endpoint is active, events are
     /// journaled even if the browser is momentarily disconnected, so replay
@@ -2899,14 +2888,6 @@ impl RemoteControlManager {
     }
 }
 
-fn has_active_event_subscription(
-    web_client_connected: bool,
-    subscriptions: &HashSet<String>,
-    event: &str,
-) -> bool {
-    web_client_connected && is_event_subscribed(subscriptions, event)
-}
-
 #[cfg(test)]
 mod tests {
     use super::persistence::{
@@ -2926,16 +2907,6 @@ mod tests {
 
         assert!(is_event_subscribed(&subscriptions, "session:deleted"));
         assert!(!is_event_subscribed(&subscriptions, "session:list_changed"));
-        assert!(!has_active_event_subscription(
-            false,
-            &subscriptions,
-            "session:deleted"
-        ));
-        assert!(has_active_event_subscription(
-            true,
-            &subscriptions,
-            "session:deleted"
-        ));
     }
 
     #[test]
@@ -3089,6 +3060,32 @@ mod tests {
         )
         .expect_err("digest mismatch must abort the commit");
         assert!(error.contains("完整性校验失败"));
+
+        // Malformed digests are rejected before hashing and keep the upload
+        // resumable (the entry is not consumed).
+        append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash_invalid",
+            "notes.txt",
+            0,
+            6,
+            b"abc",
+            false,
+            None,
+        )
+        .expect("first chunk");
+        let error = append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash_invalid",
+            "notes.txt",
+            3,
+            6,
+            b"def",
+            true,
+            Some("not-hex"),
+        )
+        .expect_err("malformed digest must be rejected");
+        assert!(error.contains("校验值无效"));
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
@@ -1327,6 +1327,7 @@ impl RemoteControlManager {
         total: usize,
         data: &[u8],
         commit: bool,
+        sha256: Option<&str>,
     ) -> Result<Option<(String, Vec<u8>)>, String> {
         append_web_attachment_upload_chunk(
             &mut self.inner.lock(),
@@ -1336,6 +1337,7 @@ impl RemoteControlManager {
             total,
             data,
             commit,
+            sha256,
         )
     }
 
@@ -1681,6 +1683,15 @@ impl RemoteControlManager {
             .as_ref()
             .is_some_and(|endpoint| endpoint.web_client_connected);
         has_active_event_subscription(web_client_connected, &inner.subscriptions, event)
+    }
+
+    /// Whether the remote-control endpoint is active at all. Producers use
+    /// this as the journal gate: while the endpoint is active, events are
+    /// journaled even if the browser is momentarily disconnected, so replay
+    /// on reconnect covers the disconnect window. When remote control is off,
+    /// producers skip both the projection cost and the journal entirely.
+    pub(crate) fn has_active_web_transport(&self) -> bool {
+        self.inner.lock().endpoint.is_some()
     }
 
     pub fn publish_frontend_event(&self, event: &str, payload: Value) -> Result<(), String> {
@@ -2998,6 +3009,7 @@ mod tests {
             6,
             b"abc",
             false,
+            None,
         )
         .expect("first chunk");
         assert!(first.is_none());
@@ -3010,6 +3022,7 @@ mod tests {
             6,
             b"def",
             true,
+            None,
         )
         .expect("final chunk")
         .expect("commit returns the payload");
@@ -3017,6 +3030,65 @@ mod tests {
         assert_eq!(completed.1, b"abcdef");
         assert!(inner.web_attachment_uploads.is_empty());
         assert!(inner.web_attachment_upload_order.is_empty());
+    }
+
+    #[test]
+    fn web_attachment_upload_verifies_sha256_on_commit() {
+        use sha2::{Digest, Sha256};
+
+        let mut inner = Inner::default();
+        let mut hasher = Sha256::new();
+        hasher.update(b"abcdef");
+        let good = crate::platform::encoding::hex_lower(&hasher.finalize());
+
+        append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash",
+            "notes.txt",
+            0,
+            6,
+            b"abc",
+            false,
+            None,
+        )
+        .expect("first chunk");
+
+        let completed = append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash",
+            "notes.txt",
+            3,
+            6,
+            b"def",
+            true,
+            Some(&good),
+        )
+        .expect("digest match must commit");
+        assert_eq!(completed.expect("payload").1, b"abcdef");
+
+        append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash_bad",
+            "notes.txt",
+            0,
+            6,
+            b"abc",
+            false,
+            None,
+        )
+        .expect("first chunk");
+        let error = append_web_attachment_upload_chunk(
+            &mut inner,
+            "upload_device_hash_bad",
+            "notes.txt",
+            3,
+            6,
+            b"def",
+            true,
+            Some(&"b".repeat(64)),
+        )
+        .expect_err("digest mismatch must abort the commit");
+        assert!(error.contains("完整性校验失败"));
     }
 
     #[test]
@@ -3032,6 +3104,7 @@ mod tests {
             oversized,
             b"x",
             false,
+            None,
         )
         .expect_err("uploads above MAX_FILE_BYTES must fail before transfer");
         assert!(error.contains("上限"), "unexpected error: {error}");
@@ -3049,6 +3122,7 @@ mod tests {
             8,
             b"abcd",
             false,
+            None,
         )
         .expect("first chunk");
 
@@ -3060,6 +3134,7 @@ mod tests {
             8,
             b"cdef",
             false,
+            None,
         )
         .expect_err("out-of-order chunks must be rejected");
         assert!(error.contains("偏移量"), "unexpected error: {error}");
@@ -3076,6 +3151,7 @@ mod tests {
             8,
             b"abcd",
             false,
+            None,
         )
         .expect("first chunk");
 
@@ -3091,6 +3167,7 @@ mod tests {
             8,
             b"efgh",
             true,
+            None,
         )
         .expect_err("continuing an aborted upload must fail");
         assert!(
@@ -3111,6 +3188,7 @@ mod tests {
                 8,
                 b"abcd",
                 false,
+                None,
             )
             .expect("start upload");
         }
@@ -3127,6 +3205,7 @@ mod tests {
             8,
             b"efgh",
             true,
+            None,
         )
         .expect_err("the evicted oldest upload must no longer continue");
         assert!(

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
@@ -100,6 +100,7 @@ pub(super) fn append_web_attachment_upload_chunk(
     total: usize,
     data: &[u8],
     commit: bool,
+    sha256: Option<&str>,
 ) -> Result<Option<(String, Vec<u8>)>, String> {
     if upload_id.len() < 8
         || upload_id.len() > 128
@@ -183,6 +184,19 @@ pub(super) fn append_web_attachment_upload_chunk(
             "远程控制附件上传不完整：已上传 {} / {total} 字节",
             upload.data.len()
         ));
+    }
+    if let Some(expected) = sha256 {
+        let expected = expected.trim().to_ascii_lowercase();
+        if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err("远程控制附件完整性校验值无效".into());
+        }
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&upload.data);
+        let actual = crate::platform::encoding::hex_lower(&hasher.finalize());
+        if actual != expected {
+            return Err("远程控制附件完整性校验失败，上传内容在传输中损坏".into());
+        }
     }
     let completed = inner
         .web_attachment_uploads

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
@@ -199,6 +199,15 @@ pub(super) fn append_web_attachment_upload_chunk(
         if actual != expected {
             return Err("远程控制附件完整性校验失败，上传内容在传输中损坏".into());
         }
+    } else if commit {
+        // None can mean an older WebUI (acceptable), but also a modern one on
+        // an insecure origin where Web Crypto is unavailable — exactly the
+        // remote scenario the digest protects. Surface the downgrade in the
+        // desktop log instead of silently skipping verification.
+        log::warn!(
+            "[remote_control] web attachment upload {} committed without an integrity digest (older WebUI or Web Crypto unavailable)",
+            upload.file_name
+        );
     }
     let completed = inner
         .web_attachment_uploads

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
@@ -92,6 +92,12 @@ pub(super) fn finish_web_attachment_reservation_inner(
     Ok(())
 }
 
+/// Stable wire codes for the upload integrity failures. The Web clients map
+/// them to localized zh/en/ja copy (pinned by web_access_contract.test.mjs);
+/// they must stay machine-stable, not translated.
+pub(crate) const WEB_ATTACHMENT_DIGEST_INVALID: &str = "web_attachment_digest_invalid";
+pub(crate) const WEB_ATTACHMENT_INTEGRITY_MISMATCH: &str = "web_attachment_integrity_mismatch";
+
 pub(super) fn append_web_attachment_upload_chunk(
     inner: &mut Inner,
     upload_id: &str,
@@ -188,16 +194,19 @@ pub(super) fn append_web_attachment_upload_chunk(
     if let Some(expected) = sha256 {
         // In-memory assembled bytes (bounded by MAX_FILE_BYTES), hashed under
         // the manager lock at commit only; the desktop staging stack reuses
-        // the same digest-format rule via platform::encoding.
+        // the same digest-format rule via platform::encoding. Both failures
+        // return stable wire codes (pinned by web_access_contract.test.mjs)
+        // that the Web clients map to localized zh/en/ja copy; raw,
+        // single-language text must never cross the Relay.
         let Some(expected) = crate::platform::encoding::normalize_sha256_hex(expected) else {
-            return Err("远程控制附件完整性校验值无效".into());
+            return Err(WEB_ATTACHMENT_DIGEST_INVALID.to_string());
         };
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(&upload.data);
         let actual = crate::platform::encoding::hex_lower(&hasher.finalize());
         if actual != expected {
-            return Err("远程控制附件完整性校验失败，上传内容在传输中损坏".into());
+            return Err(WEB_ATTACHMENT_INTEGRITY_MISMATCH.to_string());
         }
     } else if commit {
         // None can mean an older WebUI (acceptable), but also a modern one on

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/transfer.rs
@@ -186,10 +186,12 @@ pub(super) fn append_web_attachment_upload_chunk(
         ));
     }
     if let Some(expected) = sha256 {
-        let expected = expected.trim().to_ascii_lowercase();
-        if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+        // In-memory assembled bytes (bounded by MAX_FILE_BYTES), hashed under
+        // the manager lock at commit only; the desktop staging stack reuses
+        // the same digest-format rule via platform::encoding.
+        let Some(expected) = crate::platform::encoding::normalize_sha256_hex(expected) else {
             return Err("远程控制附件完整性校验值无效".into());
-        }
+        };
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(&upload.data);

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -349,9 +349,11 @@ pub fn run() {
             let remote_control_manager = RemoteControlManager::new(app.handle().clone());
             let remote_event_transport = remote_control_manager.clone();
             let remote_event_subscriptions = remote_control_manager.clone();
+            let remote_event_endpoint = remote_control_manager.clone();
             app.handle().manage(platform::app_events::AppEventBus::new(
                 move |event, payload| remote_event_transport.forward_local_event(event, payload),
                 move |event| remote_event_subscriptions.has_active_subscription(event),
+                move || remote_event_endpoint.has_active_web_transport(),
             ));
             app.handle().manage(remote_control_manager.clone());
             app.handle()

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -348,11 +348,9 @@ pub fn run() {
             }
             let remote_control_manager = RemoteControlManager::new(app.handle().clone());
             let remote_event_transport = remote_control_manager.clone();
-            let remote_event_subscriptions = remote_control_manager.clone();
             let remote_event_endpoint = remote_control_manager.clone();
             app.handle().manage(platform::app_events::AppEventBus::new(
                 move |event, payload| remote_event_transport.forward_local_event(event, payload),
-                move |event| remote_event_subscriptions.has_active_subscription(event),
                 move || remote_event_endpoint.has_active_web_transport(),
             ));
             app.handle().manage(remote_control_manager.clone());

--- a/pinvou3-app/src-tauri/src/platform/app_events.rs
+++ b/pinvou3-app/src-tauri/src/platform/app_events.rs
@@ -10,35 +10,27 @@ use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
 type EventForwarder = dyn Fn(&str, Value) + Send + Sync + 'static;
-type EventSubscriberProbe = dyn Fn(&str) -> bool + Send + Sync + 'static;
 type TransportProbe = dyn Fn() -> bool + Send + Sync + 'static;
 
 #[derive(Clone)]
 pub struct AppEventBus {
     forwarder: Arc<EventForwarder>,
-    subscriber_probe: Arc<EventSubscriberProbe>,
     transport_probe: Arc<TransportProbe>,
 }
 
 impl AppEventBus {
     pub fn new(
         forwarder: impl Fn(&str, Value) + Send + Sync + 'static,
-        subscriber_probe: impl Fn(&str) -> bool + Send + Sync + 'static,
         transport_probe: impl Fn() -> bool + Send + Sync + 'static,
     ) -> Self {
         Self {
             forwarder: Arc::new(forwarder),
-            subscriber_probe: Arc::new(subscriber_probe),
             transport_probe: Arc::new(transport_probe),
         }
     }
 
     pub fn forward(&self, event: &str, payload: Value) {
         (self.forwarder)(event, payload);
-    }
-
-    pub fn has_active_subscriber(&self, event: &str) -> bool {
-        (self.subscriber_probe)(event)
     }
 
     /// Whether an optional transport is configured at all, independent of the
@@ -57,14 +49,6 @@ pub fn forward_app_event(app: &AppHandle, event: &str, payload: Value) {
     }
 }
 
-/// Return whether an optional transport is currently able and subscribed to
-/// consume an event. Producers use this as a cheap projection gate; delivery
-/// still revalidates transport state at the forwarding boundary.
-pub fn has_active_app_event_subscriber(app: &AppHandle, event: &str) -> bool {
-    app.try_state::<AppEventBus>()
-        .is_some_and(|events| events.has_active_subscriber(event))
-}
-
 /// Return whether an optional transport exists at all, even if its consumer is
 /// momentarily disconnected. Events emitted now still need journaling so the
 /// consumer's reconnect replay covers the disconnect window.
@@ -79,29 +63,23 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
-    fn subscriber_probe_is_independent_from_forwarding() {
+    fn forward_and_transport_probe_are_independent() {
         let forwards = Arc::new(AtomicUsize::new(0));
         let forwarded = Arc::clone(&forwards);
         let bus = AppEventBus::new(
             move |_, _| {
                 forwarded.fetch_add(1, Ordering::Relaxed);
             },
-            |event| event == "acp:event",
             || true,
         );
 
-        assert!(bus.has_active_subscriber("acp:event"));
-        assert!(!bus.has_active_subscriber("chat:delta"));
+        assert!(bus.has_active_transport());
         assert_eq!(forwards.load(Ordering::Relaxed), 0);
 
         bus.forward("acp:event", Value::Null);
         assert_eq!(forwards.load(Ordering::Relaxed), 1);
-    }
 
-    #[test]
-    fn transport_probe_reports_configured_transport_without_subscribers() {
-        let bus = AppEventBus::new(|_, _| (), |_event| false, || true);
-        assert!(!bus.has_active_subscriber("acp:event"));
-        assert!(bus.has_active_transport());
+        let offline = AppEventBus::new(|_, _| (), || false);
+        assert!(!offline.has_active_transport());
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/app_events.rs
+++ b/pinvou3-app/src-tauri/src/platform/app_events.rs
@@ -11,21 +11,25 @@ use tauri::{AppHandle, Manager};
 
 type EventForwarder = dyn Fn(&str, Value) + Send + Sync + 'static;
 type EventSubscriberProbe = dyn Fn(&str) -> bool + Send + Sync + 'static;
+type TransportProbe = dyn Fn() -> bool + Send + Sync + 'static;
 
 #[derive(Clone)]
 pub struct AppEventBus {
     forwarder: Arc<EventForwarder>,
     subscriber_probe: Arc<EventSubscriberProbe>,
+    transport_probe: Arc<TransportProbe>,
 }
 
 impl AppEventBus {
     pub fn new(
         forwarder: impl Fn(&str, Value) + Send + Sync + 'static,
         subscriber_probe: impl Fn(&str) -> bool + Send + Sync + 'static,
+        transport_probe: impl Fn() -> bool + Send + Sync + 'static,
     ) -> Self {
         Self {
             forwarder: Arc::new(forwarder),
             subscriber_probe: Arc::new(subscriber_probe),
+            transport_probe: Arc::new(transport_probe),
         }
     }
 
@@ -35,6 +39,13 @@ impl AppEventBus {
 
     pub fn has_active_subscriber(&self, event: &str) -> bool {
         (self.subscriber_probe)(event)
+    }
+
+    /// Whether an optional transport is configured at all, independent of the
+    /// current subscription handshake. Producers use this to decide whether
+    /// journaling (replay coverage) is required while a consumer reconnects.
+    pub fn has_active_transport(&self) -> bool {
+        (self.transport_probe)()
     }
 }
 
@@ -54,6 +65,14 @@ pub fn has_active_app_event_subscriber(app: &AppHandle, event: &str) -> bool {
         .is_some_and(|events| events.has_active_subscriber(event))
 }
 
+/// Return whether an optional transport exists at all, even if its consumer is
+/// momentarily disconnected. Events emitted now still need journaling so the
+/// consumer's reconnect replay covers the disconnect window.
+pub fn has_active_app_event_transport(app: &AppHandle) -> bool {
+    app.try_state::<AppEventBus>()
+        .is_some_and(|events| events.has_active_transport())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,6 +87,7 @@ mod tests {
                 forwarded.fetch_add(1, Ordering::Relaxed);
             },
             |event| event == "acp:event",
+            || true,
         );
 
         assert!(bus.has_active_subscriber("acp:event"));
@@ -76,5 +96,12 @@ mod tests {
 
         bus.forward("acp:event", Value::Null);
         assert_eq!(forwards.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn transport_probe_reports_configured_transport_without_subscribers() {
+        let bus = AppEventBus::new(|_, _| (), |_event| false, || true);
+        assert!(!bus.has_active_subscriber("acp:event"));
+        assert!(bus.has_active_transport());
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/encoding.rs
+++ b/pinvou3-app/src-tauri/src/platform/encoding.rs
@@ -20,6 +20,14 @@ pub(crate) fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
+/// 校验并归一化客户端提供的整文件 sha256 摘要(64 个十六进制字符,容忍首尾
+/// 空白与大小写),桌面暂存文件校验与 Web 上传缓冲校验共用同一格式规则,
+/// 改规则只改一处。非法格式返回 None,由调用方给出各自的错误文案。
+pub(crate) fn normalize_sha256_hex(expected: &str) -> Option<String> {
+    let expected = expected.trim().to_ascii_lowercase();
+    (expected.len() == 64 && expected.bytes().all(|b| b.is_ascii_hexdigit())).then_some(expected)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -60,5 +68,20 @@ mod tests {
         assert!(s
             .chars()
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn sha256_digest_normalization() {
+        // 合法:64 个十六进制字符,首尾空白被裁剪,大写被归一为小写。
+        let digest = "a".repeat(63) + "B";
+        assert_eq!(
+            normalize_sha256_hex(&format!(" {digest} ")),
+            Some("a".repeat(63) + "b")
+        );
+        // 长度不是 64 / 非 hex 字符 → None。
+        assert_eq!(normalize_sha256_hex(&"a".repeat(63)), None);
+        assert_eq!(normalize_sha256_hex(&"g".repeat(64)), None);
+        assert_eq!(normalize_sha256_hex("not-hex"), None);
+        assert_eq!(normalize_sha256_hex(""), None);
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/encoding.rs
+++ b/pinvou3-app/src-tauri/src/platform/encoding.rs
@@ -20,9 +20,11 @@ pub(crate) fn hex_lower(bytes: &[u8]) -> String {
     out
 }
 
-/// 校验并归一化客户端提供的整文件 sha256 摘要(64 个十六进制字符,容忍首尾
-/// 空白与大小写),桌面暂存文件校验与 Web 上传缓冲校验共用同一格式规则,
-/// 改规则只改一处。非法格式返回 None,由调用方给出各自的错误文案。
+/// Validate and normalize a client-provided whole-file sha256 digest (64 hex
+/// characters; surrounding whitespace and letter case are tolerated). The
+/// desktop staging-file check and the web upload-buffer check share this one
+/// format rule so a rule change happens in one place. Returns None for an
+/// invalid format; callers provide their own error copy.
 pub(crate) fn normalize_sha256_hex(expected: &str) -> Option<String> {
     let expected = expected.trim().to_ascii_lowercase();
     (expected.len() == 64 && expected.bytes().all(|b| b.is_ascii_hexdigit())).then_some(expected)
@@ -72,13 +74,14 @@ mod tests {
 
     #[test]
     fn sha256_digest_normalization() {
-        // 合法:64 个十六进制字符,首尾空白被裁剪,大写被归一为小写。
+        // Valid: 64 hex characters; surrounding whitespace trimmed, uppercase
+        // normalized to lowercase.
         let digest = "a".repeat(63) + "B";
         assert_eq!(
             normalize_sha256_hex(&format!(" {digest} ")),
             Some("a".repeat(63) + "b")
         );
-        // 长度不是 64 / 非 hex 字符 → None。
+        // Wrong length or non-hex characters → None.
         assert_eq!(normalize_sha256_hex(&"a".repeat(63)), None);
         assert_eq!(normalize_sha256_hex(&"g".repeat(64)), None);
         assert_eq!(normalize_sha256_hex("not-hex"), None);

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -58,11 +58,13 @@ import { SearchOverlay } from '../features/search/SearchOverlay.jsx';
 import { UpdateNoticeButton } from '../features/updater/UpdateNoticeButton.jsx';
 import { Lanyard } from '../features/personas/persona-shared.jsx';
 import { VIEW_LOADERS, prefetchView } from './view-loaders.js';
-// 低频视图懒加载:VIEW_LOADERS(见 view-loaders.js)是统一的动态 import 出口,
-// React.lazy 与 NavItem 悬停/聚焦预取共用同一工厂,保证命中同一模块缓存。
-// codex 例外:经 LazyCodexAcpView 包装渲染,内部 import 同一 CodexAcpView
-// 模块(与预取共享缓存),并为 chunk 拉取失败提供就地重试边界。
-// ChatView 与 Lanyard 启动即渲染,保持静态 import。
+// Low-traffic views are lazy-loaded: VIEW_LOADERS (see view-loaders.js) is the
+// single dynamic-import outlet; React.lazy and the NavItem hover/focus
+// prefetch share the same factory so they hit the same module cache.
+// codex is the exception: it renders through the LazyCodexAcpView wrapper,
+// which imports the same CodexAcpView module (sharing the prefetch cache) and
+// adds an in-place retry boundary for chunk fetch failures.
+// ChatView and Lanyard render at startup and stay statically imported.
 const LazySettingsView = lazy(() => VIEW_LOADERS.settings().then(m => ({ default: m.SettingsView })));
 const LazyToolStoreView = lazy(() => VIEW_LOADERS.toolStore().then(m => ({ default: m.ToolStoreView })));
 const LazyCardPoolView = lazy(() => VIEW_LOADERS.cardpool().then(m => ({ default: m.CardPoolView })));

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -5,6 +5,7 @@ import '../styles/base.css';
 import { Edit2, BarChart2, Settings, Smartphone, Clock, Package, Search, ChevronDown, Menu, MoreHorizontal, Check, Filter, Layers, MessageSquare, X, BookOpen, Puzzle, PetPawIcon, FolderOpen, IconList } from '../components/icons.jsx';
 import { ArchiveConfirmDialog, ArchiveToast, NavItem, RecentItem } from '../components/layout/NavigationComponents.jsx';
 import { AcpAgentLogo } from '../features/codex/AcpAgentLogo.jsx';
+import { CodexAcpView } from '../features/codex/LazyCodexAcpView.jsx';
 import { PinvouLogo } from '../components/PinvouLogo.jsx';
 import { MobileMoreSheet, MobileTabBar, MobileTopBar } from '../components/layout/MobileShell.jsx';
 import { VllmSetupProgress } from '../components/VllmSetupProgress.jsx';
@@ -57,11 +58,12 @@ import { SearchOverlay } from '../features/search/SearchOverlay.jsx';
 import { UpdateNoticeButton } from '../features/updater/UpdateNoticeButton.jsx';
 import { Lanyard } from '../features/personas/persona-shared.jsx';
 import { VIEW_LOADERS, prefetchView } from './view-loaders.js';
-// 低频视图懒加载:VIEW_LOADERS(见 view-loaders.js)是唯一的动态 import 出口,
+// 低频视图懒加载:VIEW_LOADERS(见 view-loaders.js)是统一的动态 import 出口,
 // React.lazy 与 NavItem 悬停/聚焦预取共用同一工厂,保证命中同一模块缓存。
+// codex 例外:经 LazyCodexAcpView 包装渲染,内部 import 同一 CodexAcpView
+// 模块(与预取共享缓存),并为 chunk 拉取失败提供就地重试边界。
 // ChatView 与 Lanyard 启动即渲染,保持静态 import。
 const LazySettingsView = lazy(() => VIEW_LOADERS.settings().then(m => ({ default: m.SettingsView })));
-const LazyCodexAcpView = lazy(() => VIEW_LOADERS.codex().then(m => ({ default: m.CodexAcpView })));
 const LazyToolStoreView = lazy(() => VIEW_LOADERS.toolStore().then(m => ({ default: m.ToolStoreView })));
 const LazyCardPoolView = lazy(() => VIEW_LOADERS.cardpool().then(m => ({ default: m.CardPoolView })));
 const LazyScheduledTasksView = lazy(() => VIEW_LOADERS.scheduled().then(m => ({ default: m.ScheduledTasksView })));
@@ -2463,7 +2465,7 @@ function workspaceDisplayName(path) {
             {currentView === 'cardpool' && <LazyCardPoolView theme={activeTheme} t={t} bs={bs} onEquipped={() => { setCodeModeOn(false); setCurrentView('chat'); }} onAICreate={startAICard} initialMyOnly={poolMyOnly} />}
             {currentView === 'chat' && <ChatView theme={activeTheme} t={t} bs={bs} prefill={chatPrefill} focusComposerTick={petFocusComposerTick} onPrefillConsumed={() => setChatPrefill('')} onOpenEditor={handleOpenPersonaEditor} justInstalledTool={justInstalledTool} setJustInstalledTool={setJustInstalledTool} onGotoSettings={() => openSettingsSection('general')} onGotoModelSettings={() => openSettingsSection('model')} onGotoTools={() => navigateFromScheduledRun('toolStore')} onBackScheduledRun={() => navigateFromScheduledRun('scheduled')} codeModeAvailable={codexAcpSupported} onSwitchHomeMode={handleSwitchHomeMode} />}
             {codexAcpSupported && currentView === 'codex' && (
-              <LazyCodexAcpView
+              <CodexAcpView
                 theme={activeTheme}
                 t={t}
                 sessions={codexSessions}

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -115,6 +115,8 @@ import {
   listAcpSessions,
   openAcpExternalUrl,
   pickAcpWorkspace,
+  respondAcpElicitation,
+  respondAcpPermission,
   setAcpConfigOption,
   setAcpMode,
   setAcpModel,
@@ -2322,16 +2324,17 @@ export function CodexAcpView({
   }, []);
 
   useEffect(() => {
-    // 草稿态按需读取选中 Agent 的缓存状态；已有会话由 loadSession 读取，
-    // 避免切换时并发执行两次 CLI/认证探测。外部安装变化由“重新检测”强制刷新。
-    // 原生（品悟）会话没有 ACP 状态机，跳过 get_acp_agent_status（后端会拒绝非 ACP agent）。
+    // 草稿态按需读取选中 Agent 的状态：切换即强制重探测（CLI 可能刚在
+    // App 外安装/升级，缓存会停留在旧的未安装结论）。已有会话由 loadSession
+    // 读取，跳过以避免并发执行两次 CLI/认证探测。原生（品悟）会话没有 ACP
+    // 状态机，跳过 get_acp_agent_status（后端会拒绝非 ACP agent）。
     if (activeAgentId === 'pinvou') {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- native sessions have no ACP state machine; synchronously clear the status display
       setStatus(null);
       return;
     }
     if (activeId) return;
-    refreshStatus(activeAgentId).catch(showError);
+    refreshStatus(activeAgentId, true).catch(showError);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- probe only on agent/session switch edges; refreshStatus/showError reference changes must not retrigger probing
   }, [activeAgentId, activeId]);
 
@@ -2654,6 +2657,11 @@ export function CodexAcpView({
       if (canApplyAcpSendOperation(operation)) {
         showError(err);
         setDraft(message);
+      } else {
+        // The user switched sessions before this send failed. The draft
+        // belongs to the original session, so keep the new session's UI
+        // untouched, but never swallow the failure silently.
+        console.error('[codex] background ACP send failed', err);
       }
     } finally {
       finishAcpSendOperation(operation);
@@ -2763,6 +2771,11 @@ export function CodexAcpView({
       if (canApplyAcpSendOperation(operation)) {
         showError(err);
         setDraft(message);
+      } else {
+        // The user switched sessions before this send failed. The draft
+        // belongs to the original session, so keep the new session's UI
+        // untouched, but never swallow the failure silently.
+        console.error('[codex] background native send failed', err);
       }
     } finally {
       finishAcpSendOperation(operation);
@@ -3021,11 +3034,7 @@ export function CodexAcpView({
     if (!targetId || targetId !== activeIdRef.current) return;
     setRespondingSessionId(targetId); setError('');
     try {
-      await invoke(isWeb ? 'web_access_respond_codex_acp_permission' : 'respond_codex_acp_permission', {
-        sessionId: targetId,
-        toolCallId,
-        optionId,
-      });
+      await respondAcpPermission({ sessionId: targetId, toolCallId, optionId });
       setPending(current => current.filter(item => (
         item.sessionId !== targetId || item.toolCallId !== toolCallId
       )));
@@ -3043,12 +3052,7 @@ export function CodexAcpView({
     if (!targetId || targetId !== activeIdRef.current) return;
     setRespondingSessionId(targetId); setError('');
     try {
-      await invoke(isWeb ? 'web_access_respond_codex_acp_elicitation' : 'respond_codex_acp_elicitation', {
-        sessionId: targetId,
-        elicitationId,
-        action,
-        content,
-      });
+      await respondAcpElicitation({ sessionId: targetId, elicitationId, action, content });
       setPendingElicitations(current => current.filter(
         item => item.sessionId !== targetId || item.elicitationId !== elicitationId,
       ));

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -39,6 +39,7 @@ import { ComposerPopover, useOutsidePointerClose } from '../../components/Compos
 import {
   appendAcpEvent,
   buildElicitationContent,
+  createAcpEventSeqTracker,
   mergeAcpTimelineSnapshot,
   updateAcpAttachmentDraft,
   commandExecutionDetails,
@@ -1095,6 +1096,9 @@ export function CodexAcpView({
   const cancelledAttachmentIdsRef = useRef(new Set());
   const skipNextActiveLoadRef = useRef(null);
   const sessionLoadRequestRef = useRef(0);
+  const acpEventSeqTrackerRef = useRef(null);
+  if (!acpEventSeqTrackerRef.current) acpEventSeqTrackerRef.current = createAcpEventSeqTracker();
+  const acpGapResyncTimerRef = useRef(null);
   const preserveDraftWorkspaceRef = useRef(false);
   const draftEpochRef = useRef(draftEpoch);
   const activeIdRef = useRef(activeId);
@@ -1863,6 +1867,7 @@ export function CodexAcpView({
       ]);
       if (sessionLoadRequestRef.current !== requestId) return null;
       setEvents(current => mergeAcpTimelineSnapshot(timeline, current, id));
+      rebaseAcpEventSeqTracker(id, timeline);
       setPending(permissions || []);
       setPendingElicitations(elicitations || []);
       const runtime = await refreshStatus(activeAgentIdRef.current);
@@ -1880,6 +1885,42 @@ export function CodexAcpView({
     } finally {
       if (sessionLoadRequestRef.current === requestId) setSessionLoading(false);
     }
+  }
+
+  // 快照合并后把直播 seq 基线推进到快照最大 seq(只升不降),避免重取后
+  // 把已按序到达的直播事件误判为断档。
+  function rebaseAcpEventSeqTracker(sessionId, timeline) {
+    const maxSeq = (timeline || []).reduce((max, event) => Math.max(max, Number(event?.seq) || 0), 0);
+    acpEventSeqTrackerRef.current.rebase(sessionId, maxSeq);
+  }
+
+  // Web 直播流 envelope-seq 断档自愈:看门狗跳过停滞前序后,缺失的
+  // permission/终态信封不会在连接内补发。检测到跳号后防抖重取权威时间线与
+  // 挂起状态并合并(merge 对乱序/重复到达幂等),不动加载 spinner、不取消
+  // 在途的会话切换加载。
+  async function resyncAcpSessionAfterGap(sessionId) {
+    const [timeline, permissions, elicitations] = await Promise.all([
+      loadAcpTimeline(sessionId),
+      loadAcpPendingPermissions(sessionId),
+      loadAcpPendingElicitations(sessionId),
+    ]);
+    if (activeIdRef.current !== sessionId) return;
+    setEvents(current => mergeAcpTimelineSnapshot(timeline, current, sessionId));
+    rebaseAcpEventSeqTracker(sessionId, timeline);
+    setPending(permissions || []);
+    setPendingElicitations(elicitations || []);
+  }
+
+  function scheduleAcpGapResync(sessionId) {
+    if (acpGapResyncTimerRef.current) clearTimeout(acpGapResyncTimerRef.current);
+    acpGapResyncTimerRef.current = setTimeout(() => {
+      acpGapResyncTimerRef.current = null;
+      if (activeIdRef.current !== sessionId) return;
+      console.warn(`[acp] live event sequence gap detected for ${sessionId}; resyncing from the authoritative timeline`);
+      resyncAcpSessionAfterGap(sessionId).catch(error => {
+        console.warn('[acp] timeline resync after event sequence gap failed', error);
+      });
+    }, 800);
   }
 
   async function createSession({ shouldActivate = () => true, prepareSession = null } = {}) {
@@ -2094,6 +2135,9 @@ export function CodexAcpView({
         )),
         onError: err => {
           if (err?.code === 'device_upload_cancelled') return;
+          // 桌面端的完整性失败经 Relay 以稳定 wire code 到达 message
+          // (transfer.rs),映射为当前语言文案而不是透传原始错误。
+          const uploadErrorText = String(err?.message || '');
           const displayError = err?.code === 'device_upload_too_large'
             ? t.uiAttachments.deviceUploadTooLarge(file.name)
             : err?.code === 'device_upload_empty'
@@ -2102,7 +2146,11 @@ export function CodexAcpView({
                 ? t.uiAttachments.deviceUploadUnavailable
                 : err?.code === 'device_upload_invalid'
                   ? t.uiAttachments.deviceUploadInvalid(file.name)
-                  : t.uiAttachments.deviceUploadFailed(file.name);
+                  : uploadErrorText === 'web_attachment_digest_invalid'
+                    ? t.uiAttachments.deviceUploadDigestInvalid
+                    : uploadErrorText === 'web_attachment_integrity_mismatch'
+                      ? t.uiAttachments.deviceUploadIntegrityMismatch
+                      : t.uiAttachments.deviceUploadFailed(file.name);
           setAttachmentDrafts(current => updateAcpAttachmentDraft(current, id, attachment => ({
             ...attachment, status: 'error', error: displayError,
           })));
@@ -2230,6 +2278,12 @@ export function CodexAcpView({
     listenTauri('acp:event', message => {
       if (disposed) return;
       const incoming = message.payload;
+      // 直播 seq 连续性检查先于合并:看门狗跳过停滞前序后,后续事件照常到达,
+      // 仅靠 appendAcpEvent 会静默留下空洞;检测到跳号则防抖重取权威时间线自愈。
+      if (incoming && acpEventSeqTrackerRef.current.note(incoming.sessionId, incoming.seq) === 'gap'
+          && incoming.sessionId === activeIdRef.current) {
+        scheduleAcpGapResync(incoming.sessionId);
+      }
       setEvents(current => incoming && incoming.sessionId === activeIdRef.current ? appendAcpEvent(current, incoming) : current);
       if (incoming && incoming.sessionId === activeIdRef.current) {
         const type = incoming.event && incoming.event.type;
@@ -2268,6 +2322,10 @@ export function CodexAcpView({
     });
     return () => {
       disposed = true;
+      if (acpGapResyncTimerRef.current) {
+        clearTimeout(acpGapResyncTimerRef.current);
+        acpGapResyncTimerRef.current = null;
+      }
       if (unlisten) unlisten();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ACP event subscription mounts once; depending on refresh functions would repeatedly unbind/resubscribe

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -40,6 +40,7 @@ import {
   appendAcpEvent,
   buildElicitationContent,
   createAcpEventSeqTracker,
+  createAcpGapResyncScheduler,
   mergeAcpTimelineSnapshot,
   updateAcpAttachmentDraft,
   commandExecutionDetails,
@@ -1098,7 +1099,25 @@ export function CodexAcpView({
   const sessionLoadRequestRef = useRef(0);
   const acpEventSeqTrackerRef = useRef(null);
   if (!acpEventSeqTrackerRef.current) acpEventSeqTrackerRef.current = createAcpEventSeqTracker();
-  const acpGapResyncTimerRef = useRef(null);
+  const acpGapResyncRef = useRef(null);
+  if (!acpGapResyncRef.current) {
+    acpGapResyncRef.current = createAcpGapResyncScheduler(sessionId => {
+      if (activeIdRef.current !== sessionId) return;
+      return resyncAcpSessionAfterGap(sessionId);
+    }, {
+      onAttempt: (sessionId, attempt) => console.warn(
+        `[acp] live event sequence gap detected for ${sessionId}; resyncing from the authoritative timeline (attempt ${attempt})`,
+      ),
+      onRetry: (sessionId, attempt, error) => console.warn(
+        `[acp] timeline resync after event sequence gap failed (attempt ${attempt}); retrying with backoff`,
+        error,
+      ),
+      onGiveUp: (sessionId, attempt, error) => console.warn(
+        `[acp] timeline resync after event sequence gap gave up after ${attempt} attempts; the gap stays unhealed until reconnect or session reopen`,
+        error,
+      ),
+    });
+  }
   const preserveDraftWorkspaceRef = useRef(false);
   const draftEpochRef = useRef(draftEpoch);
   const activeIdRef = useRef(activeId);
@@ -1887,17 +1906,22 @@ export function CodexAcpView({
     }
   }
 
-  // 快照合并后把直播 seq 基线推进到快照最大 seq(只升不降),避免重取后
-  // 把已按序到达的直播事件误判为断档。
+  // After merging a snapshot, advance the live-seq baseline to the snapshot's
+  // max seq (never regress) so refetches do not misjudge in-order live events
+  // as gaps.
   function rebaseAcpEventSeqTracker(sessionId, timeline) {
     const maxSeq = (timeline || []).reduce((max, event) => Math.max(max, Number(event?.seq) || 0), 0);
     acpEventSeqTrackerRef.current.rebase(sessionId, maxSeq);
   }
 
-  // Web 直播流 envelope-seq 断档自愈:看门狗跳过停滞前序后,缺失的
-  // permission/终态信封不会在连接内补发。检测到跳号后防抖重取权威时间线与
-  // 挂起状态并合并(merge 对乱序/重复到达幂等),不动加载 spinner、不取消
-  // 在途的会话切换加载。
+  // Self-healing for envelope-seq gaps in the web live stream: after the
+  // watchdog skips a stalled predecessor, the missing permission/terminal
+  // envelopes are not re-delivered within the connection. On a detected gap,
+  // debounce-refetch the authoritative timeline and pending state and merge
+  // (merge is idempotent for out-of-order/duplicate arrivals), without
+  // touching the loading spinner or cancelling an in-flight session-switch
+  // load. A failed refetch retries with bounded exponential backoff so a
+  // single transient failure cannot permanently disable healing for that gap.
   async function resyncAcpSessionAfterGap(sessionId) {
     const [timeline, permissions, elicitations] = await Promise.all([
       loadAcpTimeline(sessionId),
@@ -1912,15 +1936,7 @@ export function CodexAcpView({
   }
 
   function scheduleAcpGapResync(sessionId) {
-    if (acpGapResyncTimerRef.current) clearTimeout(acpGapResyncTimerRef.current);
-    acpGapResyncTimerRef.current = setTimeout(() => {
-      acpGapResyncTimerRef.current = null;
-      if (activeIdRef.current !== sessionId) return;
-      console.warn(`[acp] live event sequence gap detected for ${sessionId}; resyncing from the authoritative timeline`);
-      resyncAcpSessionAfterGap(sessionId).catch(error => {
-        console.warn('[acp] timeline resync after event sequence gap failed', error);
-      });
-    }, 800);
+    acpGapResyncRef.current.schedule(sessionId);
   }
 
   async function createSession({ shouldActivate = () => true, prepareSession = null } = {}) {
@@ -2135,8 +2151,9 @@ export function CodexAcpView({
         )),
         onError: err => {
           if (err?.code === 'device_upload_cancelled') return;
-          // 桌面端的完整性失败经 Relay 以稳定 wire code 到达 message
-          // (transfer.rs),映射为当前语言文案而不是透传原始错误。
+          // Desktop integrity failures arrive as a stable wire code in
+          // message (transfer.rs); map to the current-language copy instead
+          // of passing the raw error through.
           const uploadErrorText = String(err?.message || '');
           const displayError = err?.code === 'device_upload_too_large'
             ? t.uiAttachments.deviceUploadTooLarge(file.name)
@@ -2278,8 +2295,10 @@ export function CodexAcpView({
     listenTauri('acp:event', message => {
       if (disposed) return;
       const incoming = message.payload;
-      // 直播 seq 连续性检查先于合并:看门狗跳过停滞前序后,后续事件照常到达,
-      // 仅靠 appendAcpEvent 会静默留下空洞;检测到跳号则防抖重取权威时间线自愈。
+      // Live seq continuity check runs before merging: after the watchdog
+      // skips a stalled predecessor, later events still arrive in order, and
+      // appendAcpEvent alone would silently keep the hole; on a detected gap,
+      // debounce-refetch the authoritative timeline to self-heal.
       if (incoming && acpEventSeqTrackerRef.current.note(incoming.sessionId, incoming.seq) === 'gap'
           && incoming.sessionId === activeIdRef.current) {
         scheduleAcpGapResync(incoming.sessionId);
@@ -2322,10 +2341,7 @@ export function CodexAcpView({
     });
     return () => {
       disposed = true;
-      if (acpGapResyncTimerRef.current) {
-        clearTimeout(acpGapResyncTimerRef.current);
-        acpGapResyncTimerRef.current = null;
-      }
+      acpGapResyncRef.current.cancel();
       if (unlisten) unlisten();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- ACP event subscription mounts once; depending on refresh functions would repeatedly unbind/resubscribe
@@ -2382,10 +2398,13 @@ export function CodexAcpView({
   }, []);
 
   useEffect(() => {
-    // 草稿态按需读取选中 Agent 的状态：切换即强制重探测（CLI 可能刚在
-    // App 外安装/升级，缓存会停留在旧的未安装结论）。已有会话由 loadSession
-    // 读取，跳过以避免并发执行两次 CLI/认证探测。原生（品悟）会话没有 ACP
-    // 状态机，跳过 get_acp_agent_status（后端会拒绝非 ACP agent）。
+    // In draft, read the selected agent's status on demand: switching agents
+    // forces a fresh probe (the CLI may have been installed/upgraded outside
+    // the app, and the cache would keep a stale not-installed verdict).
+    // Sessions with an id are covered by loadSession; skip here to avoid
+    // running the CLI/auth probes twice concurrently. Native (pinvou)
+    // sessions have no ACP state machine; skip get_acp_agent_status (the
+    // backend rejects non-ACP agents).
     if (activeAgentId === 'pinvou') {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- native sessions have no ACP state machine; synchronously clear the status display
       setStatus(null);

--- a/pinvou3-app/src/features/codex/LazyCodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/LazyCodexAcpView.jsx
@@ -1,16 +1,65 @@
-import { lazy, Suspense } from 'react';
+import React, { lazy, Suspense } from 'react';
 
-const CodexAcpWorkspace = lazy(() => import('./CodexAcpView.jsx')
-  .then(module => ({ default: module.CodexAcpView })));
+const loadCodexAcpWorkspace = () => import('./CodexAcpView.jsx')
+  .then(module => ({ default: module.CodexAcpView }));
+
+// The lazy chunk loads over the network on Web builds. A failed import must
+// not unmount the whole app, and a retry must issue a fresh dynamic import.
+class CodexAcpLoadErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      const copy = this.props.t.uiCodex;
+      return (
+        <div className="relative z-10 flex flex-1 items-center justify-center px-6">
+          <div className="max-w-[440px] rounded-2xl border p-5 bg-white border-[#DDE3EA] text-[#1F1F1F] dark:bg-[#1F2023] dark:border-[#333537] dark:text-[#E8EAED]">
+            <div className="text-[15px] font-semibold mb-2">{copy.viewLoadFailed}</div>
+            <button
+              type="button"
+              className="mt-3 rounded-lg border border-[#DDE3EA] px-3 py-1.5 text-[13px] hover:bg-[#F5F7FA] dark:border-[#333537] dark:hover:bg-[#26282B]"
+              onClick={() => this.props.onRetry()}
+            >
+              {copy.viewRetry}
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 export function CodexAcpView({ t, ...props }) {
+  const [attempt, setAttempt] = React.useState(0);
+  // A per-attempt component ensures the retry remounts the lazy element and
+  // re-runs the loader instead of replaying the failed import result.
+  const Workspace = React.useMemo(
+    () => lazy(loadCodexAcpWorkspace),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 'attempt' is the point: each retry mints a fresh lazy component so the rejected import is not replayed
+    [attempt],
+  );
   return (
-    <Suspense fallback={(
-      <div className="relative z-10 flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-300">
-        {t.uiCodex.checking}
-      </div>
-    )}>
-      <CodexAcpWorkspace t={t} {...props} />
-    </Suspense>
+    <CodexAcpLoadErrorBoundary
+      key={attempt}
+      t={t}
+      onRetry={() => setAttempt(value => value + 1)}
+    >
+      <Suspense fallback={(
+        <div className="relative z-10 flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-300">
+          {t.uiCodex.viewLoading}
+        </div>
+      )}>
+        {/* eslint-disable-next-line react-hooks/static-components -- a fresh lazy component per retry attempt is required so React.lazy re-runs the loader; state reset is exactly the intent */}
+        <Workspace key={attempt} t={t} {...props} />
+      </Suspense>
+    </CodexAcpLoadErrorBoundary>
   );
 }

--- a/pinvou3-app/src/features/codex/LazyCodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/LazyCodexAcpView.jsx
@@ -15,9 +15,17 @@ class CodexAcpLoadErrorBoundary extends React.Component {
     return { error };
   }
 
+  componentDidCatch(error, info) {
+    console.error(
+      '[codex] ACP workspace render failed',
+      error && error.stack ? error.stack : error,
+      info && info.componentStack ? info.componentStack : info,
+    );
+  }
+
   render() {
     if (this.state.error) {
-      const copy = this.props.t.uiCodex;
+      const copy = (this.props.t && this.props.t.uiCodex) || {};
       return (
         <div className="relative z-10 flex flex-1 items-center justify-center px-6">
           <div className="max-w-[440px] rounded-2xl border p-5 bg-white border-[#DDE3EA] text-[#1F1F1F] dark:bg-[#1F2023] dark:border-[#333537] dark:text-[#E8EAED]">

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -416,8 +416,12 @@ export function createAcpEventSeqTracker() {
 // transient failure would permanently disable healing for that gap. schedule()
 // debounces a burst of gap reports into one attempt; each failure reschedules
 // with exponential backoff until an attempt succeeds or the attempt budget is
-// exhausted. A fresh gap report after exhaustion starts a new cycle, and
-// cancel() drops any pending attempt (unmount).
+// exhausted. Retry state is scoped to the cycle: schedule() starts a fresh
+// cycle for its session (a burst of gap reports still debounces into one
+// attempt), and cancel() drops any pending attempt (unmount). Both also start
+// a new generation, invalidating any attempt still in flight: its late
+// completion can no longer reset the failure count, cancel the superseding
+// pending attempt, or schedule a retry after cancel().
 export function createAcpGapResyncScheduler(resync, {
   maxAttempts = 5,
   baseDelayMs = 800,
@@ -435,6 +439,7 @@ export function createAcpGapResyncScheduler(resync, {
   const cancelTimer = clearTimeout || globalThis.clearTimeout.bind(globalThis);
   let timer = null;
   let failures = 0;
+  let generation = 0;
   const delayAfterFailures = count => Math.min(firstDelayMs * 2 ** count, ceilingMs);
   const clearTimer = () => {
     if (timer !== null) {
@@ -442,30 +447,37 @@ export function createAcpGapResyncScheduler(resync, {
       timer = null;
     }
   };
-  const fire = async sessionId => {
+  const fire = async (sessionId, cycle) => {
+    if (cycle !== generation) return;
     timer = null;
     if (onAttempt) onAttempt(sessionId, failures + 1);
     try {
       await resync(sessionId);
+      if (cycle !== generation) return;
       failures = 0;
     } catch (error) {
+      if (cycle !== generation) return;
       failures += 1;
       if (failures >= attemptBudget) {
         if (onGiveUp) onGiveUp(sessionId, failures, error);
         return;
       }
       if (onRetry) onRetry(sessionId, failures, error);
-      clearTimer();
-      timer = scheduleTimer(() => { fire(sessionId); }, delayAfterFailures(failures));
+      timer = scheduleTimer(() => { fire(sessionId, cycle); }, delayAfterFailures(failures));
     }
   };
   return {
     schedule(sessionId) {
-      if (failures >= attemptBudget) failures = 0;
+      generation += 1;
+      failures = 0;
       clearTimer();
-      timer = scheduleTimer(() => { fire(sessionId); }, firstDelayMs);
+      const cycle = generation;
+      timer = scheduleTimer(() => { fire(sessionId, cycle); }, firstDelayMs);
     },
-    cancel: clearTimer,
+    cancel() {
+      generation += 1;
+      clearTimer();
+    },
   };
 }
 

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -382,6 +382,31 @@ export function appendAcpEvent(events, incoming) {
   return [...(events || []), incoming].sort((a, b) => Number(a.seq || 0) - Number(b.seq || 0));
 }
 
+// 服务端 OrderedWebDelivery 看门狗在停滞前序超时后跳过空洞,Web 直播流因此
+// 可能出现 envelope-seq 跳号(桌面原生链路在同一有序单元内落盘+广播,无损
+// 有序,不受影响)。该跟踪器按会话记录直播已见的最大 seq:发现跳号即报告
+// 'gap',由视图层防抖触发权威时间线重取,把缺失的 permission/终态事件补回;
+// 重连回放与重复投递按 'duplicate' 忽略。
+export function createAcpEventSeqTracker() {
+  const lastSeqBySession = new Map();
+  return {
+    note(sessionId, seq) {
+      const value = Number(seq) || 0;
+      if (!sessionId || value <= 0) return 'ignored';
+      const last = lastSeqBySession.get(sessionId) || 0;
+      if (value <= last) return 'duplicate';
+      lastSeqBySession.set(sessionId, value);
+      return last > 0 && value > last + 1 ? 'gap' : 'ok';
+    },
+    // 快照合并后以已知最大 seq 为基线;直播已推进到的更高 seq 不回退。
+    rebase(sessionId, seq) {
+      const value = Number(seq) || 0;
+      if (!sessionId || value <= 0) return;
+      if (value > (lastSeqBySession.get(sessionId) || 0)) lastSeqBySession.set(sessionId, value);
+    },
+  };
+}
+
 export function mergeAcpTimelineSnapshot(snapshot, current, sessionId) {
   return (current || [])
     .filter(event => event?.sessionId === sessionId)

--- a/pinvou3-app/src/features/codex/acp-state.js
+++ b/pinvou3-app/src/features/codex/acp-state.js
@@ -382,11 +382,13 @@ export function appendAcpEvent(events, incoming) {
   return [...(events || []), incoming].sort((a, b) => Number(a.seq || 0) - Number(b.seq || 0));
 }
 
-// 服务端 OrderedWebDelivery 看门狗在停滞前序超时后跳过空洞,Web 直播流因此
-// 可能出现 envelope-seq 跳号(桌面原生链路在同一有序单元内落盘+广播,无损
-// 有序,不受影响)。该跟踪器按会话记录直播已见的最大 seq:发现跳号即报告
-// 'gap',由视图层防抖触发权威时间线重取,把缺失的 permission/终态事件补回;
-// 重连回放与重复投递按 'duplicate' 忽略。
+// The server-side OrderedWebDelivery watchdog skips a hole after a stalled
+// predecessor times out, so the web live stream can show envelope-seq jumps
+// (the desktop native path persists and broadcasts within the same ordered
+// unit and is unaffected). The tracker records the max live seq per session
+// and reports 'gap' on a jump so the view layer can refetch the authoritative
+// timeline and restore the missing permission/terminal events; reconnect
+// replays and duplicate deliveries return 'duplicate' and are ignored.
 export function createAcpEventSeqTracker() {
   const lastSeqBySession = new Map();
   return {
@@ -398,12 +400,72 @@ export function createAcpEventSeqTracker() {
       lastSeqBySession.set(sessionId, value);
       return last > 0 && value > last + 1 ? 'gap' : 'ok';
     },
-    // 快照合并后以已知最大 seq 为基线;直播已推进到的更高 seq 不回退。
+    // After a snapshot merge, baseline on the known max seq; a higher seq the
+    // live stream already advanced to never regresses.
     rebase(sessionId, seq) {
       const value = Number(seq) || 0;
       if (!sessionId || value <= 0) return;
       if (value > (lastSeqBySession.get(sessionId) || 0)) lastSeqBySession.set(sessionId, value);
     },
+  };
+}
+
+// Bounded backoff driver for gap resyncs. note() advances its baseline before
+// reporting 'gap', so after a failed resync the following live envelopes look
+// continuous and never retrigger on their own; without retries a single
+// transient failure would permanently disable healing for that gap. schedule()
+// debounces a burst of gap reports into one attempt; each failure reschedules
+// with exponential backoff until an attempt succeeds or the attempt budget is
+// exhausted. A fresh gap report after exhaustion starts a new cycle, and
+// cancel() drops any pending attempt (unmount).
+export function createAcpGapResyncScheduler(resync, {
+  maxAttempts = 5,
+  baseDelayMs = 800,
+  maxDelayMs = 12800,
+  setTimeout = null,
+  clearTimeout = null,
+  onAttempt = null,
+  onRetry = null,
+  onGiveUp = null,
+} = {}) {
+  const attemptBudget = Math.max(1, Number(maxAttempts) || 1);
+  const firstDelayMs = Math.max(0, Number(baseDelayMs) || 0);
+  const ceilingMs = Math.max(firstDelayMs, Number(maxDelayMs) || 0);
+  const scheduleTimer = setTimeout || globalThis.setTimeout.bind(globalThis);
+  const cancelTimer = clearTimeout || globalThis.clearTimeout.bind(globalThis);
+  let timer = null;
+  let failures = 0;
+  const delayAfterFailures = count => Math.min(firstDelayMs * 2 ** count, ceilingMs);
+  const clearTimer = () => {
+    if (timer !== null) {
+      cancelTimer(timer);
+      timer = null;
+    }
+  };
+  const fire = async sessionId => {
+    timer = null;
+    if (onAttempt) onAttempt(sessionId, failures + 1);
+    try {
+      await resync(sessionId);
+      failures = 0;
+    } catch (error) {
+      failures += 1;
+      if (failures >= attemptBudget) {
+        if (onGiveUp) onGiveUp(sessionId, failures, error);
+        return;
+      }
+      if (onRetry) onRetry(sessionId, failures, error);
+      clearTimer();
+      timer = scheduleTimer(() => { fire(sessionId); }, delayAfterFailures(failures));
+    }
+  };
+  return {
+    schedule(sessionId) {
+      if (failures >= attemptBudget) failures = 0;
+      clearTimer();
+      timer = scheduleTimer(() => { fire(sessionId); }, firstDelayMs);
+    },
+    cancel: clearTimer,
   };
 }
 

--- a/pinvou3-app/src/features/codex/acpClient.js
+++ b/pinvou3-app/src/features/codex/acpClient.js
@@ -153,6 +153,7 @@ export async function uploadAcpDeviceAttachment(file, options = {}) {
       total: chunk.total,
       dataBase64: chunk.dataBase64,
       commit: chunk.commit,
+      ...(chunk.sha256 ? { sha256: chunk.sha256 } : {}),
     }),
     validateResult: result => isWeb ? Boolean(acpAttachmentHandle(result)) : Boolean(result?.basename),
     cleanup: async upload => {
@@ -249,6 +250,16 @@ export function loadAcpPendingPermissions(sessionId) {
 export function loadAcpPendingElicitations(sessionId) {
   return invokeAcp('get_codex_acp_pending_elicitations',
     'web_access_get_codex_acp_pending_elicitations', { sessionId });
+}
+
+export function respondAcpPermission({ sessionId, toolCallId, optionId }) {
+  return invokeAcp('respond_codex_acp_permission',
+    'web_access_respond_codex_acp_permission', { sessionId, toolCallId, optionId });
+}
+
+export function respondAcpElicitation({ sessionId, elicitationId, action, content }) {
+  return invokeAcp('respond_codex_acp_elicitation',
+    'web_access_respond_codex_acp_elicitation', { sessionId, elicitationId, action, content });
 }
 
 export function setAcpModel(sessionId, modelId) {

--- a/pinvou3-app/src/features/codex/acpErrors.js
+++ b/pinvou3-app/src/features/codex/acpErrors.js
@@ -1,4 +1,4 @@
-const CONTROLLED_WEB_ERROR = /^(?:web_workspace_(?:listing|search|preview|changes|diff)_failed|web_acp_[a-z0-9_]+_failed|invalid_web_session_id|web_session_unavailable)$/;
+const CONTROLLED_WEB_ERROR = /^(?:web_workspace_(?:listing|search|preview|changes|diff)_failed|web_acp_[a-z0-9_]+_failed|web_session_[a-z0-9_]+_failed|invalid_web_session_id|web_session_unavailable)$/;
 const CONTROLLED_CLIENT_ERRORS = new Set([
   'acp_external_url_invalid',
   'device_upload_unavailable',

--- a/pinvou3-app/src/features/codex/acpErrors.js
+++ b/pinvou3-app/src/features/codex/acpErrors.js
@@ -6,6 +6,8 @@ const CONTROLLED_CLIENT_ERRORS = new Set([
   'web_acp_command_unavailable',
   'web_acp_session_required',
   'web_acp_timeline_response_invalid',
+  'web_attachment_digest_invalid',
+  'web_attachment_integrity_mismatch',
   'web_workspace_authorization_invalid',
   'web_workspace_authorization_required',
   'web_workspace_picker_unavailable',

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -273,7 +273,6 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    attachmentDragActive: false,
     // token 预算（input_tokens / maxModelLen）
     tokens: { input: 0, max: 32768 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
@@ -1316,7 +1315,7 @@
   const STATE_SLICE_FIELDS = {
     platform: ["appVersion", "backendOnline", "platformCapabilities"],
     sessions: ["sessions", "archivedSessions", "activeSessionId", "sessionBusy", "draftEpoch"],
-    chat: ["activeSkill", "artifacts", "artifactChange", "attachmentDragActive", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
+    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
     voice: ["voiceInput", "voiceAsrSetup"],
     knowledge: ["kbModelSetup", "mountedCollection", "mountedCollections", "mountedRemoteCollections", "mountedCollectionsRevision"],
     scheduled: ["scheduledRunContext", "scheduledTaskAutoOpenId", "scheduledTaskBusyAction", "scheduledTaskCreationSessionId", "scheduledTaskDetail", "scheduledTaskDraft", "scheduledTaskError", "scheduledTaskErrorKind", "scheduledTaskLoading", "scheduledTaskPendingGuide", "scheduledTaskRecentRuns", "scheduledTaskRuns", "scheduledTasks", "scheduledTaskSelectionGeneration", "selectedScheduledTaskId"],

--- a/pinvou3-app/src/platform/tauri/bridge/artifacts.js
+++ b/pinvou3-app/src/platform/tauri/bridge/artifacts.js
@@ -145,6 +145,7 @@
             total: chunk.total,
             dataBase64: chunk.dataBase64,
             commit: chunk.commit,
+            ...(chunk.sha256 ? { sha256: chunk.sha256 } : {}),
           });
         },
         validateResult: function (result) { return Boolean(result && result.basename); },

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -395,6 +395,8 @@
       deviceUploadTooLarge: name => `⚠️ ${name} exceeds the 20 MB attachment limit`,
       deviceUploadEmpty: name => `⚠️ ${name} is empty and cannot be attached`,
       deviceUploadFailed: "⚠️ Upload failed: ",
+      deviceUploadDigestInvalid: "the attachment integrity digest was invalid. Try again.",
+      deviceUploadIntegrityMismatch: "the attachment content was corrupted in transit. Upload it again.",
       turnAlreadyInProgress: "⚠️ This chat is already processing a turn. The duplicate send was not executed.",
       compactStart: "⏳ Compacting context", compactDone: "✓ Context compacted", compactFail: "⚠️ Compaction failed", compactAuto: " (auto)",
       compactPruneMerged: "Auto-compaction: tool-result cleanup, messages unchanged",
@@ -504,6 +506,8 @@
       deviceUploadTooLarge: name => `⚠️ ${name} は添付の上限 20 MB を超えています`,
       deviceUploadEmpty: name => `⚠️ ${name} は空のため添付できません`,
       deviceUploadFailed: "⚠️ アップロードに失敗: ",
+      deviceUploadDigestInvalid: "添付ファイルの整合性ダイジェストが無効です。もう一度お試しください。",
+      deviceUploadIntegrityMismatch: "添付ファイルの内容が転送中に破損しました。再度アップロードしてください。",
       turnAlreadyInProgress: "⚠️ このチャットでは別のターンを処理中です。重複した送信は実行されませんでした。",
       compactStart: "⏳ コンテキストを圧縮中", compactDone: "✓ コンテキスト圧縮完了", compactFail: "⚠️ 圧縮に失敗", compactAuto: "（自動）",
       compactPruneMerged: "自動圧縮: ツール結果を整理、メッセージ数は不変",
@@ -613,6 +617,8 @@
       deviceUploadTooLarge: name => `⚠️ ${name} 超过附件 20 MB 上限`,
       deviceUploadEmpty: name => `⚠️ ${name} 是空文件，无法添加`,
       deviceUploadFailed: "⚠️ 上传失败: ",
+      deviceUploadDigestInvalid: "附件完整性校验值无效，请重试",
+      deviceUploadIntegrityMismatch: "附件内容在传输中损坏，请重新上传",
       turnAlreadyInProgress: "⚠️ 当前会话已有一轮正在处理，本次重复发送未执行。",
       compactStart: "⏳ 正在压缩上下文", compactDone: "✓ 上下文压缩完成", compactFail: "⚠️ 压缩失败", compactAuto: "（自动）",
       compactPruneMerged: "自动压缩：已整理工具结果，消息数不变",
@@ -8247,11 +8253,18 @@
     } catch (e) {
       if (!e || e.code !== "device_upload_cancelled") {
         att.status = "error";
+        // 桌面端完整性失败回稳定 wire code(transfer.rs),按当前语言映射;
+        // 其余错误沿用原文(既有行为,翻译收敛另行跟进)。
+        const rawUploadError = String(e && e.message ? e.message : e);
         att.error = e && e.code === "device_upload_empty"
           ? bt("deviceUploadEmpty")(file.name)
           : e && e.code === "device_upload_too_large"
             ? bt("deviceUploadTooLarge")(file.name)
-            : String(e && e.message ? e.message : e);
+            : rawUploadError === "web_attachment_digest_invalid"
+              ? bt("deviceUploadDigestInvalid")
+              : rawUploadError === "web_attachment_integrity_mismatch"
+                ? bt("deviceUploadIntegrityMismatch")
+                : rawUploadError;
         addSystemItem(bt("deviceUploadFailed") + att.error);
       }
     }

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -5330,8 +5330,9 @@
     state.composerPrefill = { id: (state.composerPrefill.id || 0) + 1, text: String(text || "") };
     notify();
   }
-  // 撤销一条待发消息(点 chip 的 ✕)。排队项携带的附件句柄同步释放,
-  // 与桌面端 removeQueued 的 discard 语义对齐。
+  // Undo one queued message (the ✕ on its chip). Attachment handles carried
+  // by the queued item are released in lockstep, matching the discard
+  // semantics of the desktop removeQueued path.
   function removeQueued(id) {
     let removed = null;
     state.queued = state.queued.filter(function (q) {
@@ -8253,8 +8254,10 @@
     } catch (e) {
       if (!e || e.code !== "device_upload_cancelled") {
         att.status = "error";
-        // 桌面端完整性失败回稳定 wire code(transfer.rs),按当前语言映射;
-        // 其余错误沿用原文(既有行为,翻译收敛另行跟进)。
+        // Desktop integrity failures come back as a stable wire code
+        // (transfer.rs) and map to the current language; other errors keep
+        // their raw text (existing behavior; translation convergence is a
+        // separate follow-up).
         const rawUploadError = String(e && e.message ? e.message : e);
         att.error = e && e.code === "device_upload_empty"
           ? bt("deviceUploadEmpty")(file.name)

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -234,7 +234,6 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    attachmentDragActive: false,
     // token 预算（input_tokens / maxModelLen）
     tokens: { input: 0, max: 32768 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
@@ -5325,9 +5324,18 @@
     state.composerPrefill = { id: (state.composerPrefill.id || 0) + 1, text: String(text || "") };
     notify();
   }
-  // 撤销一条待发消息(点 chip 的 ✕)。
+  // 撤销一条待发消息(点 chip 的 ✕)。排队项携带的附件句柄同步释放,
+  // 与桌面端 removeQueued 的 discard 语义对齐。
   function removeQueued(id) {
-    state.queued = state.queued.filter(function (q) { return q.id !== id; });
+    let removed = null;
+    state.queued = state.queued.filter(function (q) {
+      if (q.id !== id) return true;
+      removed = q;
+      return false;
+    });
+    if (removed && Array.isArray(removed.attachments)) {
+      removed.attachments.forEach(releaseAttachmentOnDesktop);
+    }
     notify();
   }
 
@@ -8156,7 +8164,10 @@
     } catch (e) { addSystemItem(bt("pasteImageFailed") + e); }
   }
   function releaseAttachmentOnDesktop(attachment) {
-    const handle = attachment && attachment.result && attachment.result.handle;
+    // Accepts a composer attachment ({ result, uploadId }) or a bare
+    // WebAttachmentSummary ({ handle }) carried by a queued message.
+    const handle = attachment
+      && (attachment.result ? attachment.result.handle : attachment.handle);
     if (handle && canInvoke("web_access_discard_attachment")) {
       invoke("web_access_discard_attachment", { handle }).catch(function () {});
       return;
@@ -8218,6 +8229,7 @@
             total: chunk.total,
             dataBase64: chunk.dataBase64,
             commit: chunk.commit,
+            ...(chunk.sha256 ? { sha256: chunk.sha256 } : {}),
           });
         },
         onProgress: function (progress) { att.progress = progress; notify(); },

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -15,7 +15,7 @@
   const fields = {
     platform: ["appVersion", "backendOnline", "platformCapabilities"],
     sessions: ["sessions", "archivedSessions", "activeSessionId", "sessionBusy", "draftEpoch"],
-    chat: ["activeSkill", "artifacts", "artifactChange", "attachmentDragActive", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
+    chat: ["activeSkill", "artifacts", "artifactChange", "attachments", "busy", "chatItems", "composerDraft", "composerPrefill", "messages", "modeState", "planSnapshot", "queued", "thinking", "tokens", "turnDirtyArtifacts", "turnPresentedArtifacts", "turnTimeline"],
     voice: ["voiceInput", "voiceAsrSetup"],
     knowledge: ["kbModelSetup", "mountedCollection", "mountedCollections", "mountedCollectionsRevision"],
     scheduled: ["scheduledRunContext", "scheduledTaskAutoOpenId", "scheduledTaskBusyAction", "scheduledTaskCreationSessionId", "scheduledTaskDetail", "scheduledTaskDraft", "scheduledTaskError", "scheduledTaskErrorKind", "scheduledTaskLoading", "scheduledTaskPendingGuide", "scheduledTaskRecentRuns", "scheduledTaskRuns", "scheduledTasks", "scheduledTaskSelectionGeneration", "selectedScheduledTaskId"],

--- a/pinvou3-app/src/platform/web/host-file-picker.js
+++ b/pinvou3-app/src/platform/web/host-file-picker.js
@@ -298,6 +298,7 @@
           // the mint RPC is in flight cannot pair the new display path with
           // the handle minted for the confirmed directory.
           const confirmedPath = currentPath;
+          const confirmedGeneration = loadGeneration;
           confirm.disabled = true;
           client.invoke("web_access_list_host_files", {
             path: confirmedPath,
@@ -308,6 +309,10 @@
             if (!handle) throw new Error("workspace handle missing");
             finish({ path: confirmedPath, workspaceHandle: handle });
           }).catch(function (error) {
+            // A failure that lands after the picker closed or after a newer
+            // listing rendered must not touch the current UI (finish() keeps
+            // its own disposed guard on the success path).
+            if (disposed || confirmedGeneration !== loadGeneration) return;
             confirm.disabled = false;
             body.replaceChildren(element("div", "pinvou-host-picker-error",
               labels.loadFailed(localizedPickerError(error))));

--- a/pinvou3-app/src/platform/web/host-file-picker.js
+++ b/pinvou3-app/src/platform/web/host-file-picker.js
@@ -77,7 +77,6 @@
       const selected = new Map();
       let currentPath = null;
       let parentPath = null;
-      let currentWorkspaceHandle = null;
       let rootEntries = [];
       let showingRoots = false;
       let disposed = false;
@@ -147,9 +146,7 @@
         selectionLabel.textContent = directoryMode
           ? (currentPath ? labels.currentFolder(currentPath) : "")
           : (count ? labels.selectedCount(count) : "");
-        confirm.disabled = directoryMode
-          ? (!currentPath || (options.workspaceGrant === true && !currentWorkspaceHandle))
-          : count === 0;
+        confirm.disabled = directoryMode ? !currentPath : count === 0;
       }
 
       function chooseEntry(entry, row) {
@@ -226,7 +223,6 @@
         showingRoots = true;
         currentPath = null;
         parentPath = null;
-        currentWorkspaceHandle = null;
         pathLabel.textContent = labels.thisComputer;
         rootsButton.disabled = false;
         up.disabled = true;
@@ -238,25 +234,36 @@
         showingRoots = false;
         currentPath = listing && (listing.path || listing.current_path || listing.currentPath) || null;
         parentPath = listing && (listing.parent || listing.parent_path || listing.parentPath) || null;
-        currentWorkspaceHandle = listing
-          && (listing.workspace_handle || listing.workspaceHandle) || null;
         pathLabel.textContent = currentPath || labels.thisComputer;
         rootsButton.disabled = rootEntries.length === 0;
         up.disabled = !parentPath && rootEntries.length === 0;
         renderEntries(listing && Array.isArray(listing.entries) ? [...listing.entries] : [], false);
       }
 
+      // Maps stable host-workspace authorization codes to localized copy for
+      // both the listing and the confirm-mint failure paths.
+      function localizedPickerError(error) {
+        const message = String(error && error.message ? error.message : error);
+        const code = String(error && error.code ? error.code : "");
+        if (code === "host_workspace_not_authorized" || message === "host_workspace_not_authorized") {
+          return labels.workspaceNotAuthorized;
+        }
+        return message;
+      }
+
       function load(path) {
         const generation = ++loadGeneration;
         showingRoots = false;
-        currentWorkspaceHandle = null;
         rootsButton.disabled = rootEntries.length === 0;
         up.disabled = true;
         confirm.disabled = true;
         body.replaceChildren(element("div", "pinvou-host-picker-status", labels.loadingPath));
         client.invoke("web_access_list_host_files", {
           path: path || null,
-          issueWorkspaceHandle: options.workspaceGrant === true,
+          // Grants are minted only for the directory the user finally
+          // confirms (see the confirm handler); navigating must not mint
+          // one-shot handles for every folder visited along the way.
+          issueWorkspaceHandle: false,
         }).then(function (listing) {
           if (disposed || generation !== loadGeneration) return;
           if (initialPathPending && path === initialPath) initialPathPending = false;
@@ -269,12 +276,8 @@
             return;
           }
           rootsButton.disabled = rootEntries.length === 0;
-          let message = String(error && error.message ? error.message : error);
-          const code = String(error && error.code ? error.code : "");
-          if (code === "host_workspace_not_authorized" || message === "host_workspace_not_authorized") {
-            message = labels.workspaceNotAuthorized;
-          }
-          body.replaceChildren(element("div", "pinvou-host-picker-error", labels.loadFailed(message)));
+          body.replaceChildren(element("div", "pinvou-host-picker-error",
+            labels.loadFailed(localizedPickerError(error))));
         });
       }
 
@@ -291,7 +294,24 @@
       });
       confirm.addEventListener("click", function () {
         if (directoryMode && options.workspaceGrant === true) {
-          finish({ path: currentPath, workspaceHandle: currentWorkspaceHandle });
+          // Capture the path at click time so a navigation that lands while
+          // the mint RPC is in flight cannot pair the new display path with
+          // the handle minted for the confirmed directory.
+          const confirmedPath = currentPath;
+          confirm.disabled = true;
+          client.invoke("web_access_list_host_files", {
+            path: confirmedPath,
+            issueWorkspaceHandle: true,
+          }).then(function (listing) {
+            const handle = listing
+              && (listing.workspace_handle || listing.workspaceHandle) || null;
+            if (!handle) throw new Error("workspace handle missing");
+            finish({ path: confirmedPath, workspaceHandle: handle });
+          }).catch(function (error) {
+            confirm.disabled = false;
+            body.replaceChildren(element("div", "pinvou-host-picker-error",
+              labels.loadFailed(localizedPickerError(error))));
+          });
         } else if (directoryMode) finish(currentPath);
         else finish(multiple ? [...selected.keys()] : [...selected.keys()][0] || null);
       });

--- a/pinvou3-app/src/platform/web/host-file-picker.js
+++ b/pinvou3-app/src/platform/web/host-file-picker.js
@@ -81,6 +81,7 @@
       let showingRoots = false;
       let disposed = false;
       let loadGeneration = 0;
+      let mintInFlight = false;
       const initialPath = options.defaultPath || null;
       let initialPathPending = Boolean(initialPath);
 
@@ -146,7 +147,7 @@
         selectionLabel.textContent = directoryMode
           ? (currentPath ? labels.currentFolder(currentPath) : "")
           : (count ? labels.selectedCount(count) : "");
-        confirm.disabled = directoryMode ? !currentPath : count === 0;
+        confirm.disabled = mintInFlight || (directoryMode ? !currentPath : count === 0);
       }
 
       function chooseEntry(entry, row) {
@@ -220,6 +221,10 @@
       function showRoots() {
         if (!rootEntries.length) return;
         loadGeneration += 1;
+        // Navigation supersedes any confirm-mint still in flight; its late
+        // callbacks are ignored via the generation guard, and the confirm
+        // button must become usable again for the newly shown location.
+        mintInFlight = false;
         showingRoots = true;
         currentPath = null;
         parentPath = null;
@@ -253,6 +258,7 @@
 
       function load(path) {
         const generation = ++loadGeneration;
+        mintInFlight = false;
         showingRoots = false;
         rootsButton.disabled = rootEntries.length === 0;
         up.disabled = true;
@@ -299,11 +305,17 @@
           // the handle minted for the confirmed directory.
           const confirmedPath = currentPath;
           const confirmedGeneration = loadGeneration;
+          mintInFlight = true;
           confirm.disabled = true;
           client.invoke("web_access_list_host_files", {
             path: confirmedPath,
             issueWorkspaceHandle: true,
           }).then(function (listing) {
+            // A mint that settles after the user navigated away must not
+            // close the picker on the stale directory; navigation already
+            // reset the in-flight state, and the abandoned one-shot handle
+            // is reclaimed by its TTL.
+            if (disposed || confirmedGeneration !== loadGeneration) return;
             const handle = listing
               && (listing.workspace_handle || listing.workspaceHandle) || null;
             if (!handle) throw new Error("workspace handle missing");
@@ -313,6 +325,7 @@
             // listing rendered must not touch the current UI (finish() keeps
             // its own disposed guard on the success path).
             if (disposed || confirmedGeneration !== loadGeneration) return;
+            mintInFlight = false;
             confirm.disabled = false;
             body.replaceChildren(element("div", "pinvou-host-picker-error",
               labels.loadFailed(localizedPickerError(error))));

--- a/pinvou3-app/src/shared/chunked-file-upload.js
+++ b/pinvou3-app/src/shared/chunked-file-upload.js
@@ -25,12 +25,6 @@
     return typeof size === "number" && Number.isSafeInteger(size) && size >= 0;
   }
 
-  function integrityError(reason) {
-    const error = new Error("device attachment integrity check failed" + (reason ? ": " + reason : ""));
-    error.code = "device_upload_integrity_failed";
-    return error;
-  }
-
   function toHex(bytes) {
     let hex = "";
     for (let i = 0; i < bytes.length; i += 1) {
@@ -151,7 +145,6 @@
     MAX_FILE_BYTES,
     bytesToBase64,
     cancelledError,
-    integrityError,
     uploadFile,
     uploadId,
   });

--- a/pinvou3-app/src/shared/chunked-file-upload.js
+++ b/pinvou3-app/src/shared/chunked-file-upload.js
@@ -33,21 +33,32 @@
     return hex;
   }
 
+  // crypto.subtle is undefined on insecure origins (e.g. plain-HTTP remote
+  // access) — exactly where transfer corruption is most likely. The unchecked
+  // downgrade stays safe, but it must not be invisible.
+  function warnUncheckedUpload(reason) {
+    if (root.console && typeof root.console.warn === "function") {
+      root.console.warn("device upload integrity unavailable (" + reason + "); transfer proceeds unchecked");
+    }
+  }
+
   // Web Crypto has no incremental digest, so the whole file (bounded by
   // MAX_FILE_BYTES) is hashed once before the first chunk is sent. The hash
   // rides the final chunk and the desktop re-verifies the assembled bytes.
   async function fileSha256Hex(file) {
     const subtle = root.crypto && root.crypto.subtle;
     if (!subtle || typeof subtle.digest !== "function" || typeof file.arrayBuffer !== "function") {
+      warnUncheckedUpload("web crypto unavailable in this context");
       return null;
     }
     try {
       const buffer = await file.arrayBuffer();
       const digest = await subtle.digest("SHA-256", buffer);
       return toHex(new Uint8Array(digest));
-    } catch (_) {
+    } catch (error) {
       // A hash we cannot compute locally degrades to an unchecked transfer;
       // the desktop side still verifies whatever digest does arrive.
+      warnUncheckedUpload("digest failed: " + (error && error.message ? error.message : error));
       return null;
     }
   }

--- a/pinvou3-app/src/shared/chunked-file-upload.js
+++ b/pinvou3-app/src/shared/chunked-file-upload.js
@@ -25,6 +25,39 @@
     return typeof size === "number" && Number.isSafeInteger(size) && size >= 0;
   }
 
+  function integrityError(reason) {
+    const error = new Error("device attachment integrity check failed" + (reason ? ": " + reason : ""));
+    error.code = "device_upload_integrity_failed";
+    return error;
+  }
+
+  function toHex(bytes) {
+    let hex = "";
+    for (let i = 0; i < bytes.length; i += 1) {
+      hex += (bytes[i] + 0x100).toString(16).slice(1);
+    }
+    return hex;
+  }
+
+  // Web Crypto has no incremental digest, so the whole file (bounded by
+  // MAX_FILE_BYTES) is hashed once before the first chunk is sent. The hash
+  // rides the final chunk and the desktop re-verifies the assembled bytes.
+  async function fileSha256Hex(file) {
+    const subtle = root.crypto && root.crypto.subtle;
+    if (!subtle || typeof subtle.digest !== "function" || typeof file.arrayBuffer !== "function") {
+      return null;
+    }
+    try {
+      const buffer = await file.arrayBuffer();
+      const digest = await subtle.digest("SHA-256", buffer);
+      return toHex(new Uint8Array(digest));
+    } catch (_) {
+      // A hash we cannot compute locally degrades to an unchecked transfer;
+      // the desktop side still verifies whatever digest does arrive.
+      return null;
+    }
+  }
+
   function bytesToBase64(bytes) {
     let binary = "";
     for (let offset = 0; offset < bytes.length; offset += 0x8000) {
@@ -59,6 +92,8 @@
     let offset = 0;
     let result = null;
     let commitAcknowledged = false;
+    const integrity = options.integrity !== false;
+    let sha256Hex = null;
     function assertActive() {
       if (typeof options.isCancelled === "function" && options.isCancelled()) {
         throw cancelledError();
@@ -66,6 +101,9 @@
     }
 
     try {
+      if (integrity) {
+        sha256Hex = await fileSha256Hex(file);
+      }
       while (offset < file.size) {
         const end = Math.min(offset + CHUNK_BYTES, file.size);
         const bytes = new Uint8Array(await file.slice(offset, end).arrayBuffer());
@@ -77,6 +115,7 @@
           total: file.size,
           dataBase64: bytesToBase64(bytes),
           commit: end === file.size,
+          ...(end === file.size && sha256Hex ? { sha256: sha256Hex } : {}),
         });
         commitAcknowledged = end === file.size;
         offset = end;
@@ -112,6 +151,7 @@
     MAX_FILE_BYTES,
     bytesToBase64,
     cancelledError,
+    integrityError,
     uploadFile,
     uploadId,
   });

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -759,7 +759,7 @@ dictEn.uiArtifacts = {
 
 dictEn.uiCodexView = { ended:'Finished', stepsFailed:'Steps include failures', processing:'Processing', codexTool:'Codex tool' };
 
-Object.assign(dictEn.uiAttachments, { uploading:pct=>`Uploading ${pct}%`, deviceUploadTooLarge:name=>`${name} exceeds the 20 MB attachment limit`, deviceUploadEmpty:name=>`${name} is empty and cannot be attached`, deviceUploadUnavailable:'Uploading from this device is currently unavailable', deviceUploadInvalid:name=>`${name} is not a valid attachment`, deviceUploadFailed:name=>`${name} could not be uploaded. Try again.` });
+Object.assign(dictEn.uiAttachments, { uploading:pct=>`Uploading ${pct}%`, deviceUploadTooLarge:name=>`${name} exceeds the 20 MB attachment limit`, deviceUploadEmpty:name=>`${name} is empty and cannot be attached`, deviceUploadUnavailable:'Uploading from this device is currently unavailable', deviceUploadInvalid:name=>`${name} is not a valid attachment`, deviceUploadFailed:name=>`${name} could not be uploaded. Try again.`, deviceUploadDigestInvalid:'The attachment integrity digest was invalid. Try again', deviceUploadIntegrityMismatch:'The attachment content was corrupted in transit. Upload it again' });
 
 Object.assign(dictEn.uiToolStore, {
   toolNames:{ feishu:'Feishu', wecom:'WeCom', dingtalk:'DingTalk', tmeet:'Tencent Meeting', ima:'Tencent ima' },

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -57,7 +57,7 @@ const codexEn = {
   connectedSuffix:'connected', notReadySuffix:'not ready',
   notSet:'Not set', choiceTitle:'The Agent needs your choice', submit:'Submit', cancel:'Cancel', submitted:'Submitted', canceled:'Canceled', inputExpired:'This input request has expired',
   checking:'Checking ACP Agents…', bridgeUnavailable:'Codex ACP Bridge unavailable',
-  viewLoading:'Loading code mode…', viewLoadFailed:'Failed to load code mode, possibly due to unstable network connection.', viewRetry:'Retry',
+  viewLoading:'Loading code mode…', viewLoadFailed:'Failed to load code mode, possibly due to an unstable network connection.', viewRetry:'Retry',
   bridgeRepair:'Repair or reinstall Pinvou. In development, run npm run prepare:codex-bridge.',
   cliMissing:agent=>`${agent} CLI not detected`, cliOutdated:(version,minVersion)=>`Detected old version ${version} (requires ≥ ${minVersion})`,
   cliUpdateAvailable:(agent,version,latest)=>`${agent} is ${version || 'unknown'}; the latest official version is ${latest || 'unknown'}. Upgrading is recommended`,

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -57,6 +57,7 @@ const codexEn = {
   connectedSuffix:'connected', notReadySuffix:'not ready',
   notSet:'Not set', choiceTitle:'The Agent needs your choice', submit:'Submit', cancel:'Cancel', submitted:'Submitted', canceled:'Canceled', inputExpired:'This input request has expired',
   checking:'Checking ACP Agents…', bridgeUnavailable:'Codex ACP Bridge unavailable',
+  viewLoading:'Loading code mode…', viewLoadFailed:'Failed to load code mode, possibly due to unstable network connection.', viewRetry:'Retry',
   bridgeRepair:'Repair or reinstall Pinvou. In development, run npm run prepare:codex-bridge.',
   cliMissing:agent=>`${agent} CLI not detected`, cliOutdated:(version,minVersion)=>`Detected old version ${version} (requires ≥ ${minVersion})`,
   cliUpdateAvailable:(agent,version,latest)=>`${agent} is ${version || 'unknown'}; the latest official version is ${latest || 'unknown'}. Upgrading is recommended`,

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -58,6 +58,7 @@ const codexJa = {
   connectedSuffix:'接続済み', notReadySuffix:'は準備できていません',
   notSet:'未設定', choiceTitle:'Agent が選択を求めています', submit:'送信', cancel:'キャンセル', submitted:'送信済み', canceled:'キャンセル済み', inputExpired:'この入力リクエストは期限切れです',
   checking:'ACP Agent を確認中…', bridgeUnavailable:'Codex ACP Bridge を利用できません',
+  viewLoading:'コードモードを読み込み中…', viewLoadFailed:'コードモードの読み込みに失敗しました。ネットワーク接続が不安定な可能性があります。', viewRetry:'再試行',
   bridgeRepair:'Pinvou を修復または再インストールしてください。開発環境では npm run prepare:codex-bridge を実行できます。',
   cliMissing:agent=>`${agent} CLI が見つかりません`, cliOutdated:(version,minVersion)=>`古いバージョン ${version} を検出しました（${minVersion} 以上が必要です）`,
   cliUpdateAvailable:(agent,version,latest)=>`${agent} の現在のバージョンは ${version || '不明'}、公式最新版は ${latest || '不明'} です。アップグレードを推奨します`,

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -762,7 +762,7 @@ dictJa.uiArtifacts = {
 
 dictJa.uiCodexView = { ended:'終了', stepsFailed:'失敗を含む実行手順', processing:'処理中', codexTool:'Codex ツール' };
 
-Object.assign(dictJa.uiAttachments, { uploading:pct=>`アップロード中 ${pct}%`, deviceUploadTooLarge:name=>`${name} は添付ファイル上限の 20 MB を超えています`, deviceUploadEmpty:name=>`${name} は空のため添付できません`, deviceUploadUnavailable:'現在、このデバイスから添付ファイルをアップロードできません', deviceUploadInvalid:name=>`${name} は有効な添付ファイルではありません`, deviceUploadFailed:name=>`${name} をアップロードできませんでした。もう一度お試しください。` });
+Object.assign(dictJa.uiAttachments, { uploading:pct=>`アップロード中 ${pct}%`, deviceUploadTooLarge:name=>`${name} は添付ファイル上限の 20 MB を超えています`, deviceUploadEmpty:name=>`${name} は空のため添付できません`, deviceUploadUnavailable:'現在、このデバイスから添付ファイルをアップロードできません', deviceUploadInvalid:name=>`${name} は有効な添付ファイルではありません`, deviceUploadFailed:name=>`${name} をアップロードできませんでした。もう一度お試しください。`, deviceUploadDigestInvalid:'添付ファイルの整合性ダイジェストが無効です。もう一度お試しください', deviceUploadIntegrityMismatch:'添付ファイルの内容が転送中に破損しました。再度アップロードしてください' });
 
 Object.assign(dictJa.uiToolStore, {
   toolNames:{ feishu:'Feishu', wecom:'WeCom', dingtalk:'DingTalk', tmeet:'Tencent Meeting', ima:'Tencent ima' },

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -56,6 +56,7 @@ const codexZh = {
   connectedSuffix:'已连接', notReadySuffix:'未就绪',
   notSet:'未设置', choiceTitle:'Agent 需要你的选择', submit:'提交', cancel:'取消', submitted:'已提交', canceled:'已取消', inputExpired:'该输入请求已过期',
   checking:'正在检查 ACP Agent…', bridgeUnavailable:'Codex ACP Bridge 不可用',
+  viewLoading:'正在加载代码模式…', viewLoadFailed:'代码模式加载失败，可能是网络连接不稳定。', viewRetry:'重试',
   bridgeRepair:'请修复或重新安装 Pinvou。开发环境可运行 npm run prepare:codex-bridge。',
   cliMissing:agent=>`未检测到 ${agent} CLI`, cliOutdated:(version,minVersion)=>`检测到旧版本 ${version}（需要 ≥ ${minVersion}）`,
   cliUpdateAvailable:(agent,version,latest)=>`${agent} 当前版本 ${version || '未知'}，官方最新版 ${latest || '未知'}，建议升级`,

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -787,7 +787,7 @@ dictZh.uiArtifacts = {
 
 dictZh.uiCodexView = { ended:'已结束', stepsFailed:'执行步骤包含失败', processing:'正在处理', codexTool:'Codex 工具' };
 
-Object.assign(dictZh.uiAttachments, { uploading:pct=>`上传中 ${pct}%`, deviceUploadTooLarge:name=>`${name} 超过 20 MB 附件上限`, deviceUploadEmpty:name=>`${name} 是空文件，无法添加`, deviceUploadUnavailable:'当前无法从此设备上传附件', deviceUploadInvalid:name=>`${name} 不是有效附件`, deviceUploadFailed:name=>`${name} 上传失败，请重试` });
+Object.assign(dictZh.uiAttachments, { uploading:pct=>`上传中 ${pct}%`, deviceUploadTooLarge:name=>`${name} 超过 20 MB 附件上限`, deviceUploadEmpty:name=>`${name} 是空文件，无法添加`, deviceUploadUnavailable:'当前无法从此设备上传附件', deviceUploadInvalid:name=>`${name} 不是有效附件`, deviceUploadFailed:name=>`${name} 上传失败，请重试`, deviceUploadDigestInvalid:'附件完整性校验值无效，请重试', deviceUploadIntegrityMismatch:'附件内容在传输中损坏，请重新上传' });
 
 
 // uiToolStore 词条补充（ToolStoreView / oauth-marketplace-logic）：命名空间已在 dict 主体定义，这里增量合并。

--- a/pinvou3-app/tests/acp_error_message.test.mjs
+++ b/pinvou3-app/tests/acp_error_message.test.mjs
@@ -14,6 +14,8 @@ for (const code of [
   'web_acp_timeline_response_invalid',
   'web_workspace_authorization_required',
   'web_workspace_session_required',
+  'web_session_list_sessions_failed',
+  'web_session_load_session_chunk_failed',
   'acp_external_url_invalid',
   'invalid_web_session_id',
   'web_session_unavailable',

--- a/pinvou3-app/tests/attachment_drop_logic.test.mjs
+++ b/pinvou3-app/tests/attachment_drop_logic.test.mjs
@@ -102,10 +102,10 @@ for (const [name, bridgeSource] of [
   ['Tauri', tauriBridgeSource],
   ['Web', webDomainAdapterSource],
 ]) {
-  assert.match(
+  assert.doesNotMatch(
     bridgeSource,
     /chat: \[[^\]]*"attachmentDragActive"/,
-    `${name} chat state slice must publish attachmentDragActive to React`,
+    `${name} chat state slice must not publish the dead attachmentDragActive flag`,
   );
 }
 

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -81,7 +81,7 @@ const protocolSources = {
 const expectedProtocolHashes = {
   multiAgent: 'a6d045e87f7f5f3537fdeadb262d54622edd6dcafa2c0253f0b44e7de439315d',
   orchestration: '493f46eef80e6ded5243d2c75ca1c8dbcc06097051d949d4ef656267c1bbada9',
-  artifacts: 'f6174eb62922bc222338e12049ce28dc9fae81db37998086dfa6d159d2dc7422',
+  artifacts: '37ca694534c7e6cf44b6d262c40e388999c3ba136faca0d6f57821d5b9b3df53',
   chat: '8e7dc2c966f6724ba16ea35c4f1b6216570356745b6bb40ee2e1a7a8d6c14ed5',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',

--- a/pinvou3-app/tests/chunked_file_upload.test.mjs
+++ b/pinvou3-app/tests/chunked_file_upload.test.mjs
@@ -90,4 +90,55 @@ await assert.rejects(
   error => error.code === 'device_upload_too_large',
 );
 
+// SHA-256 integrity: when Web Crypto is available, the whole-file digest rides
+// the committing chunk; a transport without crypto (or integrity: false)
+// sends no digest instead of failing.
+{
+  const digestBytes = Uint8Array.from({ length: 32 }, (_, index) => index);
+  const digestHex = Array.from(digestBytes, byte => (byte + 0x100).toString(16).slice(1)).join('');
+  const cryptoWindow = {
+    btoa: windowObject.btoa,
+    crypto: { subtle: { digest: async () => digestBytes } },
+  };
+  vm.runInNewContext(source, { window: cryptoWindow }, { filename: 'chunked-file-upload.js' });
+  const cryptoUploader = cryptoWindow.PinvouChunkedFileUpload;
+  const file = fileOfSize(10, 'hashed.txt');
+  file.arrayBuffer = async () => bytesOf(10).buffer;
+  function bytesOf(size) {
+    return Uint8Array.from({ length: size }, (_, index) => index % 251);
+  }
+  const seen = [];
+  await cryptoUploader.uploadFile({
+    file,
+    uploadId: 'upload_hashed',
+    async sendChunk(chunk) { seen.push(chunk); return chunk.commit ? { handle: 'ok' } : null; },
+    validateResult: () => true,
+  });
+  assert.equal(seen.at(-1).sha256, digestHex, 'commit chunk must carry the whole-file digest');
+  assert.ok(seen.slice(0, -1).every(chunk => chunk.sha256 === undefined));
+
+  // integrity: false skips hashing entirely.
+  const plain = [];
+  const plainFile = fileOfSize(10, 'plain.txt');
+  plainFile.arrayBuffer = async () => { throw new Error('must not hash'); };
+  await cryptoUploader.uploadFile({
+    file: plainFile,
+    uploadId: 'upload_plain',
+    integrity: false,
+    async sendChunk(chunk) { plain.push(chunk); return chunk.commit ? { handle: 'ok' } : null; },
+    validateResult: () => true,
+  });
+  assert.ok(plain.every(chunk => chunk.sha256 === undefined));
+
+  // A File without arrayBuffer degrades to an unchecked transfer, not a crash.
+  const degraded = [];
+  await cryptoUploader.uploadFile({
+    file: fileOfSize(10, 'degraded.txt'),
+    uploadId: 'upload_degraded',
+    async sendChunk(chunk) { degraded.push(chunk); return chunk.commit ? { handle: 'ok' } : null; },
+    validateResult: () => true,
+  });
+  assert.ok(degraded.every(chunk => chunk.sha256 === undefined));
+}
+
 console.log('chunked file upload tests passed');

--- a/pinvou3-app/tests/chunked_file_upload.test.mjs
+++ b/pinvou3-app/tests/chunked_file_upload.test.mjs
@@ -139,6 +139,25 @@ await assert.rejects(
     validateResult: () => true,
   });
   assert.ok(degraded.every(chunk => chunk.sha256 === undefined));
+
+  // The unchecked downgrade must stay observable: insecure origins (remote
+  // HTTP access) lose crypto.subtle exactly where corruption is most likely,
+  // so a silent skip would hide the protection gap. A context without a
+  // console (older embedders) must not crash either.
+  const warns = [];
+  const warnWindow = {
+    btoa: windowObject.btoa,
+    console: { warn: (...args) => warns.push(args.join(' ')) },
+  };
+  vm.runInNewContext(source, { window: warnWindow }, { filename: 'chunked-file-upload.js' });
+  await warnWindow.PinvouChunkedFileUpload.uploadFile({
+    file: fileOfSize(10, 'nohash.txt'),
+    uploadId: 'upload_nohash',
+    async sendChunk(chunk) { return chunk.commit ? { handle: 'ok' } : null; },
+    validateResult: () => true,
+  });
+  assert.equal(warns.length, 1, 'the crypto-unavailable downgrade must log one warning');
+  assert.match(warns[0], /integrity unavailable/);
 }
 
 console.log('chunked file upload tests passed');

--- a/pinvou3-app/tests/codex_acp_runtime_notice.test.mjs
+++ b/pinvou3-app/tests/codex_acp_runtime_notice.test.mjs
@@ -129,7 +129,7 @@ const runtimeStatus = await readFile(
   'utf8',
 );
 const draftStatusEffect = view.match(
-  /useEffect\(\(\) => \{\s+\/\/ 草稿态按需读取([\s\S]*?)\n {2}\}, \[activeAgentId, activeId\]\);/,
+  /useEffect\(\(\) => \{\s+\/\/ In draft, read the selected agent's status([\s\S]*?)\n {2}\}, \[activeAgentId, activeId\]\);/,
 );
 assert.ok(draftStatusEffect, 'draft Agent status effect must remain explicit');
 assert.match(

--- a/pinvou3-app/tests/codex_acp_runtime_notice.test.mjs
+++ b/pinvou3-app/tests/codex_acp_runtime_notice.test.mjs
@@ -134,13 +134,13 @@ const draftStatusEffect = view.match(
 assert.ok(draftStatusEffect, 'draft Agent status effect must remain explicit');
 assert.match(
   draftStatusEffect[1],
-  /if \(activeId\) return;[\s\S]*refreshStatus\(activeAgentId\)\.catch\(showError\)/,
-  'draft Agent switches must use the cached probe while session loading owns active-session status',
+  /if \(activeId\) return;[\s\S]*refreshStatus\(activeAgentId, true\)\.catch\(showError\)/,
+  'draft Agent switches must force a fresh CLI probe (installs outside the app) while session loading owns active-session status',
 );
 assert.doesNotMatch(
   draftStatusEffect[1],
-  /refreshStatus\(activeAgentId, true\)/,
-  'ordinary Agent switches must not force a duplicate CLI probe',
+  /refreshStatus\(activeAgentId\)\.catch\(showError\)/,
+  'draft Agent switches must not silently read a stale probe cache',
 );
 assert.match(
   view,

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -378,6 +378,80 @@ try {
     assert.equal(liveTimers().length, 1, 'a rescheduled attempt is pending');
     debounced.cancel();
     assert.equal(liveTimers().length, 0, 'cancel() drops the pending attempt');
+
+    // A schedule() that supersedes an in-flight attempt must invalidate it: a
+    // late rejection of the old attempt must neither cancel the superseding
+    // pending repair nor schedule a retry of its own, and the new session's
+    // gap still heals when its attempt runs.
+    {
+      const supersedeAttempts = [];
+      const supersedeRetries = [];
+      const supersedeGiveUps = [];
+      let rejectInFlight = null;
+      const superseded = createAcpGapResyncScheduler(
+        sessionId => {
+          supersedeAttempts.push(sessionId);
+          return new Promise((resolve, reject) => { rejectInFlight = reject; });
+        },
+        {
+          maxAttempts: 5,
+          baseDelayMs: 800,
+          maxDelayMs: 3200,
+          onRetry: (sessionId, attempt, error) => supersedeRetries.push([sessionId, attempt, error.message]),
+          onGiveUp: (sessionId, attempt, error) => supersedeGiveUps.push([sessionId, attempt, error.message]),
+          ...useFakeTimers(),
+        },
+      );
+      superseded.schedule('session-a');
+      fireLatest();
+      await Promise.resolve();
+      assert.deepEqual(supersedeAttempts, ['session-a'], 'the first attempt is in flight');
+      superseded.schedule('session-b');
+      assert.equal(liveTimers().length, 1, 'the superseding schedule installs its own pending attempt');
+      rejectInFlight(new Error('transient network failure'));
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.equal(liveTimers().length, 1,
+        'a stale in-flight rejection must not cancel the superseding attempt');
+      assert.deepEqual(supersedeRetries, [],
+        'a stale in-flight rejection must not schedule a retry for the old session');
+      assert.deepEqual(supersedeGiveUps, [],
+        'a stale in-flight rejection must not report a give-up');
+      fireLatest();
+      await Promise.resolve();
+      assert.deepEqual(supersedeAttempts, ['session-a', 'session-b'],
+        'the superseding attempt still runs and heals its own gap');
+    }
+
+    // cancel() while an attempt is in flight must invalidate it: a late
+    // rejection must not schedule a retry after the unmount cleanup ran.
+    {
+      const cancelRetries = [];
+      const cancelGiveUps = [];
+      let rejectInFlight = null;
+      const cancelled = createAcpGapResyncScheduler(
+        () => new Promise((resolve, reject) => { rejectInFlight = reject; }),
+        {
+          maxAttempts: 5,
+          baseDelayMs: 800,
+          maxDelayMs: 3200,
+          onRetry: (sessionId, attempt, error) => cancelRetries.push([sessionId, attempt, error.message]),
+          onGiveUp: (sessionId, attempt, error) => cancelGiveUps.push([sessionId, attempt, error.message]),
+          ...useFakeTimers(),
+        },
+      );
+      cancelled.schedule('session-c');
+      fireLatest();
+      await Promise.resolve();
+      cancelled.cancel();
+      rejectInFlight(new Error('transient network failure'));
+      await Promise.resolve();
+      await Promise.resolve();
+      assert.equal(liveTimers().length, 0,
+        'a rejection landing after cancel() must not schedule a retry');
+      assert.deepEqual(cancelRetries, [], 'no retry is reported after cancel()');
+      assert.deepEqual(cancelGiveUps, [], 'no give-up is reported after cancel()');
+    }
   }
 
   const liveAfterSnapshot = event(14, 'agent_message_chunk', {

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -294,8 +294,13 @@ try {
   assert.ok(main.includes('<LazyCodexAcpView'), 'Codex view renders via lazy chunk');
   assert.match(
     lazyCodexView,
-    /lazy\(\(\) => import\('\.\/CodexAcpView\.jsx'\)/,
+    /import\('\.\/CodexAcpView\.jsx'\)/,
     'the ACP workspace must stay out of the initial WebUI bundle',
+  );
+  assert.match(
+    lazyCodexView,
+    /extends React\.Component[\s\S]*?getDerivedStateFromError/,
+    'the lazy ACP workspace must sit behind an error boundary',
   );
   assert.ok(
     detachedShell.includes("../features/codex/LazyCodexAcpView.jsx")
@@ -304,8 +309,8 @@ try {
   );
   assert.match(
     lazyCodexView,
-    /<Suspense fallback=\{\([\s\S]*?<CodexAcpWorkspace/,
-    'the lazy ACP workspace must render a stable loading state',
+    /<Suspense fallback=\{\([\s\S]*?t\.uiCodex\.viewLoading[\s\S]*?<Workspace/,
+    'the lazy ACP workspace must render a dedicated loading state',
   );
   assert.ok(main.includes('codexAcpSupported &&'), 'Codex entry must stay platform capability-gated');
   assert.ok(main.includes(".concat(codexHistory)") || main.includes("...codexHistory,"),
@@ -641,7 +646,7 @@ try {
     'Codex and DeepSeek must share the same choice-card presentation');
   assert.ok(codexView.includes('loadAcpPendingElicitations(id)'),
     'pending Codex input requests must recover when a session is reopened');
-  assert.ok(codexView.includes("isWeb ? 'web_access_respond_codex_acp_elicitation' : 'respond_codex_acp_elicitation'"),
+  assert.ok(codexView.includes('respondAcpElicitation({ sessionId: targetId, elicitationId, action, content })'),
     'Codex input answers must be returned through the ACP request');
   assert.ok(conversationView.includes('className={`codex-markdown'), 'conversation Markdown must keep the isolated Codex style scope');
   assert.ok(codexView.includes('<ConversationTurn'), 'Codex must render through the shared Turn renderer by default');

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -291,7 +291,15 @@ try {
   const i18n = ['zh', 'en', 'ja'].map((l) => readFileSync(path.join(root, 'src', 'shared', 'i18n', `${l}.js`), 'utf8')).join('\n'); // 拆分后三语在 i18n/ 目录
   const navigationComponents = readFileSync(path.join(root, 'src', 'components', 'layout', 'NavigationComponents.jsx'), 'utf8');
   assert.ok(main.includes("currentView === 'codex'"));
-  assert.ok(main.includes('<LazyCodexAcpView'), 'Codex view renders via lazy chunk');
+  assert.ok(
+    main.includes("from '../features/codex/LazyCodexAcpView.jsx'") && main.includes('<CodexAcpView'),
+    'the main window must render the codex view through the LazyCodexAcpView wrapper (retryable error boundary)',
+  );
+  assert.doesNotMatch(
+    main,
+    /VIEW_LOADERS\.codex\(\)\.then/,
+    'the main window must not bypass the wrapper with a direct lazy import of CodexAcpView',
+  );
   assert.match(
     lazyCodexView,
     /import\('\.\/CodexAcpView\.jsx'\)/,
@@ -299,8 +307,8 @@ try {
   );
   assert.match(
     lazyCodexView,
-    /extends React\.Component[\s\S]*?getDerivedStateFromError/,
-    'the lazy ACP workspace must sit behind an error boundary',
+    /extends React\.Component[\s\S]*?getDerivedStateFromError[\s\S]*?componentDidCatch/,
+    'the lazy ACP workspace must sit behind an error boundary that logs failures',
   );
   assert.ok(
     detachedShell.includes("../features/codex/LazyCodexAcpView.jsx")

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -834,6 +834,32 @@ try {
     assert.equal(Array.isArray(Object.getPrototypeOf(content)), false, 'content 保持无原型对象，不得被 __proto__ 赋值改原型');
   }
 
+  // ── M-E journal 探针语义锁定：transport 级（endpoint 活跃）而非订阅者级 ──
+  // #336 把 acp:event 的 projection+journal 门控从「有浏览器订阅者」改为
+  // 「远程端点活跃」：断线窗口（端点在、浏览器暂离）事件仍须进 journal，
+  // 重连 replay 才能补齐；反之把语义改回订阅者级会静默重开断线窗口丢事件。
+  // 锁定三处：manager 探针只看 endpoint；事件侧投影门控走 transport 探针；
+  // AppEventBus 的接线不回退到 subscriber 语义。
+  {
+    const managerMod = readFileSync(
+      path.join(root, 'src-tauri', 'src', 'features', 'remote_control', 'manager', 'mod.rs'),
+      'utf8',
+    );
+    const eventsRs = readFileSync(
+      path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'events.rs'),
+      'utf8',
+    );
+    const libRs = readFileSync(path.join(root, 'src-tauri', 'src', 'lib.rs'), 'utf8');
+    assert.match(managerMod, /pub\(crate\) fn has_active_web_transport\(&self\) -> bool \{\s*self\.inner\.lock\(\)\.endpoint\.is_some\(\)/,
+      'the journal gate must be endpoint-activeness (endpoint.is_some), not a live subscriber');
+    assert.match(eventsRs, /has_active_app_event_transport\(&self\.app\)/,
+      'the ACP projection gate must consult the transport probe');
+    assert.doesNotMatch(eventsRs, /has_active_app_event_subscriber/,
+      'the ACP event path must not regress to subscriber-based journal gating');
+    assert.match(libRs, /has_active_web_transport\(\)/,
+      'the AppEventBus transport probe must stay wired to the remote-control endpoint');
+  }
+
   console.log('codex_acp_timeline: ok');
 } finally {
   rmSync(temp, { recursive: true, force: true });

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -35,6 +35,7 @@ try {
     appendAcpEvent,
     buildElicitationContent,
     commandExecutionDetails,
+    createAcpEventSeqTracker,
     mergeAcpTimelineSnapshot,
     projectAcpTimeline,
     resolveAcpSessionControls,
@@ -241,6 +242,28 @@ try {
 
   assert.equal(appendAcpEvent(events, events[0]).length, events.length, 'duplicate seq must be ignored');
   assert.equal(appendAcpEvent(events.slice(0, 2), events[2]).length, 3);
+
+  // 看门狗跳过停滞前序后,Web 直播流出现 envelope-seq 空洞:跟踪器必须报告
+  // 'gap' 让视图层重取权威时间线;重连回放(旧 seq 重复投递)与会话隔离不得误报。
+  const seqTracker = createAcpEventSeqTracker();
+  assert.equal(seqTracker.note('session-1', 0), 'ignored', 'non-positive seq carries no ordering signal');
+  assert.equal(seqTracker.note('', 3), 'ignored', 'a missing session id carries no ordering signal');
+  assert.equal(seqTracker.note('session-1', 1), 'ok', 'first observed envelope sets the baseline');
+  assert.equal(seqTracker.note('session-1', 2), 'ok', 'in-order successor is not a gap');
+  assert.equal(
+    seqTracker.note('session-1', 5),
+    'gap',
+    'a live event after a skipped predecessor (seq 3/4 never delivered) must be flagged',
+  );
+  assert.equal(seqTracker.note('session-1', 6), 'ok', 'stream stays continuous after the gap');
+  assert.equal(seqTracker.note('session-1', 6), 'duplicate', 'reconnect replay must not retrigger a resync');
+  assert.equal(seqTracker.note('session-1', 4), 'duplicate', 'late replayed predecessors stay ignored');
+  assert.equal(seqTracker.note('session-2', 9), 'ok', 'other sessions track an independent baseline');
+  seqTracker.rebase('session-2', 12);
+  assert.equal(seqTracker.note('session-2', 13), 'ok', 'snapshot rebase advances the baseline without a gap');
+  seqTracker.rebase('session-1', 2);
+  assert.equal(seqTracker.note('session-1', 7), 'ok', 'rebase never regresses a live-advanced baseline');
+
   const liveAfterSnapshot = event(14, 'agent_message_chunk', {
     update: { content: { type: 'text', text: '重连期间到达' } },
   });

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -36,6 +36,7 @@ try {
     buildElicitationContent,
     commandExecutionDetails,
     createAcpEventSeqTracker,
+    createAcpGapResyncScheduler,
     mergeAcpTimelineSnapshot,
     projectAcpTimeline,
     resolveAcpSessionControls,
@@ -243,8 +244,10 @@ try {
   assert.equal(appendAcpEvent(events, events[0]).length, events.length, 'duplicate seq must be ignored');
   assert.equal(appendAcpEvent(events.slice(0, 2), events[2]).length, 3);
 
-  // 看门狗跳过停滞前序后,Web 直播流出现 envelope-seq 空洞:跟踪器必须报告
-  // 'gap' 让视图层重取权威时间线;重连回放(旧 seq 重复投递)与会话隔离不得误报。
+  // After the watchdog skips a stalled predecessor, the web live stream shows
+  // an envelope-seq hole: the tracker must report 'gap' so the view layer can
+  // refetch the authoritative timeline; reconnect replay (duplicate delivery
+  // of older seqs) and session isolation must not misreport.
   const seqTracker = createAcpEventSeqTracker();
   assert.equal(seqTracker.note('session-1', 0), 'ignored', 'non-positive seq carries no ordering signal');
   assert.equal(seqTracker.note('', 3), 'ignored', 'a missing session id carries no ordering signal');
@@ -263,6 +266,119 @@ try {
   assert.equal(seqTracker.note('session-2', 13), 'ok', 'snapshot rebase advances the baseline without a gap');
   seqTracker.rebase('session-1', 2);
   assert.equal(seqTracker.note('session-1', 7), 'ok', 'rebase never regresses a live-advanced baseline');
+
+  // A transient resync failure must not permanently disable healing: note()
+  // advances its baseline before reporting 'gap', so later live envelopes
+  // look continuous and never retrigger on their own. The scheduler retries
+  // a failed resync with exponential backoff until an attempt succeeds or
+  // the attempt budget is exhausted.
+  {
+    const timers = [];
+    const useFakeTimers = () => ({
+      setTimeout: (fn, delay) => {
+        timers.push({ fn, delay });
+        return timers.length;
+      },
+      clearTimeout: (id) => {
+        const pending = timers[id - 1];
+        if (pending) pending.fn = null;
+      },
+    });
+    const attemptLog = [];
+    const retryLog = [];
+    const giveUpLog = [];
+    const makeScheduler = attempts => createAcpGapResyncScheduler(
+      async sessionId => {
+        attemptLog.push(sessionId);
+        if (attemptLog.length < attempts) throw new Error('transient network failure');
+      },
+      {
+        maxAttempts: 5,
+        baseDelayMs: 800,
+        maxDelayMs: 3200,
+        onRetry: (sessionId, attempt, error) => retryLog.push([sessionId, attempt, error.message]),
+        onGiveUp: (sessionId, attempt, error) => giveUpLog.push([sessionId, attempt, error.message]),
+        ...useFakeTimers(),
+      },
+    );
+    const fireNext = () => {
+      const pending = timers.find(entry => entry.fn);
+      assert.ok(pending, 'a timer must be pending when the scheduler expects to fire');
+      const fn = pending.fn;
+      pending.fn = null;
+      fn();
+      return Promise.resolve();
+    };
+    const fireLatest = () => {
+      const pending = timers.filter(entry => entry.fn).pop();
+      assert.ok(pending, 'a timer must be pending when the scheduler expects to fire');
+      const fn = pending.fn;
+      pending.fn = null;
+      fn();
+      return Promise.resolve();
+    };
+
+    // Heal on the second attempt: the first resync fails, the retry lands.
+    const healing = makeScheduler(2);
+    healing.schedule('session-1');
+    assert.equal(timers[0].delay, 800, 'the first attempt is debounced by the base delay');
+    await fireNext();
+    assert.deepEqual(attemptLog, ['session-1'], 'the debounced timer fires one resync attempt');
+    await Promise.resolve();
+    assert.deepEqual(retryLog, [['session-1', 1, 'transient network failure']],
+      'a failed attempt schedules a backoff retry instead of giving up');
+    const backoff = timers.find(entry => entry.fn);
+    assert.equal(backoff.delay, 1600, 'the retry delay doubles after the first failure');
+    await fireNext();
+    await Promise.resolve();
+    assert.deepEqual(attemptLog, ['session-1', 'session-1'],
+      'the retry attempt runs and succeeds, healing the gap');
+    assert.deepEqual(giveUpLog, [], 'no give-up once an attempt succeeds');
+
+    // Exhaust the budget: five consecutive failures stop rescheduling, and a
+    // later gap report starts a fresh cycle with the base delay again.
+    const givingUp = makeScheduler(Infinity);
+    givingUp.schedule('session-2');
+    const delays = [];
+    for (let i = 0; i < 5; i += 1) {
+      const pending = timers.find(entry => entry.fn);
+      assert.ok(pending, `attempt ${i + 1} must have a pending timer`);
+      delays.push(pending.delay);
+      await fireNext();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    assert.deepEqual(delays, [800, 1600, 3200, 3200, 3200],
+      'backoff doubles per failure and is capped at maxDelayMs');
+    assert.equal(attemptLog.length, 7, 'five failing attempts plus the two healing attempts above');
+    assert.deepEqual(giveUpLog, [['session-2', 5, 'transient network failure']],
+      'the scheduler gives up only after the attempt budget is exhausted');
+    assert.ok(!timers.some(entry => entry.fn), 'no timer remains after giving up');
+    givingUp.schedule('session-2');
+    const fresh = timers.find(entry => entry.fn);
+    assert.equal(fresh.delay, 800, 'a fresh gap report after exhaustion restarts at the base delay');
+    givingUp.cancel();
+
+    // A burst of gap reports collapses into one attempt, and cancel() drops
+    // the pending attempt entirely.
+    const debounced = makeScheduler(Infinity);
+    debounced.schedule('session-3');
+    debounced.schedule('session-3');
+    debounced.schedule('session-3');
+    assert.equal(attemptLog.filter(id => id === 'session-3').length, 0, 'nothing fires before the debounce window');
+    const liveTimers = () => timers.filter(entry => entry.fn);
+    assert.equal(liveTimers().length, 1,
+      'a burst of gap reports collapses into a single pending timer');
+    fireLatest();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(attemptLog.filter(id => id === 'session-3').length, 1,
+      'the collapsed timer fires a single resync attempt');
+    debounced.schedule('session-3');
+    assert.equal(liveTimers().length, 1, 'a rescheduled attempt is pending');
+    debounced.cancel();
+    assert.equal(liveTimers().length, 0, 'cancel() drops the pending attempt');
+  }
 
   const liveAfterSnapshot = event(14, 'agent_message_chunk', {
     update: { content: { type: 'text', text: '重连期间到达' } },
@@ -857,12 +973,16 @@ try {
     assert.equal(Array.isArray(Object.getPrototypeOf(content)), false, 'content 保持无原型对象，不得被 __proto__ 赋值改原型');
   }
 
-  // ── M-E journal 探针语义锁定：transport 级（endpoint 活跃）而非订阅者级 ──
-  // #336 把 acp:event 的 projection+journal 门控从「有浏览器订阅者」改为
-  // 「远程端点活跃」：断线窗口（端点在、浏览器暂离）事件仍须进 journal，
-  // 重连 replay 才能补齐；反之把语义改回订阅者级会静默重开断线窗口丢事件。
-  // 锁定三处：manager 探针只看 endpoint；事件侧投影门控走 transport 探针；
-  // AppEventBus 的接线不回退到 subscriber 语义。
+  // ── M-E journal probe semantics lock: transport-level (endpoint active),
+  // not subscriber-level ──
+  // #336 changes the acp:event projection+journal gate from "a browser
+  // subscriber exists" to "a remote endpoint is active": during a disconnect
+  // window (endpoint up, browser temporarily away) events must still be
+  // journaled so reconnect replay can backfill; reverting to the subscriber
+  // semantics would silently reopen that disconnect window and drop events.
+  // Three places are locked: the manager probe looks only at the endpoint;
+  // the event-side projection gate uses the transport probe; the AppEventBus
+  // wiring must not fall back to subscriber semantics.
   {
     const managerMod = readFileSync(
       path.join(root, 'src-tauri', 'src', 'features', 'remote_control', 'manager', 'mod.rs'),

--- a/pinvou3-app/tests/ui_language_coverage.test.mjs
+++ b/pinvou3-app/tests/ui_language_coverage.test.mjs
@@ -123,7 +123,9 @@ assert.match(main, /<LazyToolStoreView[^>]*t=\{t\}/);
 assert.match(main, /<WebConnectionStatus[^>]*t=\{t\}/);
 assert.match(main, /<SettingsErrorBoundary[^>]*t=\{t\}/);
 assert.match(viewLoaders, new RegExp("codex: \\(\\) => import\\('\\.\\./features/codex/CodexAcpView\\.jsx'\\)"));
-assert.match(main, /<LazyCodexAcpView[^>]*t=\{t\}/);
+// 主窗口经 LazyCodexAcpView 包装渲染(wrapper 内部消费同一 view-loaders chunk),
+// 错误兜底文案仍走 i18n。
+assert.match(main, /<CodexAcpView[^>]*t=\{t\}/);
 const settingsErrorBoundary = source('features/settings/SettingsErrorBoundary.jsx');
 assert.match(settingsErrorBoundary, /settingsCopy\.settingsLoadFailed/);
 assert.doesNotMatch(settingsErrorBoundary, />设置页加载失败</);

--- a/pinvou3-app/tests/ui_language_coverage.test.mjs
+++ b/pinvou3-app/tests/ui_language_coverage.test.mjs
@@ -123,8 +123,9 @@ assert.match(main, /<LazyToolStoreView[^>]*t=\{t\}/);
 assert.match(main, /<WebConnectionStatus[^>]*t=\{t\}/);
 assert.match(main, /<SettingsErrorBoundary[^>]*t=\{t\}/);
 assert.match(viewLoaders, new RegExp("codex: \\(\\) => import\\('\\.\\./features/codex/CodexAcpView\\.jsx'\\)"));
-// 主窗口经 LazyCodexAcpView 包装渲染(wrapper 内部消费同一 view-loaders chunk),
-// 错误兜底文案仍走 i18n。
+// The main window renders codex through the LazyCodexAcpView wrapper (which
+// internally consumes the same view-loaders chunk); its error fallback copy
+// still flows through i18n.
 assert.match(main, /<CodexAcpView[^>]*t=\{t\}/);
 const settingsErrorBoundary = source('features/settings/SettingsErrorBoundary.jsx');
 assert.match(settingsErrorBoundary, /settingsCopy\.settingsLoadFailed/);

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -438,12 +438,15 @@ assert.match(hostFilePicker, /issueWorkspaceHandle:\s*true/,
   'the one-shot host capability must be minted on confirm');
 assert.match(hostFilePicker, /issueWorkspaceHandle:\s*false/,
   'directory browsing must not mint one-shot workspace handles');
-assert.match(hostFilePicker, /(?:var|const|let) confirmedPath = currentPath;[\s\S]{0,400}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
+assert.match(hostFilePicker, /(?:var|const|let) confirmedPath = currentPath;[\s\S]{0,600}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
   'workspace selection must finish with the click-time path and the handle minted for it');
 assert.doesNotMatch(hostFilePicker, /currentWorkspaceHandle/,
   'browsing never carries a workspace handle, so no stale-handle fallback path may remain');
 assert.match(hostFilePicker, /localizedPickerError/,
   'both the listing and confirm-mint failures must map stable authorization codes to localized copy');
+assert.match(hostFilePicker,
+  /(?:var|const|let) confirmedGeneration = loadGeneration;[\s\S]{0,900}if \(disposed \|\| confirmedGeneration !== loadGeneration\) return;/,
+  'a late confirm-mint failure must not touch the UI after the picker closed or a newer listing rendered');
 assert.match(remoteControlManager,
   /HOST_WORKSPACE_NOT_AUTHORIZED:\s*&str\s*=\s*"host_workspace_not_authorized"[\s\S]*?Err\(HOST_WORKSPACE_NOT_AUTHORIZED\.to_string\(\)\)/,
   'the desktop and browser must share the stable host-workspace authorization error code');

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -411,9 +411,11 @@ assert.doesNotMatch(codexView,
 assert.match(acpErrors, /CONTROLLED_WEB_ERROR[\s\S]*?copy\.operationFailed/,
   'controlled Web error codes must become localized UI copy instead of raw browser text');
 
-// 上传完整性失败必须回稳定 wire code,由 Web 客户端映射为三语文案;中文原文
-// 不得再经 Relay 透传给 en/ja 用户(评审 P2)。web_access_upload_attachment_chunk
-// 同时服务普通会话与 ACP 代码模式,两侧展示路径都必须识别这两个码。
+// Upload integrity failures must surface a stable wire code that the web
+// client maps to trilingual copy; the Chinese raw text must no longer pass
+// through the Relay to en/ja users (review P2).
+// web_access_upload_attachment_chunk serves both plain sessions and the ACP
+// code mode, so both display paths must recognize these two codes.
 assert.match(remoteControlManager, /WEB_ATTACHMENT_DIGEST_INVALID: &str = "web_attachment_digest_invalid"/,
   'the malformed-digest failure must be a stable wire code');
 assert.match(remoteControlManager, /WEB_ATTACHMENT_INTEGRITY_MISMATCH: &str = "web_attachment_integrity_mismatch"/,
@@ -439,15 +441,17 @@ assert.equal((i18n.match(/deviceUploadDigestInvalid:/g) || []).length, 3,
 assert.equal((i18n.match(/deviceUploadIntegrityMismatch:/g) || []).length, 3,
   'the ACP mismatch copy must exist in all three i18n dictionaries');
 
-// 看门狗跳过停滞前序后,Web 直播流出现 envelope-seq 空洞;监听器必须检测跳号
-// 并防抖重取权威时间线自愈(不再只能等重连/重开会话),合并后推进跟踪器基线。
+// After the watchdog skips a stalled predecessor, the web live stream shows
+// an envelope-seq hole; the listener must detect the jump and debounce-refetch
+// the authoritative timeline to self-heal (instead of waiting for a
+// reconnect/session reopen), merging the snapshot and rebasing the tracker.
 assert.match(codexView, /acpEventSeqTrackerRef\.current\.note\(incoming\.sessionId, incoming\.seq\) === 'gap'[\s\S]*?scheduleAcpGapResync\(incoming\.sessionId\)/,
   'the live acp:event listener must detect envelope-seq gaps and schedule a resync');
-assert.match(codexView, /setTimeout\([\s\S]*?resyncAcpSessionAfterGap\(sessionId\)[\s\S]*?\}, 800\)/,
-  'the gap resync must be debounced');
+assert.match(codexView, /createAcpGapResyncScheduler\(sessionId => \{[\s\S]*?resyncAcpSessionAfterGap\(sessionId\);[\s\S]*?\}, \{/,
+  'the gap resync must go through the bounded-retry scheduler wrapping resyncAcpSessionAfterGap');
 assert.match(codexView, /mergeAcpTimelineSnapshot\(timeline, current, sessionId\)[\s\S]*?rebaseAcpEventSeqTracker\(sessionId, timeline\)/,
   'the gap resync must merge the authoritative snapshot and rebase the tracker');
-assert.match(codexView, /clearTimeout\(acpGapResyncTimerRef\.current\)/,
+assert.match(codexView, /acpGapResyncRef\.current\.cancel\(\)/,
   'the pending gap resync must be cancelled on unmount');
 
 assert.match(bootstrap, /sendRaw\(\{ \.\.\.value, v: protocolVersion, lease_id: this\.leaseId \}\)/);

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -3,47 +3,53 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// Source-regex assertions use bounded character gaps (e.g. [\s\S]{0,200});
+// a Windows checkout with core.autocrlf=true inflates those gaps with \r
+// characters, so normalize line endings before matching.
+const readSource = (filePath, encoding) =>
+  fs.readFileSync(filePath, encoding).replace(/\r\n/g, '\n');
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const bridgeRoot = path.join(root, 'src', 'platform', 'tauri');
-const chunkedUpload = fs.readFileSync(
+const chunkedUpload = readSource(
   path.join(root, 'src', 'shared', 'chunked-file-upload.js'),
   'utf8',
 );
-const webBridge = fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'bridge.js'), 'utf8');
-const webDomainAdapter = fs.readFileSync(
+const webBridge = readSource(path.join(root, 'src', 'platform', 'web', 'bridge.js'), 'utf8');
+const webDomainAdapter = readSource(
   path.join(root, 'src', 'platform', 'web', 'bridge', 'domain-adapter.js'),
   'utf8',
 );
-const attachmentDropController = fs.readFileSync(
+const attachmentDropController = readSource(
   path.join(root, 'src', 'features', 'attachments', 'attachment-drop-controller.js'),
   'utf8',
 );
-const attachmentDropHook = fs.readFileSync(
+const attachmentDropHook = readSource(
   path.join(root, 'src', 'features', 'attachments', 'useAttachmentDrop.js'),
   'utf8',
 );
-const desktopRemoteControlBridge = fs.readFileSync(
+const desktopRemoteControlBridge = readSource(
   path.join(bridgeRoot, 'bridge', 'remote-control.js'),
   'utf8',
 );
-const desktopSessionsBridge = fs.readFileSync(
+const desktopSessionsBridge = readSource(
   path.join(bridgeRoot, 'bridge', 'sessions.js'),
   'utf8',
 );
 const desktopBridgeSources = [
-  fs.readFileSync(path.join(bridgeRoot, 'bridge.js'), 'utf8'),
+  readSource(path.join(bridgeRoot, 'bridge.js'), 'utf8'),
   ...fs.readdirSync(path.join(bridgeRoot, 'bridge'))
     .filter(name => name.endsWith('.js'))
     .sort() // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic order of the string array is the asserted expectation
-    .map(name => fs.readFileSync(path.join(bridgeRoot, 'bridge', name), 'utf8')),
+    .map(name => readSource(path.join(bridgeRoot, 'bridge', name), 'utf8')),
 ];
 const bridge = [
   webBridge,
   webDomainAdapter,
   ...desktopBridgeSources,
 ].join('\n');
-const bootstrap = fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'bootstrap.js'), 'utf8');
-const hostFilePicker = fs.readFileSync(
+const bootstrap = readSource(path.join(root, 'src', 'platform', 'web', 'bootstrap.js'), 'utf8');
+const hostFilePicker = readSource(
   path.join(root, 'src', 'platform', 'web', 'host-file-picker.js'),
   'utf8',
 );
@@ -51,9 +57,9 @@ const commandsRoot = path.join(root, 'src-tauri', 'src', 'app', 'commands');
 const commands = fs.readdirSync(commandsRoot)
   .filter(name => name.endsWith('.rs'))
   .sort() // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic order of the string array is the asserted expectation
-  .map(name => fs.readFileSync(path.join(commandsRoot, name), 'utf8'))
+  .map(name => readSource(path.join(commandsRoot, name), 'utf8'))
   .join('\n');
-const remoteControlCommands = fs.readFileSync(path.join(commandsRoot, 'remote_control.rs'), 'utf8');
+const remoteControlCommands = readSource(path.join(commandsRoot, 'remote_control.rs'), 'utf8');
 const remoteControlManagerRoot = path.join(
   root,
   'src-tauri',
@@ -65,7 +71,7 @@ const remoteControlManagerRoot = path.join(
 const remoteControlManager = fs.readdirSync(remoteControlManagerRoot)
   .filter(name => name.endsWith('.rs'))
   .sort() // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic order of the string array is the asserted expectation
-  .map(name => fs.readFileSync(path.join(remoteControlManagerRoot, name), 'utf8'))
+  .map(name => readSource(path.join(remoteControlManagerRoot, name), 'utf8'))
   .join('\n');
 const remoteControlPlatformRoot = path.join(
   root,
@@ -78,34 +84,34 @@ const remoteControlPlatformRoot = path.join(
 const remoteControlPlatform = fs.readdirSync(remoteControlPlatformRoot)
   .filter(name => name.endsWith('.rs'))
   .sort() // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic order of the string array is the asserted expectation
-  .map(name => fs.readFileSync(path.join(remoteControlPlatformRoot, name), 'utf8'))
+  .map(name => readSource(path.join(remoteControlPlatformRoot, name), 'utf8'))
   .join('\n');
-const settingsView = fs.readFileSync(path.join(root, 'src', 'features', 'settings', 'SettingsView.jsx'), 'utf8');
-const artifactsPanel = fs.readFileSync(path.join(root, 'src', 'features', 'artifacts', 'ArtifactsPanel.jsx'), 'utf8');
-const toolStoreView = fs.readFileSync(path.join(root, 'src', 'features', 'tools', 'ToolStoreView.jsx'), 'utf8');
-const toolRenderers = fs.readFileSync(path.join(root, 'src', 'features', 'tools', 'tool-renderers.jsx'), 'utf8');
-const knowledgeView = fs.readFileSync(path.join(root, 'src', 'features', 'knowledge', 'KnowledgeView.jsx'), 'utf8');
-const toolCommon = fs.readFileSync(path.join(root, 'src', 'features', 'tools', 'tool-common.jsx'), 'utf8');
-const connectionStatus = fs.readFileSync(path.join(root, 'src', 'features', 'web', 'WebConnectionStatus.jsx'), 'utf8');
-const chatView = fs.readFileSync(path.join(root, 'src', 'features', 'chat', 'ChatView.jsx'), 'utf8');
-const codexView = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'CodexAcpView.jsx'), 'utf8');
-const acpRuntimeNotices = fs.readFileSync(
+const settingsView = readSource(path.join(root, 'src', 'features', 'settings', 'SettingsView.jsx'), 'utf8');
+const artifactsPanel = readSource(path.join(root, 'src', 'features', 'artifacts', 'ArtifactsPanel.jsx'), 'utf8');
+const toolStoreView = readSource(path.join(root, 'src', 'features', 'tools', 'ToolStoreView.jsx'), 'utf8');
+const toolRenderers = readSource(path.join(root, 'src', 'features', 'tools', 'tool-renderers.jsx'), 'utf8');
+const knowledgeView = readSource(path.join(root, 'src', 'features', 'knowledge', 'KnowledgeView.jsx'), 'utf8');
+const toolCommon = readSource(path.join(root, 'src', 'features', 'tools', 'tool-common.jsx'), 'utf8');
+const connectionStatus = readSource(path.join(root, 'src', 'features', 'web', 'WebConnectionStatus.jsx'), 'utf8');
+const chatView = readSource(path.join(root, 'src', 'features', 'chat', 'ChatView.jsx'), 'utf8');
+const codexView = readSource(path.join(root, 'src', 'features', 'codex', 'CodexAcpView.jsx'), 'utf8');
+const acpRuntimeNotices = readSource(
   path.join(root, 'src', 'features', 'codex', 'AcpRuntimeNotices.jsx'),
   'utf8',
 );
-const codexWorkspacePanel = fs.readFileSync(
+const codexWorkspacePanel = readSource(
   path.join(root, 'src', 'features', 'codex', 'CodexWorkspacePanel.jsx'),
   'utf8',
 );
-const codeViewerModal = fs.readFileSync(
+const codeViewerModal = readSource(
   path.join(root, 'src', 'features', 'codex', 'CodeViewerModal.jsx'),
   'utf8',
 );
-const acpPlatformClient = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
-const acpErrors = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpErrors.js'), 'utf8');
-const i18n = ['zh', 'en', 'ja'].map((l) => fs.readFileSync(path.join(root, 'src', 'shared', 'i18n', `${l}.js`), 'utf8')).join('\n'); // 拆分后三语在 i18n/ 目录
-const appMain = fs.readFileSync(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
-const policy = JSON.parse(fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'access-policy.json'), 'utf8'));
+const acpPlatformClient = readSource(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
+const acpErrors = readSource(path.join(root, 'src', 'features', 'codex', 'acpErrors.js'), 'utf8');
+const i18n = ['zh', 'en', 'ja'].map((l) => readSource(path.join(root, 'src', 'shared', 'i18n', `${l}.js`), 'utf8')).join('\n'); // 拆分后三语在 i18n/ 目录
+const appMain = readSource(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
+const policy = JSON.parse(readSource(path.join(root, 'src', 'platform', 'web', 'access-policy.json'), 'utf8'));
 const allowed = new Set(policy.allowed_commands);
 const allowedEvents = new Set(policy.allowed_events);
 
@@ -535,7 +541,7 @@ assert.match(bootstrap, /state_ready: stateReady/);
 assert.match(bootstrap, /markStateReady\(\)/);
 assert.match(bootstrap, /if \(!this\.frontendReady \|\| !this\.stateReady\)/);
 assert.match(bootstrap, /if \(!this\.frontendReady \|\| !this\.stateReady\)/);
-const main = fs.readFileSync(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
+const main = readSource(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
 const webSearchRestartBody = webBridge.slice(
   webBridge.indexOf('async function saveSearchSettingsAndRestart'),
   webBridge.indexOf('async function submitFeedback'),
@@ -690,7 +696,7 @@ assert.match(bridge, /if \(client && !client\.stateReady\) \{[\s\S]{0,120}initPr
 // UI mutation affordances must follow the browser capability allowlist while
 // leaving desktop defaults and per-session model switching intact.
 assert.match(settingsView, /const canManageModels = can\('modelManagement'\);/);
-const composerShared = fs.readFileSync(path.join(root, 'src', 'features', 'settings', 'composer-shared.jsx'), 'utf8');
+const composerShared = readSource(path.join(root, 'src', 'features', 'settings', 'composer-shared.jsx'), 'utf8');
 assert.match(composerShared, /const canSwitchModels = can\('sessionModelSwitch'\);/);
 assert.match(composerShared, /const canMutateToolStore = can\('toolStoreMutations'\);/);
 assert.match(composerShared, /const toolSwitchDisabled = !canMutateToolStore;/);
@@ -724,7 +730,7 @@ assert.ok(
   (codexView.match(/notifyChatRoundCommitted\('code'\);/g) || []).length >= 2,
   'native code lane send and accept-plan must each commit pending enables',
 );
-const toolEvents = fs.readFileSync(path.join(root, 'src', 'features', 'tools', 'tool-events.js'), 'utf8');
+const toolEvents = readSource(path.join(root, 'src', 'features', 'tools', 'tool-events.js'), 'utf8');
 assert.match(toolEvents, /export \{ notifyComposerToolsChanged, notifyChatRoundCommitted \};/);
 assert.match(composerShared, /bridge\.models\.switchModel\(activeSessionId, id\)/);
 assert.match(settingsView, /\{canManageModels && editingModel && \(/);
@@ -773,7 +779,7 @@ assert.match(desktopRemoteControlBridge, /listen\("web_access:status"/,
   'desktop bridge must consume live browser connection status events');
 assert.match(desktopRemoteControlBridge, /web_client_connected: false, host_workspace_authorized: false, status: "stopped"/,
   'stopping remote access must clear any stale connected state');
-const desktopBridge = fs.readFileSync(path.join(bridgeRoot, 'bridge.js'), 'utf8');
+const desktopBridge = readSource(path.join(bridgeRoot, 'bridge.js'), 'utf8');
 assert.match(desktopBridge, /web_client_connected: false/,
   'desktop bridge state must start with an explicit disconnected browser state');
 for (const source of [settingsView, connectionStatus]) {

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -103,7 +103,6 @@ const codeViewerModal = fs.readFileSync(
 );
 const acpPlatformClient = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
 const acpErrors = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpErrors.js'), 'utf8');
-const acpClient = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
 const i18n = ['zh', 'en', 'ja'].map((l) => fs.readFileSync(path.join(root, 'src', 'shared', 'i18n', `${l}.js`), 'utf8')).join('\n'); // 拆分后三语在 i18n/ 目录
 const appMain = fs.readFileSync(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
 const policy = JSON.parse(fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'access-policy.json'), 'utf8'));
@@ -400,10 +399,10 @@ assert.equal(allowed.has('respond_codex_acp_elicitation'), false,
   'Web must not call the native ACP elicitation response command');
 assert.equal(allowed.has('web_access_respond_codex_acp_permission'), true);
 assert.equal(allowed.has('web_access_respond_codex_acp_elicitation'), true);
-assert.match(acpClient,
+assert.match(acpPlatformClient,
   /respond_codex_acp_permission',[\s\S]*?'web_access_respond_codex_acp_permission'/,
   'permission responses must preserve the native command and use a stable Web wrapper');
-assert.match(acpClient,
+assert.match(acpPlatformClient,
   /respond_codex_acp_elicitation',[\s\S]*?'web_access_respond_codex_acp_elicitation'/,
   'elicitation responses must preserve the native command and use a stable Web wrapper');
 assert.doesNotMatch(codexView,

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -103,6 +103,7 @@ const codeViewerModal = fs.readFileSync(
 );
 const acpPlatformClient = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
 const acpErrors = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpErrors.js'), 'utf8');
+const acpClient = fs.readFileSync(path.join(root, 'src', 'features', 'codex', 'acpClient.js'), 'utf8');
 const i18n = ['zh', 'en', 'ja'].map((l) => fs.readFileSync(path.join(root, 'src', 'shared', 'i18n', `${l}.js`), 'utf8')).join('\n'); // 拆分后三语在 i18n/ 目录
 const appMain = fs.readFileSync(path.join(root, 'src', 'app', 'main.jsx'), 'utf8');
 const policy = JSON.parse(fs.readFileSync(path.join(root, 'src', 'platform', 'web', 'access-policy.json'), 'utf8'));
@@ -348,31 +349,33 @@ assert.match(webBridge,
   /IS_WEB \? "web_access_list_sessions" : "list_sessions"[\s\S]*?IS_WEB \? "web_access_list_archived_sessions" : "list_archived_sessions"/,
   'Web history refreshes must use path-redacted session list commands');
 assert.match(remoteControlCommands,
-  /fn web_workspace_result[\s\S]*?web_workspace_\{operation\}_failed[\s\S]*?web_access_list_codex_workspace[\s\S]*?web_workspace_result\("listing", result\)[\s\S]*?web_access_search_codex_workspace[\s\S]*?web_workspace_result\("search", result\)[\s\S]*?web_access_preview_codex_workspace_file[\s\S]*?web_workspace_result\("preview", result\)[\s\S]*?web_access_get_codex_workspace_changes[\s\S]*?web_workspace_result\("changes", result\)[\s\S]*?web_access_get_codex_workspace_diff[\s\S]*?web_workspace_result\("diff", result\)/,
+  /fn web_workspace_result[\s\S]*?web_workspace_\{\}_failed", operation\.as_str\(\)[\s\S]*?web_access_list_codex_workspace[\s\S]*?web_workspace_result\(WebWorkspaceOperation::Listing, result\)[\s\S]*?web_access_search_codex_workspace[\s\S]*?web_workspace_result\(WebWorkspaceOperation::Search, result\)[\s\S]*?web_access_preview_codex_workspace_file[\s\S]*?web_workspace_result\(WebWorkspaceOperation::Preview, result\)[\s\S]*?web_access_get_codex_workspace_changes[\s\S]*?web_workspace_result\(WebWorkspaceOperation::Changes, result\)[\s\S]*?web_access_get_codex_workspace_diff[\s\S]*?web_workspace_result\(WebWorkspaceOperation::Diff, result\)/,
   'Web workspace RPC failures must not return host paths embedded in native errors');
 assert.match(remoteControlCommands,
-  /web_access_get_codex_acp_timeline[\s\S]*?web_acp_result\([\s\S]*?"timeline"/,
+  /web_access_get_codex_acp_timeline[\s\S]*?web_acp_result\(WebAcpOperation::Timeline/,
   'Web ACP timeline failures must cross Relay as a controlled error code');
-for (const [command, operation] of Object.entries({
-  web_access_create_codex_acp_session: 'session_create',
-  web_access_cancel_codex_acp: 'cancel',
-  web_access_codex_acp_prompt: 'prompt',
-  web_access_get_codex_acp_timeline: 'timeline',
-  web_access_get_codex_acp_session_info: 'session_info',
-  web_access_set_codex_acp_model: 'set_model',
-  web_access_set_codex_acp_mode: 'set_mode',
-  web_access_set_codex_acp_config_option: 'set_config_option',
-  web_access_get_codex_acp_pending_permissions: 'pending_permissions',
-  web_access_respond_codex_acp_permission: 'respond_permission',
-  web_access_get_codex_acp_pending_elicitations: 'pending_elicitations',
-  web_access_respond_codex_acp_elicitation: 'respond_elicitation',
-  web_access_list_codex_acp_sessions: 'list_sessions',
-  web_access_list_acp_agents: 'list_agents',
-  web_access_get_acp_agent_status: 'agent_status',
+// Every web_access_* ACP command maps failures through a WebAcpOperation enum
+// variant; the Rust test stable_web_error_codes_are_locked pins the wire codes.
+for (const [command, variant] of Object.entries({
+  web_access_create_codex_acp_session: 'SessionCreate',
+  web_access_cancel_codex_acp: 'Cancel',
+  web_access_codex_acp_prompt: 'Prompt',
+  web_access_get_codex_acp_timeline: 'Timeline',
+  web_access_get_codex_acp_session_info: 'SessionInfo',
+  web_access_set_codex_acp_model: 'SetModel',
+  web_access_set_codex_acp_mode: 'SetMode',
+  web_access_set_codex_acp_config_option: 'SetConfigOption',
+  web_access_get_codex_acp_pending_permissions: 'PendingPermissions',
+  web_access_respond_codex_acp_permission: 'RespondPermission',
+  web_access_get_codex_acp_pending_elicitations: 'PendingElicitations',
+  web_access_respond_codex_acp_elicitation: 'RespondElicitation',
+  web_access_list_codex_acp_sessions: 'ListSessions',
+  web_access_list_acp_agents: 'ListAgents',
+  web_access_get_acp_agent_status: 'AgentStatus',
 })) {
   assert.match(
     rustCommandBlock(remoteControlCommands, command),
-    new RegExp(`web_acp_result\\("${operation}"`),
+    new RegExp(`web_acp_result\\(WebAcpOperation::${variant}`),
     `${command} must map every failure to its stable Web ACP error code`,
   );
 }
@@ -397,12 +400,15 @@ assert.equal(allowed.has('respond_codex_acp_elicitation'), false,
   'Web must not call the native ACP elicitation response command');
 assert.equal(allowed.has('web_access_respond_codex_acp_permission'), true);
 assert.equal(allowed.has('web_access_respond_codex_acp_elicitation'), true);
-assert.match(codexView,
-  /isWeb \? 'web_access_respond_codex_acp_permission' : 'respond_codex_acp_permission'/,
+assert.match(acpClient,
+  /respond_codex_acp_permission',[\s\S]*?'web_access_respond_codex_acp_permission'/,
   'permission responses must preserve the native command and use a stable Web wrapper');
-assert.match(codexView,
-  /isWeb \? 'web_access_respond_codex_acp_elicitation' : 'respond_codex_acp_elicitation'/,
+assert.match(acpClient,
+  /respond_codex_acp_elicitation',[\s\S]*?'web_access_respond_codex_acp_elicitation'/,
   'elicitation responses must preserve the native command and use a stable Web wrapper');
+assert.doesNotMatch(codexView,
+  /isWeb \? 'web_access_respond_/,
+  'the view must route permission/elicitation responses through the acp client');
 assert.match(acpErrors, /CONTROLLED_WEB_ERROR[\s\S]*?copy\.operationFailed/,
   'controlled Web error codes must become localized UI copy instead of raw browser text');
 
@@ -429,12 +435,16 @@ assert.doesNotMatch(hostFilePicker, /Array\.isArray\(listing\.roots\) && !parent
   'filesystem roots must not be mixed into a drive directory listing');
 assert.match(hostFilePicker, /openWorkspace:/,
   'the host picker must expose a dedicated code-workspace selection flow');
-assert.match(hostFilePicker, /issueWorkspaceHandle:\s*options\.workspaceGrant === true/,
-  'only workspace selection should request a one-shot host capability');
-assert.match(hostFilePicker, /workspaceHandle:\s*currentWorkspaceHandle/,
-  'workspace selection must return the host-issued handle with its display path');
-assert.match(hostFilePicker, /message === "host_workspace_not_authorized"[\s\S]{0,120}workspaceNotAuthorized/,
-  'an unapproved legacy endpoint must receive a localized desktop-authorization prompt');
+assert.match(hostFilePicker, /issueWorkspaceHandle:\s*true/,
+  'the one-shot host capability must be minted on confirm');
+assert.match(hostFilePicker, /issueWorkspaceHandle:\s*false/,
+  'directory browsing must not mint one-shot workspace handles');
+assert.match(hostFilePicker, /(?:var|const|let) confirmedPath = currentPath;[\s\S]{0,400}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
+  'workspace selection must finish with the click-time path and the handle minted for it');
+assert.doesNotMatch(hostFilePicker, /currentWorkspaceHandle/,
+  'browsing never carries a workspace handle, so no stale-handle fallback path may remain');
+assert.match(hostFilePicker, /localizedPickerError/,
+  'both the listing and confirm-mint failures must map stable authorization codes to localized copy');
 assert.match(remoteControlManager,
   /HOST_WORKSPACE_NOT_AUTHORIZED:\s*&str\s*=\s*"host_workspace_not_authorized"[\s\S]*?Err\(HOST_WORKSPACE_NOT_AUTHORIZED\.to_string\(\)\)/,
   'the desktop and browser must share the stable host-workspace authorization error code');

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -438,7 +438,7 @@ assert.match(hostFilePicker, /issueWorkspaceHandle:\s*true/,
   'the one-shot host capability must be minted on confirm');
 assert.match(hostFilePicker, /issueWorkspaceHandle:\s*false/,
   'directory browsing must not mint one-shot workspace handles');
-assert.match(hostFilePicker, /(?:var|const|let) confirmedPath = currentPath;[\s\S]{0,600}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
+assert.match(hostFilePicker, /(?:var|const|let) confirmedPath = currentPath;[\s\S]{0,1000}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
   'workspace selection must finish with the click-time path and the handle minted for it');
 assert.doesNotMatch(hostFilePicker, /currentWorkspaceHandle/,
   'browsing never carries a workspace handle, so no stale-handle fallback path may remain');
@@ -447,6 +447,16 @@ assert.match(hostFilePicker, /localizedPickerError/,
 assert.match(hostFilePicker,
   /(?:var|const|let) confirmedGeneration = loadGeneration;[\s\S]{0,900}if \(disposed \|\| confirmedGeneration !== loadGeneration\) return;/,
   'a late confirm-mint failure must not touch the UI after the picker closed or a newer listing rendered');
+assert.match(hostFilePicker,
+  /\.then\(function \(listing\) \{[\s\S]{0,600}if \(disposed \|\| confirmedGeneration !== loadGeneration\) return;[\s\S]{0,200}finish\(\{ path: confirmedPath, workspaceHandle: handle \}\);/,
+  'a late confirm-mint success must not close the picker on a directory the user already navigated away from');
+assert.match(hostFilePicker, /mintInFlight = true;/,
+  'the confirm handler must mark the mint as in flight before its RPC');
+assert.match(hostFilePicker,
+  /confirm\.disabled = mintInFlight \|\| \(directoryMode \? !currentPath : count === 0\);/,
+  'navigation must not re-enable the confirm button while a mint is still in flight');
+assert.match(hostFilePicker, /(?:var|const|let) generation = \+\+loadGeneration;\s*\n\s*mintInFlight = false;/,
+  'navigation must supersede any in-flight mint instead of racing a second one');
 assert.match(remoteControlManager,
   /HOST_WORKSPACE_NOT_AUTHORIZED:\s*&str\s*=\s*"host_workspace_not_authorized"[\s\S]*?Err\(HOST_WORKSPACE_NOT_AUTHORIZED\.to_string\(\)\)/,
   'the desktop and browser must share the stable host-workspace authorization error code');

--- a/pinvou3-app/tests/web_access_contract.test.mjs
+++ b/pinvou3-app/tests/web_access_contract.test.mjs
@@ -411,6 +411,45 @@ assert.doesNotMatch(codexView,
 assert.match(acpErrors, /CONTROLLED_WEB_ERROR[\s\S]*?copy\.operationFailed/,
   'controlled Web error codes must become localized UI copy instead of raw browser text');
 
+// 上传完整性失败必须回稳定 wire code,由 Web 客户端映射为三语文案;中文原文
+// 不得再经 Relay 透传给 en/ja 用户(评审 P2)。web_access_upload_attachment_chunk
+// 同时服务普通会话与 ACP 代码模式,两侧展示路径都必须识别这两个码。
+assert.match(remoteControlManager, /WEB_ATTACHMENT_DIGEST_INVALID: &str = "web_attachment_digest_invalid"/,
+  'the malformed-digest failure must be a stable wire code');
+assert.match(remoteControlManager, /WEB_ATTACHMENT_INTEGRITY_MISMATCH: &str = "web_attachment_integrity_mismatch"/,
+  'the digest-mismatch failure must be a stable wire code');
+assert.doesNotMatch(remoteControlManager, /远程控制附件完整性校验/,
+  'single-language integrity errors must not cross the Relay');
+assert.match(acpErrors, /'web_attachment_digest_invalid'[\s\S]*?'web_attachment_integrity_mismatch'/,
+  'the session-level fallback must fold both codes into localized copy');
+assert.match(webBridge, /rawUploadError === "web_attachment_digest_invalid"[\s\S]*?bt\("deviceUploadDigestInvalid"\)/,
+  'the Web chat upload path must localize the malformed-digest code');
+assert.match(webBridge, /rawUploadError === "web_attachment_integrity_mismatch"[\s\S]*?bt\("deviceUploadIntegrityMismatch"\)/,
+  'the Web chat upload path must localize the mismatch code');
+assert.equal((webBridge.match(/deviceUploadDigestInvalid:/g) || []).length, 3,
+  'the malformed-digest copy must exist in all three BT_TABLE language blocks');
+assert.equal((webBridge.match(/deviceUploadIntegrityMismatch:/g) || []).length, 3,
+  'the mismatch copy must exist in all three BT_TABLE language blocks');
+assert.match(codexView, /uploadErrorText === 'web_attachment_digest_invalid'[\s\S]*?uiAttachments\.deviceUploadDigestInvalid/,
+  'the ACP attachment path must localize the malformed-digest code');
+assert.match(codexView, /uploadErrorText === 'web_attachment_integrity_mismatch'[\s\S]*?uiAttachments\.deviceUploadIntegrityMismatch/,
+  'the ACP attachment path must localize the mismatch code');
+assert.equal((i18n.match(/deviceUploadDigestInvalid:/g) || []).length, 3,
+  'the ACP malformed-digest copy must exist in all three i18n dictionaries');
+assert.equal((i18n.match(/deviceUploadIntegrityMismatch:/g) || []).length, 3,
+  'the ACP mismatch copy must exist in all three i18n dictionaries');
+
+// 看门狗跳过停滞前序后,Web 直播流出现 envelope-seq 空洞;监听器必须检测跳号
+// 并防抖重取权威时间线自愈(不再只能等重连/重开会话),合并后推进跟踪器基线。
+assert.match(codexView, /acpEventSeqTrackerRef\.current\.note\(incoming\.sessionId, incoming\.seq\) === 'gap'[\s\S]*?scheduleAcpGapResync\(incoming\.sessionId\)/,
+  'the live acp:event listener must detect envelope-seq gaps and schedule a resync');
+assert.match(codexView, /setTimeout\([\s\S]*?resyncAcpSessionAfterGap\(sessionId\)[\s\S]*?\}, 800\)/,
+  'the gap resync must be debounced');
+assert.match(codexView, /mergeAcpTimelineSnapshot\(timeline, current, sessionId\)[\s\S]*?rebaseAcpEventSeqTracker\(sessionId, timeline\)/,
+  'the gap resync must merge the authoritative snapshot and rebase the tracker');
+assert.match(codexView, /clearTimeout\(acpGapResyncTimerRef\.current\)/,
+  'the pending gap resync must be cancelled on unmount');
+
 assert.match(bootstrap, /sendRaw\(\{ \.\.\.value, v: protocolVersion, lease_id: this\.leaseId \}\)/);
 assert.match(bootstrap, /desktopCapabilitiesReady/);
 assert.match(bootstrap, /SEMANTIC_COMMAND_REQUIREMENTS/);


### PR DESCRIPTION
## Summary

Post-merge follow-up for #159 (feat(web): sync ACP code mode and attachment flows). A 13-domain review of the merged change found no blockers, but six major findings and several minor gaps deserved hardening. This PR fixes all of them.

## Background

The merged Web ACP surface had six major issues found during review:

1. `OrderedWebDelivery` waited on a condvar with no timeout; a sequence stuck between allocation and delivery would stall the session's entire event pipeline (timeline persistence, desktop emission, state patches) with no watchdog.
2. The "stable" Web error codes were `format!`-built strings with zero Rust-side locking; the only guard was a JS test regex-matching Rust source text.
3. The lazily-loaded ACP workspace had no error boundary; a failed chunk import (weak network on Web) unmounted the whole app.
4. Switching agents in draft mode stopped forcing a fresh CLI probe, so installs/upgrades outside the app were not reflected without a manual recheck (a regression vs. the pre-#159 behavior).
5. `acp:event` was journaled only while a browser subscriber was attached; events emitted during a disconnect window never reached the journal, so reconnect replay silently missed them.
6. Chunked uploads carried no integrity check: corrupted bytes crossing the (plaintext) Relay were silently assembled, ingested, and handed to the agent.

## Changes

- **Ordered delivery watchdog**: 30s bounded wait, then skip the dead gap with a diagnostic log; late predecessors never double-deliver (`events.rs`, 2 unit tests).
- **Enum-backed stable error codes**: new `WebAcpOperation` / `WebWorkspaceOperation` / `WebSessionOperation` enums replace stringly-typed operations; `stable_web_error_codes_are_locked` pins the full wire-code list (all four `WebSessionOperation` variants included) in Rust. Legacy `web_access_list_sessions` / `list_archived_sessions` / `create_session` fold native errors into stable codes so host paths cannot leak through them.
- **`load_session_chunk` error folding**: the whole command now folds into `web_session_load_session_chunk_failed`; the native error chain (which can embed the host sessions directory via store io errors and previously rendered raw in the web transcript) goes to the desktop log only. `web_session_*_failed` codes are matched by the `CONTROLLED_WEB_ERROR` regex so web users see localized copy.
- **Retryable lazy chunk**: `LazyCodexAcpView` sits behind an error boundary with a retry button; the boundary is remounted per retry attempt (`key`), so the per-attempt `lazy()` component and its fresh dynamic import actually run after a failed chunk load. Dedicated `viewLoading` / `viewLoadFailed` / `viewRetry` copy in zh/en/ja.
- **Draft agent switch re-probes**: `refreshStatus(agent, true)` is restored (the `if (activeId) return` guard still avoids double probing while a session loads).
- **Journal coverage across disconnects**: a new transport-level probe (`has_active_web_transport`) gates projection+journaling on the endpoint being active rather than on a live subscriber; pure desktop usage skips both costs as before.
- **Upload SHA-256 integrity**: the JS uploader attaches a whole-file digest (Web Crypto, defensive fallback to unchecked) to the committing chunk; both the desktop draft stack (`append_chunk`) and the web buffer (`transfer.rs`) verify it before commit/ingest. Malformed digests and mismatches abort the commit. Tests on both stacks.
- **One-shot workspace handles mint on confirm only** — directory browsing no longer mints a grant per visited folder. The confirm-mint failure path maps stable authorization codes to the localized desktop-authorization copy (same as listing failures), and the confirmed path is captured at click time so a navigation landing mid-RPC cannot pair a different display path with the minted handle.
- **Provider switch rejects busy sessions** of the switched session's agent — the restart is agent-wide, so the busy guard now covers every session of that backend instead of hard-killing a sibling's running turn (matches set_model/set_mode semantics).
- **Permission/elicitation responses route through the acp client**, gaining `canInvoke` gating and controlled error codes like every other ACP command.
- **Smaller fixes**: background send failures log via `console.error` instead of vanishing; web `removeQueued` discards queued attachment handles (aligned with desktop); dead `attachmentDragActive` state flag removed from both bridges and its publishing contract flipped; auth/CLI probe cache validity rules (generation / executable / TTL) now have unit tests via a pure `AgentAuthProbeState::cached_auth_valid`.

### Round-2 review hardening (d2e6abda)

- **Unchecked SHA-256 downgrade is now observable**: the JS uploader warns via `console.warn` when Web Crypto is unavailable (insecure origins lose `crypto.subtle` exactly where transfer corruption is most likely), and the web buffer stack logs a desktop-side warning when a commit arrives without a digest. The downgrade itself stays safe and compatible with older WebUIs.
- **M-E journal probe semantics locked by tests**: `codex_acp_timeline` now pins the endpoint-based transport probe (`has_active_web_transport` → `endpoint.is_some()`), the ACP projection gate, and the `AppEventBus` wiring; a regression to subscriber-based gating would fail tests instead of silently reopening disconnect-window event loss.
- **Confirm-mint success path guarded in the host picker**: a mint settling after the user navigated away no longer closes the picker on the stale directory, and navigation keeps the confirm button disabled while a mint is in flight (no double minting); pinned by new `web_access_contract` assertions.
- i18n: the `viewLoading`/`viewLoadFailed`/`viewRetry` keys moved into the per-language chunks introduced by #341; one dropped article in the English `viewLoadFailed` copy was restored.

## Verification

Validated on the branch (rebased on `main@c6329649a`):

- [x] `npm run test:node`: 260 tests, 259 passed, 0 failed, 1 skipped (Linux-only platform skip)
- [x] `npm run lint:ui`, `npm run build:ui`
- [x] `cargo test --lib` domain filters (`codex_acp`, `remote_control`, `files`, `app::commands`, `encoding`): all pass (147 + 236 + 242 across three filter runs)
- [x] `cargo fmt --check`
- [x] `python3 scripts/architecture-guard.py`
- [x] `./scripts/fork-guard.sh --fast`

## Compatibility and known risks

- The SHA-256 parameter is optional on both Rust commands and both upload stacks; older WebUIs keep working unchecked, newer WebUIs verify when Web Crypto is available (non-File inputs degrade gracefully).
- The new `web_session_load_session_chunk_failed` code replaces raw native error text on the chunk-loading path; web consumers previously saw that raw text (which could embed host paths), so behavior is same-or-better. The remaining legacy session commands' codes render through the existing controlled/raw-error fallback, now also matched by `CONTROLLED_WEB_ERROR`.
- Workspace handle minting now happens on confirm; if that single mint fails, the picker stays open with the error instead of failing at session creation later.
- The provider busy guard is broader than the session the user is switching from: any busy sibling session of the same agent blocks the switch until its turn finishes.
- The `CodeWhale` gitlink and fork behavior are unchanged; `docs/fork-modifications.md` is unaffected (no submodule change).
