### PR TITLE
fix: memory leaks and object reuse repo-wide

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -532,6 +532,12 @@ fn visual_cache_insert(
     key: String,
     result: VisualResult,
 ) {
+    // 单条即超字节预算的结果直接不缓存：否则插入后淘汰循环会先把整库
+    // （含无关热条目）清空、最后连它自己也逐出，等于一次大结果抹掉全缓存。
+    // 调用方拿到的响应在插入前已 clone，跳过缓存不影响本次返回。
+    if visual_result_bytes(&result) > MAX_VISUAL_CACHE_BYTES {
+        return;
+    }
     let path = visual_cache_path(&key).to_string();
     state.retain(|k, _| visual_cache_path(k) != path);
     let touched = visual_cache_next_tick();
@@ -661,9 +667,11 @@ fn open_with_libreoffice(path: &std::path::Path) -> Result<(), String> {
         return Err(crate::platform::os::libreoffice_missing_message().into());
     }
 
-    std::process::Command::new(&program)
-        .arg(crate::platform::os::external_application_path(path))
-        .spawn()
+    // spawn 后 drop Child 不回收子进程（Unix 僵尸），统一走点火即忘 +
+    // 收割的平台接口（soffice 首实例可能长驻，收割线程会停驻到其退出）。
+    let mut command = std::process::Command::new(&program);
+    command.arg(crate::platform::os::external_application_path(path));
+    crate::platform::os::spawn_detached_and_reap(&mut command)
         .map_err(|e| format!("LibreOffice 打开失败: {e}"))?;
     Ok(())
 }
@@ -1079,5 +1087,27 @@ mod visual_cache_tests {
             "累计字节应回落到预算内"
         );
         assert!(state.len() >= 1, "至少保留最新一条");
+    }
+
+    #[test]
+    fn over_budget_single_entry_is_skipped_and_keeps_warm_entries() {
+        // 单条结果即超字节预算：不得入库，更不得在淘汰循环里把整库
+        // （含无关热条目）一起抹掉。
+        let mut state = fresh_state();
+        visual_cache_insert(&mut state, "/a/small.pdf|1".into(), result_with(8));
+        visual_cache_insert(
+            &mut state,
+            "/a/huge.pdf|1".into(),
+            result_with(MAX_VISUAL_CACHE_BYTES + 1),
+        );
+        assert_eq!(state.len(), 1);
+        assert!(
+            state.contains_key("/a/small.pdf|1"),
+            "超预算插入不得清掉已有热条目"
+        );
+        assert!(
+            !state.contains_key("/a/huge.pdf|1"),
+            "单条超字节预算的结果不缓存"
+        );
     }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -1034,6 +1034,25 @@ mod visual_cache_tests {
     }
 
     #[test]
+    fn pipe_in_filename_parses_key_on_last_separator() {
+        // 文件名可含 `|`：键解析必须按最后一个分隔符右切（rsplit_once）。
+        // 左切分会把 `/tmp/a|b.pdf|1` 解析成 `/tmp/a`，让同前缀的无关文件
+        // （`/tmp/a|c.pdf`）互相误逐出对方的条目。
+        let mut state = fresh_state();
+        visual_cache_insert(&mut state, "/tmp/a|b.pdf|1".into(), result_with(8));
+        visual_cache_insert(&mut state, "/tmp/a|c.pdf|1".into(), result_with(8));
+        assert_eq!(state.len(), 2, "文件名含 | 的两个不同文件必须共存");
+        assert!(state.contains_key("/tmp/a|b.pdf|1"));
+        assert!(state.contains_key("/tmp/a|c.pdf|1"));
+        // 同名文件（含 |）新 mtime 仍应让位旧条目。
+        visual_cache_insert(&mut state, "/tmp/a|b.pdf|2".into(), result_with(8));
+        assert_eq!(state.len(), 2, "同名含 | 文件按路径让位，不影响邻居");
+        assert!(!state.contains_key("/tmp/a|b.pdf|1"));
+        assert!(state.contains_key("/tmp/a|b.pdf|2"));
+        assert!(state.contains_key("/tmp/a|c.pdf|1"));
+    }
+
+    #[test]
     fn entry_cap_evicts_oldest_touched() {
         let mut state = fresh_state();
         for i in 0..=MAX_VISUAL_CACHE_ENTRIES as u64 {

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -495,9 +495,9 @@ struct VisualCacheEntry {
 }
 
 /// Cache budget: a single result can reach several MB (30-page PDF data
-///     /// URIs / inline-image HTML), and keys embed mtime — every rewrite of the
-///     /// same artifact yields a new key. Without a cap, long sessions accumulate
-///     /// hundreds of MB.
+/// URIs / inline-image HTML), and keys embed mtime — every rewrite of the
+/// same artifact yields a new key. Without a cap, long sessions accumulate
+/// hundreds of MB.
 const MAX_VISUAL_CACHE_ENTRIES: usize = 16;
 const MAX_VISUAL_CACHE_BYTES: usize = 96 * 1024 * 1024;
 
@@ -521,16 +521,16 @@ fn visual_cache_next_tick() -> u64 {
 }
 
 /// Key format is `path|mtime_millis`. Paths on macOS/Linux may contain `|`
-///     /// (a legal filename byte) while the numeric mtime field never does —
-///     /// same-path yielding must split from the right; a left split parses
-///     /// `/tmp/a|b.pdf` as `/tmp/a` and clobbers unrelated entries.
+/// (a legal filename byte) while the numeric mtime field never does —
+/// same-path yielding must split from the right; a left split parses
+/// `/tmp/a|b.pdf` as `/tmp/a` and clobbers unrelated entries.
 fn visual_cache_path(key: &str) -> &str {
     key.rsplit_once('|').map_or(key, |(path, _)| path)
 }
 
 /// Hits refresh the LRU clock; on insert, stale same-path keys yield
-///     /// directly, then the byte+entry dual budget evicts from the
-///     /// least-recently-used side.
+/// directly, then the byte+entry dual budget evicts from the
+/// least-recently-used side.
 fn visual_cache_insert(
     state: &mut std::collections::HashMap<String, VisualCacheEntry>,
     key: String,
@@ -583,8 +583,8 @@ pub async fn render_artifact_visual(path: String) -> Result<VisualResult, String
         return Err(format!("not a file: {}", p.display()));
     }
     // Millisecond precision: an agent's atomic rewrites can emit several
-    //     // versions within the same second; second-granularity mtime would serve
-    //     // the second version a stale preview of the first.
+    // versions within the same second; second-granularity mtime would serve
+    // the second version a stale preview of the first.
     let mtime = std::fs::metadata(&p)
         .and_then(|m| m.modified())
         .ok()
@@ -676,9 +676,9 @@ fn open_with_libreoffice(path: &std::path::Path) -> Result<(), String> {
     }
 
     // Dropping the Child after spawn never reclaims the process (Unix
-    //     // zombies); route through the platform's fire-and-forget + reap
-    //     // interface (the first soffice instance can stay resident, and the
-    //     // reaper thread then parks until it exits).
+    // zombies); route through the platform's fire-and-forget + reap
+    // interface (the first soffice instance can stay resident, and the
+    // reaper thread then parks until it exits).
     let mut command = std::process::Command::new(&program);
     command.arg(crate::platform::os::external_application_path(path));
     crate::platform::os::spawn_detached_and_reap(&mut command)
@@ -1054,9 +1054,9 @@ mod visual_cache_tests {
     #[test]
     fn pipe_in_filename_parses_key_on_last_separator() {
         // Filenames may contain `|`: key parsing must split on the last
-        //         // separator (rsplit_once). A left split parses `/tmp/a|b.pdf|1` as
-        //         // `/tmp/a`, making unrelated files sharing the prefix
-        //         // (`/tmp/a|c.pdf`) evict each other's entries.
+        // separator (rsplit_once). A left split parses `/tmp/a|b.pdf|1` as
+        // `/tmp/a`, making unrelated files sharing the prefix
+        // (`/tmp/a|c.pdf`) evict each other's entries.
         let mut state = fresh_state();
         visual_cache_insert(&mut state, "/tmp/a|b.pdf|1".into(), result_with(8));
         visual_cache_insert(&mut state, "/tmp/a|c.pdf|1".into(), result_with(8));
@@ -1114,8 +1114,8 @@ mod visual_cache_tests {
     #[test]
     fn over_budget_single_entry_is_skipped_and_keeps_warm_entries() {
         // A single result over the byte budget: it must not be inserted,
-        //         // let alone wipe the whole table (including unrelated hot entries)
-        //         // in the eviction loop.
+        // let alone wipe the whole table (including unrelated hot entries)
+        // in the eviction loop.
         let mut state = fresh_state();
         visual_cache_insert(&mut state, "/a/small.pdf|1".into(), result_with(8));
         visual_cache_insert(

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -494,8 +494,10 @@ struct VisualCacheEntry {
     touched: u64,
 }
 
-/// 缓存预算：单条结果可达数 MB（30 页 PDF data URI / 内联图片 HTML），
-/// 且键含 mtime——同一产物每次重写都会产生新键。无上限会让长会话累积数百 MB。
+/// Cache budget: a single result can reach several MB (30-page PDF data
+///     /// URIs / inline-image HTML), and keys embed mtime — every rewrite of the
+///     /// same artifact yields a new key. Without a cap, long sessions accumulate
+///     /// hundreds of MB.
 const MAX_VISUAL_CACHE_ENTRIES: usize = 16;
 const MAX_VISUAL_CACHE_BYTES: usize = 96 * 1024 * 1024;
 
@@ -518,23 +520,28 @@ fn visual_cache_next_tick() -> u64 {
     VISUAL_CACHE_CLOCK.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
-/// 键格式为 `路径|毫秒mtime`。路径在 macOS/Linux 上可含 `|`(合法文件名字节),
-/// mtime 数字段不会——同路径让位判定必须从右侧切分,左侧切分会把 `/tmp/a|b.pdf`
-/// 误解析成 `/tmp/a` 而误伤无关条目。
+/// Key format is `path|mtime_millis`. Paths on macOS/Linux may contain `|`
+///     /// (a legal filename byte) while the numeric mtime field never does —
+///     /// same-path yielding must split from the right; a left split parses
+///     /// `/tmp/a|b.pdf` as `/tmp/a` and clobbers unrelated entries.
 fn visual_cache_path(key: &str) -> &str {
     key.rsplit_once('|').map_or(key, |(path, _)| path)
 }
 
-/// 命中刷新 LRU 时钟；插入时同路径旧 mtime 键直接让位，再按字节+条目双预算
-/// 从最久未用侧淘汰。
+/// Hits refresh the LRU clock; on insert, stale same-path keys yield
+///     /// directly, then the byte+entry dual budget evicts from the
+///     /// least-recently-used side.
 fn visual_cache_insert(
     state: &mut std::collections::HashMap<String, VisualCacheEntry>,
     key: String,
     result: VisualResult,
 ) {
-    // 单条即超字节预算的结果直接不缓存：否则插入后淘汰循环会先把整库
-    // （含无关热条目）清空、最后连它自己也逐出，等于一次大结果抹掉全缓存。
-    // 调用方拿到的响应在插入前已 clone，跳过缓存不影响本次返回。
+    // A result that alone exceeds the byte budget is simply not cached:
+    // once inserted, the eviction loop would drain the whole table
+    // (including unrelated hot entries) and finally evict the result
+    // itself — one large result wiping the entire cache. The caller's
+    // response was cloned before insert, so skipping the cache does not
+    // affect this return.
     if visual_result_bytes(&result) > MAX_VISUAL_CACHE_BYTES {
         return;
     }
@@ -575,8 +582,9 @@ pub async fn render_artifact_visual(path: String) -> Result<VisualResult, String
     if !p.is_file() {
         return Err(format!("not a file: {}", p.display()));
     }
-    // 毫秒精度：agent 的原子重写可以在同一秒内连发多版，秒级 mtime 会让
-    // 第二版拿到第一版的陈旧预览。
+    // Millisecond precision: an agent's atomic rewrites can emit several
+    //     // versions within the same second; second-granularity mtime would serve
+    //     // the second version a stale preview of the first.
     let mtime = std::fs::metadata(&p)
         .and_then(|m| m.modified())
         .ok()
@@ -667,8 +675,10 @@ fn open_with_libreoffice(path: &std::path::Path) -> Result<(), String> {
         return Err(crate::platform::os::libreoffice_missing_message().into());
     }
 
-    // spawn 后 drop Child 不回收子进程（Unix 僵尸），统一走点火即忘 +
-    // 收割的平台接口（soffice 首实例可能长驻，收割线程会停驻到其退出）。
+    // Dropping the Child after spawn never reclaims the process (Unix
+    //     // zombies); route through the platform's fire-and-forget + reap
+    //     // interface (the first soffice instance can stay resident, and the
+    //     // reaper thread then parks until it exits).
     let mut command = std::process::Command::new(&program);
     command.arg(crate::platform::os::external_application_path(path));
     crate::platform::os::spawn_detached_and_reap(&mut command)
@@ -1037,24 +1047,33 @@ mod visual_cache_tests {
         let mut state = fresh_state();
         visual_cache_insert(&mut state, "/a/doc.docx|1001".into(), result_with(8));
         visual_cache_insert(&mut state, "/a/doc.docx|2002".into(), result_with(8));
-        assert_eq!(state.len(), 1, "同路径旧 mtime 键应让位");
+        assert_eq!(state.len(), 1, "stale same-path mtime key must yield");
         assert!(state.contains_key("/a/doc.docx|2002"));
     }
 
     #[test]
     fn pipe_in_filename_parses_key_on_last_separator() {
-        // 文件名可含 `|`：键解析必须按最后一个分隔符右切（rsplit_once）。
-        // 左切分会把 `/tmp/a|b.pdf|1` 解析成 `/tmp/a`，让同前缀的无关文件
-        // （`/tmp/a|c.pdf`）互相误逐出对方的条目。
+        // Filenames may contain `|`: key parsing must split on the last
+        //         // separator (rsplit_once). A left split parses `/tmp/a|b.pdf|1` as
+        //         // `/tmp/a`, making unrelated files sharing the prefix
+        //         // (`/tmp/a|c.pdf`) evict each other's entries.
         let mut state = fresh_state();
         visual_cache_insert(&mut state, "/tmp/a|b.pdf|1".into(), result_with(8));
         visual_cache_insert(&mut state, "/tmp/a|c.pdf|1".into(), result_with(8));
-        assert_eq!(state.len(), 2, "文件名含 | 的两个不同文件必须共存");
+        assert_eq!(
+            state.len(),
+            2,
+            "two distinct files with | in the name must coexist"
+        );
         assert!(state.contains_key("/tmp/a|b.pdf|1"));
         assert!(state.contains_key("/tmp/a|c.pdf|1"));
-        // 同名文件（含 |）新 mtime 仍应让位旧条目。
+        // A same-name file (containing |) with a fresh mtime must still yield the old entry.
         visual_cache_insert(&mut state, "/tmp/a|b.pdf|2".into(), result_with(8));
-        assert_eq!(state.len(), 2, "同名含 | 文件按路径让位，不影响邻居");
+        assert_eq!(
+            state.len(),
+            2,
+            "same-name | file yields by path without affecting neighbors"
+        );
         assert!(!state.contains_key("/tmp/a|b.pdf|1"));
         assert!(state.contains_key("/tmp/a|b.pdf|2"));
         assert!(state.contains_key("/tmp/a|c.pdf|1"));
@@ -1067,7 +1086,10 @@ mod visual_cache_tests {
             visual_cache_insert(&mut state, format!("/p/{i}.pdf|1"), result_with(8));
         }
         assert_eq!(state.len(), MAX_VISUAL_CACHE_ENTRIES);
-        assert!(!state.contains_key("/p/0.pdf|1"), "最旧条目应被淘汰");
+        assert!(
+            !state.contains_key("/p/0.pdf|1"),
+            "oldest entry must be evicted"
+        );
         assert!(state.contains_key(&format!("/p/{}.pdf|1", MAX_VISUAL_CACHE_ENTRIES)));
     }
 
@@ -1084,15 +1106,16 @@ mod visual_cache_tests {
                 .map(|e| visual_result_bytes(&e.result))
                 .sum::<usize>()
                 <= MAX_VISUAL_CACHE_BYTES,
-            "累计字节应回落到预算内"
+            "total bytes must fall back within the budget"
         );
-        assert!(state.len() >= 1, "至少保留最新一条");
+        assert!(state.len() >= 1, "at least the newest entry must survive");
     }
 
     #[test]
     fn over_budget_single_entry_is_skipped_and_keeps_warm_entries() {
-        // 单条结果即超字节预算：不得入库，更不得在淘汰循环里把整库
-        // （含无关热条目）一起抹掉。
+        // A single result over the byte budget: it must not be inserted,
+        //         // let alone wipe the whole table (including unrelated hot entries)
+        //         // in the eviction loop.
         let mut state = fresh_state();
         visual_cache_insert(&mut state, "/a/small.pdf|1".into(), result_with(8));
         visual_cache_insert(
@@ -1103,11 +1126,11 @@ mod visual_cache_tests {
         assert_eq!(state.len(), 1);
         assert!(
             state.contains_key("/a/small.pdf|1"),
-            "超预算插入不得清掉已有热条目"
+            "an over-budget insert must not clear existing hot entries"
         );
         assert!(
             !state.contains_key("/a/huge.pdf|1"),
-            "单条超字节预算的结果不缓存"
+            "a single result over the byte budget is not cached"
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -518,6 +518,13 @@ fn visual_cache_next_tick() -> u64 {
     VISUAL_CACHE_CLOCK.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
+/// 键格式为 `路径|毫秒mtime`。路径在 macOS/Linux 上可含 `|`(合法文件名字节),
+/// mtime 数字段不会——同路径让位判定必须从右侧切分,左侧切分会把 `/tmp/a|b.pdf`
+/// 误解析成 `/tmp/a` 而误伤无关条目。
+fn visual_cache_path(key: &str) -> &str {
+    key.rsplit_once('|').map_or(key, |(path, _)| path)
+}
+
 /// 命中刷新 LRU 时钟；插入时同路径旧 mtime 键直接让位，再按字节+条目双预算
 /// 从最久未用侧淘汰。
 fn visual_cache_insert(
@@ -525,8 +532,8 @@ fn visual_cache_insert(
     key: String,
     result: VisualResult,
 ) {
-    let path = key.split('|').next().unwrap_or(&key).to_string();
-    state.retain(|k, _| k.split('|').next() != Some(path.as_str()));
+    let path = visual_cache_path(&key).to_string();
+    state.retain(|k, _| visual_cache_path(k) != path);
     let touched = visual_cache_next_tick();
     state.insert(key, VisualCacheEntry { result, touched });
     while state.len() > MAX_VISUAL_CACHE_ENTRIES {

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -562,11 +562,13 @@ pub async fn render_artifact_visual(path: String) -> Result<VisualResult, String
     if !p.is_file() {
         return Err(format!("not a file: {}", p.display()));
     }
+    // 毫秒精度：agent 的原子重写可以在同一秒内连发多版，秒级 mtime 会让
+    // 第二版拿到第一版的陈旧预览。
     let mtime = std::fs::metadata(&p)
         .and_then(|m| m.modified())
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis())
         .unwrap_or(0);
     let cache_key = format!("{}|{}", p.display(), mtime);
     if let Some(hit) = visual_cache().lock().get_mut(&cache_key) {
@@ -996,4 +998,60 @@ pub async fn open_artifact_window(
         .build()
         .map_err(|e| format!("build artifact window: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod visual_cache_tests {
+    use super::*;
+
+    fn result_with(bytes: usize) -> VisualResult {
+        VisualResult {
+            mode: "html".into(),
+            html: Some("x".repeat(bytes)),
+            images: vec![],
+            warning: None,
+        }
+    }
+
+    fn fresh_state() -> std::collections::HashMap<String, VisualCacheEntry> {
+        std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn same_path_stale_mtime_yields_on_insert() {
+        let mut state = fresh_state();
+        visual_cache_insert(&mut state, "/a/doc.docx|1001".into(), result_with(8));
+        visual_cache_insert(&mut state, "/a/doc.docx|2002".into(), result_with(8));
+        assert_eq!(state.len(), 1, "同路径旧 mtime 键应让位");
+        assert!(state.contains_key("/a/doc.docx|2002"));
+    }
+
+    #[test]
+    fn entry_cap_evicts_oldest_touched() {
+        let mut state = fresh_state();
+        for i in 0..=MAX_VISUAL_CACHE_ENTRIES as u64 {
+            visual_cache_insert(&mut state, format!("/p/{i}.pdf|1"), result_with(8));
+        }
+        assert_eq!(state.len(), MAX_VISUAL_CACHE_ENTRIES);
+        assert!(!state.contains_key("/p/0.pdf|1"), "最旧条目应被淘汰");
+        assert!(state.contains_key(&format!("/p/{}.pdf|1", MAX_VISUAL_CACHE_ENTRIES)));
+    }
+
+    #[test]
+    fn byte_budget_evicts_until_under_cap() {
+        let mut state = fresh_state();
+        let per = MAX_VISUAL_CACHE_BYTES / 4 + 1024;
+        for i in 0..4 {
+            visual_cache_insert(&mut state, format!("/big/{i}.pdf|1"), result_with(per));
+        }
+        assert!(
+            state
+                .values()
+                .map(|e| visual_result_bytes(&e.result))
+                .sum::<usize>()
+                <= MAX_VISUAL_CACHE_BYTES,
+            "累计字节应回落到预算内"
+        );
+        assert!(state.len() >= 1, "至少保留最新一条");
+    }
 }

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -489,11 +489,68 @@ impl VisualResult {
 }
 
 /// 可视化预览结果缓存（按 路径|mtime 键）。soffice/pdftoppm 一次 1-3s，缓存后二次秒开。
-fn visual_cache() -> &'static parking_lot::Mutex<std::collections::HashMap<String, VisualResult>> {
+struct VisualCacheEntry {
+    result: VisualResult,
+    touched: u64,
+}
+
+/// 缓存预算：单条结果可达数 MB（30 页 PDF data URI / 内联图片 HTML），
+/// 且键含 mtime——同一产物每次重写都会产生新键。无上限会让长会话累积数百 MB。
+const MAX_VISUAL_CACHE_ENTRIES: usize = 16;
+const MAX_VISUAL_CACHE_BYTES: usize = 96 * 1024 * 1024;
+
+fn visual_result_bytes(result: &VisualResult) -> usize {
+    result.html.as_ref().map_or(0, |s| s.len())
+        + result.images.iter().map(|s| s.len()).sum::<usize>()
+}
+
+fn visual_cache() -> &'static parking_lot::Mutex<std::collections::HashMap<String, VisualCacheEntry>>
+{
     static CACHE: std::sync::OnceLock<
-        parking_lot::Mutex<std::collections::HashMap<String, VisualResult>>,
+        parking_lot::Mutex<std::collections::HashMap<String, VisualCacheEntry>>,
     > = std::sync::OnceLock::new();
     CACHE.get_or_init(|| parking_lot::Mutex::new(std::collections::HashMap::new()))
+}
+
+static VISUAL_CACHE_CLOCK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn visual_cache_next_tick() -> u64 {
+    VISUAL_CACHE_CLOCK.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// 命中刷新 LRU 时钟；插入时同路径旧 mtime 键直接让位，再按字节+条目双预算
+/// 从最久未用侧淘汰。
+fn visual_cache_insert(
+    state: &mut std::collections::HashMap<String, VisualCacheEntry>,
+    key: String,
+    result: VisualResult,
+) {
+    let path = key.split('|').next().unwrap_or(&key).to_string();
+    state.retain(|k, _| k.split('|').next() != Some(path.as_str()));
+    let touched = visual_cache_next_tick();
+    state.insert(key, VisualCacheEntry { result, touched });
+    while state.len() > MAX_VISUAL_CACHE_ENTRIES {
+        evict_oldest_visual_entry(state);
+    }
+    while state
+        .values()
+        .map(|e| visual_result_bytes(&e.result))
+        .sum::<usize>()
+        > MAX_VISUAL_CACHE_BYTES
+        && !state.is_empty()
+    {
+        evict_oldest_visual_entry(state);
+    }
+}
+
+fn evict_oldest_visual_entry(state: &mut std::collections::HashMap<String, VisualCacheEntry>) {
+    if let Some(oldest) = state
+        .iter()
+        .min_by_key(|(_, entry)| entry.touched)
+        .map(|(k, _)| k.clone())
+    {
+        state.remove(&oldest);
+    }
 }
 
 /// 把 office/pdf/图片产物转成可视化预览：office→自包含 HTML，pdf→逐页 PNG，图片→data URI。
@@ -512,8 +569,9 @@ pub async fn render_artifact_visual(path: String) -> Result<VisualResult, String
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let cache_key = format!("{}|{}", p.display(), mtime);
-    if let Some(hit) = visual_cache().lock().get(&cache_key).cloned() {
-        return Ok(hit);
+    if let Some(hit) = visual_cache().lock().get_mut(&cache_key) {
+        hit.touched = visual_cache_next_tick();
+        return Ok(hit.result.clone());
     }
 
     let ext = p
@@ -574,7 +632,7 @@ pub async fn render_artifact_visual(path: String) -> Result<VisualResult, String
 
     // unsupported 不缓存：可能是工具暂缺，装上后下次重试。
     if result.mode != "unsupported" {
-        visual_cache().lock().insert(cache_key, result.clone());
+        visual_cache_insert(&mut visual_cache().lock(), cache_key, result.clone());
     }
     Ok(result)
 }

--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -281,18 +281,15 @@ pub(crate) async fn codex_acp_prompt_with_attachments(
         message.as_str()
     };
     super::sessions::apply_default_session_title(&store, &session_id, title_source)?;
-    crate::features::assistant::timing::start_turn(&session_id);
+    // start_turn 必须在 send_message 的 busy 准入成功之后：ACP 无原生链路的
+    // reserve/terminal_closing 闸门，若在准入前入队，并发的第二次提交失败时
+    // send_error 收尾会把队列整段清掉，吞掉在飞轮的终态记点。
     acp_pool
         .send_message(&session_id, message, attachments, workspace_references)
         .await
-        .map_err(|error| {
-            crate::features::assistant::timing::finish_turn(
-                &session_id,
-                "send_error",
-                Some(&format!("{error:#}")),
-            );
-            format!("ACP Agent send failed: {error:#}")
-        })
+        .map_err(|error| format!("ACP Agent send failed: {error:#}"))?;
+    let _turn_id = crate::features::assistant::timing::start_turn(&session_id);
+    Ok(())
 }
 
 // 会话内浏览走 session_id（解析会话工作区并校验可用性）；

--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -281,16 +281,14 @@ pub(crate) async fn codex_acp_prompt_with_attachments(
         message.as_str()
     };
     super::sessions::apply_default_session_title(&store, &session_id, title_source)?;
-    // start_turn must run after send_message's busy admission succeeds: ACP
-    //     // has no native-lane reserve/terminal_closing gate, so if the turn were
-    //     // queued before admission, a failed concurrent submit's send_error finish
-    //     // would clear the whole queue and swallow the in-flight turn's terminal
-    //     // recording.
+    // Timing registration lives inside `AcpPool::send_message`, after busy
+    // admission succeeds but before the prompt task is spawned: the spawned
+    // turn can complete before `send_message` returns, so registering here
+    // (after the await) would race that finish and drop the completion.
     acp_pool
         .send_message(&session_id, message, attachments, workspace_references)
         .await
         .map_err(|error| format!("ACP Agent send failed: {error:#}"))?;
-    let _turn_id = crate::features::assistant::timing::start_turn(&session_id);
     Ok(())
 }
 

--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -281,9 +281,11 @@ pub(crate) async fn codex_acp_prompt_with_attachments(
         message.as_str()
     };
     super::sessions::apply_default_session_title(&store, &session_id, title_source)?;
-    // start_turn 必须在 send_message 的 busy 准入成功之后：ACP 无原生链路的
-    // reserve/terminal_closing 闸门，若在准入前入队，并发的第二次提交失败时
-    // send_error 收尾会把队列整段清掉，吞掉在飞轮的终态记点。
+    // start_turn must run after send_message's busy admission succeeds: ACP
+    //     // has no native-lane reserve/terminal_closing gate, so if the turn were
+    //     // queued before admission, a failed concurrent submit's send_error finish
+    //     // would clear the whole queue and swallow the in-flight turn's terminal
+    //     // recording.
     acp_pool
         .send_message(&session_id, message, attachments, workspace_references)
         .await

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -666,9 +666,10 @@ pub async fn web_access_create_session_and_chat(
             .delete(&session_id)
             .map_err(|rollback_error| format!("rollback Session {session_id}: {rollback_error:#}"));
         pool.forget_session(&session_id);
-        // chat 已跑过（可能 start_turn 过）：timing 队列/pending user input 等
-        // 进程级残留键由 store.delete 触发的 SessionPurgedHook 统一清理，
-        // 与 delete_session 命令同口径。
+        // The chat may have already run (possibly past start_turn):
+        //         // process-level residual keys such as the timing queue / pending
+        //         // user input are cleaned uniformly by the SessionPurgedHook fired
+        //         // from store.delete, matching the delete_session command.
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!("{error}; {rollback_error}")),

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -667,9 +667,9 @@ pub async fn web_access_create_session_and_chat(
             .map_err(|rollback_error| format!("rollback Session {session_id}: {rollback_error:#}"));
         pool.forget_session(&session_id);
         // The chat may have already run (possibly past start_turn):
-        //         // process-level residual keys such as the timing queue / pending
-        //         // user input are cleaned uniformly by the SessionPurgedHook fired
-        //         // from store.delete, matching the delete_session command.
+        // process-level residual keys such as the timing queue / pending
+        // user input are cleaned uniformly by the SessionPurgedHook fired
+        // from store.delete, matching the delete_session command.
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!("{error}; {rollback_error}")),

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -666,10 +666,9 @@ pub async fn web_access_create_session_and_chat(
             .delete(&session_id)
             .map_err(|rollback_error| format!("rollback Session {session_id}: {rollback_error:#}"));
         pool.forget_session(&session_id);
-        // chat 已跑过（可能 start_turn 过）：与 delete_session 同口径清理
-        // timing 队列与 pending user input，避免回滚会话的残留键驻留。
-        crate::features::assistant::timing::clear_session(&session_id);
-        crate::features::assistant::pending_user_input::clear_session(&session_id);
+        // chat 已跑过（可能 start_turn 过）：timing 队列/pending user input 等
+        // 进程级残留键由 store.delete 触发的 SessionPurgedHook 统一清理，
+        // 与 delete_session 命令同口径。
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!("{error}; {rollback_error}")),

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -666,6 +666,10 @@ pub async fn web_access_create_session_and_chat(
             .delete(&session_id)
             .map_err(|rollback_error| format!("rollback Session {session_id}: {rollback_error:#}"));
         pool.forget_session(&session_id);
+        // chat 已跑过（可能 start_turn 过）：与 delete_session 同口径清理
+        // timing 队列与 pending user input，避免回滚会话的残留键驻留。
+        crate::features::assistant::timing::clear_session(&session_id);
+        crate::features::assistant::pending_user_input::clear_session(&session_id);
         return match rollback {
             Ok(()) => Err(error),
             Err(rollback_error) => Err(format!("{error}; {rollback_error}")),

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -452,9 +452,11 @@ pub async fn delete_session(
     };
     if result.is_ok() {
         pool.forget_session(&id);
-        // 进程级 per-session map（timing/pending_user_input/memory/monitor）
-        // 的清键由删除路径触发的 SessionPurgedHook 统一完成（lib.rs 组合根
-        // 注册；Chat 走 store.delete，ScheduledRun 走 purge_session_side_maps）。
+        // Clearing keys of process-level per-session maps (timing/
+        //         // pending_user_input/memory/monitor) is done uniformly by the
+        //         // SessionPurgedHook fired on delete paths (registered at the lib.rs
+        //         // composition root; Chat goes through store.delete, ScheduledRun
+        //         // through purge_session_side_maps).
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -453,10 +453,10 @@ pub async fn delete_session(
     if result.is_ok() {
         pool.forget_session(&id);
         // Clearing keys of process-level per-session maps (timing/
-        //         // pending_user_input/memory/monitor) is done uniformly by the
-        //         // SessionPurgedHook fired on delete paths (registered at the lib.rs
-        //         // composition root; Chat goes through store.delete, ScheduledRun
-        //         // through purge_session_side_maps).
+        // pending_user_input/memory/monitor) is done uniformly by the
+        // SessionPurgedHook fired on delete paths (registered at the lib.rs
+        // composition root; Chat goes through store.delete, ScheduledRun
+        // through purge_session_side_maps).
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -461,6 +461,7 @@ pub async fn delete_session(
             m.drop_session(&id);
         }
         crate::features::memory::discard_turn_capture(&id);
+        crate::features::assistant::timing::clear_session(&id);
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -452,17 +452,9 @@ pub async fn delete_session(
     };
     if result.is_ok() {
         pool.forget_session(&id);
-        // 会话删除兜底：清掉进程级 store 里该 session 的打点残留，避免随会话删除
-        // 缓慢增长的自测指标泄漏（warmed_sessions 在每轮 TurnComplete 插入、从不回收）。
-        if let Some(m) = app
-            .try_state::<crate::features::monitor::MonitorState>()
-            .map(|s| s.self_metrics())
-        {
-            m.drop_session(&id);
-        }
-        crate::features::memory::discard_turn_capture(&id);
-        crate::features::assistant::timing::clear_session(&id);
-        crate::features::assistant::pending_user_input::clear_session(&id);
+        // 进程级 per-session map（timing/pending_user_input/memory/monitor）
+        // 的清键由删除路径触发的 SessionPurgedHook 统一完成（lib.rs 组合根
+        // 注册；Chat 走 store.delete，ScheduledRun 走 purge_session_side_maps）。
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/app/commands/sessions.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/sessions.rs
@@ -462,6 +462,7 @@ pub async fn delete_session(
         }
         crate::features::memory::discard_turn_capture(&id);
         crate::features::assistant::timing::clear_session(&id);
+        crate::features::assistant::pending_user_input::clear_session(&id);
         let payload = serde_json::json!({ "id": &id });
         let _ = app.emit("session:deleted", payload.clone());
         crate::features::remote_control::forward_app_event(&app, "session:deleted", payload);

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -534,6 +534,19 @@ impl TurnLifecycle {
         Ok(())
     }
 
+    /// 引擎以净化后的历史完成 `SyncSession` 重建后调用。落盘 transcript 里的
+    /// raw prompt 已在 forwarder 持久化前被 display 消息替换，旧规则不可能再
+    /// 匹配后续 `SessionUpdated` 快照；而每条规则持有完整 raw prompt +
+    /// display 双份内容，驻留只会随轮数线性累积（长会话可达数十 MB）。
+    /// 活动 turn 期间不清理（防御性约束：spawn/resync 时不应有在飞轮）。
+    pub(crate) fn prune_rules_after_resync(&self) {
+        let mut state = self.state.lock();
+        if state.active {
+            return;
+        }
+        state.transcript_rules.clear();
+    }
+
     fn ensure_reservation_active(&self, reservation_id: u64) -> Result<()> {
         let state = self.state.lock();
         if state.active
@@ -2635,6 +2648,41 @@ mod turn_lifecycle_tests {
         assert!(!matched);
         assert_eq!(messages, vec![engine_user("private actual")]);
         drop(next);
+    }
+
+    #[test]
+    fn prune_rules_after_resync_clears_stale_rules_but_respects_active_turn() {
+        let lifecycle = Arc::new(TurnLifecycle::default());
+        for round in 0..3 {
+            let mut reservation = lifecycle.reserve().expect("reserve");
+            let display_text = format!("display {round}");
+            let raw_text = format!("private raw {round}");
+            reservation
+                .set_transcript(TranscriptOperation::Append, message("user", &display_text))
+                .unwrap();
+            reservation.prepare_actual_user_content(raw_text).unwrap();
+            reservation.mark_submitted();
+            assert!(lifecycle.finish_once(|| {}).is_some());
+        }
+
+        // Resync 重建后，落盘历史已是 display 消息：旧规则应整段清理。
+        lifecycle.prune_rules_after_resync();
+        let (messages, matched) = lifecycle.sanitize_messages(vec![engine_user("private raw 1")]);
+        assert!(!matched);
+        assert_eq!(messages, vec![engine_user("private raw 1")]);
+
+        // 活动 turn（reservation 持有）期间是防御性禁区：规则必须保留。
+        let mut active = lifecycle.reserve().expect("reserve");
+        active
+            .set_transcript(TranscriptOperation::Append, message("user", "live display"))
+            .unwrap();
+        active
+            .prepare_actual_user_content("live raw".to_string())
+            .unwrap();
+        lifecycle.prune_rules_after_resync();
+        let (sanitized, matched) = lifecycle.sanitize_messages(vec![engine_user("live raw")]);
+        assert!(matched);
+        assert_eq!(sanitized, vec![message("user", "live display")]);
     }
 }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -534,13 +534,17 @@ impl TurnLifecycle {
         Ok(())
     }
 
-    /// 修剪不再可能匹配引擎快照的 transcript 规则，仅保留当前在飞预留的规则
-    /// （兜底防御，正常调用点不存在并发在飞轮）。两个调用点：`SyncSession`
-    /// 重建成功后——注水的是 forwarder 净化后的历史，落盘 transcript 里的
-    /// raw prompt 已被 display 消息替换，旧规则不可能再匹配新引擎的快照；
-    /// 引擎回收后——引擎 transcript 随之销毁，raw prompt 的唯一存活载体消失。
-    /// 每条规则持有完整 raw prompt + display 双份内容，驻留只会随轮数线性
-    /// 累积（长会话可达数十 MB）。
+    /// Prune transcript rules that can no longer match an engine snapshot,
+    ///     /// keeping only the current in-flight reservation's rule (a defensive
+    ///     /// backstop; well-formed call sites never see concurrent in-flight
+    ///     /// turns). Two call sites: after a successful `SyncSession` rebuild —
+    ///     /// the hydrated history is the forwarder-sanitized one, the raw prompts
+    ///     /// in the persisted transcript were replaced by display messages, and
+    ///     /// stale rules can no longer match the new engine's snapshot; and after
+    ///     /// engine reclaim — the engine transcript is destroyed with it, removing
+    ///     /// the only live carrier of the raw prompts. Each rule holds both the
+    ///     /// full raw prompt and the display copy, so residency only accumulates
+    ///     /// linearly with turns (long sessions can reach tens of MB).
     pub(crate) fn prune_stale_transcript_rules(&self) {
         let mut state = self.state.lock();
         let keep = state.active_reservation_id;
@@ -2667,9 +2671,10 @@ mod turn_lifecycle_tests {
             assert!(lifecycle.finish_once(|| {}).is_some());
         }
 
-        // 生产形态：交互路径 reserve（lifecycle active）→ 安装本轮规则 →
-        // spawn/resync 触发修剪。陈旧规则（已完成轮）必须清掉，而在飞预留的
-        // 规则必须保留。
+        // Production shape: the interactive path reserves (lifecycle
+        //         // active) → installs this turn's rule → spawn/resync triggers the
+        //         // prune. Stale rules (completed turns) must be dropped while the
+        //         // in-flight reservation's rule survives.
         let mut active = lifecycle.reserve().expect("reserve");
         active
             .set_transcript(TranscriptOperation::Append, message("user", "live display"))
@@ -2685,7 +2690,7 @@ mod turn_lifecycle_tests {
         assert!(matched);
         assert_eq!(sanitized, vec![message("user", "live display")]);
 
-        // 引擎回收（idle，无在飞预留）：全部规则都不再可能匹配，整段清理。
+        // Engine reclaim (idle, no in-flight reservation): no rule can match anymore; clear the whole section.
         active.mark_submitted();
         assert!(lifecycle.finish_once(|| {}).is_some());
         lifecycle.prune_stale_transcript_rules();

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -534,17 +534,19 @@ impl TurnLifecycle {
         Ok(())
     }
 
-    /// 引擎以净化后的历史完成 `SyncSession` 重建后调用。落盘 transcript 里的
-    /// raw prompt 已在 forwarder 持久化前被 display 消息替换，旧规则不可能再
-    /// 匹配后续 `SessionUpdated` 快照；而每条规则持有完整 raw prompt +
-    /// display 双份内容，驻留只会随轮数线性累积（长会话可达数十 MB）。
-    /// 活动 turn 期间不清理（防御性约束：spawn/resync 时不应有在飞轮）。
-    pub(crate) fn prune_rules_after_resync(&self) {
+    /// 修剪不再可能匹配引擎快照的 transcript 规则，仅保留当前在飞预留的规则
+    /// （兜底防御，正常调用点不存在并发在飞轮）。两个调用点：`SyncSession`
+    /// 重建成功后——注水的是 forwarder 净化后的历史，落盘 transcript 里的
+    /// raw prompt 已被 display 消息替换，旧规则不可能再匹配新引擎的快照；
+    /// 引擎回收后——引擎 transcript 随之销毁，raw prompt 的唯一存活载体消失。
+    /// 每条规则持有完整 raw prompt + display 双份内容，驻留只会随轮数线性
+    /// 累积（长会话可达数十 MB）。
+    pub(crate) fn prune_stale_transcript_rules(&self) {
         let mut state = self.state.lock();
-        if state.active {
-            return;
-        }
-        state.transcript_rules.clear();
+        let keep = state.active_reservation_id;
+        state
+            .transcript_rules
+            .retain(|rule| Some(rule.reservation_id) == keep);
     }
 
     fn ensure_reservation_active(&self, reservation_id: u64) -> Result<()> {
@@ -2651,7 +2653,7 @@ mod turn_lifecycle_tests {
     }
 
     #[test]
-    fn prune_rules_after_resync_clears_stale_rules_but_respects_active_turn() {
+    fn prune_stale_transcript_rules_keeps_only_active_reservation() {
         let lifecycle = Arc::new(TurnLifecycle::default());
         for round in 0..3 {
             let mut reservation = lifecycle.reserve().expect("reserve");
@@ -2665,13 +2667,9 @@ mod turn_lifecycle_tests {
             assert!(lifecycle.finish_once(|| {}).is_some());
         }
 
-        // Resync 重建后，落盘历史已是 display 消息：旧规则应整段清理。
-        lifecycle.prune_rules_after_resync();
-        let (messages, matched) = lifecycle.sanitize_messages(vec![engine_user("private raw 1")]);
-        assert!(!matched);
-        assert_eq!(messages, vec![engine_user("private raw 1")]);
-
-        // 活动 turn（reservation 持有）期间是防御性禁区：规则必须保留。
+        // 生产形态：交互路径 reserve（lifecycle active）→ 安装本轮规则 →
+        // spawn/resync 触发修剪。陈旧规则（已完成轮）必须清掉，而在飞预留的
+        // 规则必须保留。
         let mut active = lifecycle.reserve().expect("reserve");
         active
             .set_transcript(TranscriptOperation::Append, message("user", "live display"))
@@ -2679,10 +2677,21 @@ mod turn_lifecycle_tests {
         active
             .prepare_actual_user_content("live raw".to_string())
             .unwrap();
-        lifecycle.prune_rules_after_resync();
+        lifecycle.prune_stale_transcript_rules();
+        let (messages, matched) = lifecycle.sanitize_messages(vec![engine_user("private raw 1")]);
+        assert!(!matched);
+        assert_eq!(messages, vec![engine_user("private raw 1")]);
         let (sanitized, matched) = lifecycle.sanitize_messages(vec![engine_user("live raw")]);
         assert!(matched);
         assert_eq!(sanitized, vec![message("user", "live display")]);
+
+        // 引擎回收（idle，无在飞预留）：全部规则都不再可能匹配，整段清理。
+        active.mark_submitted();
+        assert!(lifecycle.finish_once(|| {}).is_some());
+        lifecycle.prune_stale_transcript_rules();
+        let (messages, matched) = lifecycle.sanitize_messages(vec![engine_user("live raw")]);
+        assert!(!matched);
+        assert_eq!(messages, vec![engine_user("live raw")]);
     }
 }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -535,16 +535,16 @@ impl TurnLifecycle {
     }
 
     /// Prune transcript rules that can no longer match an engine snapshot,
-    ///     /// keeping only the current in-flight reservation's rule (a defensive
-    ///     /// backstop; well-formed call sites never see concurrent in-flight
-    ///     /// turns). Two call sites: after a successful `SyncSession` rebuild —
-    ///     /// the hydrated history is the forwarder-sanitized one, the raw prompts
-    ///     /// in the persisted transcript were replaced by display messages, and
-    ///     /// stale rules can no longer match the new engine's snapshot; and after
-    ///     /// engine reclaim — the engine transcript is destroyed with it, removing
-    ///     /// the only live carrier of the raw prompts. Each rule holds both the
-    ///     /// full raw prompt and the display copy, so residency only accumulates
-    ///     /// linearly with turns (long sessions can reach tens of MB).
+    /// keeping only the current in-flight reservation's rule (a defensive
+    /// backstop; well-formed call sites never see concurrent in-flight
+    /// turns). Two call sites: after a successful `SyncSession` rebuild —
+    /// the hydrated history is the forwarder-sanitized one, the raw prompts
+    /// in the persisted transcript were replaced by display messages, and
+    /// stale rules can no longer match the new engine's snapshot; and after
+    /// engine reclaim — the engine transcript is destroyed with it, removing
+    /// the only live carrier of the raw prompts. Each rule holds both the
+    /// full raw prompt and the display copy, so residency only accumulates
+    /// linearly with turns (long sessions can reach tens of MB).
     pub(crate) fn prune_stale_transcript_rules(&self) {
         let mut state = self.state.lock();
         let keep = state.active_reservation_id;
@@ -2672,9 +2672,9 @@ mod turn_lifecycle_tests {
         }
 
         // Production shape: the interactive path reserves (lifecycle
-        //         // active) → installs this turn's rule → spawn/resync triggers the
-        //         // prune. Stale rules (completed turns) must be dropped while the
-        //         // in-flight reservation's rule survives.
+        // active) → installs this turn's rule → spawn/resync triggers the
+        // prune. Stale rules (completed turns) must be dropped while the
+        // in-flight reservation's rule survives.
         let mut active = lifecycle.reserve().expect("reserve");
         active
             .set_transcript(TranscriptOperation::Append, message("user", "live display"))

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -1093,6 +1093,7 @@ impl EnginePool {
             .map_err(|e| anyhow::anyhow!("materialize session skills join: {e}"))?
             .map_err(|e| anyhow::anyhow!("materialize session skills: {e}"))?;
         }
+        let turn_lifecycle = self.turn_lifecycles.for_session(session_id);
         let (engine, forwarder) = AppEngine::spawn_for_session(
             self.app.clone(),
             self.store.clone(),
@@ -1101,7 +1102,7 @@ impl EnginePool {
             extra_tools,
             self.bridge
                 .shape_disallowed_tools(session_id, self.compute_disallowed_tools()),
-            self.turn_lifecycles.for_session(session_id),
+            turn_lifecycle.clone(),
             shell_manager,
             turn_shell_tasks,
         )
@@ -1124,6 +1125,10 @@ impl EnginePool {
                         });
                     }
                     eprintln!("[engine_pool] sync history for {session_id} failed: {error:?}");
+                } else {
+                    // 注水的是 forwarder 净化后的历史：旧 transcript 规则不可能再
+                    // 匹配新引擎的快照，清理以阻止规则随轮数累积驻留。
+                    turn_lifecycle.prune_rules_after_resync();
                 }
             }
             Ok(_) => {}

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -1127,8 +1127,10 @@ impl EnginePool {
                     eprintln!("[engine_pool] sync history for {session_id} failed: {error:?}");
                 } else {
                     // 注水的是 forwarder 净化后的历史：旧 transcript 规则不可能再
-                    // 匹配新引擎的快照，清理以阻止规则随轮数累积驻留。
-                    turn_lifecycle.prune_rules_after_resync();
+                    // 匹配新引擎的快照，清理以阻止规则随轮数累积驻留。交互路径
+                    // 的规则安装在 spawn 前后（reserve 已置 active），retain 谓词
+                    // 保证在飞预留的规则仍被保留。
+                    turn_lifecycle.prune_stale_transcript_rules();
                 }
             }
             Ok(_) => {}
@@ -1356,6 +1358,12 @@ impl EnginePool {
                 "[engine_pool] emitted interrupted terminal before reclaim sid={}",
                 session_id
             );
+        }
+        // 引擎回收后其 transcript 随之销毁，旧 raw prompt 的唯一存活载体消失
+        // （磁盘历史是净化后的）。清掉不再可能匹配的规则，阻止跨引擎世代驻留
+        // 到会话删除；在飞预留的规则兜底保留（正常回收已先终态化在飞轮）。
+        if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
+            lifecycle.prune_stale_transcript_rules();
         }
         // 先级联取消全部后台子智能体，再关闭引擎（ADR-0006）。两个 op 走同一条
         // 通道，FIFO 保证取消先于关闭被处理；否则删除/换模型回收后，会话派生的

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -290,6 +290,11 @@ where
     evict_locked().await;
     store.delete(session_id)?;
     forget();
+    // timing 是同 feature 的进程级状态，可直接清键（无依赖倒置问题）。
+    // 这条覆盖不经 app 组合根、SessionPurgedHook 未注册的路径（eval 拆除、
+    // 测试）：未配对 turn 队列的键随会话 id 驻留会随 GAIA 这类建删循环
+    // 无界增长。与 store.delete 触发的钩子清理幂等重叠，无重复副作用。
+    crate::features::assistant::timing::clear_session(session_id);
     Ok(())
 }
 
@@ -3155,6 +3160,53 @@ mod scheduled_model_tests {
         assert!(!fake_engine_present.load(Ordering::Acquire));
         assert!(forgotten.load(Ordering::Acquire));
         assert!(store.load(&session_id).is_err());
+
+        match previous_home {
+            Some(value) => std::env::set_var("PINVOU3_HOME", value),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    /// 回归：eval 拆除路径（`ProductChatRuntime::close` / `delete_eval_session`）
+    /// 复用 delete_chat_session，但 submit 已 `timing::start_turn`；删除必须清掉
+    /// ACTIVE_TURNS 里该会话的未配对队列键，否则 GAIA 单 pass ~165 个建删循环
+    /// 会让进程级 map 无界增长。
+    #[tokio::test]
+    async fn chat_delete_clears_queued_turn_timing_state() {
+        let _env_guard = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let home = std::env::temp_dir().join(format!(
+            "pinvou3-engine-pool-chat-delete-timing-{}",
+            std::process::id()
+        ));
+        let previous_home = std::env::var("PINVOU3_HOME").ok();
+        let _ = std::fs::remove_dir_all(&home);
+        std::env::set_var("PINVOU3_HOME", &home);
+
+        let store = SessionStore::boot().expect("session store");
+        let session_id = store
+            .create_new("wire-model".to_string(), None, home.join("workspace"))
+            .expect("chat session")
+            .metadata
+            .id;
+        // eval submit 路径先 start_turn；提交失败/中断时该键驻留，由删除兜底。
+        crate::features::assistant::timing::start_turn(&session_id);
+        assert!(
+            crate::features::assistant::timing::has_queued_active_turn(&session_id),
+            "precondition: turn 已入队"
+        );
+
+        let locks = SessionTurnLocks::default();
+        delete_chat_session_with_gate(&locks, &store, &session_id, || async {}, || {})
+            .await
+            .expect("delete chat");
+
+        assert!(
+            !crate::features::assistant::timing::has_queued_active_turn(&session_id),
+            "delete_chat_session 必须清空该会话的未配对 turn 队列"
+        );
 
         match previous_home {
             Some(value) => std::env::set_var("PINVOU3_HOME", value),

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -290,10 +290,13 @@ where
     evict_locked().await;
     store.delete(session_id)?;
     forget();
-    // timing 是同 feature 的进程级状态，可直接清键（无依赖倒置问题）。
-    // 这条覆盖不经 app 组合根、SessionPurgedHook 未注册的路径（eval 拆除、
-    // 测试）：未配对 turn 队列的键随会话 id 驻留会随 GAIA 这类建删循环
-    // 无界增长。与 store.delete 触发的钩子清理幂等重叠，无重复副作用。
+    // timing is process-level state within the same feature, so keys can
+    //     // be cleared directly (no dependency inversion needed). This covers
+    //     // paths that bypass the app composition root where the
+    //     // SessionPurgedHook is not registered (eval teardown, tests): unpaired
+    //     // turn-queue keys pinned by session id would otherwise grow unbounded
+    //     // under create/delete cycles like GAIA. Idempotent overlap with the
+    //     // hook cleanup fired from store.delete; no duplicated side effects.
     crate::features::assistant::timing::clear_session(session_id);
     Ok(())
 }
@@ -1131,10 +1134,12 @@ impl EnginePool {
                     }
                     eprintln!("[engine_pool] sync history for {session_id} failed: {error:?}");
                 } else {
-                    // 注水的是 forwarder 净化后的历史：旧 transcript 规则不可能再
-                    // 匹配新引擎的快照，清理以阻止规则随轮数累积驻留。交互路径
-                    // 的规则安装在 spawn 前后（reserve 已置 active），retain 谓词
-                    // 保证在飞预留的规则仍被保留。
+                    // The hydrated history is forwarder-sanitized: old
+                    //                     // transcript rules can no longer match the new engine's
+                    //                     // snapshot, so prune them to stop rules accumulating per
+                    //                     // turn. The interactive path installs rules around spawn
+                    //                     // (reserve already marked active); the retain predicate
+                    //                     // guarantees the in-flight reservation's rule survives.
                     turn_lifecycle.prune_stale_transcript_rules();
                 }
             }
@@ -1364,9 +1369,12 @@ impl EnginePool {
                 session_id
             );
         }
-        // 引擎回收后其 transcript 随之销毁，旧 raw prompt 的唯一存活载体消失
-        // （磁盘历史是净化后的）。清掉不再可能匹配的规则，阻止跨引擎世代驻留
-        // 到会话删除；在飞预留的规则兜底保留（正常回收已先终态化在飞轮）。
+        // After reclaim the engine transcript is destroyed with it,
+        //         // removing the only live carrier of old raw prompts (the on-disk
+        //         // history is sanitized). Drop rules that can no longer match,
+        //         // stopping cross-engine-generation residency until session deletion;
+        //         // the in-flight reservation's rule is kept as a backstop (normal
+        //         // reclaim finalizes in-flight turns first).
         if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
             lifecycle.prune_stale_transcript_rules();
         }
@@ -3168,10 +3176,11 @@ mod scheduled_model_tests {
         let _ = std::fs::remove_dir_all(home);
     }
 
-    /// 回归：eval 拆除路径（`ProductChatRuntime::close` / `delete_eval_session`）
-    /// 复用 delete_chat_session，但 submit 已 `timing::start_turn`；删除必须清掉
-    /// ACTIVE_TURNS 里该会话的未配对队列键，否则 GAIA 单 pass ~165 个建删循环
-    /// 会让进程级 map 无界增长。
+    /// Regression: the eval teardown paths (`ProductChatRuntime::close` /
+    ///     /// `delete_eval_session`) reuse delete_chat_session, but submit already
+    ///     /// ran `timing::start_turn`; deletion must clear the session's unpaired
+    ///     /// queue key in ACTIVE_TURNS, or a single GAIA pass's ~165 create/delete
+    ///     /// cycles would grow the process-level map unbounded.
     #[tokio::test]
     async fn chat_delete_clears_queued_turn_timing_state() {
         let _env_guard = crate::platform::paths::tests::ENV_LOCK
@@ -3191,11 +3200,11 @@ mod scheduled_model_tests {
             .expect("chat session")
             .metadata
             .id;
-        // eval submit 路径先 start_turn；提交失败/中断时该键驻留，由删除兜底。
+        // The eval submit path runs start_turn first; on submit failure or interruption the key stays resident, and deletion is the backstop.
         crate::features::assistant::timing::start_turn(&session_id);
         assert!(
             crate::features::assistant::timing::has_queued_active_turn(&session_id),
-            "precondition: turn 已入队"
+            "precondition: turn already queued"
         );
 
         let locks = SessionTurnLocks::default();
@@ -3205,7 +3214,7 @@ mod scheduled_model_tests {
 
         assert!(
             !crate::features::assistant::timing::has_queued_active_turn(&session_id),
-            "delete_chat_session 必须清空该会话的未配对 turn 队列"
+            "delete_chat_session must clear the session's unpaired turn queue"
         );
 
         match previous_home {

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -291,12 +291,12 @@ where
     store.delete(session_id)?;
     forget();
     // timing is process-level state within the same feature, so keys can
-    //     // be cleared directly (no dependency inversion needed). This covers
-    //     // paths that bypass the app composition root where the
-    //     // SessionPurgedHook is not registered (eval teardown, tests): unpaired
-    //     // turn-queue keys pinned by session id would otherwise grow unbounded
-    //     // under create/delete cycles like GAIA. Idempotent overlap with the
-    //     // hook cleanup fired from store.delete; no duplicated side effects.
+    // be cleared directly (no dependency inversion needed). This covers
+    // paths that bypass the app composition root where the
+    // SessionPurgedHook is not registered (eval teardown, tests): unpaired
+    // turn-queue keys pinned by session id would otherwise grow unbounded
+    // under create/delete cycles like GAIA. Idempotent overlap with the
+    // hook cleanup fired from store.delete; no duplicated side effects.
     crate::features::assistant::timing::clear_session(session_id);
     Ok(())
 }
@@ -1135,11 +1135,11 @@ impl EnginePool {
                     eprintln!("[engine_pool] sync history for {session_id} failed: {error:?}");
                 } else {
                     // The hydrated history is forwarder-sanitized: old
-                    //                     // transcript rules can no longer match the new engine's
-                    //                     // snapshot, so prune them to stop rules accumulating per
-                    //                     // turn. The interactive path installs rules around spawn
-                    //                     // (reserve already marked active); the retain predicate
-                    //                     // guarantees the in-flight reservation's rule survives.
+                    // transcript rules can no longer match the new engine's
+                    // snapshot, so prune them to stop rules accumulating per
+                    // turn. The interactive path installs rules around spawn
+                    // (reserve already marked active); the retain predicate
+                    // guarantees the in-flight reservation's rule survives.
                     turn_lifecycle.prune_stale_transcript_rules();
                 }
             }
@@ -1370,11 +1370,11 @@ impl EnginePool {
             );
         }
         // After reclaim the engine transcript is destroyed with it,
-        //         // removing the only live carrier of old raw prompts (the on-disk
-        //         // history is sanitized). Drop rules that can no longer match,
-        //         // stopping cross-engine-generation residency until session deletion;
-        //         // the in-flight reservation's rule is kept as a backstop (normal
-        //         // reclaim finalizes in-flight turns first).
+        // removing the only live carrier of old raw prompts (the on-disk
+        // history is sanitized). Drop rules that can no longer match,
+        // stopping cross-engine-generation residency until session deletion;
+        // the in-flight reservation's rule is kept as a backstop (normal
+        // reclaim finalizes in-flight turns first).
         if let Some(lifecycle) = self.turn_lifecycles.get(session_id) {
             lifecycle.prune_stale_transcript_rules();
         }
@@ -3177,10 +3177,10 @@ mod scheduled_model_tests {
     }
 
     /// Regression: the eval teardown paths (`ProductChatRuntime::close` /
-    ///     /// `delete_eval_session`) reuse delete_chat_session, but submit already
-    ///     /// ran `timing::start_turn`; deletion must clear the session's unpaired
-    ///     /// queue key in ACTIVE_TURNS, or a single GAIA pass's ~165 create/delete
-    ///     /// cycles would grow the process-level map unbounded.
+    /// `delete_eval_session`) reuse delete_chat_session, but submit already
+    /// ran `timing::start_turn`; deletion must clear the session's unpaired
+    /// queue key in ACTIVE_TURNS, or a single GAIA pass's ~165 create/delete
+    /// cycles would grow the process-level map unbounded.
     #[tokio::test]
     async fn chat_delete_clears_queued_turn_timing_state() {
         let _env_guard = crate::platform::paths::tests::ENV_LOCK

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -42,9 +42,9 @@ use crate::features::assistant::session_policy::SessionPolicy;
 use crate::platform::credential_store::{CredentialStore, SystemCredentialStore};
 
 /// Process-wide shared credential-store handle. `SystemCredentialStore`'s
-/// /// backend caches (one `Secrets` per keyring service) live on the instance;
-/// /// a per-call new() throws the probe/service resolution away and repeats it
-/// /// several times per turn.
+/// backend caches (one `Secrets` per keyring service) live on the instance;
+/// a per-call new() throws the probe/service resolution away and repeats it
+/// several times per turn.
 fn shared_credential_store() -> &'static SystemCredentialStore {
     static STORE: std::sync::OnceLock<SystemCredentialStore> = std::sync::OnceLock::new();
     STORE.get_or_init(SystemCredentialStore::new)

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -41,9 +41,10 @@ use crate::features::assistant::runtime_model::RuntimeModelCredential;
 use crate::features::assistant::session_policy::SessionPolicy;
 use crate::platform::credential_store::{CredentialStore, SystemCredentialStore};
 
-/// 进程级共享凭据库句柄。`SystemCredentialStore` 的后端缓存（每个 keyring
-/// service 一个 `Secrets`）挂在实例上，逐调用点 new() 会把 probe/service 解析
-/// 结果整个丢弃，每轮 turn 重复执行多次。
+/// Process-wide shared credential-store handle. `SystemCredentialStore`'s
+/// /// backend caches (one `Secrets` per keyring service) live on the instance;
+/// /// a per-call new() throws the probe/service resolution away and repeats it
+/// /// several times per turn.
 fn shared_credential_store() -> &'static SystemCredentialStore {
     static STORE: std::sync::OnceLock<SystemCredentialStore> = std::sync::OnceLock::new();
     STORE.get_or_init(SystemCredentialStore::new)

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -41,6 +41,14 @@ use crate::features::assistant::runtime_model::RuntimeModelCredential;
 use crate::features::assistant::session_policy::SessionPolicy;
 use crate::platform::credential_store::{CredentialStore, SystemCredentialStore};
 
+/// 进程级共享凭据库句柄。`SystemCredentialStore` 的后端缓存（每个 keyring
+/// service 一个 `Secrets`）挂在实例上，逐调用点 new() 会把 probe/service 解析
+/// 结果整个丢弃，每轮 turn 重复执行多次。
+fn shared_credential_store() -> &'static SystemCredentialStore {
+    static STORE: std::sync::OnceLock<SystemCredentialStore> = std::sync::OnceLock::new();
+    STORE.get_or_init(SystemCredentialStore::new)
+}
+
 // Qwen3.6 在 vLLM 里是 passthrough 字符串（不走 alias）;`_256k` 后缀语义与
 // ops 同步要求见 `ModelPreset::default_model` 的 LocalVllm 注释（prefs/model.rs）。
 const LOCAL_VLLM_API_KEY: &str = "local-no-auth";
@@ -847,7 +855,7 @@ impl Pinvou3Bridge {
             }
         }
         if let Some(m) = self.effective_model() {
-            let store = SystemCredentialStore::new();
+            let store = shared_credential_store();
             if let Some(reference) = &m.credential_ref {
                 match store.get(reference) {
                     Ok(Some(key)) if !key.trim().is_empty() => return key,
@@ -882,7 +890,7 @@ impl Pinvou3Bridge {
     /// 本地 vLLM/loopback 无鉴权场景返回占位 key(底座要求非空)。
     fn api_key_for_saved_model(model: &SavedModel) -> String {
         if let Some(reference) = &model.credential_ref {
-            let store = SystemCredentialStore::new();
+            let store = shared_credential_store();
             match store.get(reference) {
                 Ok(Some(key)) if !key.trim().is_empty() => return key,
                 Ok(_) => {}
@@ -1028,7 +1036,7 @@ impl Pinvou3Bridge {
         }
         if let Some(credential) = self.prefs.search.credentials.get(&provider) {
             if let Some(reference) = &credential.credential_ref {
-                let store = SystemCredentialStore::new();
+                let store = shared_credential_store();
                 match store.get(reference) {
                     Ok(Some(key)) if !key.trim().is_empty() => return Some(key),
                     Ok(_) => {}

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -178,6 +178,15 @@ pub fn clear_session(session_id: &str) {
     }
 }
 
+/// 测试探针：该 session 是否仍有未配对 turn 队列条目（删除路径回归断言用）。
+#[cfg(test)]
+pub(crate) fn has_queued_active_turn(session_id: &str) -> bool {
+    active_turns()
+        .lock()
+        .map(|map| map.contains_key(session_id))
+        .unwrap_or(false)
+}
+
 /// 旧调用点(无 usage):落盘不带 usage 字段,reader API 反序列化为 None。
 /// 保留是为了不强迫所有调用点同步升级(commands.rs:200 的 send_error 兜底等)。
 pub fn finish_turn(session_id: &str, status: &str, error: Option<&str>) {
@@ -1259,7 +1268,7 @@ mod tests {
     /// 的 turn,更早条目是"未提交即取消"残留的陈旧轮——终态落在 second 上,
     /// 整队清除后陈旧的 first 不产生终态事件,后续收尾为 no-op。
     #[test]
-    fn queued_second_turn_survives_single_observation_finish() {
+    fn single_observation_finish_tail_pops_latest_turn_and_clears_queue() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let tmp = std::env::temp_dir().join(format!(
             "pinvou3-timing-queued-{}",

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -171,8 +171,8 @@ pub fn start_turn(session_id: &str) -> String {
 }
 
 /// On session deletion, clear its residual unpaired turn queues (map keys
-/// /// accumulate per session id and would grow unbounded over the app lifetime
-/// /// without this).
+/// accumulate per session id and would grow unbounded over the app lifetime
+/// without this).
 pub fn clear_session(session_id: &str) {
     if let Ok(mut map) = active_turns().lock() {
         map.remove(session_id);
@@ -307,13 +307,13 @@ fn finish_turn_internal(
     #[cfg(any(feature = "benchmark-hooks", test))] include_observation: bool,
 ) {
     // Only one turn per session is in flight at a time (turn-lock
-    //     // serialization), so the finishing turn is always the last one queued;
-    //     // take from the tail. Earlier entries can only be stale ids left by the
-    //     // "canceled before submit" path (start_turn followed by
-    //     // emit_unsubmitted_interrupted_terminal, no assistant_done) — popping
-    //     // FIFO would attribute assistant_done to the stale turn and leave the
-    //     // real id stuck in the queue forever. Clear the whole queue here;
-    //     // stale turns produce no terminal event.
+    // serialization), so the finishing turn is always the last one queued;
+    // take from the tail. Earlier entries can only be stale ids left by the
+    // "canceled before submit" path (start_turn followed by
+    // emit_unsubmitted_interrupted_terminal, no assistant_done) — popping
+    // FIFO would attribute assistant_done to the stale turn and leave the
+    // real id stuck in the queue forever. Clear the whole queue here;
+    // stale turns produce no terminal event.
     let active_turn = active_turns().lock().ok().and_then(|mut map| {
         let id = map.get_mut(session_id)?.pop_back();
         map.remove(session_id);
@@ -358,8 +358,8 @@ fn finish_turn_internal(
 #[cfg(any(feature = "benchmark-hooks", test))]
 fn record_first_event(session_id: &str, event: &'static str, tool_name: Option<&str>) {
     // Take the tail: consistent with finish_turn_internal's tail-pop
-    //     // semantics — earlier entries are stale turns left by "canceled before
-    //     // submit"; observation events must land on the truly in-flight turn.
+    // semantics — earlier entries are stale turns left by "canceled before
+    // submit"; observation events must land on the truly in-flight turn.
     let turn_id = active_turns().lock().ok().and_then(|mut map| {
         let active = map.get_mut(session_id)?.back_mut()?;
         active
@@ -1143,12 +1143,12 @@ mod tests {
     }
 
     /// Earlier entries in the queue can only be stale ids left by the
-    ///     /// "canceled before submit" path (no terminal recorded). Start two
-    ///     /// turns in a row to simulate stale residue, then finish: the terminal
-    ///     /// must be attributed to the last queued turn, and once the queue is
-    ///     /// cleared a further finish records nothing — a FIFO pop would
-    ///     /// attribute assistant_done to the stale turn while the real id stays
-    ///     /// stuck in the queue, mis-attributing later turns.
+    /// "canceled before submit" path (no terminal recorded). Start two
+    /// turns in a row to simulate stale residue, then finish: the terminal
+    /// must be attributed to the last queued turn, and once the queue is
+    /// cleared a further finish records nothing — a FIFO pop would
+    /// attribute assistant_done to the stale turn while the real id stays
+    /// stuck in the queue, mis-attributing later turns.
     #[test]
     fn finish_turn_attributes_terminal_to_newest_queued_turn() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1195,8 +1195,8 @@ mod tests {
     }
 
     /// After clear_session removes a session's residual unpaired queues, a
-    ///     /// late finish must not record events to that session's sidecar;
-    ///     /// repeated clears are idempotent.
+    /// late finish must not record events to that session's sidecar;
+    /// repeated clears are idempotent.
     #[test]
     fn clear_session_empties_queue_and_silences_late_finish() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1288,11 +1288,11 @@ mod tests {
     /// single observation finish, and this test pins the "one finish
     /// consumes one active turn" semantics.
     /// Attribution follows the tail-pop semantics (finish_turn_internal):
-    ///     /// under the single-flight guarantee the in-flight turn is the last one
-    ///     /// queued, and earlier entries are stale turns left by "canceled before
-    ///     /// submit" — the terminal lands on second, the whole queue is cleared,
-    ///     /// stale first produces no terminal event, and later finishes are
-    ///     /// no-ops.
+    /// under the single-flight guarantee the in-flight turn is the last one
+    /// queued, and earlier entries are stale turns left by "canceled before
+    /// submit" — the terminal lands on second, the whole queue is cleared,
+    /// stale first produces no terminal event, and later finishes are
+    /// no-ops.
     #[test]
     fn single_observation_finish_tail_pops_latest_turn_and_clears_queue() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1326,8 +1326,8 @@ mod tests {
             .collect();
         assert_eq!(done_events.len(), 1, "exactly one turn must be finished");
         // Tail-pop attribution: the terminal lands on the last-queued
-        //         // second (the in-flight turn under single flight); stale first
-        //         // produces no terminal event.
+        // second (the in-flight turn under single flight); stale first
+        // produces no terminal event.
         assert_eq!(done_events[0].turn_id, second);
         // observation 字段随该次收尾落盘,不因重复收尾丢失。
         assert_eq!(done_events[0].tool_calls, Some(0));

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -170,6 +170,14 @@ pub fn start_turn(session_id: &str) -> String {
     turn_id
 }
 
+/// 会话删除时清空其残留的未配对 turn 队列（map 键随会话 id 累积，不清理会
+/// 随 app 生命周期无界增长）。
+pub fn clear_session(session_id: &str) {
+    if let Ok(mut map) = active_turns().lock() {
+        map.remove(session_id);
+    }
+}
+
 /// 旧调用点(无 usage):落盘不带 usage 字段,reader API 反序列化为 None。
 /// 保留是为了不强迫所有调用点同步升级(commands.rs:200 的 send_error 兜底等)。
 pub fn finish_turn(session_id: &str, status: &str, error: Option<&str>) {
@@ -277,13 +285,15 @@ fn finish_turn_internal(
     >,
     #[cfg(any(feature = "benchmark-hooks", test))] include_observation: bool,
 ) {
+    // 每会话同一时刻只有一轮在飞（turn lock 串行），收尾的必是最后入队的 turn；
+    // 从队尾取。队列里更早的条目只能是"未提交即取消"路径（start_turn 后走
+    // emit_unsubmitted_interrupted_terminal，不落 assistant_done）残留的陈旧
+    // id——若按 FIFO 弹出，assistant_done 会记到陈旧 turn 上，且真 id 永远
+    // 留在队列里。这里整段清掉，陈旧轮不产生终态事件。
     let active_turn = active_turns().lock().ok().and_then(|mut map| {
-        let queue = map.get_mut(session_id)?;
-        let active = queue.pop_front();
-        if queue.is_empty() {
-            map.remove(session_id);
-        }
-        active
+        let id = map.get_mut(session_id)?.pop_back();
+        map.remove(session_id);
+        id
     });
 
     let Some(active_turn) = active_turn else {
@@ -323,8 +333,10 @@ fn finish_turn_internal(
 
 #[cfg(any(feature = "benchmark-hooks", test))]
 fn record_first_event(session_id: &str, event: &'static str, tool_name: Option<&str>) {
+    // 取队尾:与 finish_turn_internal 的尾弹语义一致——队列更早的条目是
+    // "未提交即取消"残留的陈旧 turn,观测事件必须落在真正在飞的一轮上。
     let turn_id = active_turns().lock().ok().and_then(|mut map| {
-        let active = map.get_mut(session_id)?.front_mut()?;
+        let active = map.get_mut(session_id)?.back_mut()?;
         active
             .recorded_first_events
             .insert(event)
@@ -359,7 +371,7 @@ pub fn record_first_message_delta(session_id: &str) {
 #[cfg(any(feature = "benchmark-hooks", test))]
 pub fn record_tool_started(session_id: &str, tool_name: &str) {
     if let Ok(mut map) = active_turns().lock() {
-        if let Some(active) = map.get_mut(session_id).and_then(VecDeque::front_mut) {
+        if let Some(active) = map.get_mut(session_id).and_then(VecDeque::back_mut) {
             active.tool_calls = active.tool_calls.saturating_add(1);
         }
     }
@@ -370,7 +382,7 @@ pub fn record_tool_started(session_id: &str, tool_name: &str) {
 pub fn record_tool_completed(session_id: &str, tool_name: &str, success: bool) {
     if !success {
         if let Ok(mut map) = active_turns().lock() {
-            if let Some(active) = map.get_mut(session_id).and_then(VecDeque::front_mut) {
+            if let Some(active) = map.get_mut(session_id).and_then(VecDeque::back_mut) {
                 active.tool_failures = active.tool_failures.saturating_add(1);
             }
         }
@@ -389,7 +401,7 @@ pub fn record_milestone(session_id: &str, milestone: &str) {
 pub fn record_milestone_meta(session_id: &str, milestone: &str, meta: serde_json::Value) {
     let turn_id = active_turns().lock().ok().and_then(|map| {
         map.get(session_id)
-            .and_then(|queue| queue.front())
+            .and_then(|queue| queue.back())
             .map(|active| active.turn_id.clone())
     });
     let Some(turn_id) = turn_id else { return };
@@ -1105,6 +1117,85 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp);
     }
 
+    /// 队列里更早的条目只能是"未提交即取消"路径残留的陈旧 id(不落终态)。
+    /// 连续两轮 start 模拟陈旧残留后收尾:终态必须归属最后入队的 turn,且
+    /// 清队后再次收尾不再落事件——按 FIFO 弹出会把 assistant_done 记到陈旧
+    /// turn 上,且真 id 永远滞留在队列里轮转误记后续轮次。
+    #[test]
+    fn finish_turn_attributes_terminal_to_newest_queued_turn() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-timing-tail-pop-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let sid = "session-tail-pop";
+        let stale = start_turn(sid);
+        let live = start_turn(sid);
+        finish_turn(sid, "Completed", None);
+
+        let timeline = read_timeline(sid).unwrap();
+        let done: Vec<_> = timeline
+            .iter()
+            .filter(|e| e.event == "assistant_done")
+            .collect();
+        assert_eq!(done.len(), 1);
+        assert_eq!(
+            done[0].turn_id, live,
+            "terminal must be attributed to the newest queued turn"
+        );
+        assert_ne!(done[0].turn_id, stale);
+
+        // 队列已整段清空:再次收尾不得再落终态事件。
+        finish_turn(sid, "Completed", None);
+        assert_eq!(
+            read_timeline(sid)
+                .unwrap()
+                .iter()
+                .filter(|e| e.event == "assistant_done")
+                .count(),
+            1,
+            "finish on an emptied queue must be a no-op"
+        );
+
+        clear_session(sid);
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// clear_session 清掉会话残留的未配对队列后,迟到的 finish 不得再向该
+    /// 会话的 sidecar 落事件;重复 clear 幂等。
+    #[test]
+    fn clear_session_empties_queue_and_silences_late_finish() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-timing-clear-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let sid = "session-clear";
+        start_turn(sid);
+        clear_session(sid);
+        finish_turn(sid, "Completed", None);
+
+        let timeline = read_timeline(sid).unwrap();
+        assert_eq!(timeline.len(), 1);
+        assert_eq!(timeline[0].event, "user_start");
+
+        clear_session(sid);
+        finish_turn(sid, "Completed", None);
+        assert_eq!(read_timeline(sid).unwrap().len(), 1);
+
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
     /// Full chain for TurnUsage: persisting all fields, reading them back, and
     /// compute_stats accumulation. [F3] verifies the forward-compat field set
     /// (cache_write_tokens / reasoning_tokens) keeps every field, while also
@@ -1161,9 +1252,12 @@ mod tests {
     }
 
     /// 排队双轮:同 session 连续两个 start_turn 入队后,一次 observation 收尾
-    /// 只允许 pop 队首轮。此前 forwarder 双重 finish(usage 版 + observation 版)
+    /// 只消费一个轮次。此前 forwarder 双重 finish(usage 版 + observation 版)
     /// 会连 pop 两次,把第二轮的 assistant_done 提前写坏;该调用点已收敛为
     /// 单次 observation 收尾,本测试钉住"一次收尾只消费一个活跃轮"的语义。
+    /// 归属按尾弹语义(finish_turn_internal):单飞保证下在飞的必是最后入队
+    /// 的 turn,更早条目是"未提交即取消"残留的陈旧轮——终态落在 second 上,
+    /// 整队清除后陈旧的 first 不产生终态事件,后续收尾为 no-op。
     #[test]
     fn queued_second_turn_survives_single_observation_finish() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1196,20 +1290,27 @@ mod tests {
             .filter(|event| event.event == "assistant_done")
             .collect();
         assert_eq!(done_events.len(), 1, "exactly one turn must be finished");
-        assert_eq!(done_events[0].turn_id, first);
+        // 尾弹归属:终态落在最后入队的 second(单飞下的在飞轮),陈旧的
+        // first 不产生终态事件。
+        assert_eq!(done_events[0].turn_id, second);
         // observation 字段随该次收尾落盘,不因重复收尾丢失。
         assert_eq!(done_events[0].tool_calls, Some(0));
         assert!(done_events[0].authorized_tool_catalog.is_some());
 
-        // 第二轮仍在队首,后续收尾应归属它。
+        // 队列已整段清除:后续收尾为 no-op,不得再落终态事件。
         finish_turn_with_observation(sid, "Completed", None, None, None);
         let timeline = read_timeline(sid).unwrap();
         let done_events: Vec<_> = timeline
             .iter()
             .filter(|event| event.event == "assistant_done")
             .collect();
-        assert_eq!(done_events.len(), 2);
-        assert_eq!(done_events[1].turn_id, second);
+        assert_eq!(done_events.len(), 1, "finish on an emptied queue is a no-op");
+        assert!(
+            !timeline
+                .iter()
+                .any(|event| event.turn_id == first && event.event == "assistant_done"),
+            "stale unsubmitted-cancel residue must not receive a terminal"
+        );
 
         let _ = std::fs::remove_dir_all(tmp);
     }

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -188,6 +188,17 @@ pub(crate) fn has_queued_active_turn(session_id: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Test probe: queue length for this session (1 means exactly the single
+/// in-flight turn; admission-race tests assert a rejected submit leaves it
+/// at 1 rather than enqueueing a ghost second entry).
+#[cfg(test)]
+pub(crate) fn has_extra_queued_turns(session_id: &str) -> bool {
+    active_turns()
+        .lock()
+        .map(|map| map.get(session_id).is_some_and(|queue| queue.len() > 1))
+        .unwrap_or(false)
+}
+
 /// 旧调用点(无 usage):落盘不带 usage 字段,reader API 反序列化为 None。
 /// 保留是为了不强迫所有调用点同步升级(commands.rs:200 的 send_error 兜底等)。
 pub fn finish_turn(session_id: &str, status: &str, error: Option<&str>) {

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -170,15 +170,16 @@ pub fn start_turn(session_id: &str) -> String {
     turn_id
 }
 
-/// 会话删除时清空其残留的未配对 turn 队列（map 键随会话 id 累积，不清理会
-/// 随 app 生命周期无界增长）。
+/// On session deletion, clear its residual unpaired turn queues (map keys
+/// /// accumulate per session id and would grow unbounded over the app lifetime
+/// /// without this).
 pub fn clear_session(session_id: &str) {
     if let Ok(mut map) = active_turns().lock() {
         map.remove(session_id);
     }
 }
 
-/// 测试探针：该 session 是否仍有未配对 turn 队列条目（删除路径回归断言用）。
+/// Test probe: whether this session still has unpaired turn-queue entries (for deletion-path regression assertions).
 #[cfg(test)]
 pub(crate) fn has_queued_active_turn(session_id: &str) -> bool {
     active_turns()
@@ -294,11 +295,14 @@ fn finish_turn_internal(
     >,
     #[cfg(any(feature = "benchmark-hooks", test))] include_observation: bool,
 ) {
-    // 每会话同一时刻只有一轮在飞（turn lock 串行），收尾的必是最后入队的 turn；
-    // 从队尾取。队列里更早的条目只能是"未提交即取消"路径（start_turn 后走
-    // emit_unsubmitted_interrupted_terminal，不落 assistant_done）残留的陈旧
-    // id——若按 FIFO 弹出，assistant_done 会记到陈旧 turn 上，且真 id 永远
-    // 留在队列里。这里整段清掉，陈旧轮不产生终态事件。
+    // Only one turn per session is in flight at a time (turn-lock
+    //     // serialization), so the finishing turn is always the last one queued;
+    //     // take from the tail. Earlier entries can only be stale ids left by the
+    //     // "canceled before submit" path (start_turn followed by
+    //     // emit_unsubmitted_interrupted_terminal, no assistant_done) — popping
+    //     // FIFO would attribute assistant_done to the stale turn and leave the
+    //     // real id stuck in the queue forever. Clear the whole queue here;
+    //     // stale turns produce no terminal event.
     let active_turn = active_turns().lock().ok().and_then(|mut map| {
         let id = map.get_mut(session_id)?.pop_back();
         map.remove(session_id);
@@ -342,8 +346,9 @@ fn finish_turn_internal(
 
 #[cfg(any(feature = "benchmark-hooks", test))]
 fn record_first_event(session_id: &str, event: &'static str, tool_name: Option<&str>) {
-    // 取队尾:与 finish_turn_internal 的尾弹语义一致——队列更早的条目是
-    // "未提交即取消"残留的陈旧 turn,观测事件必须落在真正在飞的一轮上。
+    // Take the tail: consistent with finish_turn_internal's tail-pop
+    //     // semantics — earlier entries are stale turns left by "canceled before
+    //     // submit"; observation events must land on the truly in-flight turn.
     let turn_id = active_turns().lock().ok().and_then(|mut map| {
         let active = map.get_mut(session_id)?.back_mut()?;
         active
@@ -1126,10 +1131,13 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp);
     }
 
-    /// 队列里更早的条目只能是"未提交即取消"路径残留的陈旧 id(不落终态)。
-    /// 连续两轮 start 模拟陈旧残留后收尾:终态必须归属最后入队的 turn,且
-    /// 清队后再次收尾不再落事件——按 FIFO 弹出会把 assistant_done 记到陈旧
-    /// turn 上,且真 id 永远滞留在队列里轮转误记后续轮次。
+    /// Earlier entries in the queue can only be stale ids left by the
+    ///     /// "canceled before submit" path (no terminal recorded). Start two
+    ///     /// turns in a row to simulate stale residue, then finish: the terminal
+    ///     /// must be attributed to the last queued turn, and once the queue is
+    ///     /// cleared a further finish records nothing — a FIFO pop would
+    ///     /// attribute assistant_done to the stale turn while the real id stays
+    ///     /// stuck in the queue, mis-attributing later turns.
     #[test]
     fn finish_turn_attributes_terminal_to_newest_queued_turn() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1159,7 +1167,7 @@ mod tests {
         );
         assert_ne!(done[0].turn_id, stale);
 
-        // 队列已整段清空:再次收尾不得再落终态事件。
+        // The queue has been fully cleared: another finish must not record a terminal event.
         finish_turn(sid, "Completed", None);
         assert_eq!(
             read_timeline(sid)
@@ -1175,8 +1183,9 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp);
     }
 
-    /// clear_session 清掉会话残留的未配对队列后,迟到的 finish 不得再向该
-    /// 会话的 sidecar 落事件;重复 clear 幂等。
+    /// After clear_session removes a session's residual unpaired queues, a
+    ///     /// late finish must not record events to that session's sidecar;
+    ///     /// repeated clears are idempotent.
     #[test]
     fn clear_session_empties_queue_and_silences_late_finish() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1260,13 +1269,19 @@ mod tests {
         let _ = std::fs::remove_dir_all(tmp);
     }
 
-    /// 排队双轮:同 session 连续两个 start_turn 入队后,一次 observation 收尾
-    /// 只消费一个轮次。此前 forwarder 双重 finish(usage 版 + observation 版)
-    /// 会连 pop 两次,把第二轮的 assistant_done 提前写坏;该调用点已收敛为
-    /// 单次 observation 收尾,本测试钉住"一次收尾只消费一个活跃轮"的语义。
-    /// 归属按尾弹语义(finish_turn_internal):单飞保证下在飞的必是最后入队
-    /// 的 turn,更早条目是"未提交即取消"残留的陈旧轮——终态落在 second 上,
-    /// 整队清除后陈旧的 first 不产生终态事件,后续收尾为 no-op。
+    /// Two queued turns: after two consecutive start_turn calls enqueue on
+    /// the same session, one observation finish consumes a single turn.
+    /// The forwarder previously double-finished (usage variant +
+    /// observation variant), popping twice and corrupting the second
+    /// turn's assistant_done; that call site has since converged to a
+    /// single observation finish, and this test pins the "one finish
+    /// consumes one active turn" semantics.
+    /// Attribution follows the tail-pop semantics (finish_turn_internal):
+    ///     /// under the single-flight guarantee the in-flight turn is the last one
+    ///     /// queued, and earlier entries are stale turns left by "canceled before
+    ///     /// submit" — the terminal lands on second, the whole queue is cleared,
+    ///     /// stale first produces no terminal event, and later finishes are
+    ///     /// no-ops.
     #[test]
     fn single_observation_finish_tail_pops_latest_turn_and_clears_queue() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -1299,14 +1314,15 @@ mod tests {
             .filter(|event| event.event == "assistant_done")
             .collect();
         assert_eq!(done_events.len(), 1, "exactly one turn must be finished");
-        // 尾弹归属:终态落在最后入队的 second(单飞下的在飞轮),陈旧的
-        // first 不产生终态事件。
+        // Tail-pop attribution: the terminal lands on the last-queued
+        //         // second (the in-flight turn under single flight); stale first
+        //         // produces no terminal event.
         assert_eq!(done_events[0].turn_id, second);
         // observation 字段随该次收尾落盘,不因重复收尾丢失。
         assert_eq!(done_events[0].tool_calls, Some(0));
         assert!(done_events[0].authorized_tool_catalog.is_some());
 
-        // 队列已整段清除:后续收尾为 no-op,不得再落终态事件。
+        // The queue has been fully cleared: later finishes are no-ops and must not record terminal events.
         finish_turn_with_observation(sid, "Completed", None, None, None);
         let timeline = read_timeline(sid).unwrap();
         let done_events: Vec<_> = timeline

--- a/pinvou3-app/src-tauri/src/features/assistant/timing.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/timing.rs
@@ -1304,7 +1304,11 @@ mod tests {
             .iter()
             .filter(|event| event.event == "assistant_done")
             .collect();
-        assert_eq!(done_events.len(), 1, "finish on an emptied queue is a no-op");
+        assert_eq!(
+            done_events.len(),
+            1,
+            "finish on an emptied queue is a no-op"
+        );
         assert!(
             !timeline
                 .iter()

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -848,9 +848,9 @@ impl EventBridge {
         if terminal {
             self.record_tool_complete(&call);
             // When the first notification is already terminal (no later
-            //             // update), the tool_update removal path never runs; leaving the
-            //             // entry here would pin its raw_input/raw_output until bridge
-            //             // teardown.
+            // update), the tool_update removal path never runs; leaving the
+            // entry here would pin its raw_input/raw_output until bridge
+            // teardown.
             self.tools.lock().remove(&id);
         }
     }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -847,8 +847,10 @@ impl EventBridge {
         self.emit_protocol("tool_call", call.clone(), notification_meta);
         if terminal {
             self.record_tool_complete(&call);
-            // 首个通知即终态（无后续 update）时没有 tool_update 的删除路径兜底，
-            // 不在此移除会让含 raw_input/raw_output 的条目驻留到 bridge 销毁。
+            // When the first notification is already terminal (no later
+            //             // update), the tool_update removal path never runs; leaving the
+            //             // entry here would pin its raw_input/raw_output until bridge
+            //             // teardown.
             self.tools.lock().remove(&id);
         }
     }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -843,10 +843,13 @@ impl EventBridge {
             &input,
         );
         let terminal = is_terminal(call.status);
-        self.tools.lock().insert(id, call.clone());
+        self.tools.lock().insert(id.clone(), call.clone());
         self.emit_protocol("tool_call", call.clone(), notification_meta);
         if terminal {
             self.record_tool_complete(&call);
+            // 首个通知即终态（无后续 update）时没有 tool_update 的删除路径兜底，
+            // 不在此移除会让含 raw_input/raw_output 的条目驻留到 bridge 销毁。
+            self.tools.lock().remove(&id);
         }
     }
 

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -74,7 +74,7 @@ pub use events::{
     AcpEventEnvelope,
 };
 use latest::LatestVersionProbe;
-use operation_gate::begin_prompt;
+use operation_gate::begin_prompt_turn;
 pub use providers::{
     AcpProvidersView, ImportResult, ProviderManager, ProviderRecord, ProviderWireApi,
 };
@@ -2988,7 +2988,7 @@ impl AcpPool {
             &workspace_references,
             &runtime.prompt_capabilities,
         )?;
-        begin_prompt(&runtime.busy, &runtime.configuring)?;
+        begin_prompt_turn(&runtime.busy, &runtime.configuring, session_id)?;
         if let Err(error) = self.session_store.touch_activity(session_id) {
             runtime.busy.store(false, Ordering::Release);
             return Err(error).context("更新 ACP 会话最近活跃时间失败");

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -2829,10 +2829,9 @@ impl AcpPool {
         .into_iter()
         .find_map(find_in_path)
         {
-            std::process::Command::new(&browser)
-                .arg("--new-window")
-                .arg(&url)
-                .spawn()
+            let mut browser_command = std::process::Command::new(&browser);
+            browser_command.arg("--new-window").arg(&url);
+            crate::platform::os::spawn_detached_and_reap(&mut browser_command)
                 .with_context(|| format!("启动浏览器失败: {}", browser.display()))?;
             eprintln!(
                 "[pinvou3-app] {} authorization page requested via {}",

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -74,7 +74,7 @@ pub use events::{
     AcpEventEnvelope,
 };
 use latest::LatestVersionProbe;
-use operation_gate::begin_prompt_turn;
+use operation_gate::admit_prompt_turn;
 pub use providers::{
     AcpProvidersView, ImportResult, ProviderManager, ProviderRecord, ProviderWireApi,
 };
@@ -2988,11 +2988,11 @@ impl AcpPool {
             &workspace_references,
             &runtime.prompt_capabilities,
         )?;
-        begin_prompt_turn(&runtime.busy, &runtime.configuring, session_id)?;
-        if let Err(error) = self.session_store.touch_activity(session_id) {
-            runtime.busy.store(false, Ordering::Release);
-            return Err(error).context("更新 ACP 会话最近活跃时间失败");
-        }
+        admit_prompt_turn(&runtime.busy, &runtime.configuring, session_id, || {
+            self.session_store
+                .touch_activity(session_id)
+                .context("更新 ACP 会话最近活跃时间失败")
+        })?;
         let pool = self.clone();
         let session_id = session_id.to_string();
         tokio::spawn(async move {

--- a/pinvou3-app/src-tauri/src/features/codex_acp/operation_gate.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/operation_gate.rs
@@ -53,23 +53,37 @@ pub(super) fn begin_prompt(busy: &AtomicBool, configuring: &AtomicBool) -> Resul
     Ok(())
 }
 
-/// Admit a prompt turn: reserve the busy slot, then register the timing turn.
+/// Admit a prompt turn atomically across the fallible activity touch.
 ///
-/// The registration must happen inside the admitted section and before the
-/// prompt task is spawned: the spawned task can complete (fast mock response,
-/// instant connection error) and call `timing::finish_turn` before
-/// `send_message` returns, so registering from the caller after the await
-/// would race that finish — the completion would find an empty queue and be
-/// dropped, leaving the late registration as a stale unpaired entry.
-/// Registering only after admission also guarantees a rejected concurrent
-/// submit never enqueues a ghost turn whose send_error finish would clear
-/// the in-flight turn's queue (round-7 review invariant).
-pub(super) fn begin_prompt_turn(
+/// The sequence — busy admission, activity touch, timing registration — must
+/// stay atomic with respect to the touch failure: registration writes both a
+/// queue entry and a persisted `user_start` event that only a spawned prompt's
+/// `timing::finish_turn` can pair, so registering before a touch that then
+/// fails would leak both with no task left to finish them (round-8 review).
+/// Running the touch inside the admitted section (busy held) preserves the
+/// admission semantics and lets the failure path roll back the slot before
+/// returning.
+///
+/// The timing registration must also happen inside the admitted section and
+/// before the prompt task is spawned: the spawned task can complete (fast mock
+/// response, instant connection error) and call `timing::finish_turn` before
+/// `send_message` returns, so registering from the caller after the await would
+/// race that finish — the completion would find an empty queue and be dropped,
+/// leaving the late registration as a stale unpaired entry. Registering only
+/// after admission also guarantees a rejected concurrent submit never enqueues
+/// a ghost turn whose send_error finish would clear the in-flight turn's
+/// queue (round-7 review invariant).
+pub(super) fn admit_prompt_turn(
     busy: &AtomicBool,
     configuring: &AtomicBool,
     session_id: &str,
+    touch_activity: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
     begin_prompt(busy, configuring)?;
+    if let Err(error) = touch_activity() {
+        busy.store(false, Ordering::Release);
+        return Err(error);
+    }
     crate::features::assistant::timing::start_turn(session_id);
     Ok(())
 }
@@ -253,12 +267,12 @@ mod tests {
 
     /// The timing turn must be registered inside the admitted section, before
     /// the caller can race an immediate completion. Simulates the production
-    /// sequence in `AcpPool::send_message`: `begin_prompt_turn` (admission +
-    /// registration), then a synchronous completion arriving before the
-    /// method would have returned. The terminal must be attributed to the
-    /// registered turn and the queue must be empty afterwards; a caller-side
-    /// registration after the await would instead leave the completion
-    /// dropped and a stale unpaired entry behind.
+    /// sequence in `AcpPool::send_message`: `admit_prompt_turn` (admission +
+    /// activity touch + registration), then a synchronous completion arriving
+    /// before the method would have returned. The terminal must be attributed
+    /// to the registered turn and the queue must be empty afterwards; a
+    /// caller-side registration after the await would instead leave the
+    /// completion dropped and a stale unpaired entry behind.
     #[test]
     fn admitted_prompt_turn_survives_immediate_completion() {
         let _guard = crate::platform::paths::tests::ENV_LOCK
@@ -278,14 +292,14 @@ mod tests {
         let configuring = AtomicBool::new(false);
         let sid = "acp-admission-immediate-completion";
 
-        begin_prompt_turn(&busy, &configuring, sid).unwrap();
+        admit_prompt_turn(&busy, &configuring, sid, || Ok(())).unwrap();
         // Admission registered the turn synchronously, before any spawned
         // prompt task can run: the queue holds it at this point.
         assert!(crate::features::assistant::timing::has_queued_active_turn(
             sid
         ));
         // Immediate completion: happens-before any post-await caller code.
-        // begin_prompt_turn has already registered the turn, so the terminal
+        // admit_prompt_turn has already registered the turn, so the terminal
         // lands on it instead of being dropped on an empty queue.
         crate::features::assistant::timing::finish_turn(sid, "Completed", None);
 
@@ -332,10 +346,10 @@ mod tests {
         let sid = "acp-admission-rejected-submit";
 
         // First submit is admitted and its turn registered.
-        begin_prompt_turn(&busy, &configuring, sid).unwrap();
+        admit_prompt_turn(&busy, &configuring, sid, || Ok(())).unwrap();
         // Concurrent second submit is rejected by busy admission: no turn is
         // registered (no ghost queue entry).
-        let rejected = begin_prompt_turn(&busy, &configuring, sid);
+        let rejected = admit_prompt_turn(&busy, &configuring, sid, || Ok(()));
         assert!(rejected.is_err());
         assert!(
             !crate::features::assistant::timing::has_extra_queued_turns(sid),
@@ -359,6 +373,77 @@ mod tests {
             "in-flight terminal must be recorded exactly once"
         );
         assert_eq!(done[0].status.as_deref(), Some("Completed"));
+
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// Round-8 regression (failure injection): an activity-touch failure after
+    /// successful busy admission must leave no residue of any kind — the busy
+    /// slot is released for the next submit, no timing queue entry remains,
+    /// and no `user_start` lifecycle event is persisted (registration writes
+    /// both, and with no prompt task spawned nothing would ever pair a
+    /// terminal with them). The next admitted submit must then behave as if
+    /// the failed one never happened.
+    #[test]
+    fn activity_touch_failure_releases_slot_and_defers_registration() {
+        let _guard = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-acp-touch-failure-timing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let busy = AtomicBool::new(false);
+        let configuring = AtomicBool::new(false);
+        let sid = "acp-admission-touch-failure";
+
+        // Injected store failure: the session store cannot persist the
+        // activity update (disk full, corrupted session file, invalid id...).
+        let failed = admit_prompt_turn(&busy, &configuring, sid, || {
+            Err(anyhow::anyhow!("simulated touch_activity failure"))
+        });
+        assert!(failed.is_err(), "touch failure must propagate to caller");
+
+        // Busy slot rolled back: the session is immediately submittable.
+        assert!(
+            !busy.load(Ordering::Acquire),
+            "busy slot must be released on touch failure"
+        );
+        // No queue entry was registered for the failed submit.
+        assert!(
+            !crate::features::assistant::timing::has_queued_active_turn(sid),
+            "failed submit must not leave a queued timing entry"
+        );
+        // No lifecycle event was persisted: there is no accepted turn whose
+        // start a later terminal could be misattributed to.
+        let timeline = crate::features::assistant::timing::read_timeline(sid).unwrap();
+        assert!(
+            timeline.is_empty(),
+            "failed submit must not persist any timing event"
+        );
+
+        // The next submit on the same session is unaffected: admitted, turn
+        // registered, and a terminal pairs with it exactly.
+        admit_prompt_turn(&busy, &configuring, sid, || Ok(())).unwrap();
+        assert!(crate::features::assistant::timing::has_queued_active_turn(
+            sid
+        ));
+        crate::features::assistant::timing::finish_turn(sid, "Completed", None);
+
+        let timeline = crate::features::assistant::timing::read_timeline(sid).unwrap();
+        let done: Vec<_> = timeline
+            .iter()
+            .filter(|e| e.event == "assistant_done")
+            .collect();
+        assert_eq!(done.len(), 1, "next turn terminal recorded exactly once");
+        assert_eq!(timeline[0].event, "user_start");
+        assert_eq!(done[0].turn_id, timeline[0].turn_id);
 
         let _ = std::fs::remove_dir_all(tmp);
     }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/operation_gate.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/operation_gate.rs
@@ -53,6 +53,27 @@ pub(super) fn begin_prompt(busy: &AtomicBool, configuring: &AtomicBool) -> Resul
     Ok(())
 }
 
+/// Admit a prompt turn: reserve the busy slot, then register the timing turn.
+///
+/// The registration must happen inside the admitted section and before the
+/// prompt task is spawned: the spawned task can complete (fast mock response,
+/// instant connection error) and call `timing::finish_turn` before
+/// `send_message` returns, so registering from the caller after the await
+/// would race that finish — the completion would find an empty queue and be
+/// dropped, leaving the late registration as a stale unpaired entry.
+/// Registering only after admission also guarantees a rejected concurrent
+/// submit never enqueues a ghost turn whose send_error finish would clear
+/// the in-flight turn's queue (round-7 review invariant).
+pub(super) fn begin_prompt_turn(
+    busy: &AtomicBool,
+    configuring: &AtomicBool,
+    session_id: &str,
+) -> Result<()> {
+    begin_prompt(busy, configuring)?;
+    crate::features::assistant::timing::start_turn(session_id);
+    Ok(())
+}
+
 enum SessionConfigChange<'a> {
     Model(&'a str),
     Mode(&'a str),
@@ -228,5 +249,117 @@ mod tests {
             assert!(configuring.load(Ordering::Acquire));
         }
         assert!(!configuring.load(Ordering::Acquire));
+    }
+
+    /// The timing turn must be registered inside the admitted section, before
+    /// the caller can race an immediate completion. Simulates the production
+    /// sequence in `AcpPool::send_message`: `begin_prompt_turn` (admission +
+    /// registration), then a synchronous completion arriving before the
+    /// method would have returned. The terminal must be attributed to the
+    /// registered turn and the queue must be empty afterwards; a caller-side
+    /// registration after the await would instead leave the completion
+    /// dropped and a stale unpaired entry behind.
+    #[test]
+    fn admitted_prompt_turn_survives_immediate_completion() {
+        let _guard = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-acp-admission-timing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let busy = AtomicBool::new(false);
+        let configuring = AtomicBool::new(false);
+        let sid = "acp-admission-immediate-completion";
+
+        begin_prompt_turn(&busy, &configuring, sid).unwrap();
+        // Admission registered the turn synchronously, before any spawned
+        // prompt task can run: the queue holds it at this point.
+        assert!(crate::features::assistant::timing::has_queued_active_turn(
+            sid
+        ));
+        // Immediate completion: happens-before any post-await caller code.
+        // begin_prompt_turn has already registered the turn, so the terminal
+        // lands on it instead of being dropped on an empty queue.
+        crate::features::assistant::timing::finish_turn(sid, "Completed", None);
+
+        let timeline = crate::features::assistant::timing::read_timeline(sid).unwrap();
+        let done: Vec<_> = timeline
+            .iter()
+            .filter(|e| e.event == "assistant_done")
+            .collect();
+        assert_eq!(done.len(), 1, "immediate completion must be recorded");
+        assert_eq!(
+            timeline[0].event, "user_start",
+            "terminal must pair with the registered turn"
+        );
+        assert_eq!(done[0].turn_id, timeline[0].turn_id);
+        assert!(
+            !crate::features::assistant::timing::has_queued_active_turn(sid),
+            "queue must be empty after the paired finish"
+        );
+
+        let _ = std::fs::remove_dir_all(tmp);
+    }
+
+    /// A submit rejected by busy admission must neither enqueue a ghost turn
+    /// nor disturb the in-flight turn's queue entry: its send_error finish
+    /// (if the caller emits one) finds only the in-flight turn and would be
+    /// attributed correctly, and the in-flight terminal is never swallowed.
+    #[test]
+    fn rejected_concurrent_submit_never_clears_in_flight_turn() {
+        let _guard = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-acp-reject-timing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::env::set_var("PINVOU3_HOME", &tmp);
+
+        let busy = AtomicBool::new(false);
+        let configuring = AtomicBool::new(false);
+        let sid = "acp-admission-rejected-submit";
+
+        // First submit is admitted and its turn registered.
+        begin_prompt_turn(&busy, &configuring, sid).unwrap();
+        // Concurrent second submit is rejected by busy admission: no turn is
+        // registered (no ghost queue entry).
+        let rejected = begin_prompt_turn(&busy, &configuring, sid);
+        assert!(rejected.is_err());
+        assert!(
+            !crate::features::assistant::timing::has_extra_queued_turns(sid),
+            "rejected submit must not enqueue a second queue entry"
+        );
+
+        // The in-flight turn finishes; a late send_error from the rejected
+        // caller afterwards must be a no-op (empty queue), so the in-flight
+        // terminal is recorded exactly once and never swallowed.
+        crate::features::assistant::timing::finish_turn(sid, "Completed", None);
+        crate::features::assistant::timing::finish_turn(sid, "send_error", Some("busy"));
+
+        let timeline = crate::features::assistant::timing::read_timeline(sid).unwrap();
+        let done: Vec<_> = timeline
+            .iter()
+            .filter(|e| e.event == "assistant_done")
+            .collect();
+        assert_eq!(
+            done.len(),
+            1,
+            "in-flight terminal must be recorded exactly once"
+        );
+        assert_eq!(done[0].status.as_deref(), Some("Completed"));
+
+        let _ = std::fs::remove_dir_all(tmp);
     }
 }

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -127,12 +127,14 @@ async fn request_ima(
         return Err("IMA 请求 body 必须是 JSON object。".to_string());
     }
 
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| format!("创建 IMA 客户端失败: {e}"))?;
+    // 进程级共享客户端：每次调用新建 Client 会重建 TLS 配置/连接池，
+    // 对同一 host（ima.qq.com）完全浪费 keep-alive/h2 复用。超时语义移到
+    // per-request（reqwest::RequestBuilder::timeout）保持 30s 不变。
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    let client = CLIENT.get_or_init(|| reqwest::Client::builder().build().unwrap_or_default());
     let response = client
         .post(format!("{IMA_BASE_URL}/{api_path}"))
+        .timeout(std::time::Duration::from_secs(30))
         .header("ima-openapi-clientid", client_id)
         .header("ima-openapi-apikey", api_key)
         .header(

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -130,8 +130,13 @@ async fn request_ima(
     // 进程级共享客户端：每次调用新建 Client 会重建 TLS 配置/连接池，
     // 对同一 host（ima.qq.com）完全浪费 keep-alive/h2 复用。超时语义移到
     // per-request（reqwest::RequestBuilder::timeout）保持 30s 不变。
-    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
-    let client = CLIENT.get_or_init(|| reqwest::Client::builder().build().unwrap_or_default());
+    // 构建失败（TLS/系统配置不可用）保持逐调用错误传播——Client::default()
+    // 在同类失败上同样 panic，不是可用的回退。
+    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> = std::sync::OnceLock::new();
+    let client = CLIENT
+        .get_or_init(|| reqwest::Client::builder().build().map_err(|e| format!("创建 IMA 客户端失败: {e}")))
+        .as_ref()
+        .map_err(Clone::clone)?;
     let response = client
         .post(format!("{IMA_BASE_URL}/{api_path}"))
         .timeout(std::time::Duration::from_secs(30))

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -127,16 +127,21 @@ async fn request_ima(
         return Err("IMA 请求 body 必须是 JSON object。".to_string());
     }
 
-    // 进程级共享客户端：每次调用新建 Client 会重建 TLS 配置/连接池，
-    // 对同一 host（ima.qq.com）完全浪费 keep-alive/h2 复用。超时语义移到
-    // per-request（reqwest::RequestBuilder::timeout）保持 30s 不变。
-    // OnceLock 口径注意两点：
-    // 1. reqwest 默认启用系统代理检测，代理配置在首次构建时快照、进程生命
-    //    周期内不再重读——会话中途改系统代理需重启应用才生效。
-    // 2. 构建失败（TLS/系统配置不可用）的 Err 同样被进程级缓存，不做逐调用
-    //    重试（同类失败重试无意义，Client::default() 在同类失败上直接 panic，
-    //    不是可用的回退）。请求级错误（连接受拒/超时）不受缓存影响，仍逐调用
-    //    传播。
+    // Process-wide shared client: building a Client per call re-creates the
+    //     // TLS config/connection pool, wasting all keep-alive/h2 reuse against
+    //     // the same host (ima.qq.com). The timeout moves to per-request
+    //     // (reqwest::RequestBuilder::timeout), keeping the same 30s.
+    //     // Two OnceLock caveats:
+    //     // 1. reqwest enables system-proxy detection by default; the proxy
+    //     //    config is snapshotted at first build and never re-read for the
+    //     //    process lifetime — changing the system proxy mid-session needs an
+    //     //    app restart to take effect.
+    //     // 2. A build failure (TLS/system config unavailable) is cached
+    //     //    process-wide as Err with no per-call retry (retrying an identical
+    //     //    failure is pointless; Client::default() panics on the same failure
+    //     //    and is not a usable fallback). Request-level errors (connection
+    //     //    refused/timeout) are unaffected by the cache and still propagate
+    //     //    per call.
     static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
         std::sync::OnceLock::new();
     let client = CLIENT

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -132,9 +132,14 @@ async fn request_ima(
     // per-request（reqwest::RequestBuilder::timeout）保持 30s 不变。
     // 构建失败（TLS/系统配置不可用）保持逐调用错误传播——Client::default()
     // 在同类失败上同样 panic，不是可用的回退。
-    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> = std::sync::OnceLock::new();
+    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
     let client = CLIENT
-        .get_or_init(|| reqwest::Client::builder().build().map_err(|e| format!("创建 IMA 客户端失败: {e}")))
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .build()
+                .map_err(|e| format!("创建 IMA 客户端失败: {e}"))
+        })
         .as_ref()
         .map_err(Clone::clone)?;
     let response = client

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -128,20 +128,20 @@ async fn request_ima(
     }
 
     // Process-wide shared client: building a Client per call re-creates the
-    //     // TLS config/connection pool, wasting all keep-alive/h2 reuse against
-    //     // the same host (ima.qq.com). The timeout moves to per-request
-    //     // (reqwest::RequestBuilder::timeout), keeping the same 30s.
-    //     // Two OnceLock caveats:
-    //     // 1. reqwest enables system-proxy detection by default; the proxy
-    //     //    config is snapshotted at first build and never re-read for the
-    //     //    process lifetime — changing the system proxy mid-session needs an
-    //     //    app restart to take effect.
-    //     // 2. A build failure (TLS/system config unavailable) is cached
-    //     //    process-wide as Err with no per-call retry (retrying an identical
-    //     //    failure is pointless; Client::default() panics on the same failure
-    //     //    and is not a usable fallback). Request-level errors (connection
-    //     //    refused/timeout) are unaffected by the cache and still propagate
-    //     //    per call.
+    // TLS config/connection pool, wasting all keep-alive/h2 reuse against
+    // the same host (ima.qq.com). The timeout moves to per-request
+    // (reqwest::RequestBuilder::timeout), keeping the same 30s.
+    // Two OnceLock caveats:
+    // 1. reqwest enables system-proxy detection by default; the proxy
+    // config is snapshotted at first build and never re-read for the
+    // process lifetime — changing the system proxy mid-session needs an
+    // app restart to take effect.
+    // 2. A build failure (TLS/system config unavailable) is cached
+    // process-wide as Err with no per-call retry (retrying an identical
+    // failure is pointless; Client::default() panics on the same failure
+    // and is not a usable fallback). Request-level errors (connection
+    // refused/timeout) are unaffected by the cache and still propagate
+    // per call.
     static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
         std::sync::OnceLock::new();
     let client = CLIENT

--- a/pinvou3-app/src-tauri/src/features/connectors/ima.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/ima.rs
@@ -130,8 +130,13 @@ async fn request_ima(
     // 进程级共享客户端：每次调用新建 Client 会重建 TLS 配置/连接池，
     // 对同一 host（ima.qq.com）完全浪费 keep-alive/h2 复用。超时语义移到
     // per-request（reqwest::RequestBuilder::timeout）保持 30s 不变。
-    // 构建失败（TLS/系统配置不可用）保持逐调用错误传播——Client::default()
-    // 在同类失败上同样 panic，不是可用的回退。
+    // OnceLock 口径注意两点：
+    // 1. reqwest 默认启用系统代理检测，代理配置在首次构建时快照、进程生命
+    //    周期内不再重读——会话中途改系统代理需重启应用才生效。
+    // 2. 构建失败（TLS/系统配置不可用）的 Err 同样被进程级缓存，不做逐调用
+    //    重试（同类失败重试无意义，Client::default() 在同类失败上直接 panic，
+    //    不是可用的回退）。请求级错误（连接受拒/超时）不受缓存影响，仍逐调用
+    //    传播。
     static CLIENT: std::sync::OnceLock<Result<reqwest::Client, String>> =
         std::sync::OnceLock::new();
     let client = CLIENT

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -198,10 +198,12 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 ///
 /// 客户端进程级共享：监控页 1 Hz 轮询 + 聊天页顶栏状态点都会走这里，
 /// 每次新建 Client 意味着每秒重建 TLS/连接池、零复用。3s 探测超时移到
-/// per-request 保持原语义。
-fn shared_probe_client() -> &'static reqwest::Client {
-    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
-    CLIENT.get_or_init(|| reqwest::Client::builder().build().unwrap_or_default())
+/// per-request 保持原语义。构建失败（TLS/系统配置不可用）返回 None 保持
+/// 调用方「探测失败 → fallback 配置值」的原降级路径——Client::default()
+/// 在同类失败上同样 panic，不是可用的回退。
+fn shared_probe_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| reqwest::Client::builder().build().ok()).as_ref()
 }
 
 async fn snapshot_for_model_config(
@@ -212,7 +214,7 @@ async fn snapshot_for_model_config(
     provider: String,
     api_key: Option<&str>,
 ) -> Option<VllmSnapshot> {
-    let client = shared_probe_client();
+    let client = shared_probe_client()?;
     let target_kind = if preset == ModelPreset::LocalVllm {
         "local"
     } else {
@@ -581,7 +583,9 @@ fn vllm_target_kind(upstream: &str) -> &'static str {
 /// 窗口推导(见 docs/context-compaction-设计.md)。探测失败(vLLM 没起/超时)返回
 /// `(None, None)`,调用方 fallback 配置值 + 名字 hint 老路。
 pub async fn probe_vllm_model_info(base_url: &str) -> (Option<String>, Option<u32>) {
-    let client = shared_probe_client();
+    let Some(client) = shared_probe_client() else {
+        return (None, None);
+    };
     let url = if base_url.trim_end_matches('/').ends_with("/v1") {
         format!("{}/models", base_url.trim_end_matches('/'))
     } else {

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -195,6 +195,15 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 }
 
 /// 当前模型健康探测 + 本地 vLLM Prometheus metrics 解析。
+///
+/// 客户端进程级共享：监控页 1 Hz 轮询 + 聊天页顶栏状态点都会走这里，
+/// 每次新建 Client 意味着每秒重建 TLS/连接池、零复用。3s 探测超时移到
+/// per-request 保持原语义。
+fn shared_probe_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| reqwest::Client::builder().build().unwrap_or_default())
+}
+
 async fn snapshot_for_model_config(
     upstream: &str,
     configured_model: Option<String>,
@@ -203,10 +212,7 @@ async fn snapshot_for_model_config(
     provider: String,
     api_key: Option<&str>,
 ) -> Option<VllmSnapshot> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()
-        .ok()?;
+    let client = shared_probe_client();
     let target_kind = if preset == ModelPreset::LocalVllm {
         "local"
     } else {
@@ -216,7 +222,7 @@ async fn snapshot_for_model_config(
 
     // 1) /models 健康
     let models_url = models_probe_url(upstream);
-    let mut request = client.get(models_url);
+    let mut request = client.get(models_url).timeout(Duration::from_secs(3));
     if let Some(key) = api_key.map(str::trim).filter(|key| !key.is_empty()) {
         if is_anthropic_endpoint(upstream) {
             request = request
@@ -328,7 +334,12 @@ async fn snapshot_for_model_config(
         .then(|| strip_v1_suffix(upstream).map(|h| format!("{h}/metrics")))
         .flatten();
     let metrics_resp = match metrics_url {
-        Some(u) => client.get(&u).send().await.ok(),
+        Some(u) => client
+            .get(&u)
+            .timeout(Duration::from_secs(3))
+            .send()
+            .await
+            .ok(),
         None => None,
     };
     let metrics_text = match metrics_resp {
@@ -570,18 +581,13 @@ fn vllm_target_kind(upstream: &str) -> &'static str {
 /// 窗口推导(见 docs/context-compaction-设计.md)。探测失败(vLLM 没起/超时)返回
 /// `(None, None)`,调用方 fallback 配置值 + 名字 hint 老路。
 pub async fn probe_vllm_model_info(base_url: &str) -> (Option<String>, Option<u32>) {
-    let Ok(client) = reqwest::Client::builder()
-        .timeout(Duration::from_secs(3))
-        .build()
-    else {
-        return (None, None);
-    };
+    let client = shared_probe_client();
     let url = if base_url.trim_end_matches('/').ends_with("/v1") {
         format!("{}/models", base_url.trim_end_matches('/'))
     } else {
         format!("{}/v1/models", base_url.trim_end_matches('/'))
     };
-    let Ok(resp) = client.get(url).send().await else {
+    let Ok(resp) = client.get(url).timeout(Duration::from_secs(3)).send().await else {
         return (None, None);
     };
     if !resp.status().is_success() {

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -197,20 +197,20 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 /// 当前模型健康探测 + 本地 vLLM Prometheus metrics 解析。
 ///
 /// Process-wide shared client: both the monitor page's 1 Hz polling and the
-/// /// chat page's status dot go through here; a fresh Client per call would
-/// /// rebuild TLS/connection pools every second with zero reuse. The 3s probe
-/// /// timeout moves to per-request, keeping the original semantics. Two
-/// /// OnceLock caveats:
-/// /// 1. reqwest enables system-proxy detection by default; the proxy config
-/// ///    is snapshotted at first build and never re-read for the process
-/// ///    lifetime — changing the system proxy mid-session needs an app
-/// ///    restart to take effect;
-/// /// 2. A build failure (TLS/system config unavailable) is cached
-/// ///    process-wide as `None` with no per-call retry, preserving the
-/// ///    caller's "probe failed → fall back to configured values" downgrade —
-/// ///    Client::default() panics on the same failure and is not a usable
-/// ///    fallback. Request-level errors are unaffected and remain per-call,
-/// ///    handled by the caller.
+/// chat page's status dot go through here; a fresh Client per call would
+/// rebuild TLS/connection pools every second with zero reuse. The 3s probe
+/// timeout moves to per-request, keeping the original semantics. Two
+/// OnceLock caveats:
+/// 1. reqwest enables system-proxy detection by default; the proxy config
+/// is snapshotted at first build and never re-read for the process
+/// lifetime — changing the system proxy mid-session needs an app
+/// restart to take effect;
+/// 2. A build failure (TLS/system config unavailable) is cached
+/// process-wide as `None` with no per-call retry, preserving the
+/// caller's "probe failed → fall back to configured values" downgrade —
+/// Client::default() panics on the same failure and is not a usable
+/// fallback. Request-level errors are unaffected and remain per-call,
+/// handled by the caller.
 fn shared_probe_client() -> Option<&'static reqwest::Client> {
     static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
     CLIENT

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -196,15 +196,21 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 
 /// 当前模型健康探测 + 本地 vLLM Prometheus metrics 解析。
 ///
-/// 客户端进程级共享：监控页 1 Hz 轮询 + 聊天页顶栏状态点都会走这里，
-/// 每次新建 Client 意味着每秒重建 TLS/连接池、零复用。3s 探测超时移到
-/// per-request 保持原语义。OnceLock 口径注意两点：
-/// 1. reqwest 默认启用系统代理检测，代理配置在首次构建时快照、进程生命
-///    周期内不再重读——会话中途改系统代理需重启应用才生效；
-/// 2. 构建失败（TLS/系统配置不可用）缓存为进程级 `None`，不做逐调用重试，
-///    保持调用方「探测失败 → fallback 配置值」的原降级路径——Client::default()
-///    在同类失败上同样 panic，不是可用的回退。请求级错误不受影响，仍逐调用
-///    由调用方处理。
+/// Process-wide shared client: both the monitor page's 1 Hz polling and the
+/// /// chat page's status dot go through here; a fresh Client per call would
+/// /// rebuild TLS/connection pools every second with zero reuse. The 3s probe
+/// /// timeout moves to per-request, keeping the original semantics. Two
+/// /// OnceLock caveats:
+/// /// 1. reqwest enables system-proxy detection by default; the proxy config
+/// ///    is snapshotted at first build and never re-read for the process
+/// ///    lifetime — changing the system proxy mid-session needs an app
+/// ///    restart to take effect;
+/// /// 2. A build failure (TLS/system config unavailable) is cached
+/// ///    process-wide as `None` with no per-call retry, preserving the
+/// ///    caller's "probe failed → fall back to configured values" downgrade —
+/// ///    Client::default() panics on the same failure and is not a usable
+/// ///    fallback. Request-level errors are unaffected and remain per-call,
+/// ///    handled by the caller.
 fn shared_probe_client() -> Option<&'static reqwest::Client> {
     static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
     CLIENT

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -203,7 +203,9 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 /// 在同类失败上同样 panic，不是可用的回退。
 fn shared_probe_client() -> Option<&'static reqwest::Client> {
     static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
-    CLIENT.get_or_init(|| reqwest::Client::builder().build().ok()).as_ref()
+    CLIENT
+        .get_or_init(|| reqwest::Client::builder().build().ok())
+        .as_ref()
 }
 
 async fn snapshot_for_model_config(

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -198,9 +198,13 @@ fn model_api_key(model: &SavedModel) -> Option<String> {
 ///
 /// 客户端进程级共享：监控页 1 Hz 轮询 + 聊天页顶栏状态点都会走这里，
 /// 每次新建 Client 意味着每秒重建 TLS/连接池、零复用。3s 探测超时移到
-/// per-request 保持原语义。构建失败（TLS/系统配置不可用）返回 None 保持
-/// 调用方「探测失败 → fallback 配置值」的原降级路径——Client::default()
-/// 在同类失败上同样 panic，不是可用的回退。
+/// per-request 保持原语义。OnceLock 口径注意两点：
+/// 1. reqwest 默认启用系统代理检测，代理配置在首次构建时快照、进程生命
+///    周期内不再重读——会话中途改系统代理需重启应用才生效；
+/// 2. 构建失败（TLS/系统配置不可用）缓存为进程级 `None`，不做逐调用重试，
+///    保持调用方「探测失败 → fallback 配置值」的原降级路径——Client::default()
+///    在同类失败上同样 panic，不是可用的回退。请求级错误不受影响，仍逐调用
+///    由调用方处理。
 fn shared_probe_client() -> Option<&'static reqwest::Client> {
     static CLIENT: std::sync::OnceLock<Option<reqwest::Client>> = std::sync::OnceLock::new();
     CLIENT

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -164,9 +164,9 @@ pub struct SessionStore {
     /// 的扫描结果不得回填(陈旧快照复活会驻留到下一次写)。见 store.rs。
     pub(crate) list_cache_generation: Arc<AtomicU64>,
     /// Session-purged hook (dependency inversion): see
-    ///     /// [`SessionPurgedHook`]. None = nobody registered (tests/early
-    ///     /// startup); deletion proceeds and only the process-level state goes
-    ///     /// unnotified.
+    /// [`SessionPurgedHook`]. None = nobody registered (tests/early
+    /// startup); deletion proceeds and only the process-level state goes
+    /// unnotified.
     session_purged_hooks: Arc<RwLock<Vec<SessionPurgedHook>>>,
 }
 
@@ -185,12 +185,12 @@ pub type ExecutionRootResolver = Arc<dyn Fn(&str) -> Option<PathBuf> + Send + Sy
 pub type CodeSessionPredicate = Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
 /// Session-purged hook: fired by [`SessionStore::delete`] and deep deletion
-/// /// paths inside the sessions feature (retention policy/scheduled cleanup),
-/// /// notifying process-level state holders (timing/pending_user_input, etc.)
-/// /// to clear their keys. Same injection reason as `ExecutionRootResolver` —
-/// /// `sessions` must not depend on `assistant` in reverse (the architecture
-/// /// guard's feature dependency direction); the app composition root
-/// /// registers it.
+/// paths inside the sessions feature (retention policy/scheduled cleanup),
+/// notifying process-level state holders (timing/pending_user_input, etc.)
+/// to clear their keys. Same injection reason as `ExecutionRootResolver` —
+/// `sessions` must not depend on `assistant` in reverse (the architecture
+/// guard's feature dependency direction); the app composition root
+/// registers it.
 pub type SessionPurgedHook = Arc<dyn Fn(&str) + Send + Sync>;
 
 /// 一个会话的两个根:

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -163,6 +163,9 @@ pub struct SessionStore {
     /// `list_cache` 的代数计数:每次失效自增,回填前比对——miss 期间发生过写
     /// 的扫描结果不得回填(陈旧快照复活会驻留到下一次写)。见 store.rs。
     pub(crate) list_cache_generation: Arc<AtomicU64>,
+    /// 会话删除钩子（依赖倒置）：见 [`SessionPurgedHook`]。None = 无人注册
+    /// （测试/启动早期），删除照常、仅进程级状态无人跟进。
+    session_purged_hooks: Arc<RwLock<Vec<SessionPurgedHook>>>,
 }
 
 /// 原生代码会话(品悟 Engine)的执行根解析器:绑定了项目目录的原生代码会话
@@ -178,6 +181,12 @@ pub type ExecutionRootResolver = Arc<dyn Fn(&str) -> Option<PathBuf> + Send + Sy
 /// ACP 会话在其 store 里恒为 plain（`bind_*` 时显式重置），故本判定命中即
 /// "品悟原生 code 会话"，不会误伤 ACP 会话自己的权限模式。
 pub type CodeSessionPredicate = Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
+/// 会话删除钩子：保留策略/定时清理在 sessions feature 深层直接删除会话时
+/// 通知进程级状态持有者（timing/pending_user_input 等）同步清键。与
+/// `ExecutionRootResolver` 同样的注入理由——`sessions` 不能反向依赖
+/// `assistant`（架构守卫的 feature 依赖方向），由 app 组合根注册。
+pub type SessionPurgedHook = Arc<dyn Fn(&str) + Send + Sync>;
 
 /// 一个会话的两个根:
 /// - `execution`:Engine cwd / shell 执行目录。绑了项目目录的原生代码会话 = 项目

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -163,8 +163,10 @@ pub struct SessionStore {
     /// `list_cache` 的代数计数:每次失效自增,回填前比对——miss 期间发生过写
     /// 的扫描结果不得回填(陈旧快照复活会驻留到下一次写)。见 store.rs。
     pub(crate) list_cache_generation: Arc<AtomicU64>,
-    /// 会话删除钩子（依赖倒置）：见 [`SessionPurgedHook`]。None = 无人注册
-    /// （测试/启动早期），删除照常、仅进程级状态无人跟进。
+    /// Session-purged hook (dependency inversion): see
+    ///     /// [`SessionPurgedHook`]. None = nobody registered (tests/early
+    ///     /// startup); deletion proceeds and only the process-level state goes
+    ///     /// unnotified.
     session_purged_hooks: Arc<RwLock<Vec<SessionPurgedHook>>>,
 }
 
@@ -182,10 +184,13 @@ pub type ExecutionRootResolver = Arc<dyn Fn(&str) -> Option<PathBuf> + Send + Sy
 /// "品悟原生 code 会话"，不会误伤 ACP 会话自己的权限模式。
 pub type CodeSessionPredicate = Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
-/// 会话删除钩子：[`SessionStore::delete`] 及保留策略/定时清理等 sessions
-/// feature 深层删除路径触发，通知进程级状态持有者（timing/pending_user_input
-/// 等）同步清键。与 `ExecutionRootResolver` 同样的注入理由——`sessions` 不能
-/// 反向依赖 `assistant`（架构守卫的 feature 依赖方向），由 app 组合根注册。
+/// Session-purged hook: fired by [`SessionStore::delete`] and deep deletion
+/// /// paths inside the sessions feature (retention policy/scheduled cleanup),
+/// /// notifying process-level state holders (timing/pending_user_input, etc.)
+/// /// to clear their keys. Same injection reason as `ExecutionRootResolver` —
+/// /// `sessions` must not depend on `assistant` in reverse (the architecture
+/// /// guard's feature dependency direction); the app composition root
+/// /// registers it.
 pub type SessionPurgedHook = Arc<dyn Fn(&str) + Send + Sync>;
 
 /// 一个会话的两个根:

--- a/pinvou3-app/src-tauri/src/features/sessions/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mod.rs
@@ -182,10 +182,10 @@ pub type ExecutionRootResolver = Arc<dyn Fn(&str) -> Option<PathBuf> + Send + Sy
 /// "品悟原生 code 会话"，不会误伤 ACP 会话自己的权限模式。
 pub type CodeSessionPredicate = Arc<dyn Fn(&str) -> bool + Send + Sync>;
 
-/// 会话删除钩子：保留策略/定时清理在 sessions feature 深层直接删除会话时
-/// 通知进程级状态持有者（timing/pending_user_input 等）同步清键。与
-/// `ExecutionRootResolver` 同样的注入理由——`sessions` 不能反向依赖
-/// `assistant`（架构守卫的 feature 依赖方向），由 app 组合根注册。
+/// 会话删除钩子：[`SessionStore::delete`] 及保留策略/定时清理等 sessions
+/// feature 深层删除路径触发，通知进程级状态持有者（timing/pending_user_input
+/// 等）同步清键。与 `ExecutionRootResolver` 同样的注入理由——`sessions` 不能
+/// 反向依赖 `assistant`（架构守卫的 feature 依赖方向），由 app 组合根注册。
 pub type SessionPurgedHook = Arc<dyn Fn(&str) + Send + Sync>;
 
 /// 一个会话的两个根:

--- a/pinvou3-app/src-tauri/src/features/sessions/retention.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/retention.rs
@@ -250,6 +250,15 @@ impl SessionStore {
         if removed_hidden {
             self.save_hidden_sessions();
         }
+
+        // 进程级 turn 状态 map（timing/pending_user_input）的键随会话 id 累
+        // 积，由 app 组合根注册的删除钩子清理（见 SessionPurgedHook；这里不
+        // 能直接依赖 assistant feature）。否则残留的未配对 turn 队列会随 app
+        // 生命周期无界增长，迟到的 finish 还会在已删会话目录外重建孤儿
+        // timing sidecar。
+        for id in ids {
+            self.notify_session_purged(id);
+        }
     }
 
     pub(crate) fn purge_all_scheduled_side_maps(&self) {

--- a/pinvou3-app/src-tauri/src/features/sessions/retention.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/retention.rs
@@ -251,11 +251,13 @@ impl SessionStore {
             self.save_hidden_sessions();
         }
 
-        // 进程级 turn 状态 map（timing/pending_user_input）的键随会话 id 累
-        // 积，由 app 组合根注册的删除钩子清理（见 SessionPurgedHook；这里不
-        // 能直接依赖 assistant feature）。否则残留的未配对 turn 队列会随 app
-        // 生命周期无界增长，迟到的 finish 还会在已删会话目录外重建孤儿
-        // timing sidecar。
+        // Keys of process-level turn-state maps (timing/pending_user_input)
+        //         // accumulate per session id and are cleaned by the purge hook
+        //         // registered by the app composition root (see SessionPurgedHook;
+        //         // this module must not depend on the assistant feature directly).
+        //         // Otherwise residual unpaired turn queues grow unbounded over the
+        //         // app lifetime, and a late finish would rebuild an orphan timing
+        //         // sidecar outside the deleted session's directory.
         for id in ids {
             self.notify_session_purged(id);
         }

--- a/pinvou3-app/src-tauri/src/features/sessions/retention.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/retention.rs
@@ -252,12 +252,12 @@ impl SessionStore {
         }
 
         // Keys of process-level turn-state maps (timing/pending_user_input)
-        //         // accumulate per session id and are cleaned by the purge hook
-        //         // registered by the app composition root (see SessionPurgedHook;
-        //         // this module must not depend on the assistant feature directly).
-        //         // Otherwise residual unpaired turn queues grow unbounded over the
-        //         // app lifetime, and a late finish would rebuild an orphan timing
-        //         // sidecar outside the deleted session's directory.
+        // accumulate per session id and are cleaned by the purge hook
+        // registered by the app composition root (see SessionPurgedHook;
+        // this module must not depend on the assistant feature directly).
+        // Otherwise residual unpaired turn queues grow unbounded over the
+        // app lifetime, and a late finish would rebuild an orphan timing
+        // sidecar outside the deleted session's directory.
         for id in ids {
             self.notify_session_purged(id);
         }

--- a/pinvou3-app/src-tauri/src/features/sessions/store.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/store.rs
@@ -28,6 +28,7 @@ use super::scheduled::ChatEngineState;
 use super::transcript::{looks_like_truncating_overwrite, transcript_revision};
 use super::validators::{generate_session_id, persisted_system_prompt, validate_session_id};
 use super::CodeSessionPredicate;
+use super::SessionPurgedHook;
 use crate::core::mode_state::SerializableMode;
 use crate::platform::prefs::UserPrefs;
 use std::collections::HashSet;
@@ -175,6 +176,7 @@ impl SessionStore {
             session_mode_states: Arc::new(RwLock::new(HashMap::new())),
             code_permission: Arc::new(RwLock::new(prefs_snapshot.code_permission)),
             mode_defaults: Arc::new(RwLock::new(prefs_snapshot.mode_defaults)),
+            session_purged_hooks: Arc::new(RwLock::new(Vec::new())),
         };
         store.load_scheduled_profiles()?;
         store.reconcile_scheduled_profiles_locked()?;
@@ -353,6 +355,21 @@ impl SessionStore {
     pub fn set_code_session_predicate(&self, predicate: CodeSessionPredicate) {
         *self.code_session_predicate.write() = Some(predicate);
         self.reconcile_code_default_modes();
+    }
+
+    /// 注册会话删除钩子（依赖倒置，见 [`SessionPurgedHook`]）。app 组合根在
+    /// pool 就绪后注册 timing/pending_user_input 清理；store clone 共享同一
+    /// Arc，注入即时生效。
+    pub fn register_session_purged_hook(&self, hook: SessionPurgedHook) {
+        self.session_purged_hooks.write().push(hook);
+    }
+
+    /// 会话从 store 删除（含保留策略/定时清理等无 app handle 的深层路径）后
+    /// 通知全部注册方。失败静默（钩子方自负责幂等），不得阻塞删除主流程。
+    pub(crate) fn notify_session_purged(&self, id: &str) {
+        for hook in self.session_purged_hooks.read().iter() {
+            hook(id);
+        }
     }
 
     pub(crate) fn reconcile_code_default_modes(&self) {

--- a/pinvou3-app/src-tauri/src/features/sessions/store.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/store.rs
@@ -337,6 +337,10 @@ impl SessionStore {
         if removed_hidden {
             self.save_hidden_sessions();
         }
+        // 钩子在所有 store 侧 map 锁释放后触发（与 retention.rs 保留路径
+        // 同口径）：回调进程级清理时持锁会引入锁序风险。钩子方只做幂等的
+        // keyed removal；未注册（测试/启动早期）时删除照常完成。
+        self.notify_session_purged(id);
         Ok(())
     }
 
@@ -364,8 +368,9 @@ impl SessionStore {
         self.session_purged_hooks.write().push(hook);
     }
 
-    /// 会话从 store 删除（含保留策略/定时清理等无 app handle 的深层路径）后
-    /// 通知全部注册方。失败静默（钩子方自负责幂等），不得阻塞删除主流程。
+    /// 会话从 store 删除（[`SessionStore::delete`] 及保留策略/定时清理等无
+    /// app handle 的深层路径）后通知全部注册方。失败静默（钩子方自负责幂等），
+    /// 不得阻塞删除主流程；调用方必须在 store 侧锁全部释放后触发。
     pub(crate) fn notify_session_purged(&self, id: &str) {
         for hook in self.session_purged_hooks.read().iter() {
             hook(id);

--- a/pinvou3-app/src-tauri/src/features/sessions/store.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/store.rs
@@ -337,9 +337,12 @@ impl SessionStore {
         if removed_hidden {
             self.save_hidden_sessions();
         }
-        // 钩子在所有 store 侧 map 锁释放后触发（与 retention.rs 保留路径
-        // 同口径）：回调进程级清理时持锁会引入锁序风险。钩子方只做幂等的
-        // keyed removal；未注册（测试/启动早期）时删除照常完成。
+        // The hook fires after all store-side map locks are released (same
+        //         // policy as the retention path in retention.rs): holding locks
+        //         // while calling process-level cleanup would introduce lock-ordering
+        //         // risk. Hook implementations only do idempotent keyed removal; when
+        //         // nobody registered (tests/early startup), deletion completes as
+        //         // usual.
         self.notify_session_purged(id);
         Ok(())
     }
@@ -361,16 +364,20 @@ impl SessionStore {
         self.reconcile_code_default_modes();
     }
 
-    /// 注册会话删除钩子（依赖倒置，见 [`SessionPurgedHook`]）。app 组合根在
-    /// pool 就绪后注册 timing/pending_user_input 清理；store clone 共享同一
-    /// Arc，注入即时生效。
+    /// Register a session-purged hook (dependency inversion, see
+    ///     /// [`SessionPurgedHook`]). The app composition root registers the
+    ///     /// timing/pending_user_input cleanup once the pool is ready; store
+    ///     /// clones share the same Arc, so injection takes effect immediately.
     pub fn register_session_purged_hook(&self, hook: SessionPurgedHook) {
         self.session_purged_hooks.write().push(hook);
     }
 
-    /// 会话从 store 删除（[`SessionStore::delete`] 及保留策略/定时清理等无
-    /// app handle 的深层路径）后通知全部注册方。失败静默（钩子方自负责幂等），
-    /// 不得阻塞删除主流程；调用方必须在 store 侧锁全部释放后触发。
+    /// Notifies all registered parties after a session is deleted from the
+    ///     /// store ([`SessionStore::delete`] and deep paths without an app handle
+    ///     /// such as retention policy/scheduled cleanup). Failures are silent
+    ///     /// (hook implementations own their idempotency) and must not block the
+    ///     /// deletion path; callers must fire this only after all store-side
+    ///     /// locks are released.
     pub(crate) fn notify_session_purged(&self, id: &str) {
         for hook in self.session_purged_hooks.read().iter() {
             hook(id);

--- a/pinvou3-app/src-tauri/src/features/sessions/store.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/store.rs
@@ -338,11 +338,11 @@ impl SessionStore {
             self.save_hidden_sessions();
         }
         // The hook fires after all store-side map locks are released (same
-        //         // policy as the retention path in retention.rs): holding locks
-        //         // while calling process-level cleanup would introduce lock-ordering
-        //         // risk. Hook implementations only do idempotent keyed removal; when
-        //         // nobody registered (tests/early startup), deletion completes as
-        //         // usual.
+        // policy as the retention path in retention.rs): holding locks
+        // while calling process-level cleanup would introduce lock-ordering
+        // risk. Hook implementations only do idempotent keyed removal; when
+        // nobody registered (tests/early startup), deletion completes as
+        // usual.
         self.notify_session_purged(id);
         Ok(())
     }
@@ -365,19 +365,19 @@ impl SessionStore {
     }
 
     /// Register a session-purged hook (dependency inversion, see
-    ///     /// [`SessionPurgedHook`]). The app composition root registers the
-    ///     /// timing/pending_user_input cleanup once the pool is ready; store
-    ///     /// clones share the same Arc, so injection takes effect immediately.
+    /// [`SessionPurgedHook`]). The app composition root registers the
+    /// timing/pending_user_input cleanup once the pool is ready; store
+    /// clones share the same Arc, so injection takes effect immediately.
     pub fn register_session_purged_hook(&self, hook: SessionPurgedHook) {
         self.session_purged_hooks.write().push(hook);
     }
 
     /// Notifies all registered parties after a session is deleted from the
-    ///     /// store ([`SessionStore::delete`] and deep paths without an app handle
-    ///     /// such as retention policy/scheduled cleanup). Failures are silent
-    ///     /// (hook implementations own their idempotency) and must not block the
-    ///     /// deletion path; callers must fire this only after all store-side
-    ///     /// locks are released.
+    /// store ([`SessionStore::delete`] and deep paths without an app handle
+    /// such as retention policy/scheduled cleanup). Failures are silent
+    /// (hook implementations own their idempotency) and must not block the
+    /// deletion path; callers must fire this only after all store-side
+    /// locks are released.
     pub(crate) fn notify_session_purged(&self, id: &str) {
         for hook in self.session_purged_hooks.read().iter() {
             hook(id);

--- a/pinvou3-app/src-tauri/src/features/sessions/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/tests.rs
@@ -2429,6 +2429,28 @@ fn retention_purge_also_updates_multi_agent_flags() {
     );
 }
 
+#[test]
+fn retention_purge_notifies_session_purged_hooks() {
+    let (store, _guard) = isolated_store();
+    let chat = store
+        .create_new("m".into(), None, std::env::temp_dir())
+        .expect("create chat");
+    let id = chat.metadata.id.clone();
+
+    // 依赖倒置：sessions feature 深层的保留策略删除经钩子通知进程级状态持有
+    // 者（timing/pending_user_input 由组合根注册），未注册时删除照常。
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorder = seen.clone();
+    store.register_session_purged_hook(std::sync::Arc::new(move |sid: &str| {
+        recorder.lock().unwrap().push(sid.to_string());
+    }));
+
+    store.purge_session_side_maps(&[id.clone()]);
+
+    let notified = seen.lock().unwrap().clone();
+    assert_eq!(notified, vec![id], "删除钩子必须收到被清会话 id");
+}
+
 // ===================== code 会话权限模式（两层持久化 + 默认值解析）=====================
 
 /// 注入一个简易 code 会话判定：列表内的 id 视为品悟原生 code 会话。

--- a/pinvou3-app/src-tauri/src/features/sessions/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/tests.rs
@@ -2437,8 +2437,10 @@ fn retention_purge_notifies_session_purged_hooks() {
         .expect("create chat");
     let id = chat.metadata.id.clone();
 
-    // 依赖倒置：sessions feature 深层的保留策略删除经钩子通知进程级状态持有
-    // 者（timing/pending_user_input 由组合根注册），未注册时删除照常。
+    // Dependency inversion: deep retention-policy deletions inside the
+    //     // sessions feature notify process-level state holders via the hook
+    //     // (timing/pending_user_input registered by the composition root); with
+    //     // nobody registered, deletion proceeds as usual.
     let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let recorder = seen.clone();
     store.register_session_purged_hook(std::sync::Arc::new(move |sid: &str| {
@@ -2448,7 +2450,11 @@ fn retention_purge_notifies_session_purged_hooks() {
     store.purge_session_side_maps(&[id.clone()]);
 
     let notified = seen.lock().unwrap().clone();
-    assert_eq!(notified, vec![id], "删除钩子必须收到被清会话 id");
+    assert_eq!(
+        notified,
+        vec![id],
+        "the purge hook must receive the deleted session id"
+    );
 }
 
 // ===================== code 会话权限模式（两层持久化 + 默认值解析）=====================

--- a/pinvou3-app/src-tauri/src/features/sessions/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/tests.rs
@@ -2438,9 +2438,9 @@ fn retention_purge_notifies_session_purged_hooks() {
     let id = chat.metadata.id.clone();
 
     // Dependency inversion: deep retention-policy deletions inside the
-    //     // sessions feature notify process-level state holders via the hook
-    //     // (timing/pending_user_input registered by the composition root); with
-    //     // nobody registered, deletion proceeds as usual.
+    // sessions feature notify process-level state holders via the hook
+    // (timing/pending_user_input registered by the composition root); with
+    // nobody registered, deletion proceeds as usual.
     let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let recorder = seen.clone();
     store.register_session_purged_hook(std::sync::Arc::new(move |sid: &str| {

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -451,6 +451,17 @@ pub fn run() {
                         let agents = code_session_agents.clone();
                         move |session_id: &str| agents.is_code_session(session_id)
                     }));
+                    // 保留策略/定时清理在 sessions feature 深层直接删会话（无 app
+                    // handle）：进程级 turn 状态 map 的清键经删除钩子在此接线，
+                    // 与 delete_session 命令的清理同口径（依赖倒置，见
+                    // SessionPurgedHook——sessions 不能反向依赖 assistant）。
+                    store_for_engine
+                        .register_session_purged_hook(std::sync::Arc::new(|session_id: &str| {
+                            crate::features::assistant::timing::clear_session(session_id);
+                            crate::features::assistant::pending_user_input::clear_session(
+                                session_id,
+                            );
+                        }));
                     // 远程端正式支持代码会话之前，先过滤原生代码会话事件（与 Engine
                     // bridge 共用同一份 SessionAgentStore 判定）。
                     remote_control_manager.set_code_session_predicate(std::sync::Arc::new({

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -451,12 +451,16 @@ pub fn run() {
                         let agents = code_session_agents.clone();
                         move |session_id: &str| agents.is_code_session(session_id)
                     }));
-                    // SessionStore::delete 与保留策略/定时清理等深层删除路径（无
-                    // app handle）统一经删除钩子清进程级 per-session 键，与
-                    // delete_session 命令的清理同口径（依赖倒置，见
-                    // SessionPurgedHook——sessions 不能反向依赖 assistant）。
-                    // MonitorState 在 setup 后段才 manage，钩子在删除时才执行，
-                    // try_state 读时已在位；未 manage（极早期删除）则跳过该项。
+                    // SessionStore::delete and deep deletion paths without
+                    //                     // an app handle (retention policy/scheduled cleanup)
+                    //                     // clear process-level per-session keys uniformly via
+                    //                     // the purge hook, matching the delete_session command's
+                    //                     // cleanup (dependency inversion, see SessionPurgedHook —
+                    //                     // sessions must not depend on assistant in reverse).
+                    //                     // MonitorState is managed late in setup while the hook
+                    //                     // only runs at deletion time, so try_state finds it in
+                    //                     // place; if unmanaged (very early deletions) the item is
+                    //                     // skipped.
                     let app_for_purge_hook = handle.clone();
                     store_for_engine
                         .register_session_purged_hook(std::sync::Arc::new(move |session_id: &str| {
@@ -465,8 +469,10 @@ pub fn run() {
                                 session_id,
                             );
                             crate::features::memory::discard_turn_capture(session_id);
-                            // 自测指标按 session 键累积（warmed_sessions 在每轮
-                            // TurnComplete 插入、从不回收），随删除一并清键。
+                            // Self-metrics accumulate per session key
+                            //                             // (warmed_sessions inserts on every TurnComplete
+                            //                             // and is never reclaimed); clear the keys on
+                            //                             // deletion.
                             if let Some(metrics) = app_for_purge_hook
                                 .try_state::<crate::features::monitor::MonitorState>()
                                 .map(|state| state.self_metrics())

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -451,16 +451,28 @@ pub fn run() {
                         let agents = code_session_agents.clone();
                         move |session_id: &str| agents.is_code_session(session_id)
                     }));
-                    // 保留策略/定时清理在 sessions feature 深层直接删会话（无 app
-                    // handle）：进程级 turn 状态 map 的清键经删除钩子在此接线，
-                    // 与 delete_session 命令的清理同口径（依赖倒置，见
+                    // SessionStore::delete 与保留策略/定时清理等深层删除路径（无
+                    // app handle）统一经删除钩子清进程级 per-session 键，与
+                    // delete_session 命令的清理同口径（依赖倒置，见
                     // SessionPurgedHook——sessions 不能反向依赖 assistant）。
+                    // MonitorState 在 setup 后段才 manage，钩子在删除时才执行，
+                    // try_state 读时已在位；未 manage（极早期删除）则跳过该项。
+                    let app_for_purge_hook = handle.clone();
                     store_for_engine
-                        .register_session_purged_hook(std::sync::Arc::new(|session_id: &str| {
+                        .register_session_purged_hook(std::sync::Arc::new(move |session_id: &str| {
                             crate::features::assistant::timing::clear_session(session_id);
                             crate::features::assistant::pending_user_input::clear_session(
                                 session_id,
                             );
+                            crate::features::memory::discard_turn_capture(session_id);
+                            // 自测指标按 session 键累积（warmed_sessions 在每轮
+                            // TurnComplete 插入、从不回收），随删除一并清键。
+                            if let Some(metrics) = app_for_purge_hook
+                                .try_state::<crate::features::monitor::MonitorState>()
+                                .map(|state| state.self_metrics())
+                            {
+                                metrics.drop_session(session_id);
+                            }
                         }));
                     // 远程端正式支持代码会话之前，先过滤原生代码会话事件（与 Engine
                     // bridge 共用同一份 SessionAgentStore 判定）。

--- a/pinvou3-app/src-tauri/src/lib.rs
+++ b/pinvou3-app/src-tauri/src/lib.rs
@@ -452,15 +452,15 @@ pub fn run() {
                         move |session_id: &str| agents.is_code_session(session_id)
                     }));
                     // SessionStore::delete and deep deletion paths without
-                    //                     // an app handle (retention policy/scheduled cleanup)
-                    //                     // clear process-level per-session keys uniformly via
-                    //                     // the purge hook, matching the delete_session command's
-                    //                     // cleanup (dependency inversion, see SessionPurgedHook —
-                    //                     // sessions must not depend on assistant in reverse).
-                    //                     // MonitorState is managed late in setup while the hook
-                    //                     // only runs at deletion time, so try_state finds it in
-                    //                     // place; if unmanaged (very early deletions) the item is
-                    //                     // skipped.
+                    // an app handle (retention policy/scheduled cleanup)
+                    // clear process-level per-session keys uniformly via
+                    // the purge hook, matching the delete_session command's
+                    // cleanup (dependency inversion, see SessionPurgedHook —
+                    // sessions must not depend on assistant in reverse).
+                    // MonitorState is managed late in setup while the hook
+                    // only runs at deletion time, so try_state finds it in
+                    // place; if unmanaged (very early deletions) the item is
+                    // skipped.
                     let app_for_purge_hook = handle.clone();
                     store_for_engine
                         .register_session_purged_hook(std::sync::Arc::new(move |session_id: &str| {
@@ -470,9 +470,9 @@ pub fn run() {
                             );
                             crate::features::memory::discard_turn_capture(session_id);
                             // Self-metrics accumulate per session key
-                            //                             // (warmed_sessions inserts on every TurnComplete
-                            //                             // and is never reclaimed); clear the keys on
-                            //                             // deletion.
+                            // (warmed_sessions inserts on every TurnComplete
+                            // and is never reclaimed); clear the keys on
+                            // deletion.
                             if let Some(metrics) = app_for_purge_hook
                                 .try_state::<crate::features::monitor::MonitorState>()
                                 .map(|state| state.self_metrics())

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -30,6 +30,9 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// `KEY_LOCKS` 为每个 `(service, account)` 维护一把 `Arc<Mutex<()>>`,`get`/`set`/`delete`
 /// 在"访问 Keychain + 读写值缓存"整段持有对应 key 的锁,串行化同一凭据的所有操作;不同 key
 /// 互不阻塞。锁内部从不嵌套 `value_cache`/`KEY_LOCKS` 之外的锁,无死锁风险。
+/// 唯一例外:`delete` 成功后注销锁登记,与一个尚持有旧锁实例的在飞 `get`/`set` 短暂失去
+/// 互斥(窗口为单次后端访问;仅动态 key 的 delete 竞态可及,后果退化为一次陈旧缓存,
+/// 由下次 `set`/`delete`/重启自愈)。
 ///
 /// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与本 crate 内其他明文 secret
 /// 在内存中的驻留(如 bridge 注入给引擎的 api_key、marketplace 重灌进进程 env 的 mcp
@@ -675,7 +678,7 @@ mod tests {
     /// remote-knowledge 的 request_id 不留残余）；后续 `get` 走缓存未命中
     /// → 后端确认"不存在"，仍返回 None。
     #[test]
-    fn system_store_delete_marks_cache_known_absent() {
+    fn system_store_delete_removes_cache_and_lock_entries() {
         let backend = Arc::new(FakeKeyringStore::new());
         backend.seed("model:delete-probe", "sk-will-be-deleted-12345");
         let store = SystemCredentialStore::new();

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -31,9 +31,9 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// 在"访问 Keychain + 读写值缓存"整段持有对应 key 的锁,串行化同一凭据的所有操作;不同 key
 /// 互不阻塞。锁内部从不嵌套 `value_cache`/`KEY_LOCKS` 之外的锁,无死锁风险。
 /// Sole exception: after a successful `delete`, the lock registration is
-/// /// removed only when no in-flight thread still holds the old lock handle
-/// /// (`Arc::strong_count` gate); otherwise the registration stays and
-/// /// converges on the next `delete`, so mutual exclusion never breaks.
+/// removed only when no in-flight thread still holds the old lock handle
+/// (`Arc::strong_count` gate); otherwise the registration stays and
+/// converges on the next `delete`, so mutual exclusion never breaks.
 ///
 /// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与本 crate 内其他明文 secret
 /// 在内存中的驻留(如 bridge 注入给引擎的 api_key、marketplace 重灌进进程 env 的 mcp
@@ -45,13 +45,13 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// 访问"App 或其它进程新增了该 item,本应用在重启前仍读到 `None`(设置页误显示"未配置")。
 /// 这是进程级内存缓存的固有边界,正常改 keychain 的路径走应用 UI(经 `set`/`delete` 同步
 /// updating the cache synchronously), so the impact is limited. The
-/// /// symmetric cost: after a successful `delete` the `None` placeholder is no
-/// /// longer kept (preventing unbounded accumulation for dynamic keys), so the
-/// /// first `get` after a delete touches the keyring backend once more — under
-/// /// macOS ad-hoc signing this can surface one extra authorization prompt;
-/// /// this trades "at most one backend access per delete" for cache
-/// /// correctness and does not affect #175's "no repeated prompts during use"
-/// /// goal.
+/// symmetric cost: after a successful `delete` the `None` placeholder is no
+/// longer kept (preventing unbounded accumulation for dynamic keys), so the
+/// first `get` after a delete touches the keyring backend once more — under
+/// macOS ad-hoc signing this can surface one extra authorization prompt;
+/// this trades "at most one backend access per delete" for cache
+/// correctness and does not affect #175's "no repeated prompts during use"
+/// goal.
 static VALUE_CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
 
 fn value_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
@@ -432,18 +432,18 @@ impl CredentialStore for SystemCredentialStore {
             started_at.elapsed().as_millis()
         );
         // After a successful delete, remove the cache entry and the
-        //         // per-key lock registration outright (still inside the same
-        //         // critical section): the None placeholder in the value cache and
-        //         // KEY_LOCKS entries would otherwise accumulate forever under
-        //         // dynamic keys (e.g. remote-knowledge's per-join request_id) with
-        //         // no query value after deletion — "known absent" is expressible by
-        //         // a missing entry. The lock registration is removed only when no
-        //         // in-flight handle remains (map holds 1 + this function's local
-        //         // 1 = 2): if a get/set still held the old handle, deregistering
-        //         // would let later operations create a second lock and lose mutual
-        //         // exclusion with the in-flight operation (cache and backend
-        //         // effects could reorder); a leftover registration converges on the
-        //         // next delete.
+        // per-key lock registration outright (still inside the same
+        // critical section): the None placeholder in the value cache and
+        // KEY_LOCKS entries would otherwise accumulate forever under
+        // dynamic keys (e.g. remote-knowledge's per-join request_id) with
+        // no query value after deletion — "known absent" is expressible by
+        // a missing entry. The lock registration is removed only when no
+        // in-flight handle remains (map holds 1 + this function's local
+        // 1 = 2): if a get/set still held the old handle, deregistering
+        // would let later operations create a second lock and lose mutual
+        // exclusion with the in-flight operation (cache and backend
+        // effects could reorder); a leftover registration converges on the
+        // next delete.
         if result.is_ok() {
             if let Ok(mut cache) = value_cache().lock() {
                 cache.remove(&(reference.service.clone(), reference.account.clone()));
@@ -694,10 +694,10 @@ mod tests {
     }
 
     /// After a successful `delete`, the cache entry and the per-key lock
-    ///     /// registration are both removed (dynamic keys such as
-    ///     /// remote-knowledge's request_id leave no residue); a later `get` takes
-    ///     /// the cache-miss path → the backend confirms "absent" and still
-    ///     /// returns None.
+    /// registration are both removed (dynamic keys such as
+    /// remote-knowledge's request_id leave no residue); a later `get` takes
+    /// the cache-miss path → the backend confirms "absent" and still
+    /// returns None.
     #[test]
     fn system_store_delete_removes_cache_and_lock_entries() {
         let backend = Arc::new(FakeKeyringStore::new());

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -420,10 +420,16 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
-        // 删除成功后缓存为 None(仍在同一临界区内),避免下次 get 再次访问 Keychain(命中"已知不存在")。
+        // 删除成功后直接移除缓存与 per-key 锁登记（仍在同一临界区内）：
+        // get 缓存 None 占位与 KEY_LOCKS 条目会随动态 key（如 remote-knowledge
+        // 逐 join 请求的 request_id）永久累积，删后无查询价值——"已知不存在"
+        // 可由缺失条目表达。
         if result.is_ok() {
             if let Ok(mut cache) = value_cache().lock() {
-                cache.insert((reference.service.clone(), reference.account.clone()), None);
+                cache.remove(&(reference.service.clone(), reference.account.clone()));
+            }
+            if let Ok(mut locks) = key_locks().lock() {
+                locks.remove(&(reference.service.clone(), reference.account.clone()));
             }
         }
         result
@@ -665,8 +671,9 @@ mod tests {
         assert_eq!(backend.get_count(), 0, "set 后 get 应命中缓存,不访问后端");
     }
 
-    /// `delete` 成功后缓存为"已知不存在"(None),后续 `get` 命中缓存返回 None,
-    /// 不再访问后端(命中"已知不存在"分支)。
+    /// `delete` 成功后缓存条目与 per-key 锁登记一并移除（动态 key 如
+    /// remote-knowledge 的 request_id 不留残余）；后续 `get` 走缓存未命中
+    /// → 后端确认"不存在"，仍返回 None。
     #[test]
     fn system_store_delete_marks_cache_known_absent() {
         let backend = Arc::new(FakeKeyringStore::new());
@@ -685,15 +692,31 @@ mod tests {
             Some("sk-will-be-deleted-12345")
         );
         let count_before_delete = backend.get_count();
-        // delete 后缓存更新为 None。
+        // delete 后缓存条目移除而非留 None 占位。
         store.delete(&reference).unwrap();
-        // 后续 get 命中"已知不存在",返回 None 且不触后端。
+        assert!(
+            !value_cache()
+                .lock()
+                .unwrap()
+                .contains_key(&(reference.service.clone(), reference.account.clone())),
+            "delete 后缓存条目应被移除,不再保留 None 占位"
+        );
+        assert!(
+            !key_locks()
+                .lock()
+                .unwrap()
+                .contains_key(&(reference.service.clone(), reference.account.clone())),
+            "delete 后 per-key 锁登记应被移除"
+        );
+        // 后续 get 重新触达后端(条目已删)并确认不存在。
         assert_eq!(store.get(&reference).unwrap(), None);
         assert_eq!(
             backend.get_count(),
-            count_before_delete,
-            "delete 后 get 应命中缓存,不访问后端"
+            count_before_delete + 1,
+            "delete 后缓存条目已移除,get 重新触达后端确认不存在"
         );
+        // 再次 delete 仍成功(幂等,后端已无该条目)。
+        store.delete(&reference).unwrap();
     }
 
     /// 缓存按 `(service, account)` 隔离:一个凭据的缓存不影响另一凭据的后端访问。

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -30,8 +30,10 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// `KEY_LOCKS` 为每个 `(service, account)` 维护一把 `Arc<Mutex<()>>`,`get`/`set`/`delete`
 /// 在"访问 Keychain + 读写值缓存"整段持有对应 key 的锁,串行化同一凭据的所有操作;不同 key
 /// 互不阻塞。锁内部从不嵌套 `value_cache`/`KEY_LOCKS` 之外的锁,无死锁风险。
-/// 唯一例外:`delete` 成功后注销锁登记仅在没有在飞线程仍持旧锁句柄时执行
-/// (`Arc::strong_count` 门控);否则保留登记,由下一次 `delete` 收敛,互斥不失效。
+/// Sole exception: after a successful `delete`, the lock registration is
+/// /// removed only when no in-flight thread still holds the old lock handle
+/// /// (`Arc::strong_count` gate); otherwise the registration stays and
+/// /// converges on the next `delete`, so mutual exclusion never breaks.
 ///
 /// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与本 crate 内其他明文 secret
 /// 在内存中的驻留(如 bridge 注入给引擎的 api_key、marketplace 重灌进进程 env 的 mcp
@@ -42,10 +44,14 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// **陈旧边界**:`Ok(None)`("已知不存在")会缓存整个进程生命周期;若运行期间用户经"钥匙串
 /// 访问"App 或其它进程新增了该 item,本应用在重启前仍读到 `None`(设置页误显示"未配置")。
 /// 这是进程级内存缓存的固有边界,正常改 keychain 的路径走应用 UI(经 `set`/`delete` 同步
-/// 更新缓存),故影响有限。对称的代价:`delete` 成功后不再保留 `None` 占位(动态 key 场景
-/// 防无界累积),删除后的首次 `get` 会重新触达 keyring 后端一次——macOS ad-hoc 下可能
-/// 因此多弹一次授权窗;这是用"每次删除后至多一次后端访问"换缓存正确性,不影响 #175
-/// 的"使用期间不反复弹窗"目标。
+/// updating the cache synchronously), so the impact is limited. The
+/// /// symmetric cost: after a successful `delete` the `None` placeholder is no
+/// /// longer kept (preventing unbounded accumulation for dynamic keys), so the
+/// /// first `get` after a delete touches the keyring backend once more — under
+/// /// macOS ad-hoc signing this can surface one extra authorization prompt;
+/// /// this trades "at most one backend access per delete" for cache
+/// /// correctness and does not affect #175's "no repeated prompts during use"
+/// /// goal.
 static VALUE_CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
 
 fn value_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {
@@ -425,13 +431,19 @@ impl CredentialStore for SystemCredentialStore {
             result.is_ok(),
             started_at.elapsed().as_millis()
         );
-        // 删除成功后直接移除缓存与 per-key 锁登记（仍在同一临界区内）：
-        // get 缓存 None 占位与 KEY_LOCKS 条目会随动态 key（如 remote-knowledge
-        // 逐 join 请求的 request_id）永久累积，删后无查询价值——"已知不存在"
-        // 可由缺失条目表达。锁登记仅在无在飞句柄时注销（map 持有 1 份 + 本函数
-        // 局部变量 1 份 = 2）：若仍有 get/set 持旧句柄，注销会让后续操作创建
-        // 第二把锁并与在飞操作失去互斥（缓存与后端效果可倒置）；残留登记由
-        // 下一次 delete 收敛。
+        // After a successful delete, remove the cache entry and the
+        //         // per-key lock registration outright (still inside the same
+        //         // critical section): the None placeholder in the value cache and
+        //         // KEY_LOCKS entries would otherwise accumulate forever under
+        //         // dynamic keys (e.g. remote-knowledge's per-join request_id) with
+        //         // no query value after deletion — "known absent" is expressible by
+        //         // a missing entry. The lock registration is removed only when no
+        //         // in-flight handle remains (map holds 1 + this function's local
+        //         // 1 = 2): if a get/set still held the old handle, deregistering
+        //         // would let later operations create a second lock and lose mutual
+        //         // exclusion with the in-flight operation (cache and backend
+        //         // effects could reorder); a leftover registration converges on the
+        //         // next delete.
         if result.is_ok() {
             if let Ok(mut cache) = value_cache().lock() {
                 cache.remove(&(reference.service.clone(), reference.account.clone()));
@@ -681,9 +693,11 @@ mod tests {
         assert_eq!(backend.get_count(), 0, "set 后 get 应命中缓存,不访问后端");
     }
 
-    /// `delete` 成功后缓存条目与 per-key 锁登记一并移除（动态 key 如
-    /// remote-knowledge 的 request_id 不留残余）；后续 `get` 走缓存未命中
-    /// → 后端确认"不存在"，仍返回 None。
+    /// After a successful `delete`, the cache entry and the per-key lock
+    ///     /// registration are both removed (dynamic keys such as
+    ///     /// remote-knowledge's request_id leave no residue); a later `get` takes
+    ///     /// the cache-miss path → the backend confirms "absent" and still
+    ///     /// returns None.
     #[test]
     fn system_store_delete_removes_cache_and_lock_entries() {
         let backend = Arc::new(FakeKeyringStore::new());
@@ -702,30 +716,30 @@ mod tests {
             Some("sk-will-be-deleted-12345")
         );
         let count_before_delete = backend.get_count();
-        // delete 后缓存条目移除而非留 None 占位。
+        // After the delete the cache entry is removed rather than left as a None placeholder.
         store.delete(&reference).unwrap();
         assert!(
             !value_cache()
                 .lock()
                 .unwrap()
                 .contains_key(&(reference.service.clone(), reference.account.clone())),
-            "delete 后缓存条目应被移除,不再保留 None 占位"
+            "after delete the cache entry must be removed, not kept as a None placeholder"
         );
         assert!(
             !key_locks()
                 .lock()
                 .unwrap()
                 .contains_key(&(reference.service.clone(), reference.account.clone())),
-            "delete 后 per-key 锁登记应被移除"
+            "after delete the per-key lock registration must be removed"
         );
-        // 后续 get 重新触达后端(条目已删)并确认不存在。
+        // A later get re-touches the backend (the entry is gone) and confirms absence.
         assert_eq!(store.get(&reference).unwrap(), None);
         assert_eq!(
             backend.get_count(),
             count_before_delete + 1,
-            "delete 后缓存条目已移除,get 重新触达后端确认不存在"
+            "after delete the cache entry is gone and get re-touches the backend to confirm absence"
         );
-        // 再次 delete 仍成功(幂等,后端已无该条目)。
+        // A second delete still succeeds (idempotent; the backend no longer has the entry).
         store.delete(&reference).unwrap();
     }
 

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -42,7 +42,10 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// **陈旧边界**:`Ok(None)`("已知不存在")会缓存整个进程生命周期;若运行期间用户经"钥匙串
 /// 访问"App 或其它进程新增了该 item,本应用在重启前仍读到 `None`(设置页误显示"未配置")。
 /// 这是进程级内存缓存的固有边界,正常改 keychain 的路径走应用 UI(经 `set`/`delete` 同步
-/// 更新缓存),故影响有限。
+/// 更新缓存),故影响有限。对称的代价:`delete` 成功后不再保留 `None` 占位(动态 key 场景
+/// 防无界累积),删除后的首次 `get` 会重新触达 keyring 后端一次——macOS ad-hoc 下可能
+/// 因此多弹一次授权窗;这是用"每次删除后至多一次后端访问"换缓存正确性,不影响 #175
+/// 的"使用期间不反复弹窗"目标。
 static VALUE_CACHE: OnceLock<Mutex<HashMap<(String, String), Option<String>>>> = OnceLock::new();
 
 fn value_cache() -> &'static Mutex<HashMap<(String, String), Option<String>>> {

--- a/pinvou3-app/src-tauri/src/platform/credential_store.rs
+++ b/pinvou3-app/src-tauri/src/platform/credential_store.rs
@@ -30,9 +30,8 @@ const MODEL_API_KEY_SERVICE: &str = "pinvou3-model-api-key";
 /// `KEY_LOCKS` 为每个 `(service, account)` 维护一把 `Arc<Mutex<()>>`,`get`/`set`/`delete`
 /// 在"访问 Keychain + 读写值缓存"整段持有对应 key 的锁,串行化同一凭据的所有操作;不同 key
 /// 互不阻塞。锁内部从不嵌套 `value_cache`/`KEY_LOCKS` 之外的锁,无死锁风险。
-/// 唯一例外:`delete` 成功后注销锁登记,与一个尚持有旧锁实例的在飞 `get`/`set` 短暂失去
-/// 互斥(窗口为单次后端访问;仅动态 key 的 delete 竞态可及,后果退化为一次陈旧缓存,
-/// 由下次 `set`/`delete`/重启自愈)。
+/// 唯一例外:`delete` 成功后注销锁登记仅在没有在飞线程仍持旧锁句柄时执行
+/// (`Arc::strong_count` 门控);否则保留登记,由下一次 `delete` 收敛,互斥不失效。
 ///
 /// **安全权衡**:缓存值为明文 secret,仅在进程内存(不落盘),与本 crate 内其他明文 secret
 /// 在内存中的驻留(如 bridge 注入给引擎的 api_key、marketplace 重灌进进程 env 的 mcp
@@ -426,13 +425,18 @@ impl CredentialStore for SystemCredentialStore {
         // 删除成功后直接移除缓存与 per-key 锁登记（仍在同一临界区内）：
         // get 缓存 None 占位与 KEY_LOCKS 条目会随动态 key（如 remote-knowledge
         // 逐 join 请求的 request_id）永久累积，删后无查询价值——"已知不存在"
-        // 可由缺失条目表达。
+        // 可由缺失条目表达。锁登记仅在无在飞句柄时注销（map 持有 1 份 + 本函数
+        // 局部变量 1 份 = 2）：若仍有 get/set 持旧句柄，注销会让后续操作创建
+        // 第二把锁并与在飞操作失去互斥（缓存与后端效果可倒置）；残留登记由
+        // 下一次 delete 收敛。
         if result.is_ok() {
             if let Ok(mut cache) = value_cache().lock() {
                 cache.remove(&(reference.service.clone(), reference.account.clone()));
             }
             if let Ok(mut locks) = key_locks().lock() {
-                locks.remove(&(reference.service.clone(), reference.account.clone()));
+                if Arc::strong_count(&lock) == 2 {
+                    locks.remove(&(reference.service.clone(), reference.account.clone()));
+                }
             }
         }
         result

--- a/pinvou3-app/src-tauri/src/platform/notifications.rs
+++ b/pinvou3-app/src-tauri/src/platform/notifications.rs
@@ -14,7 +14,23 @@ pub struct NotificationState {
 
 impl NotificationState {
     pub fn should_notify(&self, key: String) -> bool {
-        self.notified_turns.lock().insert(key)
+        let mut turns = self.notified_turns.lock();
+        // 同 key 重复（终态事件重放）先短路：否则下方前缀清理会把这条本身
+        // 也清掉、再插回时误报"首次"。
+        if turns.contains(&key) {
+            return false;
+        }
+        // key 形如 `{session_id}:{turn_id}`：同一 session 只需保留最新一条去重
+        // 记录（重复终态事件总是紧跟同一 turn）。不清前缀会让集合随完成轮数
+        // 无界增长。
+        let session_prefix = match key.split_once(':') {
+            Some((session, _)) => format!("{session}:"),
+            None => String::new(),
+        };
+        if !session_prefix.is_empty() {
+            turns.retain(|existing| !existing.starts_with(&session_prefix));
+        }
+        turns.insert(key)
     }
 }
 
@@ -66,12 +82,12 @@ fn send_native_notification(app: &AppHandle) -> Result<(), String> {
 fn send_notify_send() -> Result<(), String> {
     use std::process::Command;
 
-    Command::new("notify-send")
-        .arg(TASK_COMPLETED_TITLE)
-        .arg(TASK_COMPLETED_BODY)
-        .spawn()
-        .map_err(|e| e.to_string())?;
-    Ok(())
+    crate::platform::os::posix::spawn_detached_and_reap(
+        Command::new("notify-send")
+            .arg(TASK_COMPLETED_TITLE)
+            .arg(TASK_COMPLETED_BODY),
+    )
+    .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -137,5 +153,12 @@ mod tests {
         assert!(state.should_notify("session:turn".to_string()));
         assert!(!state.should_notify("session:turn".to_string()));
         assert!(state.should_notify("session:next-turn".to_string()));
+        assert!(!state.should_notify("session:next-turn".to_string()));
+        // next-turn 落位后同 session 只保留最新一条：旧 turn key 已按前缀淘汰
+        // （集合有界），其重现按新事件处理——重复终态事件总是紧跟同一 turn，
+        // 跨 turn 重现的旧 key 不存在真实的去重需求。
+        assert!(state.should_notify("session:turn".to_string()));
+        // 其他 session 不受影响。
+        assert!(state.should_notify("other:turn".to_string()));
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/notifications.rs
+++ b/pinvou3-app/src-tauri/src/platform/notifications.rs
@@ -16,16 +16,16 @@ impl NotificationState {
     pub fn should_notify(&self, key: String) -> bool {
         let mut turns = self.notified_turns.lock();
         // A duplicate with the same key (terminal-event replay)
-        //         // short-circuits first: otherwise the prefix cleanup below would
-        //         // remove this very entry and re-inserting it would be misreported
-        //         // as "first".
+        // short-circuits first: otherwise the prefix cleanup below would
+        // remove this very entry and re-inserting it would be misreported
+        // as "first".
         if turns.contains(&key) {
             return false;
         }
         // Keys look like `{session_id}:{turn_id}`: only the newest dedup
-        //         // record per session needs to survive (duplicate terminal events
-        //         // always follow the same turn). Without the prefix cleanup the set
-        //         // would grow unbounded with completed turns.
+        // record per session needs to survive (duplicate terminal events
+        // always follow the same turn). Without the prefix cleanup the set
+        // would grow unbounded with completed turns.
         let session_prefix = match key.split_once(':') {
             Some((session, _)) => format!("{session}:"),
             None => String::new(),
@@ -158,10 +158,10 @@ mod tests {
         assert!(state.should_notify("session:next-turn".to_string()));
         assert!(!state.should_notify("session:next-turn".to_string()));
         // Once the next turn lands, only the newest record per session
-        //         // survives: the old turn's key was already pruned by prefix (the
-        //         // set is bounded) and its reappearance is treated as a new event —
-        //         // duplicate terminal events always follow the same turn, so an old
-        //         // key reappearing across turns has no real dedup need.
+        // survives: the old turn's key was already pruned by prefix (the
+        // set is bounded) and its reappearance is treated as a new event —
+        // duplicate terminal events always follow the same turn, so an old
+        // key reappearing across turns has no real dedup need.
         assert!(state.should_notify("session:turn".to_string()));
         // Other sessions are unaffected.
         assert!(state.should_notify("other:turn".to_string()));

--- a/pinvou3-app/src-tauri/src/platform/notifications.rs
+++ b/pinvou3-app/src-tauri/src/platform/notifications.rs
@@ -82,7 +82,7 @@ fn send_native_notification(app: &AppHandle) -> Result<(), String> {
 fn send_notify_send() -> Result<(), String> {
     use std::process::Command;
 
-    crate::platform::os::posix::spawn_detached_and_reap(
+    crate::platform::os::spawn_detached_and_reap(
         Command::new("notify-send")
             .arg(TASK_COMPLETED_TITLE)
             .arg(TASK_COMPLETED_BODY),

--- a/pinvou3-app/src-tauri/src/platform/notifications.rs
+++ b/pinvou3-app/src-tauri/src/platform/notifications.rs
@@ -15,14 +15,17 @@ pub struct NotificationState {
 impl NotificationState {
     pub fn should_notify(&self, key: String) -> bool {
         let mut turns = self.notified_turns.lock();
-        // 同 key 重复（终态事件重放）先短路：否则下方前缀清理会把这条本身
-        // 也清掉、再插回时误报"首次"。
+        // A duplicate with the same key (terminal-event replay)
+        //         // short-circuits first: otherwise the prefix cleanup below would
+        //         // remove this very entry and re-inserting it would be misreported
+        //         // as "first".
         if turns.contains(&key) {
             return false;
         }
-        // key 形如 `{session_id}:{turn_id}`：同一 session 只需保留最新一条去重
-        // 记录（重复终态事件总是紧跟同一 turn）。不清前缀会让集合随完成轮数
-        // 无界增长。
+        // Keys look like `{session_id}:{turn_id}`: only the newest dedup
+        //         // record per session needs to survive (duplicate terminal events
+        //         // always follow the same turn). Without the prefix cleanup the set
+        //         // would grow unbounded with completed turns.
         let session_prefix = match key.split_once(':') {
             Some((session, _)) => format!("{session}:"),
             None => String::new(),
@@ -154,11 +157,13 @@ mod tests {
         assert!(!state.should_notify("session:turn".to_string()));
         assert!(state.should_notify("session:next-turn".to_string()));
         assert!(!state.should_notify("session:next-turn".to_string()));
-        // next-turn 落位后同 session 只保留最新一条：旧 turn key 已按前缀淘汰
-        // （集合有界），其重现按新事件处理——重复终态事件总是紧跟同一 turn，
-        // 跨 turn 重现的旧 key 不存在真实的去重需求。
+        // Once the next turn lands, only the newest record per session
+        //         // survives: the old turn's key was already pruned by prefix (the
+        //         // set is bounded) and its reappearance is treated as a new event —
+        //         // duplicate terminal events always follow the same turn, so an old
+        //         // key reappearing across turns has no real dedup need.
         assert!(state.should_notify("session:turn".to_string()));
-        // 其他 session 不受影响。
+        // Other sessions are unaffected.
         assert!(state.should_notify("other:turn".to_string()));
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/mod.rs
@@ -22,5 +22,5 @@ pub use system::{
     pdf_ocr_missing_message, pdf_render_missing_message, pdf_text_missing_message, pdf_tool_exists,
     pdf_tool_path, presentation_pdf_missing_message, reveal_target, show_archive_dependency_check,
     show_ocr_dependency_check, show_pandoc_dependency_check, show_pdf_dependency_check,
-    system_default_open_supported,
+    spawn_detached_and_reap, system_default_open_supported,
 };

--- a/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
@@ -9,10 +9,10 @@ pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String>
 /// Spawn a fire-and-forget process and reap it per platform semantics.
 ///
 /// On Unix a posix reaper thread `wait()`s to prevent zombies; Windows has
-/// /// no waitpid contract and dropping the handle after spawn lets the system
-/// /// reclaim the process. Meant for reuse from the features layer (browser
-/// /// launches for open/notify and the like), avoiding per-caller inline
-/// /// `cfg` platform details.
+/// no waitpid contract and dropping the handle after spawn lets the system
+/// reclaim the process. Meant for reuse from the features layer (browser
+/// launches for open/notify and the like), avoiding per-caller inline
+/// `cfg` platform details.
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
@@ -6,11 +6,13 @@ pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String>
     super::super::platform::open_target(target, label)
 }
 
-/// spawn 一个“点火即忘”进程并按平台语义收割。
+/// Spawn a fire-and-forget process and reap it per platform semantics.
 ///
-/// Unix 上经 posix 收割线程 `wait()` 防僵尸；Windows 无 waitpid 契约，
-/// spawn 后 drop 句柄即由系统回收。供 features 层复用（open/notify 同类
-/// 的浏览器拉起等），避免各自内联 `cfg` 平台细节。
+/// On Unix a posix reaper thread `wait()`s to prevent zombies; Windows has
+/// /// no waitpid contract and dropping the handle after spawn lets the system
+/// /// reclaim the process. Meant for reuse from the features layer (browser
+/// /// launches for open/notify and the like), avoiding per-caller inline
+/// /// `cfg` platform details.
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
     #[cfg(unix)]
     {

--- a/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/interface/system.rs
@@ -6,6 +6,22 @@ pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String>
     super::super::platform::open_target(target, label)
 }
 
+/// spawn 一个“点火即忘”进程并按平台语义收割。
+///
+/// Unix 上经 posix 收割线程 `wait()` 防僵尸；Windows 无 waitpid 契约，
+/// spawn 后 drop 句柄即由系统回收。供 features 层复用（open/notify 同类
+/// 的浏览器拉起等），避免各自内联 `cfg` 平台细节。
+pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        super::super::posix::spawn_detached_and_reap(command)
+    }
+    #[cfg(not(unix))]
+    {
+        command.spawn().map(|_| ())
+    }
+}
+
 pub fn reveal_target(target: &Path) -> Result<(), String> {
     super::super::platform::reveal_target(target)
 }

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_system.rs
@@ -5,11 +5,8 @@ use std::process::Command;
 use super::linux_path;
 
 pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String> {
-    Command::new("xdg-open")
-        .arg(target.as_ref())
-        .spawn()
-        .map_err(|e| format!("系统打开失败({label}): {e}"))?;
-    Ok(())
+    super::super::posix::spawn_detached_and_reap(Command::new("xdg-open").arg(target.as_ref()))
+        .map_err(|e| format!("系统打开失败({label}): {e}"))
 }
 
 pub fn reveal_target(target: &Path) -> Result<(), String> {

--- a/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/macos/macos_system.rs
@@ -24,20 +24,15 @@ fn is_executable(path: &Path) -> bool {
 }
 
 pub fn open_target(target: impl AsRef<OsStr>, label: &str) -> Result<(), String> {
-    Command::new("/usr/bin/open")
-        .arg(target.as_ref())
-        .spawn()
-        .map_err(|e| format!("系统打开失败({label}): {e}"))?;
-    Ok(())
+    super::super::posix::spawn_detached_and_reap(Command::new("/usr/bin/open").arg(target.as_ref()))
+        .map_err(|e| format!("系统打开失败({label}): {e}"))
 }
 
 pub fn reveal_target(target: &Path) -> Result<(), String> {
-    Command::new("/usr/bin/open")
-        .arg("-R")
-        .arg(target)
-        .spawn()
-        .map_err(|error| format!("文件管理器定位失败: {error}"))?;
-    Ok(())
+    super::super::posix::spawn_detached_and_reap(
+        Command::new("/usr/bin/open").arg("-R").arg(target),
+    )
+    .map_err(|error| format!("文件管理器定位失败: {error}"))
 }
 
 pub fn command_exists(command: &str) -> bool {

--- a/pinvou3-app/src-tauri/src/platform/os/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/mod.rs
@@ -46,6 +46,6 @@ pub use interface::{
     pdf_text_missing_message, pdf_tool_exists, pdf_tool_path, platform_compat_path,
     presentation_pdf_missing_message, python_command, reveal_target, show_archive_dependency_check,
     show_ocr_dependency_check, show_pandoc_dependency_check, show_pdf_dependency_check,
-    super_permission_is_enabled, super_permission_turn_reminder, system_default_open_supported,
-    user_home_dir, validate_upload_location,
+    spawn_detached_and_reap, super_permission_is_enabled, super_permission_turn_reminder,
+    system_default_open_supported, user_home_dir, validate_upload_location,
 };

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -14,22 +14,31 @@
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-/// spawn 一个"点火即忘"的短命外部进程并负责收割，避免 Unix 僵尸。
+/// Spawn a short-lived fire-and-forget external process and reap it, avoiding Unix zombies.
 ///
-/// std 的 `Command::spawn()` 返回的 Child 被 drop 时**不会**回收子进程
-/// （不像 tokio 的 kill_on_drop），父进程也不自动 reap；每次 open/xdg-open
-/// 都会留一个 zombie 直到父进程退出。这里起一个 detached 收割线程 `wait()`，
-/// 打开文件/发通知类命令通常毫秒级退出，线程随即结束，常驻成本可忽略。
-/// 例外是 agent 登录拉起浏览器（`codex_acp::open_agent_login_url`）：
-/// firefox/chrome 的首个实例本身就是长驻浏览器进程，收割线程会停驻在
-/// `wait()` 里直到浏览器退出——每个长驻实例占一个 parked 线程，成本仍可
-/// 接受；只是线程创建失败的同步回退会阻塞同样久（见下），仍优于僵尸累积。
-/// 收割线程创建失败（线程数/内存受限的极端场景）时在调用线程同步 `wait()`：
-/// 命令已成功启动，此时慢命令的极端卡顿优于僵尸累积 + 误报打开失败。
+/// Dropping the Child returned by std's `Command::spawn()` does **not**
+/// /// reclaim the child (unlike tokio's kill_on_drop) and the parent never
+/// /// auto-reaps; every open/xdg-open would leave a zombie until the parent
+/// /// exits. This starts a detached reaper thread to `wait()`; open-file and
+/// /// notification commands usually exit in milliseconds, ending the thread
+/// /// immediately, so the steady-state cost is negligible.
+/// /// The exception is agent-login browser launches
+/// /// (`codex_acp::open_agent_login_url`): the first firefox/chrome instance
+/// /// is itself a long-lived browser process, so the reaper thread parks in
+/// /// `wait()` until the browser exits — one parked thread per long-lived
+/// /// instance, still an acceptable cost; only the synchronous fallback on
+/// /// thread-creation failure blocks for just as long (see below), which
+/// /// remains preferable to zombie accumulation.
+/// When reaper-thread creation fails (thread-count/memory-constrained edge
+/// /// cases), `wait()` synchronously on the calling thread: the command has
+/// /// already launched successfully, and a rare stall on a slow command beats
+/// /// zombie accumulation plus a bogus "open failed" report.
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
     use std::sync::{Arc, Mutex};
-    // `Builder::spawn` 失败时闭包被 drop（不归还），Child 的所有权无法要回；
-    // 经共享的 Option 中转：收割线程与失败回退路径先到先得，只有一方能 take。
+    // When `Builder::spawn` fails the closure is dropped (not returned),
+    //     // so ownership of the Child cannot be taken back; route it through a
+    //     // shared Option instead: the reaper thread and the failure fallback
+    //     // race for it, and only one side can take it.
     let child = Arc::new(Mutex::new(Some(command.spawn()?)));
     let thread_child = Arc::clone(&child);
     match std::thread::Builder::new()
@@ -113,12 +122,15 @@ mod tests {
 
     #[test]
     fn spawn_detached_and_reap_reaps_true_command() {
-        // `true`（PATH 查找，通常解析为 /bin/true）毫秒级退出：验证 spawn
-        // 成功且收割线程不 panic。
-        // 僵尸是否复排除非查 proc 表不可见，这里至少锁定接口契约（Ok + 不死锁）。
+        // `true` (PATH lookup, usually /bin/true) exits in milliseconds:
+        //         // verifies the spawn succeeded and the reaper thread does not
+        //         // panic.
+        //         // Whether the zombie is actually reaped is invisible without
+        //         // reading the proc table; this at least pins the interface
+        //         // contract (Ok + no deadlock).
         let mut command = std::process::Command::new("true");
         spawn_detached_and_reap(&mut command).expect("spawn true");
-        // 给收割线程一点时间完成 wait，测试本身无阻塞断言。
+        // Give the reaper thread a moment to finish its wait; the test itself makes no blocking assertion.
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -20,19 +20,28 @@ use std::path::PathBuf;
 /// （不像 tokio 的 kill_on_drop），父进程也不自动 reap；每次 open/xdg-open
 /// 都会留一个 zombie 直到父进程退出。这里起一个 detached 收割线程 `wait()`，
 /// 打开文件/发通知类命令通常毫秒级退出，线程随即结束，常驻成本可忽略。
-/// 收割线程创建失败时退化为同步 wait：慢命令的极端卡顿优于僵尸累积。
+/// 收割线程创建失败（线程数/内存受限的极端场景）时在调用线程同步 `wait()`：
+/// 命令已成功启动，此时慢命令的极端卡顿优于僵尸累积 + 误报打开失败。
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
-    let mut child = command.spawn()?;
-    // 收割线程创建失败时退化为同步 wait：慢命令的极端卡顿优于僵尸累积。
-    // Child 不 Clone：先 spawn 收割线程占位，成功后用 Child::wait 的所有权
-    // 转移语义（std::process::Child 按 &mut wait）在线程内持有。
+    use std::sync::{Arc, Mutex};
+    // `Builder::spawn` 失败时闭包被 drop（不归还），Child 的所有权无法要回；
+    // 经共享的 Option 中转：收割线程与失败回退路径先到先得，只有一方能 take。
+    let child = Arc::new(Mutex::new(Some(command.spawn()?)));
+    let thread_child = Arc::clone(&child);
     match std::thread::Builder::new()
         .name("unix-child-reaper".to_string())
         .spawn(move || {
-            let _ = child.wait();
+            if let Some(mut owned) = thread_child.lock().ok().and_then(|mut slot| slot.take()) {
+                let _ = owned.wait();
+            }
         }) {
         Ok(_) => Ok(()),
-        Err(error) => Err(error),
+        Err(_) => {
+            if let Some(mut owned) = child.lock().ok().and_then(|mut slot| slot.take()) {
+                let _ = owned.wait();
+            }
+            Ok(())
+        }
     }
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -17,28 +17,28 @@ use std::path::PathBuf;
 /// Spawn a short-lived fire-and-forget external process and reap it, avoiding Unix zombies.
 ///
 /// Dropping the Child returned by std's `Command::spawn()` does **not**
-/// /// reclaim the child (unlike tokio's kill_on_drop) and the parent never
-/// /// auto-reaps; every open/xdg-open would leave a zombie until the parent
-/// /// exits. This starts a detached reaper thread to `wait()`; open-file and
-/// /// notification commands usually exit in milliseconds, ending the thread
-/// /// immediately, so the steady-state cost is negligible.
-/// /// The exception is agent-login browser launches
-/// /// (`codex_acp::open_agent_login_url`): the first firefox/chrome instance
-/// /// is itself a long-lived browser process, so the reaper thread parks in
-/// /// `wait()` until the browser exits — one parked thread per long-lived
-/// /// instance, still an acceptable cost; only the synchronous fallback on
-/// /// thread-creation failure blocks for just as long (see below), which
-/// /// remains preferable to zombie accumulation.
+/// reclaim the child (unlike tokio's kill_on_drop) and the parent never
+/// auto-reaps; every open/xdg-open would leave a zombie until the parent
+/// exits. This starts a detached reaper thread to `wait()`; open-file and
+/// notification commands usually exit in milliseconds, ending the thread
+/// immediately, so the steady-state cost is negligible.
+/// The exception is agent-login browser launches
+/// (`codex_acp::open_agent_login_url`): the first firefox/chrome instance
+/// is itself a long-lived browser process, so the reaper thread parks in
+/// `wait()` until the browser exits — one parked thread per long-lived
+/// instance, still an acceptable cost; only the synchronous fallback on
+/// thread-creation failure blocks for just as long (see below), which
+/// remains preferable to zombie accumulation.
 /// When reaper-thread creation fails (thread-count/memory-constrained edge
-/// /// cases), `wait()` synchronously on the calling thread: the command has
-/// /// already launched successfully, and a rare stall on a slow command beats
-/// /// zombie accumulation plus a bogus "open failed" report.
+/// cases), `wait()` synchronously on the calling thread: the command has
+/// already launched successfully, and a rare stall on a slow command beats
+/// zombie accumulation plus a bogus "open failed" report.
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
     use std::sync::{Arc, Mutex};
     // When `Builder::spawn` fails the closure is dropped (not returned),
-    //     // so ownership of the Child cannot be taken back; route it through a
-    //     // shared Option instead: the reaper thread and the failure fallback
-    //     // race for it, and only one side can take it.
+    // so ownership of the Child cannot be taken back; route it through a
+    // shared Option instead: the reaper thread and the failure fallback
+    // race for it, and only one side can take it.
     let child = Arc::new(Mutex::new(Some(command.spawn()?)));
     let thread_child = Arc::clone(&child);
     match std::thread::Builder::new()
@@ -123,11 +123,11 @@ mod tests {
     #[test]
     fn spawn_detached_and_reap_reaps_true_command() {
         // `true` (PATH lookup, usually /bin/true) exits in milliseconds:
-        //         // verifies the spawn succeeded and the reaper thread does not
-        //         // panic.
-        //         // Whether the zombie is actually reaped is invisible without
-        //         // reading the proc table; this at least pins the interface
-        //         // contract (Ok + no deadlock).
+        // verifies the spawn succeeded and the reaper thread does not
+        // panic.
+        // Whether the zombie is actually reaped is invisible without
+        // reading the proc table; this at least pins the interface
+        // contract (Ok + no deadlock).
         let mut command = std::process::Command::new("true");
         spawn_detached_and_reap(&mut command).expect("spawn true");
         // Give the reaper thread a moment to finish its wait; the test itself makes no blocking assertion.

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -20,6 +20,10 @@ use std::path::PathBuf;
 /// （不像 tokio 的 kill_on_drop），父进程也不自动 reap；每次 open/xdg-open
 /// 都会留一个 zombie 直到父进程退出。这里起一个 detached 收割线程 `wait()`，
 /// 打开文件/发通知类命令通常毫秒级退出，线程随即结束，常驻成本可忽略。
+/// 例外是 agent 登录拉起浏览器（`codex_acp::open_agent_login_url`）：
+/// firefox/chrome 的首个实例本身就是长驻浏览器进程，收割线程会停驻在
+/// `wait()` 里直到浏览器退出——每个长驻实例占一个 parked 线程，成本仍可
+/// 接受；只是线程创建失败的同步回退会阻塞同样久（见下），仍优于僵尸累积。
 /// 收割线程创建失败（线程数/内存受限的极端场景）时在调用线程同步 `wait()`：
 /// 命令已成功启动，此时慢命令的极端卡顿优于僵尸累积 + 误报打开失败。
 pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
@@ -109,10 +113,11 @@ mod tests {
 
     #[test]
     fn spawn_detached_and_reap_reaps_true_command() {
-        // `/usr/bin/true` 毫秒级退出：验证 spawn 成功且收割线程不 panic。
+        // `true`（PATH 查找，通常解析为 /bin/true）毫秒级退出：验证 spawn
+        // 成功且收割线程不 panic。
         // 僵尸是否复排除非查 proc 表不可见，这里至少锁定接口契约（Ok + 不死锁）。
         let mut command = std::process::Command::new("true");
-        spawn_detached_and_reap(&mut command).expect("spawn /usr/bin/true");
+        spawn_detached_and_reap(&mut command).expect("spawn true");
         // 给收割线程一点时间完成 wait，测试本身无阻塞断言。
         std::thread::sleep(std::time::Duration::from_millis(50));
     }

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -14,6 +14,28 @@
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
+/// spawn 一个"点火即忘"的短命外部进程并负责收割，避免 Unix 僵尸。
+///
+/// std 的 `Command::spawn()` 返回的 Child 被 drop 时**不会**回收子进程
+/// （不像 tokio 的 kill_on_drop），父进程也不自动 reap；每次 open/xdg-open
+/// 都会留一个 zombie 直到父进程退出。这里起一个 detached 收割线程 `wait()`，
+/// 打开文件/发通知类命令通常毫秒级退出，线程随即结束，常驻成本可忽略。
+/// 收割线程创建失败时退化为同步 wait：慢命令的极端卡顿优于僵尸累积。
+pub fn spawn_detached_and_reap(command: &mut std::process::Command) -> std::io::Result<()> {
+    let mut child = command.spawn()?;
+    // 收割线程创建失败时退化为同步 wait：慢命令的极端卡顿优于僵尸累积。
+    // Child 不 Clone：先 spawn 收割线程占位，成功后用 Child::wait 的所有权
+    // 转移语义（std::process::Child 按 &mut wait）在线程内持有。
+    match std::thread::Builder::new()
+        .name("unix-child-reaper".to_string())
+        .spawn(move || {
+            let _ = child.wait();
+        }) {
+        Ok(_) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
 /// 把外部传入的路径字符串原样转为 `PathBuf`。
 /// linux 与 macOS 实现相同（皆 `PathBuf::from(value)`），收口于此。
 pub fn platform_compat_path(value: &str) -> PathBuf {
@@ -74,5 +96,21 @@ mod tests {
         // 无论 PATH 状态如何，至少返回 python3
         let cmd = python_command();
         assert!(cmd == "python3" || cmd == "python");
+    }
+
+    #[test]
+    fn spawn_detached_and_reap_reaps_true_command() {
+        // `/usr/bin/true` 毫秒级退出：验证 spawn 成功且收割线程不 panic。
+        // 僵尸是否复排除非查 proc 表不可见，这里至少锁定接口契约（Ok + 不死锁）。
+        let mut command = std::process::Command::new("true");
+        spawn_detached_and_reap(&mut command).expect("spawn /usr/bin/true");
+        // 给收割线程一点时间完成 wait，测试本身无阻塞断言。
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    #[test]
+    fn spawn_detached_and_reap_reports_missing_binary() {
+        let mut command = std::process::Command::new("/nonexistent/pinvou3-reaper-test");
+        assert!(spawn_detached_and_reap(&mut command).is_err());
     }
 }

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -141,6 +141,20 @@ function ModelProgressIndicator({ downloading, percent, label }) {
       const [outSortDir, setOutSortDir] = useState('desc');
       const [outputPreview, setOutputPreview] = useState(null);
       const outPreviewCache = useRef({});
+      // 预览结果可达数 MB（office 全文 HTML / 图片 base64），key 含 mtime——文件
+      // 每次重写都产生新 key。无上限的 ref 缓存会随浏览过的产物无界增长。
+      const MAX_OUT_PREVIEW_CACHE = 48;
+      const rememberOutPreview = useCallback((key, value) => {
+        const cache = outPreviewCache.current;
+        if (cache[key]) { cache[key] = value; return; }
+        cache[key] = value;
+        const keys = Object.keys(cache);
+        if (keys.length <= MAX_OUT_PREVIEW_CACHE) return;
+        // Map 迭代序即插入序：删最早的 key（含同产物旧 mtime 的陈旧条目）。
+        const ordered = Object.keys(cache).sort((a, b) => keys.indexOf(b) - keys.indexOf(a));
+        const excess = ordered.length - MAX_OUT_PREVIEW_CACHE;
+        for (let i = 0; i < excess; i++) delete cache[ordered[ordered.length - 1 - i]];
+      }, []);
       const outPreviewQueue = useRef({ active: 0, jobs: [] });
       const runQueuedPreview = useCallback((job) => new Promise((resolve, reject) => {
         const q = outPreviewQueue.current;
@@ -347,17 +361,17 @@ function ModelProgressIndicator({ downloading, percent, label }) {
                 next = { kind: 'text', text: text.slice(0, 1600) };
               }
               if (!next) next = { kind: 'fallback' };
-              outPreviewCache.current[cacheKey] = next;
+              rememberOutPreview(cacheKey, next);
               return next;
             } catch (e) {
               const next = { kind: 'fallback', error: String(e) };
-              outPreviewCache.current[cacheKey] = next;
+              rememberOutPreview(cacheKey, next);
               return next;
             }
           }).then((next) => { if (alive) setPv(next); });
           }, 80);
           return () => { alive = false; clearTimeout(timer); };
-        }, [cacheKey, visible, o.path, o.category, ext, outputSessionId, runQueuedPreview]);
+        }, [cacheKey, visible, o.path, o.category, ext, outputSessionId, runQueuedPreview, rememberOutPreview]);
 
         const htmlPreviewDoc = (html) => '<style>html,body{overflow:hidden!important;}*{animation-duration:.001s!important;scrollbar-width:none!important;}*::-webkit-scrollbar{display:none!important;}</style>' + (html || '');
         const officePreviewDoc = (html) => '<style>html,body{background:#fff!important;margin:0;color:#111!important;overflow:hidden!important;}*{animation-duration:.001s!important;scrollbar-width:none!important;}*::-webkit-scrollbar{display:none!important;}</style>' + (html || '');
@@ -471,17 +485,17 @@ function ModelProgressIndicator({ downloading, percent, label }) {
                   next = { kind: 'text', text: text.slice(0, 1200) };
                 }
                 if (!next) next = { kind: 'fallback' };
-                outPreviewCache.current[cacheKey] = next;
+                rememberOutPreview(cacheKey, next);
                 return next;
               } catch (e) {
                 const next = { kind: 'fallback', error: String(e) };
-                outPreviewCache.current[cacheKey] = next;
+                rememberOutPreview(cacheKey, next);
                 return next;
               }
             }).then((next) => { if (alive) setPv(next); });
           }, 80);
           return () => { alive = false; clearTimeout(timer); };
-        }, [cacheKey, visible, f.path, ext, runQueuedPreview]);
+        }, [cacheKey, visible, f.path, ext, runQueuedPreview, rememberOutPreview]);
 
         const col = extColor(ext);
         const htmlPreviewDoc = (html) => '<style>*{animation-duration:.001s!important;}</style>' + (html || '');

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -141,9 +141,12 @@ function ModelProgressIndicator({ downloading, percent, label }) {
       const [outSortDir, setOutSortDir] = useState('desc');
       const [outputPreview, setOutputPreview] = useState(null);
       const outPreviewCache = useRef({});
-      // 预览结果可达数 MB（office 全文 HTML / 图片 base64），key 含 mtime——文件
-      // 每次重写都产生新 key。条数上限会漏掉"少量超大条目"的轴：48 × 数 MB
-      // 仍可达数百 MB。双轴封顶：条数 + 累计字节预算，插入序淘汰最旧。
+      // Preview results can reach several MB (full-text office HTML /
+      // image base64) and keys embed mtime — every file rewrite yields a
+      // new key. An entry cap alone misses the "few huge entries" axis:
+      // 48 × several MB can still reach hundreds of MB. Dual cap: entries
+      // + cumulative byte budget, evicting oldest-first by insertion
+      // order.
       const MAX_OUT_PREVIEW_CACHE = 48;
       const MAX_OUT_PREVIEW_CACHE_BYTES = 32 * 1024 * 1024;
       const outPreviewValueBytes = (v) => {
@@ -159,8 +162,10 @@ function ModelProgressIndicator({ downloading, percent, label }) {
         cache[key] = value;
         let keys = Object.keys(cache);
         let totalBytes = keys.reduce((sum, k) => sum + outPreviewValueBytes(cache[k]), 0);
-        // 超任一预算都从最旧(插入序在前)的条目开始淘汰；同产物旧 mtime 的
-        // 陈旧条目也在其中。单条超过字节预算的极端值最多留 1 条。
+        // Either budget being exceeded evicts from the oldest entries
+        // (earliest in insertion order); stale entries with old mtimes of
+        // the same artifact are included. A single entry over the byte
+        // budget leaves at most 1 entry.
         while (keys.length > 1
           && (keys.length > MAX_OUT_PREVIEW_CACHE || totalBytes > MAX_OUT_PREVIEW_CACHE_BYTES)) {
           const oldest = keys[0];

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -142,18 +142,32 @@ function ModelProgressIndicator({ downloading, percent, label }) {
       const [outputPreview, setOutputPreview] = useState(null);
       const outPreviewCache = useRef({});
       // 预览结果可达数 MB（office 全文 HTML / 图片 base64），key 含 mtime——文件
-      // 每次重写都产生新 key。无上限的 ref 缓存会随浏览过的产物无界增长。
+      // 每次重写都产生新 key。条数上限会漏掉"少量超大条目"的轴：48 × 数 MB
+      // 仍可达数百 MB。双轴封顶：条数 + 累计字节预算，插入序淘汰最旧。
       const MAX_OUT_PREVIEW_CACHE = 48;
+      const MAX_OUT_PREVIEW_CACHE_BYTES = 32 * 1024 * 1024;
+      const outPreviewValueBytes = (v) => {
+        if (!v) return 0;
+        if (typeof v.url === 'string') return v.url.length;
+        if (typeof v.html === 'string') return v.html.length;
+        if (typeof v.text === 'string') return v.text.length;
+        return 256;
+      };
       const rememberOutPreview = useCallback((key, value) => {
         const cache = outPreviewCache.current;
         if (cache[key]) { cache[key] = value; return; }
         cache[key] = value;
-        const keys = Object.keys(cache);
-        if (keys.length <= MAX_OUT_PREVIEW_CACHE) return;
-        // Map 迭代序即插入序：删最早的 key（含同产物旧 mtime 的陈旧条目）。
-        const ordered = Object.keys(cache).sort((a, b) => keys.indexOf(b) - keys.indexOf(a));
-        const excess = ordered.length - MAX_OUT_PREVIEW_CACHE;
-        for (let i = 0; i < excess; i++) delete cache[ordered[ordered.length - 1 - i]];
+        let keys = Object.keys(cache);
+        let totalBytes = keys.reduce((sum, k) => sum + outPreviewValueBytes(cache[k]), 0);
+        // 超任一预算都从最旧(插入序在前)的条目开始淘汰；同产物旧 mtime 的
+        // 陈旧条目也在其中。单条超过字节预算的极端值最多留 1 条。
+        while (keys.length > 1
+          && (keys.length > MAX_OUT_PREVIEW_CACHE || totalBytes > MAX_OUT_PREVIEW_CACHE_BYTES)) {
+          const oldest = keys[0];
+          totalBytes -= outPreviewValueBytes(cache[oldest]);
+          delete cache[oldest];
+          keys = keys.slice(1);
+        }
       }, []);
       const outPreviewQueue = useRef({ active: 0, jobs: [] });
       const runQueuedPreview = useCallback((job) => new Promise((resolve, reject) => {

--- a/pinvou3-app/src/features/pet/PetWindow.jsx
+++ b/pinvou3-app/src/features/pet/PetWindow.jsx
@@ -137,8 +137,10 @@ function PetSprite({ pet, animation }) {
   );
 }
 
-// 600ms tick 的按值稳定比较：列表长度与逐卡 (sessionId,status,updatedAt,title)
+// 600ms tick 的按值稳定比较：列表长度与逐卡 (sessionId,status,updatedAt,title,body)
 // 均一致时视为未变化，让 setState 保住旧引用、跳过整棵活动卡树的重渲染。
+// body 必须参与比较：文案派生自 i18n 词典，语言切换会不改事件字段只改 body，
+// 缺了它卡片会一直显示切换前的语言。
 function sameActivities(prev, next) {
   if (prev === next) return true;
   if (!Array.isArray(prev) || !Array.isArray(next) || prev.length !== next.length) return false;
@@ -147,7 +149,7 @@ function sameActivities(prev, next) {
     const b = next[i];
     if (!a || !b) return false;
     if (a.sessionId !== b.sessionId || a.status !== b.status
-      || a.updatedAt !== b.updatedAt || a.title !== b.title) return false;
+      || a.updatedAt !== b.updatedAt || a.title !== b.title || a.body !== b.body) return false;
   }
   return true;
 }

--- a/pinvou3-app/src/features/pet/PetWindow.jsx
+++ b/pinvou3-app/src/features/pet/PetWindow.jsx
@@ -53,7 +53,6 @@ import {
   applyEvent,
   createPetState,
   deriveActivities,
-  deriveAnimation,
   markSessionViewed,
   removeSessionActivity,
 } from './pet-state.js';
@@ -138,7 +137,22 @@ function PetSprite({ pet, animation }) {
   );
 }
 
-function PetActivityBody({ text, expanded = false }) {
+// 600ms tick 的按值稳定比较：列表长度与逐卡 (sessionId,status,updatedAt,title)
+// 均一致时视为未变化，让 setState 保住旧引用、跳过整棵活动卡树的重渲染。
+function sameActivities(prev, next) {
+  if (prev === next) return true;
+  if (!Array.isArray(prev) || !Array.isArray(next) || prev.length !== next.length) return false;
+  for (let i = 0; i < prev.length; i += 1) {
+    const a = prev[i];
+    const b = next[i];
+    if (!a || !b) return false;
+    if (a.sessionId !== b.sessionId || a.status !== b.status
+      || a.updatedAt !== b.updatedAt || a.title !== b.title) return false;
+  }
+  return true;
+}
+
+const PetActivityBody = React.memo(function PetActivityBody({ text, expanded = false }) {
   const source = String(text || '');
   const className = expanded
     ? 'pet-activity-body pet-activity-body-expanded'
@@ -150,7 +164,7 @@ function PetActivityBody({ text, expanded = false }) {
       dangerouslySetInnerHTML={{ __html: renderPetMarkdown(source) }}
     />
   );
-}
+});
 
 export default function PetWindow({
   allowResize = true,
@@ -307,8 +321,14 @@ export default function PetWindow({
 
   const refresh = () => {
     const now = Date.now();
-    setActivities(deriveActivities(stateRef.current, now, petCopy));
-    setBaseAnimation(deriveAnimation(stateRef.current, now) || 'idle');
+    const next = deriveActivities(stateRef.current, now, petCopy);
+    // 600ms 恒频 tick：deriveActivities 每次返回全新数组/对象身份，直接
+    // setState 会让空闲期也全量重渲染（每张卡重跑 markdown 渲染）。按值
+    // 稳定比较跳过未变化的提交。
+    setActivities((prev) => (sameActivities(prev, next) ? prev : next));
+    // deriveAnimation 只取首条状态：复用上面的推导，避免每 tick 双份排序。
+    const nextAnimation = next.length ? next[0].status : null;
+    setBaseAnimation((prev) => (prev === nextAnimation ? prev : (nextAnimation || 'idle')));
   };
 
   useEffect(() => {
@@ -1201,7 +1221,7 @@ export default function PetWindow({
     event.preventDefault();
     event.stopPropagation();
     removeSessionActivity(stateRef.current, sessionId);
-    setActivities(deriveActivities(stateRef.current, Date.now(), petCopy));
+    refresh();
     dispatchCardUi({ type: 'dismiss', sessionId });
   };
 

--- a/pinvou3-app/src/features/pet/PetWindow.jsx
+++ b/pinvou3-app/src/features/pet/PetWindow.jsx
@@ -137,10 +137,13 @@ function PetSprite({ pet, animation }) {
   );
 }
 
-// 600ms tick 的按值稳定比较：列表长度与逐卡 (sessionId,status,updatedAt,title,body)
-// 均一致时视为未变化，让 setState 保住旧引用、跳过整棵活动卡树的重渲染。
-// body 必须参与比较：文案派生自 i18n 词典，语言切换会不改事件字段只改 body，
-// 缺了它卡片会一直显示切换前的语言。
+// Value-based stable comparison for the 600ms tick: when the list length
+// and every card's (sessionId,status,updatedAt,title,body) all match, the
+// update is considered unchanged, letting setState keep the old reference
+// and skip re-rendering the whole activity-card tree.
+// body must participate: its text derives from the i18n dictionary, and a
+// language switch changes body without touching the event fields — without
+// it, cards would keep showing the pre-switch language forever.
 function sameActivities(prev, next) {
   if (prev === next) return true;
   if (!Array.isArray(prev) || !Array.isArray(next) || prev.length !== next.length) return false;
@@ -324,11 +327,12 @@ export default function PetWindow({
   const refresh = () => {
     const now = Date.now();
     const next = deriveActivities(stateRef.current, now, petCopy);
-    // 600ms 恒频 tick：deriveActivities 每次返回全新数组/对象身份，直接
-    // setState 会让空闲期也全量重渲染（每张卡重跑 markdown 渲染）。按值
-    // 稳定比较跳过未变化的提交。
+    // Constant 600ms tick: deriveActivities returns fresh array/object
+    // identities every time, so a direct setState would fully re-render
+    // even when idle (each card re-runs its markdown render). The
+    // value-based stable comparison skips unchanged commits.
     setActivities((prev) => (sameActivities(prev, next) ? prev : next));
-    // deriveAnimation 只取首条状态：复用上面的推导，避免每 tick 双份排序。
+    // deriveAnimation only reads the first card's status: it reuses the derivation above, avoiding a second sort per tick.
     const nextAnimation = next.length ? next[0].status : null;
     setBaseAnimation((prev) => (prev === nextAnimation ? prev : (nextAnimation || 'idle')));
   };

--- a/pinvou3-app/src/features/search/SearchView.jsx
+++ b/pinvou3-app/src/features/search/SearchView.jsx
@@ -423,7 +423,7 @@ export const SearchView = ({ theme, history, t, language, archived = [], showArc
                 </div>
               ) : searching ? (
                 matchedGroups.length > 0 ? matchedGroups.map(g => (
-                  <div key={g.key} ref={el => { if (el) groupRefs.current[g.key] = el; }}>
+                  <div key={g.key} ref={el => { if (el) groupRefs.current[g.key] = el; else delete groupRefs.current[g.key]; }}>
                     {renderDateHeader(g.key)}
                     {g.rows.map(renderChatRow)}
                   </div>

--- a/pinvou3-app/src/index.html
+++ b/pinvou3-app/src/index.html
@@ -12,6 +12,7 @@
       var entries = [];
       var sent = 0;
       var flushInFlight = false;
+      var inflightTail = null;
       var flushTimer = null;
       var longTaskCount = 0;
       var resourceCount = 0;
@@ -28,7 +29,9 @@
         // visibility/error 等监听器在启动后仍会持续打点，而 web 端 invoke 不可用、
         // 桌面端启动批次早已上报。保留最近 64 条防止数组随交互无界增长（启动
         // 关键阶段通常在 40 条以内，截断只影响极端后期的重复 visibilitychange）。
-        // sent 游标同步前移：被丢弃的恰是已上报的最旧条目。
+        // sent 游标同步前移补偿截断；sent ≥ dropped 时丢弃的确实是已上报条目，
+        // web 端 sent 恒 0，丢弃的是本就无从上报的条目。在途批次混入被删条目的
+        // 场景由 flush 回调按批次末条身份重定位兜底（见 relocateSent）。
         if (entries.length > 64) {
           var dropped = entries.length - 64;
           entries.splice(0, dropped);
@@ -59,13 +62,28 @@
         }, delay || 0);
       }
 
+      // flush 回调不能直接 sent += batch.length：截断可能已把批次里的条目从数组
+      // 删除，按计数推进会把这些已删条目计入游标，让后到的真实条目被
+      // sent >= entries.length 短路误判为已上报而永不发送。按批次末条的身份
+      // 重定位：找到即推进到它之后；整批被删则归零重发（Rust 端逐行 append、
+      // 2MiB 轮转，重复上报无害）。
+      function relocateSent() {
+        if (inflightTail == null) return 0;
+        for (var i = entries.length - 1; i >= 0; i--) {
+          if (entries[i] === inflightTail) return i + 1;
+        }
+        return 0;
+      }
+
       function flush() {
         var invoke = window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke;
         if (!invoke || flushInFlight || sent >= entries.length) return;
         var batch = entries.slice(sent);
         flushInFlight = true;
+        inflightTail = batch[batch.length - 1];
         invoke("report_frontend_startup", { entries: batch }).then(function () {
-          sent += batch.length;
+          sent = relocateSent();
+          inflightTail = null;
           flushInFlight = false;
           if (sent < entries.length) scheduleFlush(0);
         }).catch(function () {

--- a/pinvou3-app/src/index.html
+++ b/pinvou3-app/src/index.html
@@ -26,12 +26,18 @@
           since_navigation_ms: Math.max(0, Number(sinceNavigationMs) || 0),
         };
         entries.push(entry);
-        // visibility/error 等监听器在启动后仍会持续打点，而 web 端 invoke 不可用、
-        // 桌面端启动批次早已上报。保留最近 64 条防止数组随交互无界增长（启动
-        // 关键阶段通常在 40 条以内，截断只影响极端后期的重复 visibilitychange）。
-        // sent 游标同步前移补偿截断；sent ≥ dropped 时丢弃的确实是已上报条目，
-        // web 端 sent 恒 0，丢弃的是本就无从上报的条目。在途批次混入被删条目的
-        // 场景由 flush 回调按批次末条身份重定位兜底（见 relocateSent）。
+        // Listeners such as visibility/error keep marking after startup,
+        // while the web build has no invoke available and the desktop
+        // startup batch was reported long ago. Keep the most recent 64
+        // entries so the array cannot grow unbounded with interaction
+        // (startup's critical phases usually stay under 40 entries; the
+        // truncation only affects repeated late visibilitychange marks).
+        // The sent cursor advances in step to compensate; when
+        // sent >= dropped the dropped entries were indeed already
+        // reported, and on web sent stays 0, so what is dropped could
+        // never have been reported anyway. An in-flight batch mixing in
+        // truncated entries is handled by the flush callback relocating
+        // the cursor by the batch tail's identity (see relocateSent).
         if (entries.length > 64) {
           var dropped = entries.length - 64;
           entries.splice(0, dropped);
@@ -62,11 +68,15 @@
         }, delay || 0);
       }
 
-      // flush 回调不能直接 sent += batch.length：截断可能已把批次里的条目从数组
-      // 删除，按计数推进会把这些已删条目计入游标，让后到的真实条目被
-      // sent >= entries.length 短路误判为已上报而永不发送。按批次末条的身份
-      // 重定位：找到即推进到它之后；整批被删则归零重发（Rust 端逐行 append、
-      // 2MiB 轮转，重复上报无害）。
+      // The flush callback cannot simply do sent += batch.length:
+      // truncation may already have removed some of the batch's entries
+      // from the array, and advancing by count would fold those deleted
+      // entries into the cursor, letting later real entries be
+      // short-circuited by sent >= entries.length as falsely reported and
+      // never sent. Relocate by the in-flight batch tail's identity:
+      // found → advance past it; whole batch dropped → reset and resend
+      // (the Rust side appends line-by-line with a 2MiB rotation, so
+      // duplicate reports are harmless).
       function relocateSent() {
         if (inflightTail == null) return 0;
         for (var i = entries.length - 1; i >= 0; i--) {

--- a/pinvou3-app/src/index.html
+++ b/pinvou3-app/src/index.html
@@ -25,6 +25,15 @@
           since_navigation_ms: Math.max(0, Number(sinceNavigationMs) || 0),
         };
         entries.push(entry);
+        // visibility/error 等监听器在启动后仍会持续打点，而 web 端 invoke 不可用、
+        // 桌面端启动批次早已上报。保留最近 64 条防止数组随交互无界增长（启动
+        // 关键阶段通常在 40 条以内，截断只影响极端后期的重复 visibilitychange）。
+        // sent 游标同步前移：被丢弃的恰是已上报的最旧条目。
+        if (entries.length > 64) {
+          var dropped = entries.length - 64;
+          entries.splice(0, dropped);
+          sent = Math.max(0, sent - dropped);
+        }
         console.info("[startup] +" + entry.since_navigation_ms.toFixed(3) + "ms " + entry.stage, entry.detail);
         scheduleFlush(0);
       }

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -873,6 +873,9 @@
     state: state, invoke: invoke, listen: listen, notify: notify,
     sessionStates: sessionStates, scheduledRunSessionOwners: scheduledRunSessionOwners,
     personaPlaceholderTitles: personaPlaceholderTitles, turnUsageDirty: turnUsageDirty,
+    // 会话 buffer 删除/淘汰时清理宿主侧 per-session 副表（modeStateEpochs
+    // 定义在本文件后段，无法直接传入引用，用延迟取值 hook）。
+    onSessionBufferPurged: function (id) { delete modeStateEpochs[id]; },
     runSyncOnSession: runSyncOnSession, persistMessagesFor: persistMessagesFor,
     resetPendingAssistant: function () { return resetPendingAssistant.apply(null, arguments); },
     stopThinking: function () { return stopThinking.apply(null, arguments); },

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -875,11 +875,16 @@
     personaPlaceholderTitles: personaPlaceholderTitles, turnUsageDirty: turnUsageDirty,
     // 会话 buffer 删除/淘汰时清理宿主侧 per-session 副表（modeStateEpochs
     // 定义在本文件后段，无法直接传入引用，用延迟取值 hook）。
-    onSessionBufferPurged: function (id) {
+    onSessionBufferPurged: function (id, reason) {
       delete modeStateEpochs[id];
-      // scene 事件的 localStorage 缓存键也不随会话消亡而清理,会随历史会话数
-      // 无界累积（约 5MB 配额共享）。
-      if (id && window.localStorage) {
+      // scene 事件的 localStorage 缓存是 sidecar 保存失败/离线时的唯一恢复
+      // 副本（savePinvouSceneEventsForSession 的后端失败被有意吞掉，
+      // syncPinvouSceneEventsForSession 靠它兜底重放）。LRU 容量淘汰
+      // （reason === "evict"）≠ 会话删除：此时删键会让一次保存失败 +
+      // 淘汰的组合静默丢失全部 scene 映射，且键本体只有几百字节，保留
+      // 代价远低于丢数据。仅真实会话删除（"delete"）时清理，防随历史
+      // 会话数无界累积（约 5MB 配额共享）。
+      if (id && reason === "delete" && window.localStorage) {
         try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
       }
     },

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1719,13 +1719,17 @@
   }
 
   // ── Rerender from messages (session restore) ─────────────────────
-  function rerenderFromMessages() {
+  // opts.keepLiveToolMeta: live 会话注水(hydrateLiveSession)时传入 —— 此刻
+  // buffer 的 toolMeta 可能持有在飞工具的条目(tool_use 尚未进 messages),
+  // 清空会让后续 chat:tool_end 拿不到 meta(选择卡卡死/成品卡退化)。
+  function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
     // 历史 tool_use 的元数据(含 write/patch 的大 args)只服务本次重放期间的
     // tool_result 回填;实时事件路径插删均衡,但历史写入从不清理,残留会随
-    // 工作集存进 buffer 长期驻留。重放开始即清空(实时条目此刻不存在)。
-    toolMeta = {};
+    // 工作集存进 buffer 长期驻留。durable 重放开始即清空(非 live 注水时
+    // 实时条目不存在);重放会为 messages 内的历史 tool_use 重建所需条目。
+    if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];
     function emitPersonaAt(atOrAfter, isTail) {

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1730,10 +1730,11 @@
   function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
-    // 历史 tool_use 的元数据(含 write/patch 的大 args)只服务本次重放期间的
-    // tool_result 回填;实时事件路径插删均衡,但历史写入从不清理,残留会随
-    // 工作集存进 buffer 长期驻留。durable 重放开始即清空(非 live 注水时
-    // 实时条目不存在);重放会为 messages 内的历史 tool_use 重建所需条目。
+    // 重放会把每条历史 tool_use 的元数据(含 write/patch 的大 args)重新加入
+    // toolMeta 供 tool_result 回填,回填后并不删除——残留随工作集存进 buffer
+    // 驻留,内存由 32 条全会话 LRU 上限兜底。durable 重放开始即清空(非
+    // live 注水时),收回的只是中断回合留下的孤儿条目(实时事件路径本身
+    // 插删均衡);随后重放为 messages 内的历史 tool_use 重建所需条目。
     if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -873,17 +873,22 @@
     state: state, invoke: invoke, listen: listen, notify: notify,
     sessionStates: sessionStates, scheduledRunSessionOwners: scheduledRunSessionOwners,
     personaPlaceholderTitles: personaPlaceholderTitles, turnUsageDirty: turnUsageDirty,
-    // 会话 buffer 删除/淘汰时清理宿主侧 per-session 副表（modeStateEpochs
-    // 定义在本文件后段，无法直接传入引用，用延迟取值 hook）。
+    // Clean host-side per-session side tables when a session buffer is
+    // deleted/evicted (modeStateEpochs is defined later in this file, so
+    // the reference cannot be passed in directly — a lazy-lookup hook).
     onSessionBufferPurged: function (id, reason) {
       delete modeStateEpochs[id];
-      // scene 事件的 localStorage 缓存是 sidecar 保存失败/离线时的唯一恢复
-      // 副本（savePinvouSceneEventsForSession 的后端失败被有意吞掉，
-      // syncPinvouSceneEventsForSession 靠它兜底重放）。LRU 容量淘汰
-      // （reason === "evict"）≠ 会话删除：此时删键会让一次保存失败 +
-      // 淘汰的组合静默丢失全部 scene 映射，且键本体只有几百字节，保留
-      // 代价远低于丢数据。仅真实会话删除（"delete"）时清理，防随历史
-      // 会话数无界累积（约 5MB 配额共享）。
+      // The localStorage cache of scene events is the only recovery copy
+      // when the sidecar save fails or we are offline
+      // (savePinvouSceneEventsForSession intentionally swallows backend
+      // failures; syncPinvouSceneEventsForSession replays from this
+      // cache). LRU capacity eviction (reason === "evict") ≠ session
+      // deletion: removing the key here would let one failed save +
+      // eviction silently lose all scene mappings, and the key itself is
+      // only a few hundred bytes — keeping it costs far less than losing
+      // data. Clean only on real session deletion ("delete"), preventing
+      // unbounded accumulation across historical sessions (~5MB shared
+      // quota).
       if (id && reason === "delete" && window.localStorage) {
         try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
       }
@@ -1724,17 +1729,23 @@
   }
 
   // ── Rerender from messages (session restore) ─────────────────────
-  // opts.keepLiveToolMeta: live 会话注水(hydrateLiveSession)时传入 —— 此刻
-  // buffer 的 toolMeta 可能持有在飞工具的条目(tool_use 尚未进 messages),
-  // 清空会让后续 chat:tool_end 拿不到 meta(选择卡卡死/成品卡退化)。
+  // opts.keepLiveToolMeta: passed when hydrating a live session
+  // (hydrateLiveSession) — the buffer's toolMeta may hold entries for
+  // in-flight tools (tool_use not yet in messages), and clearing it would
+  // leave the later chat:tool_end without its meta (stuck selection
+  // card / degraded artifact card).
   function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
-    // 重放会把每条历史 tool_use 的元数据(含 write/patch 的大 args)重新加入
-    // toolMeta 供 tool_result 回填,回填后并不删除——残留随工作集存进 buffer
-    // 驻留,内存由 32 条全会话 LRU 上限兜底。durable 重放开始即清空(非
-    // live 注水时),收回的只是中断回合留下的孤儿条目(实时事件路径本身
-    // 插删均衡);随后重放为 messages 内的历史 tool_use 重建所需条目。
+    // Replay re-adds every historical tool_use's metadata (including
+    // write/patch's large args) to toolMeta for tool_result backfill and
+    // never deletes after backfill — the residue resides in the buffer
+    // with the working set, and memory is bounded by the 32-entry
+    // all-session LRU cap. Durable replay clears first (when not live
+    // hydrating), reclaiming only orphan entries left by interrupted
+    // turns (the live event path itself stays insert/delete balanced);
+    // the replay then rebuilds the needed entries for the historical
+    // tool_uses inside messages.
     if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -875,7 +875,14 @@
     personaPlaceholderTitles: personaPlaceholderTitles, turnUsageDirty: turnUsageDirty,
     // 会话 buffer 删除/淘汰时清理宿主侧 per-session 副表（modeStateEpochs
     // 定义在本文件后段，无法直接传入引用，用延迟取值 hook）。
-    onSessionBufferPurged: function (id) { delete modeStateEpochs[id]; },
+    onSessionBufferPurged: function (id) {
+      delete modeStateEpochs[id];
+      // scene 事件的 localStorage 缓存键也不随会话消亡而清理,会随历史会话数
+      // 无界累积（约 5MB 配额共享）。
+      if (id && window.localStorage) {
+        try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
+      }
+    },
     runSyncOnSession: runSyncOnSession, persistMessagesFor: persistMessagesFor,
     resetPendingAssistant: function () { return resetPendingAssistant.apply(null, arguments); },
     stopThinking: function () { return stopThinking.apply(null, arguments); },
@@ -1715,6 +1722,10 @@
   function rerenderFromMessages() {
     state.chatItems = [];
     itemIdSeq = 0;
+    // 历史 tool_use 的元数据(含 write/patch 的大 args)只服务本次重放期间的
+    // tool_result 回填;实时事件路径插删均衡,但历史写入从不清理,残留会随
+    // 工作集存进 buffer 长期驻留。重放开始即清空(实时条目此刻不存在)。
+    toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];
     function emitPersonaAt(atOrAfter, isTail) {

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -5,8 +5,7 @@
   registry.sessions = function (context) {
     var state = context.state;
     // 可选 hook：会话 buffer 被回收/删除时清理宿主侧 per-session 副表
-    // （bridge.js 的 modeStateEpochs 等）。返回 true 表示已处理，返回 false
-    // 或缺省时无操作。
+    // （bridge.js 的 modeStateEpochs、scene 事件 localStorage 键）。无返回值。
     var onSessionBufferPurged = context.onSessionBufferPurged || null;
     var invoke = context.invoke;
     var listen = context.listen;
@@ -137,7 +136,9 @@
     return buf;
   }
   // 全会话 LRU：scheduled 语义保护仍适用（busy/queued/remote turn 不回收），
-  // 仅淘汰"纯展示缓存"性质的空闲 buffer。active 会话由 isProtected 兜底。
+  // 仅淘汰空闲 buffer（messages/chatItems 可从磁盘重水化；composerDraft 等
+  // buffer 内草稿会随之丢弃——切走未发送的草稿本就不保证跨淘汰存活）。
+  // active 会话由 isProtected 兜底。
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
     var overflow = ids.length - MAX_SESSION_BUFFERS;
@@ -793,7 +794,16 @@
     // 多 session 并发:切换【不再 cancel】旧 session —— 它在自己的 engine 上继续跑,
     // 工作集存进 sessionStates 后台累积。切回来能看到完整(含切走期间产生的)内容。
     // 已有 buffer(切过/在跑)→ 直接换工作集;没有 → load_session 建 buffer + 重渲染。
-    if (sessionStates[id] && !forceDurableLoad && !hydrateLiveSession) {
+    // 事件监听会为任意被点名的 session 经 getBuffer 重建未落盘的空 buffer(如
+    // 淘汰后迟到的 chat:usage/artifact:disk);这种 buffer 走快路径会显示空会话,
+    // 必须落到下方磁盘重载自愈(web 桥同款 loadedFromDisk 门控)。busy/remote/
+    // 已有内容的 buffer 仍走快路径,展示实时部分视图并由 chat:done 对账补全。
+    var existingBuffer = sessionStates[id];
+    var cachedBufferUsable = existingBuffer && (existingBuffer.loadedFromDisk ||
+      existingBuffer.busy || existingBuffer.remoteTurnActive ||
+      (existingBuffer.messages && existingBuffer.messages.length) ||
+      (existingBuffer.chatItems && existingBuffer.chatItems.length));
+    if (cachedBufferUsable && !forceDurableLoad && !hydrateLiveSession) {
       if (!preserveScheduledRunContext) state.scheduledRunContext = null;
       state.scheduledTaskPendingGuide = null; // 仅在目标会话已确认可用后提交导航状态
       switchActiveTo(id, null);
@@ -855,7 +865,9 @@
         mergeHydratedArtifacts(saved.artifacts, liveArtifacts),
         state.activeSessionId
       );
-      rerenderFromMessages();
+      // live 注水:buffer 的 toolMeta 可能含在飞工具条目(tool_use 未进
+      // messages),保留给后续 chat:tool_end 用。
+      rerenderFromMessages({ keepLiveToolMeta: true });
       if (hasLivePresentation) {
         context.currentStreamId = mergeHydratedChatItems(liveChatItems, liveCurrentStreamId);
       } else {

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -4,6 +4,10 @@
   var registry = root.__PINVOU_TAURI_BRIDGE_FEATURES__ = root.__PINVOU_TAURI_BRIDGE_FEATURES__ || {};
   registry.sessions = function (context) {
     var state = context.state;
+    // 可选 hook：会话 buffer 被回收/删除时清理宿主侧 per-session 副表
+    // （bridge.js 的 modeStateEpochs 等）。返回 true 表示已处理，返回 false
+    // 或缺省时无操作。
+    var onSessionBufferPurged = context.onSessionBufferPurged || null;
     var invoke = context.invoke;
     var listen = context.listen;
     var notify = context.notify;
@@ -42,8 +46,13 @@
     var loadPinvouSceneEventsForSession = context.loadPinvouSceneEventsForSession || function () { return []; };
     var syncPinvouSceneEventsForSession = context.syncPinvouSceneEventsForSession ||
       function (sid) { return Promise.resolve(loadPinvouSceneEventsForSession(sid)); };
-    var MAX_SCHEDULED_SESSION_BUFFERS = 64;
-    var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
+  var MAX_SCHEDULED_SESSION_BUFFERS = 64;
+  var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
+  // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
+  // html)+artifacts，曾只对 scheduled 会话做 64 条 LRU——普通会话切过即永久
+  // 驻留，长时使用的内存随历史会话数无界增长。普通会话淘汰后重访问走
+  // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持）。
+  var MAX_SESSION_BUFFERS = 96;
     var sessionBufferTouchClock = 0;
     var scheduledRunOwnerTouchClock = 0;
     var scheduledRunOpenInFlight = Object.create(null);
@@ -89,6 +98,7 @@
   function isProtectedScheduledBuffer(id, buf) {
     return id === state.activeSessionId ||
       !!buf.busy ||
+      !!buf.remoteTurnActive ||
       buf.scheduledInitialTurnPhase === "active" ||
       !!(buf.queued && buf.queued.length) ||
       !!(state.scheduledRunContext && state.scheduledRunContext.sessionId === id) ||
@@ -119,11 +129,33 @@
     if (scheduled) buf.scheduledRunSession = true;
     buf.lastTouched = ++sessionBufferTouchClock;
     if (buf.scheduledRunSession) pruneScheduledSessionBuffers(id);
+    pruneSessionBuffers(id);
     return buf;
+  }
+  // 全会话 LRU：scheduled 语义保护仍适用（busy/queued/remote turn 不回收），
+  // 仅淘汰"纯展示缓存"性质的空闲 buffer。active 会话由 isProtected 兜底。
+  function pruneSessionBuffers(keepId) {
+    var ids = Object.keys(sessionStates);
+    var overflow = ids.length - MAX_SESSION_BUFFERS;
+    if (overflow <= 0) return;
+    ids.sort(function (left, right) {
+      var delta = (sessionStates[left].lastTouched || 0) - (sessionStates[right].lastTouched || 0);
+      return delta || left.localeCompare(right);
+    });
+    for (var i = 0; i < ids.length && overflow > 0; i++) {
+      var id = ids[i];
+      var buf = sessionStates[id];
+      if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      delete sessionStates[id];
+      delete turnUsageDirty[id];
+      if (onSessionBufferPurged) onSessionBufferPurged(id);
+      overflow -= 1;
+    }
   }
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;
     delete sessionStates[id];
+    if (onSessionBufferPurged) onSessionBufferPurged(id);
     delete turnUsageDirty[id];
     delete personaPlaceholderTitles[id];
     delete scheduledRunSessionOwners[id];

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -58,8 +58,11 @@
     var MAX_SESSION_BUFFERS = 32;
     // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃：磁盘 transcript
     // 只含已提交内容，淘汰前先转移到这张侧表，buffer 重建时回填。侧表只存
-    // 短字符串且上限远大于 buffer 上限，重对象仍随淘汰照常释放。
+    // 短字符串（超长草稿不入表，维持淘汰即丢弃的旧行为——外部 transport 调
+    // 用可绕过 Composer 的输入上限）且条数上限远大于 buffer 上限，重对象仍
+    // 随淘汰照常释放。
     var MAX_EVICTED_SESSION_DRAFTS = 256;
+    var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
     var sessionBufferTouchClock = 0;
     var scheduledRunOwnerTouchClock = 0;
     var scheduledRunOpenInFlight = Object.create(null);
@@ -70,6 +73,7 @@
     delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
     var draft = String(buf.composerDraft || "");
     if (!draft) return;
+    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return;
     evictedSessionDrafts[id] = draft;
     var keys = Object.keys(evictedSessionDrafts);
     if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -428,8 +428,12 @@
   function switchActiveTo(id, opts) {
     // 离开草稿（无论物化还是切去既有会话），未消费的开关寄存意图作废。
     state.pendingDraftMultiAgent = false;
-    if (state.activeSessionId) saveWorkingSetTo(getBuffer(state.activeSessionId));
+    // 先立新 active 再 touch 旧 buffer:touch 触发的 LRU 淘汰靠 activeSessionId
+    // 兜底保护目标会话;若先 touch 旧(active 仍指旧值),空闲的目标会话恰为最旧
+    // 时会被淘汰,随后的 freshBuffer() 顶替会静默显示空会话。
+    var previousActiveId = state.activeSessionId;
     state.activeSessionId = id;
+    if (previousActiveId) saveWorkingSetTo(getBuffer(previousActiveId));
     var buf = sessionStates[id];
     if (!buf || (opts && opts.fresh)) buf = sessionStates[id] = freshBuffer();
     touchSessionBuffer(id, buf, id.indexOf("sched-") === 0);
@@ -797,12 +801,14 @@
     // 事件监听会为任意被点名的 session 经 getBuffer 重建未落盘的空 buffer(如
     // 淘汰后迟到的 chat:usage/artifact:disk);这种 buffer 走快路径会显示空会话,
     // 必须落到下方磁盘重载自愈(web 桥同款 loadedFromDisk 门控)。busy/remote/
-    // 已有内容的 buffer 仍走快路径,展示实时部分视图并由 chat:done 对账补全。
+    // 已有 messages 的 buffer 仍走快路径,展示实时部分视图并由 chat:done 对账
+    // 补全。不能用 chatItems 判可用:非回合事件(如 chat:compaction)经 getBuffer
+    // 重建的空 buffer 只带一条系统 chatItem(不置 busy、无 messages),凭 chatItems
+    // 放行会永久显示无历史视图且无自愈。
     var existingBuffer = sessionStates[id];
     var cachedBufferUsable = existingBuffer && (existingBuffer.loadedFromDisk ||
       existingBuffer.busy || existingBuffer.remoteTurnActive ||
-      (existingBuffer.messages && existingBuffer.messages.length) ||
-      (existingBuffer.chatItems && existingBuffer.chatItems.length));
+      (existingBuffer.messages && existingBuffer.messages.length));
     if (cachedBufferUsable && !forceDurableLoad && !hydrateLiveSession) {
       if (!preserveScheduledRunContext) state.scheduledRunContext = null;
       state.scheduledTaskPendingGuide = null; // 仅在目标会话已确认可用后提交导航状态

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -5,7 +5,9 @@
   registry.sessions = function (context) {
     var state = context.state;
     // 可选 hook：会话 buffer 被回收/删除时清理宿主侧 per-session 副表
-    // （bridge.js 的 modeStateEpochs、scene 事件 localStorage 键）。无返回值。
+    // （bridge.js 的 modeStateEpochs、scene 事件 localStorage 键）。
+    // reason === "evict" 为 LRU 容量淘汰，"delete" 为会话真实删除；
+    // 宿主侧可据此区分保留可恢复数据（如 scene 缓存键）。无返回值。
     var onSessionBufferPurged = context.onSessionBufferPurged || null;
     var invoke = context.invoke;
     var listen = context.listen;
@@ -45,19 +47,38 @@
     var loadPinvouSceneEventsForSession = context.loadPinvouSceneEventsForSession || function () { return []; };
     var syncPinvouSceneEventsForSession = context.syncPinvouSceneEventsForSession ||
       function (sid) { return Promise.resolve(loadPinvouSceneEventsForSession(sid)); };
-  var MAX_SCHEDULED_SESSION_BUFFERS = 64;
-  var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
-  // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
-  // html)+artifacts（重会话 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——
-  // 普通会话切过即永久驻留。上限取 32：典型用户活跃切换集中在个位数会话，
-  // 96×1-4MB 最坏数百 MB 且 >20 的命中率趋近于零；被淘汰会话重访问走
-  // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持），
-  // 代价仅一次重载。
-  var MAX_SESSION_BUFFERS = 32;
+    var MAX_SCHEDULED_SESSION_BUFFERS = 64;
+    var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
+    // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
+    // html)+artifacts（重会话 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——
+    // 普通会话切过即永久驻留。上限取 32：典型用户活跃切换集中在个位数会话，
+    // 96×1-4MB 最坏数百 MB 且 >20 的命中率趋近于零；被淘汰会话重访问走
+    // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持），
+    // 代价仅一次重载。
+    var MAX_SESSION_BUFFERS = 32;
+    // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃：磁盘 transcript
+    // 只含已提交内容，淘汰前先转移到这张侧表，buffer 重建时回填。侧表只存
+    // 短字符串且上限远大于 buffer 上限，重对象仍随淘汰照常释放。
+    var MAX_EVICTED_SESSION_DRAFTS = 256;
     var sessionBufferTouchClock = 0;
     var scheduledRunOwnerTouchClock = 0;
     var scheduledRunOpenInFlight = Object.create(null);
     var sessionSwitchRequestToken = 0;
+    var evictedSessionDrafts = Object.create(null);
+  function stashEvictedSessionDraft(id, buf) {
+    if (!id || !buf) return;
+    delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
+    var draft = String(buf.composerDraft || "");
+    if (!draft) return;
+    evictedSessionDrafts[id] = draft;
+    var keys = Object.keys(evictedSessionDrafts);
+    if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];
+  }
+  function restoreEvictedSessionDraft(id, buf) {
+    if (!id || !buf || buf.composerDraft) return;
+    var draft = evictedSessionDrafts[id];
+    if (draft) buf.composerDraft = draft;
+  }
   function freshBuffer() {
     return {
       messages: [], chatItems: [], composerDraft: "", turnTimeline: [], activeTurnTimelineId: null, personaEvents: [], pinvouReviews: [], pinvouSceneEvents: [], artifacts: [], busy: false, queued: [],
@@ -93,7 +114,10 @@
   }
   function getBuffer(id) {
     if (!id) return null;
-    if (!sessionStates[id]) sessionStates[id] = freshBuffer();
+    if (!sessionStates[id]) {
+      sessionStates[id] = freshBuffer();
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+    }
     return touchSessionBuffer(id, sessionStates[id], id.indexOf("sched-") === 0);
   }
   function isProtectedScheduledBuffer(id, buf) {
@@ -119,11 +143,12 @@
       var id = scheduledIds[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
       delete personaPlaceholderTitles[id];
       pruneScheduledRunSessionOwner(id);
-      if (onSessionBufferPurged) onSessionBufferPurged(id);
+      if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
     }
   }
@@ -136,8 +161,8 @@
     return buf;
   }
   // 全会话 LRU：scheduled 语义保护仍适用（busy/queued/remote turn 不回收），
-  // 仅淘汰空闲 buffer（messages/chatItems 可从磁盘重水化；composerDraft 等
-  // buffer 内草稿会随之丢弃——切走未发送的草稿本就不保证跨淘汰存活）。
+  // 仅淘汰空闲 buffer。messages/chatItems 可从磁盘重水化；composerDraft 等
+  // 不可重水化的草稿先转移到 evictedSessionDrafts 侧表，重建时回填。
   // active 会话由 isProtected 兜底。
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
@@ -151,17 +176,20 @@
       var id = ids[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
       delete personaPlaceholderTitles[id];
-      if (onSessionBufferPurged) onSessionBufferPurged(id);
+      if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
     }
   }
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;
     delete sessionStates[id];
-    if (onSessionBufferPurged) onSessionBufferPurged(id);
+    // 真实会话删除:任何暂存草稿一并作废,不得回流到同 id 的重建 buffer。
+    delete evictedSessionDrafts[id];
+    if (onSessionBufferPurged) onSessionBufferPurged(id, "delete");
     delete turnUsageDirty[id];
     delete personaPlaceholderTitles[id];
     delete scheduledRunSessionOwners[id];
@@ -435,7 +463,10 @@
     state.activeSessionId = id;
     if (previousActiveId) saveWorkingSetTo(getBuffer(previousActiveId));
     var buf = sessionStates[id];
-    if (!buf || (opts && opts.fresh)) buf = sessionStates[id] = freshBuffer();
+    if (!buf || (opts && opts.fresh)) {
+      buf = sessionStates[id] = freshBuffer();
+      if (!opts || !opts.fresh) restoreEvictedSessionDraft(id, buf);
+    }
     touchSessionBuffer(id, buf, id.indexOf("sched-") === 0);
     loadWorkingSetFrom(buf);
     state.artifacts = filterSessionArtifacts(state.artifacts, id);
@@ -788,7 +819,10 @@
       reportSessionSwitchFailure(new Error(bt("runHasNoSession")), errorScope);
       return false;
     }
-    if (hydrateLiveSession && !sessionStates[id]) sessionStates[id] = freshBuffer();
+    if (hydrateLiveSession && !sessionStates[id]) {
+      sessionStates[id] = freshBuffer();
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+    }
     if (id === state.activeSessionId && !forceDurableLoad && !hydrateLiveSession) {
       if (!preserveScheduledRunContext) state.scheduledRunContext = null;
       state.scheduledTaskPendingGuide = null;
@@ -881,7 +915,10 @@
       }
       saveWorkingSetTo(liveBuffer);
     } else {
-      loadWorkingSetFrom(sessionStates[id] = freshBuffer());
+      sessionStates[id] = freshBuffer();
+      // 慢路径磁盘重水化不经 getBuffer,淘汰时暂存的草稿须在这里回填。
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+      loadWorkingSetFrom(sessionStates[id]);
       state.messages = Array.isArray(saved.messages) ? saved.messages : [];
       sessionStates[id].loadedFromDisk = true;
       state.personaEvents = personaEvents;

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -4,10 +4,12 @@
   var registry = root.__PINVOU_TAURI_BRIDGE_FEATURES__ = root.__PINVOU_TAURI_BRIDGE_FEATURES__ || {};
   registry.sessions = function (context) {
     var state = context.state;
-    // 可选 hook：会话 buffer 被回收/删除时清理宿主侧 per-session 副表
-    // （bridge.js 的 modeStateEpochs、scene 事件 localStorage 键）。
-    // reason === "evict" 为 LRU 容量淘汰，"delete" 为会话真实删除；
-    // 宿主侧可据此区分保留可恢复数据（如 scene 缓存键）。无返回值。
+    // Optional hook: clean host-side per-session side tables when a
+    // session buffer is reclaimed/deleted (bridge.js's modeStateEpochs,
+    // the scene-events localStorage key).
+    // reason === "evict" is an LRU capacity eviction, "delete" a real
+    // session deletion; the host distinguishes them to keep recoverable
+    // data (e.g. the scene cache key) on eviction. No return value.
     var onSessionBufferPurged = context.onSessionBufferPurged || null;
     var invoke = context.invoke;
     var listen = context.listen;
@@ -49,35 +51,48 @@
       function (sid) { return Promise.resolve(loadPinvouSceneEventsForSession(sid)); };
     var MAX_SCHEDULED_SESSION_BUFFERS = 64;
     var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
-    // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
-    // html)+artifacts（重会话 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——
-    // 普通会话切过即永久驻留。上限取 32：典型用户活跃切换集中在个位数会话，
-    // 32×1-4MB 最坏约 32-128MB，超出 32 条的冷门会话命中率趋近于零；被淘汰
-    // 会话重访问走 load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo
-    // 已支持），代价仅一次重载。
+    // All-session buffer cap: each sessionStates entry holds the full
+    // messages+chatItems (with rendered html)+artifacts (heavy sessions
+    // run 1-4MB each); previously only scheduled sessions had a 64-entry
+    // LRU — normal sessions stayed resident forever once visited. Cap at
+    // 32: typical users actively switch among single-digit session
+    // counts, 32 × 1-4MB worst case is ~32-128MB, and cold sessions
+    // beyond 32 have near-zero hit rate; revisiting an evicted session
+    // goes through load_session disk rehydration (already supported by
+    // ensureSessionBufferLoaded/switchTo), costing one reload.
     var MAX_SESSION_BUFFERS = 32;
-    // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃：磁盘 transcript
-    // 只含已提交内容，淘汰前先转移到这张侧表，buffer 重建时回填。侧表只存
-    // 短字符串且条数上限远大于 buffer 上限，重对象仍随淘汰照常释放。超过
-    // MAX_EVICTED_SESSION_DRAFT_CHARS 的超长草稿不入表、随淘汰丢弃——普通
-    // 会话此前从不被淘汰，这是全会话 LRU 新引入的丢弃面（外部 transport
-    // 调用可绕过 Composer 的输入上限产生超长草稿）。
-    var MAX_EVICTED_SESSION_DRAFTS = 256;
-    var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
-    var sessionBufferTouchClock = 0;
-    var scheduledRunOwnerTouchClock = 0;
-    var scheduledRunOpenInFlight = Object.create(null);
-    var sessionSwitchRequestToken = 0;
-    var evictedSessionDrafts = Object.create(null);
+  // Unsent composer drafts are the one piece of a working set that cannot be
+  // rebuilt from disk (transcripts hold committed content only), so eviction
+  // must never drop them: before a buffer is dropped, its draft moves to this
+  // side table and every rebuild path restores it. The table is bounded
+  // (256 entries, 1M chars per draft — 10x the composer input cap), and when
+  // a bound would be exceeded the eviction is refused instead: the buffer
+  // stays resident rather than silently losing user input. Real session
+  // deletion (purgeSessionBuffer) invalidates stashed drafts so they never
+  // flow back into a recycled session id.
+  var MAX_EVICTED_SESSION_DRAFTS = 256;
+  var MAX_EVICTED_SESSION_DRAFT_CHARS = 1000000;
+  var sessionBufferTouchClock = 0;
+  var scheduledRunOwnerTouchClock = 0;
+  var scheduledRunOpenInFlight = Object.create(null);
+  var sessionSwitchRequestToken = 0;
+  var evictedSessionDrafts = Object.create(null);
+  // Returns true when the buffer's non-rehydratable state is safely retained
+  // (or empty) and the caller may drop the buffer; false means eviction must
+  // be skipped so the draft stays in the live buffer.
   function stashEvictedSessionDraft(id, buf) {
-    if (!id || !buf) return;
-    delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
+    if (!id || !buf) return true;
     var draft = String(buf.composerDraft || "");
-    if (!draft) return;
-    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return;
+    if (!draft) {
+      delete evictedSessionDrafts[id]; // input was cleared; a stale stash must not resurrect it
+      return true;
+    }
+    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return false;
+    if (!evictedSessionDrafts[id]
+        && Object.keys(evictedSessionDrafts).length >= MAX_EVICTED_SESSION_DRAFTS) return false;
+    delete evictedSessionDrafts[id]; // re-stashing moves the entry to the table tail
     evictedSessionDrafts[id] = draft;
-    var keys = Object.keys(evictedSessionDrafts);
-    if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];
+    return true;
   }
   function restoreEvictedSessionDraft(id, buf) {
     if (!id || !buf || buf.composerDraft) return;
@@ -148,12 +163,13 @@
       var id = scheduledIds[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
-      stashEvictedSessionDraft(id, buf);
+      if (!stashEvictedSessionDraft(id, buf)) continue; // draft cannot be safely retained; keep the buffer
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      // personaPlaceholderTitles 是轻量会话元数据(占位标题可被自动标题覆盖
-      // 的标记),重水化路径不会恢复它;容量淘汰必须保留,仅真实会话删除
-      // (purgeSessionBuffer)才清理。
+      // personaPlaceholderTitles is lightweight session metadata (the marker
+      // for placeholder titles that auto-rename may override); rehydration
+      // never restores it, so capacity eviction must keep it and only real
+      // session deletion (purgeSessionBuffer) cleans it.
       pruneScheduledRunSessionOwner(id);
       if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
@@ -167,10 +183,13 @@
     pruneSessionBuffers(id);
     return buf;
   }
-  // 全会话 LRU：scheduled 语义保护仍适用（busy/queued/remote turn 不回收），
-  // 仅淘汰空闲 buffer。messages/chatItems 可从磁盘重水化；composerDraft 等
-  // 不可重水化的草稿先转移到 evictedSessionDrafts 侧表，重建时回填。
-  // active 会话由 isProtected 兜底。
+  // All-session LRU: the scheduled protection predicates still apply (busy/
+  // queued/remote turns are never reclaimed); only idle buffers are evicted.
+  // messages/chatItems rehydrate from disk; non-rehydratable drafts such as
+  // composerDraft move to the evictedSessionDrafts side table first and are
+  // restored on rebuild. The active session is covered by isProtected as a
+  // final backstop, and a buffer whose draft cannot be safely stashed is kept
+  // resident rather than evicted.
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
     var overflow = ids.length - MAX_SESSION_BUFFERS;
@@ -183,11 +202,12 @@
       var id = ids[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
-      stashEvictedSessionDraft(id, buf);
+      if (!stashEvictedSessionDraft(id, buf)) continue; // draft cannot be safely retained; keep the buffer
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      // personaPlaceholderTitles 标记随淘汰保留(见 scheduled 淘汰处说明),
-      // 仅 purgeSessionBuffer(真实删除)清理。
+      // personaPlaceholderTitles survives capacity eviction (see the comment
+      // at the scheduled eviction site); only purgeSessionBuffer (real
+      // deletion) cleans it.
       if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
     }
@@ -195,7 +215,7 @@
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;
     delete sessionStates[id];
-    // 真实会话删除:任何暂存草稿一并作废,不得回流到同 id 的重建 buffer。
+    // Real session deletion: any stashed draft is invalidated too and must not flow back into a rebuilt buffer with the same id.
     delete evictedSessionDrafts[id];
     if (onSessionBufferPurged) onSessionBufferPurged(id, "delete");
     delete turnUsageDirty[id];
@@ -464,20 +484,26 @@
   function switchActiveTo(id, opts) {
     // 离开草稿（无论物化还是切去既有会话），未消费的开关寄存意图作废。
     state.pendingDraftMultiAgent = false;
-    // 先立新 active 再 touch 旧 buffer:touch 触发的 LRU 淘汰靠 activeSessionId
-    // 兜底保护目标会话;若先 touch 旧(active 仍指旧值),空闲的目标会话恰为最旧
-    // 时会被淘汰,随后的 freshBuffer() 顶替会静默显示空会话。
+    // Set the new active before touching the old buffer: the LRU
+    // eviction triggered by touch relies on activeSessionId as the
+    // backstop protecting the target session; touching the old one first
+    // (active still pointing at the old value) would evict an idle target
+    // that happens to be oldest, and the subsequent freshBuffer()
+    // replacement would silently show an empty session.
     var previousActiveId = state.activeSessionId;
     state.activeSessionId = id;
     if (previousActiveId) saveWorkingSetTo(getBuffer(previousActiveId));
     var buf = sessionStates[id];
     if (!buf || (opts && opts.fresh)) {
       buf = sessionStates[id] = freshBuffer();
-      // fresh 用于本端刚物化的新会话:空 buffer 即权威视图,必须标
-      // loadedFromDisk——否则 switchToSessionInternal 的快路径门控会把它当
-      // 事件重建的残缺 buffer 落到慢路径,freshBuffer() 顶替时不经侧表暂存,
-      // buffer 里的未发送草稿被静默丢弃(web 桥同款门控)。fresh 不回填侧表
-      // 草稿:同 id 复用场景不得复活旧暂存。
+      // fresh is for sessions just materialized on this side: the empty
+      // buffer is the authoritative view and must be marked
+      // loadedFromDisk — otherwise switchToSessionInternal's fast-path
+      // gate routes it to the slow path as an event-rebuilt incomplete
+      // buffer, the freshBuffer() replacement bypasses the side-table
+      // stash, and the buffer's unsent draft is silently dropped (same
+      // gate as the web bridge). fresh does not restore a side-table
+      // draft: id-reuse scenarios must not resurrect an old stash.
       if (opts && opts.fresh) buf.loadedFromDisk = true;
       else restoreEvictedSessionDraft(id, buf);
     }
@@ -846,13 +872,18 @@
     // 多 session 并发:切换【不再 cancel】旧 session —— 它在自己的 engine 上继续跑,
     // 工作集存进 sessionStates 后台累积。切回来能看到完整(含切走期间产生的)内容。
     // 已有 buffer(切过/在跑)→ 直接换工作集;没有 → load_session 建 buffer + 重渲染。
-    // 事件监听会为任意被点名的 session 经 getBuffer 重建未落盘的空 buffer(如
-    // 淘汰后迟到的 chat:usage/artifact:disk);这种 buffer 走快路径会显示空会话,
-    // 必须落到下方磁盘重载自愈(web 桥同款 loadedFromDisk 门控)。busy/remote/
-    // 已有 messages 的 buffer 仍走快路径,展示实时部分视图并由 chat:done 对账
-    // 补全。不能用 chatItems 判可用:非回合事件(如 chat:compaction)经 getBuffer
-    // 重建的空 buffer 只带一条系统 chatItem(不置 busy、无 messages),凭 chatItems
-    // 放行会永久显示无历史视图且无自愈。
+    // Event listeners rebuild an unsaved empty buffer via getBuffer for
+    // any session an event names (e.g. a late chat:usage/artifact:disk
+    // after eviction); taking the fast path with such a buffer shows an
+    // empty conversation, so it must fall through to the disk reload
+    // below to self-heal (same loadedFromDisk gate as the web bridge).
+    // Buffers that are busy/remote/have messages still take the fast
+    // path, showing the live partial view completed by the chat:done
+    // reconcile. chatItems must not be the usability check: an empty
+    // buffer rebuilt by a non-turn event (e.g. chat:compaction) carries
+    // only one system chatItem (no busy flag, no messages), and admitting
+    // it by chatItems would permanently show a history-less view with no
+    // self-heal.
     var existingBuffer = sessionStates[id];
     var cachedBufferUsable = existingBuffer && (existingBuffer.loadedFromDisk ||
       existingBuffer.busy || existingBuffer.remoteTurnActive ||
@@ -919,8 +950,9 @@
         mergeHydratedArtifacts(saved.artifacts, liveArtifacts),
         state.activeSessionId
       );
-      // live 注水:buffer 的 toolMeta 可能含在飞工具条目(tool_use 未进
-      // messages),保留给后续 chat:tool_end 用。
+      // Live hydration: the buffer's toolMeta may hold in-flight tool
+      // entries (tool_use not yet in messages); keep them for the later
+      // chat:tool_end.
       rerenderFromMessages({ keepLiveToolMeta: true });
       if (hasLivePresentation) {
         context.currentStreamId = mergeHydratedChatItems(liveChatItems, liveCurrentStreamId);
@@ -930,7 +962,7 @@
       saveWorkingSetTo(liveBuffer);
     } else {
       sessionStates[id] = freshBuffer();
-      // 慢路径磁盘重水化不经 getBuffer,淘汰时暂存的草稿须在这里回填。
+      // The slow-path disk rehydration bypasses getBuffer; the draft stashed at eviction time must be restored here.
       restoreEvictedSessionDraft(id, sessionStates[id]);
       loadWorkingSetFrom(sessionStates[id]);
       state.messages = Array.isArray(saved.messages) ? saved.messages : [];

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -52,15 +52,16 @@
     // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
     // html)+artifacts（重会话 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——
     // 普通会话切过即永久驻留。上限取 32：典型用户活跃切换集中在个位数会话，
-    // 96×1-4MB 最坏数百 MB 且 >20 的命中率趋近于零；被淘汰会话重访问走
-    // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持），
-    // 代价仅一次重载。
+    // 32×1-4MB 最坏约 32-128MB，超出 32 条的冷门会话命中率趋近于零；被淘汰
+    // 会话重访问走 load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo
+    // 已支持），代价仅一次重载。
     var MAX_SESSION_BUFFERS = 32;
     // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃：磁盘 transcript
     // 只含已提交内容，淘汰前先转移到这张侧表，buffer 重建时回填。侧表只存
-    // 短字符串（超长草稿不入表，维持淘汰即丢弃的旧行为——外部 transport 调
-    // 用可绕过 Composer 的输入上限）且条数上限远大于 buffer 上限，重对象仍
-    // 随淘汰照常释放。
+    // 短字符串且条数上限远大于 buffer 上限，重对象仍随淘汰照常释放。超过
+    // MAX_EVICTED_SESSION_DRAFT_CHARS 的超长草稿不入表、随淘汰丢弃——普通
+    // 会话此前从不被淘汰，这是全会话 LRU 新引入的丢弃面（外部 transport
+    // 调用可绕过 Composer 的输入上限产生超长草稿）。
     var MAX_EVICTED_SESSION_DRAFTS = 256;
     var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
     var sessionBufferTouchClock = 0;
@@ -150,7 +151,9 @@
       stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      delete personaPlaceholderTitles[id];
+      // personaPlaceholderTitles 是轻量会话元数据(占位标题可被自动标题覆盖
+      // 的标记),重水化路径不会恢复它;容量淘汰必须保留,仅真实会话删除
+      // (purgeSessionBuffer)才清理。
       pruneScheduledRunSessionOwner(id);
       if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
@@ -183,7 +186,8 @@
       stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      delete personaPlaceholderTitles[id];
+      // personaPlaceholderTitles 标记随淘汰保留(见 scheduled 淘汰处说明),
+      // 仅 purgeSessionBuffer(真实删除)清理。
       if (onSessionBufferPurged) onSessionBufferPurged(id, "evict");
       overflow -= 1;
     }
@@ -469,7 +473,13 @@
     var buf = sessionStates[id];
     if (!buf || (opts && opts.fresh)) {
       buf = sessionStates[id] = freshBuffer();
-      if (!opts || !opts.fresh) restoreEvictedSessionDraft(id, buf);
+      // fresh 用于本端刚物化的新会话:空 buffer 即权威视图,必须标
+      // loadedFromDisk——否则 switchToSessionInternal 的快路径门控会把它当
+      // 事件重建的残缺 buffer 落到慢路径,freshBuffer() 顶替时不经侧表暂存,
+      // buffer 里的未发送草稿被静默丢弃(web 桥同款门控)。fresh 不回填侧表
+      // 草稿:同 id 复用场景不得复活旧暂存。
+      if (opts && opts.fresh) buf.loadedFromDisk = true;
+      else restoreEvictedSessionDraft(id, buf);
     }
     touchSessionBuffer(id, buf, id.indexOf("sched-") === 0);
     loadWorkingSetFrom(buf);

--- a/pinvou3-app/src/platform/tauri/bridge/sessions.js
+++ b/pinvou3-app/src/platform/tauri/bridge/sessions.js
@@ -49,10 +49,12 @@
   var MAX_SCHEDULED_SESSION_BUFFERS = 64;
   var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
   // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems(含渲染
-  // html)+artifacts，曾只对 scheduled 会话做 64 条 LRU——普通会话切过即永久
-  // 驻留，长时使用的内存随历史会话数无界增长。普通会话淘汰后重访问走
-  // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持）。
-  var MAX_SESSION_BUFFERS = 96;
+  // html)+artifacts（重会话 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——
+  // 普通会话切过即永久驻留。上限取 32：典型用户活跃切换集中在个位数会话，
+  // 96×1-4MB 最坏数百 MB 且 >20 的命中率趋近于零；被淘汰会话重访问走
+  // load_session 磁盘重水化（ensureSessionBufferLoaded/switchTo 已支持），
+  // 代价仅一次重载。
+  var MAX_SESSION_BUFFERS = 32;
     var sessionBufferTouchClock = 0;
     var scheduledRunOwnerTouchClock = 0;
     var scheduledRunOpenInFlight = Object.create(null);
@@ -120,7 +122,9 @@
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
       delete sessionStates[id];
       delete turnUsageDirty[id];
+      delete personaPlaceholderTitles[id];
       pruneScheduledRunSessionOwner(id);
+      if (onSessionBufferPurged) onSessionBufferPurged(id);
       overflow -= 1;
     }
   }
@@ -148,6 +152,7 @@
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
       delete sessionStates[id];
       delete turnUsageDirty[id];
+      delete personaPlaceholderTitles[id];
       if (onSessionBufferPurged) onSessionBufferPurged(id);
       overflow -= 1;
     }

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -778,15 +778,18 @@
   var MAX_SESSION_BUFFERS = 32;
   // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃（web 桥不落盘
   // 草稿，磁盘 transcript 只含已提交内容）：淘汰前先转移到这张侧表，buffer
-  // 重建时回填。侧表只存短字符串且上限远大于 buffer 上限，重对象仍随淘汰
-  // 照常释放。
+  // 重建时回填。侧表只存短字符串（超长草稿不入表，维持淘汰即丢弃的旧行为
+  // ——外部 transport 调用可绕过 Composer 的输入上限）且条数上限远大于
+  // buffer 上限，重对象仍随淘汰照常释放。
   var MAX_EVICTED_SESSION_DRAFTS = 256;
+  var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
   var evictedSessionDrafts = Object.create(null);
   function stashEvictedSessionDraft(id, buf) {
     if (!id || !buf) return;
     delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
     var draft = String(buf.composerDraft || "");
     if (!draft) return;
+    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return;
     evictedSessionDrafts[id] = draft;
     var keys = Object.keys(evictedSessionDrafts);
     if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -773,14 +773,16 @@
   var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
   // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems（重会话
   // 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——普通会话切过即永久驻留。
-  // 上限取 32：典型用户活跃切换集中在个位数，96×1-4MB 最坏数百 MB 且高水位
-  // 命中率趋近于零；被淘汰会话重访问走 load_session 磁盘重水化，代价仅一次重载。
+  // 上限取 32：典型用户活跃切换集中在个位数，32×1-4MB 最坏约 32-128MB，
+  // 超出上限的冷门会话命中率趋近于零；被淘汰会话重访问走 load_session 磁盘
+  // 重水化，代价仅一次重载。
   var MAX_SESSION_BUFFERS = 32;
   // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃（web 桥不落盘
   // 草稿，磁盘 transcript 只含已提交内容）：淘汰前先转移到这张侧表，buffer
-  // 重建时回填。侧表只存短字符串（超长草稿不入表，维持淘汰即丢弃的旧行为
-  // ——外部 transport 调用可绕过 Composer 的输入上限）且条数上限远大于
-  // buffer 上限，重对象仍随淘汰照常释放。
+  // 重建时回填。侧表只存短字符串且条数上限远大于 buffer 上限，重对象仍随
+  // 淘汰照常释放。超过 MAX_EVICTED_SESSION_DRAFT_CHARS 的超长草稿不入表、
+  // 随淘汰丢弃——普通会话此前从不被淘汰，这是全会话 LRU 新引入的丢弃面
+  // （外部 transport 调用可绕过 Composer 的输入上限产生超长草稿）。
   var MAX_EVICTED_SESSION_DRAFTS = 256;
   var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
   var evictedSessionDrafts = Object.create(null);
@@ -966,7 +968,9 @@
       stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      delete personaPlaceholderTitles[id];
+      // personaPlaceholderTitles 是轻量会话元数据（占位标题可被自动标题覆盖
+      // 的标记），重水化路径不会恢复它；容量淘汰必须保留，仅真实会话删除
+      // （purgeSessionBuffer）才清理。
       // scene 事件的 localStorage 缓存是 sidecar 保存失败/离线时的唯一恢复
       // 副本（savePinvouSceneEventsForSession 的后端失败被有意吞掉，
       // syncPinvouSceneEventsForSession 靠它兜底重放），容量淘汰不得删键；
@@ -1003,7 +1007,8 @@
       stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      delete personaPlaceholderTitles[id];
+      // personaPlaceholderTitles 标记随淘汰保留（见 scheduled 淘汰处说明），
+      // 仅 purgeSessionBuffer（真实删除）清理。
       // scene 缓存键在容量淘汰时保留（唯一离线恢复副本），见上方 scheduled
       // 淘汰处的说明；仅 purgeSessionBuffer（真实会话删除）清理。
       overflow -= 1;
@@ -4012,10 +4017,11 @@
   function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
-    // 历史 tool_use 的元数据(含 write/patch 的大 args)只服务本次重放期间的
-    // tool_result 回填;实时事件路径插删均衡,但历史写入从不清理,残留会随
-    // 工作集存进 buffer 长期驻留。durable 重放开始即清空(非 live 注水时
-    // 实时条目不存在);重放会为 messages 内的历史 tool_use 重建所需条目。
+    // 重放会把每条历史 tool_use 的元数据(含 write/patch 的大 args)重新加入
+    // toolMeta 供 tool_result 回填,回填后并不删除——残留随工作集存进 buffer
+    // 驻留,内存由 32 条全会话 LRU 上限兜底。durable 重放开始即清空(非
+    // live 注水时),收回的只是中断回合留下的孤儿条目(实时事件路径本身
+    // 插删均衡);随后重放为 messages 内的历史 tool_use 重建所需条目。
     if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -771,30 +771,43 @@
   var scheduledRunOpenInFlight = Object.create(null);
   var MAX_SCHEDULED_SESSION_BUFFERS = 64;
   var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
-  // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems（重会话
-  // 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——普通会话切过即永久驻留。
-  // 上限取 32：典型用户活跃切换集中在个位数，32×1-4MB 最坏约 32-128MB，
-  // 超出上限的冷门会话命中率趋近于零；被淘汰会话重访问走 load_session 磁盘
-  // 重水化，代价仅一次重载。
+  // All-session buffer cap: each sessionStates entry holds the full
+  // messages+chatItems (heavy sessions run 1-4MB each); previously only
+  // scheduled sessions had a 64-entry LRU — normal sessions stayed
+  // resident forever once visited. Cap at 32: typical users actively
+  // switch among single-digit counts, 32 × 1-4MB worst case is
+  // ~32-128MB, and cold sessions beyond the cap have near-zero hit
+  // rate; revisiting an evicted session goes through load_session disk
+  // rehydration, costing one reload.
   var MAX_SESSION_BUFFERS = 32;
-  // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃（web 桥不落盘
-  // 草稿，磁盘 transcript 只含已提交内容）：淘汰前先转移到这张侧表，buffer
-  // 重建时回填。侧表只存短字符串且条数上限远大于 buffer 上限，重对象仍随
-  // 淘汰照常释放。超过 MAX_EVICTED_SESSION_DRAFT_CHARS 的超长草稿不入表、
-  // 随淘汰丢弃——普通会话此前从不被淘汰，这是全会话 LRU 新引入的丢弃面
-  // （外部 transport 调用可绕过 Composer 的输入上限产生超长草稿）。
+  // Unsent composer drafts are the one piece of a working set that cannot be
+  // rebuilt from disk (this bridge never persists drafts; transcripts hold
+  // committed content only): before a buffer is dropped, its draft moves to
+  // this side table and every rebuild path restores it. The table is bounded
+  // (256 entries, 1M chars per draft — 10x the composer input cap), and when
+  // a bound would be exceeded the eviction is refused instead: the buffer
+  // stays resident rather than silently losing user input. Real session
+  // deletion (purgeSessionBuffer) invalidates stashed drafts so they never
+  // flow back into a recycled session id.
   var MAX_EVICTED_SESSION_DRAFTS = 256;
-  var MAX_EVICTED_SESSION_DRAFT_CHARS = 65536;
+  var MAX_EVICTED_SESSION_DRAFT_CHARS = 1000000;
   var evictedSessionDrafts = Object.create(null);
+  // Returns true when the buffer's non-rehydratable state is safely retained
+  // (or empty) and the caller may drop the buffer; false means eviction must
+  // be skipped so the draft stays in the live buffer.
   function stashEvictedSessionDraft(id, buf) {
-    if (!id || !buf) return;
-    delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
+    if (!id || !buf) return true;
     var draft = String(buf.composerDraft || "");
-    if (!draft) return;
-    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return;
+    if (!draft) {
+      delete evictedSessionDrafts[id]; // input was cleared; a stale stash must not resurrect it
+      return true;
+    }
+    if (draft.length > MAX_EVICTED_SESSION_DRAFT_CHARS) return false;
+    if (!evictedSessionDrafts[id]
+        && Object.keys(evictedSessionDrafts).length >= MAX_EVICTED_SESSION_DRAFTS) return false;
+    delete evictedSessionDrafts[id]; // re-stashing moves the entry to the table tail
     evictedSessionDrafts[id] = draft;
-    var keys = Object.keys(evictedSessionDrafts);
-    if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];
+    return true;
   }
   function restoreEvictedSessionDraft(id, buf) {
     if (!id || !buf || buf.composerDraft) return;
@@ -965,16 +978,19 @@
       var id = scheduledIds[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
-      stashEvictedSessionDraft(id, buf);
+      if (!stashEvictedSessionDraft(id, buf)) continue; // draft cannot be safely retained; keep the buffer
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      // personaPlaceholderTitles 是轻量会话元数据（占位标题可被自动标题覆盖
-      // 的标记），重水化路径不会恢复它；容量淘汰必须保留，仅真实会话删除
-      // （purgeSessionBuffer）才清理。
-      // scene 事件的 localStorage 缓存是 sidecar 保存失败/离线时的唯一恢复
-      // 副本（savePinvouSceneEventsForSession 的后端失败被有意吞掉，
-      // syncPinvouSceneEventsForSession 靠它兜底重放），容量淘汰不得删键；
-      // 真实会话删除（purgeSessionBuffer）才清理。
+      // personaPlaceholderTitles is lightweight session metadata (the marker
+      // for placeholder titles that auto-rename may override); rehydration
+      // never restores it, so capacity eviction must keep it and only real
+      // session deletion (purgeSessionBuffer) cleans it.
+      // The localStorage cache of scene events is the only recovery copy
+      // when the sidecar save fails or we are offline
+      // (savePinvouSceneEventsForSession intentionally swallows backend
+      // failures; syncPinvouSceneEventsForSession replays from this
+      // cache); capacity eviction must not delete the key — only real
+      // session deletion (purgeSessionBuffer) cleans it.
       // The owner tombstone has its own bounded LRU and must outlive a
       // presentation-buffer eviction. Otherwise a stale `running` list row can
       // resurrect a run that already emitted chat:done.
@@ -989,9 +1005,13 @@
     pruneSessionBuffers(id);
     return buf;
   }
-  // 全会话 LRU：与 scheduled 淘汰共用保护谓词（busy/queued/remote turn 不回收），
-  // 仅淘汰空闲 buffer。messages/chatItems 可从磁盘重水化；composerDraft 等
-  // 不可重水化的草稿先转移到 evictedSessionDrafts 侧表，重建时回填。
+  // All-session LRU: shares the scheduled eviction's protection
+  // predicates (busy/queued/remote turns are never reclaimed); only
+  // idle buffers are evicted. messages/chatItems rehydrate from disk;
+  // non-rehydratable drafts such as composerDraft move to the
+  // evictedSessionDrafts side table first and are restored on rebuild;
+  // when the table cannot hold a draft the eviction is refused (see
+  // stashEvictedSessionDraft).
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
     var overflow = ids.length - MAX_SESSION_BUFFERS;
@@ -1004,25 +1024,28 @@
       var id = ids[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
-      stashEvictedSessionDraft(id, buf);
+      if (!stashEvictedSessionDraft(id, buf)) continue; // draft cannot be safely retained; keep the buffer
       delete sessionStates[id];
       delete turnUsageDirty[id];
-      // personaPlaceholderTitles 标记随淘汰保留（见 scheduled 淘汰处说明），
-      // 仅 purgeSessionBuffer（真实删除）清理。
-      // scene 缓存键在容量淘汰时保留（唯一离线恢复副本），见上方 scheduled
-      // 淘汰处的说明；仅 purgeSessionBuffer（真实会话删除）清理。
+      // personaPlaceholderTitles survives capacity eviction (see the
+      // comment at the scheduled eviction site); only purgeSessionBuffer
+      // (real deletion) cleans it.
+      // The scene cache key survives capacity eviction (the only offline
+      // recovery copy), see the comment at the scheduled eviction site
+      // above; only purgeSessionBuffer (real session deletion) cleans
+      // it.
       overflow -= 1;
     }
   }
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;
     delete sessionStates[id];
-    // 真实会话删除:任何暂存草稿一并作废,不得回流到同 id 的重建 buffer。
+    // Real session deletion: any stashed draft is invalidated too and must not flow back into a rebuilt buffer with the same id.
     delete evictedSessionDrafts[id];
     delete turnUsageDirty[id];
     delete personaPlaceholderTitles[id];
     delete scheduledRunSessionOwners[id];
-    // scene 事件 localStorage 键随会话删除一并清理,避免随历史会话数无界累积。
+    // The scene-events localStorage key is cleaned together with session deletion, avoiding unbounded accumulation across historical sessions.
     if (window.localStorage) {
       try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
     }
@@ -3494,8 +3517,9 @@
         mergeHydratedArtifacts(saved.artifacts, liveArtifacts),
         state.activeSessionId
       );
-      // live 注水:toolMeta 可能含在飞工具条目(tool_use 未进 messages),
-      // 保留给后续 chat:tool_end 用。
+      // Live hydration: toolMeta may hold in-flight tool entries
+      // (tool_use not yet in messages); keep them for the later
+      // chat:tool_end.
       rerenderFromMessages({ keepLiveToolMeta: true });
       if (hasLivePresentation) {
         currentStreamId = mergeHydratedChatItems(liveChatItems, liveCurrentStreamId);
@@ -3507,7 +3531,7 @@
       saveWorkingSetTo(liveBuffer);
     } else {
       sessionStates[id] = freshBuffer();
-      // 慢路径磁盘重水化不经 getBuffer,淘汰时暂存的草稿须在这里回填。
+      // The slow-path disk rehydration bypasses getBuffer; the draft stashed at eviction time must be restored here.
       restoreEvictedSessionDraft(id, sessionStates[id]);
       loadWorkingSetFrom(sessionStates[id]);
       state.messages = Array.isArray(saved.messages) ? saved.messages : [];
@@ -4011,17 +4035,23 @@
   }
 
   // ── Rerender from messages (session restore) ─────────────────────
-  // opts.keepLiveToolMeta: live 会话注水(hydrateLiveSession)时传入 —— 此刻
-  // toolMeta 可能持有在飞工具的条目(tool_use 尚未进 messages),清空会让
-  // 后续 chat:tool_end 拿不到 meta(选择卡卡死/成品卡退化)。
+  // opts.keepLiveToolMeta: passed when hydrating a live session
+  // (hydrateLiveSession) — toolMeta may hold entries for in-flight
+  // tools (tool_use not yet in messages), and clearing it would leave
+  // the later chat:tool_end without its meta (stuck selection card /
+  // degraded artifact card).
   function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
-    // 重放会把每条历史 tool_use 的元数据(含 write/patch 的大 args)重新加入
-    // toolMeta 供 tool_result 回填,回填后并不删除——残留随工作集存进 buffer
-    // 驻留,内存由 32 条全会话 LRU 上限兜底。durable 重放开始即清空(非
-    // live 注水时),收回的只是中断回合留下的孤儿条目(实时事件路径本身
-    // 插删均衡);随后重放为 messages 内的历史 tool_use 重建所需条目。
+    // Replay re-adds every historical tool_use's metadata (including
+    // write/patch's large args) to toolMeta for tool_result backfill and
+    // never deletes after backfill — the residue resides in the buffer
+    // with the working set, and memory is bounded by the 32-entry
+    // all-session LRU cap. Durable replay clears first (when not live
+    // hydrating), reclaiming only orphan entries left by interrupted
+    // turns (the live event path itself stays insert/delete balanced);
+    // the replay then rebuilds the needed entries for the historical
+    // tool_uses inside messages.
     if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];
@@ -5347,7 +5377,7 @@
     notify();
     if (!actions || !actions.length) return;
     // 按动作类型分组,组装一条 Boss 消息发给主 AI(Boss 驾驶,非自动回传):
-    //   fix/verify=产物缺陷定向修订(verify 先核实);adopt=Boss 已定的决策;ask=让 AI 正式问。
+    // fix/verify=产物缺陷定向修订(verify 先核实);adopt=Boss 已定的决策;ask=让 AI 正式问。
     var fix = actions.filter(function (a) { return a.t === "fix"; });
     var verify = actions.filter(function (a) { return a.t === "verify"; });
     var adopt = actions.filter(function (a) { return a.t === "adopt"; });
@@ -8325,10 +8355,10 @@
   }
   // 挂件还原的请求序号 + 最近成功加持的目标会话(与 tauri personas.js 对齐)：
   // - syncActivePersona 仅 sid 校验挡不住 A→B→A 的 ABA 与同会话乱序(慢响应
-  //   返回 null 会把刚加持的挂件覆盖掉,且无人再纠正)。序号在每次 sync 发起
-  //   与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
+  // 返回 null 会把刚加持的挂件覆盖掉,且无人再纠正)。序号在每次 sync 发起
+  // 与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
   // - lastEquippedSid 供 equip 后紧随的播报(如卡牌制造者引导卡)定向回
-  //   发起会话——equip 的 await 窗口用户可能已切走。
+  // 发起会话——equip 的 await 窗口用户可能已切走。
   var personaSyncSeq = 0;
   var lastEquippedSid = null;
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -776,6 +776,26 @@
   // 上限取 32：典型用户活跃切换集中在个位数，96×1-4MB 最坏数百 MB 且高水位
   // 命中率趋近于零；被淘汰会话重访问走 load_session 磁盘重水化，代价仅一次重载。
   var MAX_SESSION_BUFFERS = 32;
+  // composerDraft 等不可重水化的轻量草稿不随 buffer 淘汰丢弃（web 桥不落盘
+  // 草稿，磁盘 transcript 只含已提交内容）：淘汰前先转移到这张侧表，buffer
+  // 重建时回填。侧表只存短字符串且上限远大于 buffer 上限，重对象仍随淘汰
+  // 照常释放。
+  var MAX_EVICTED_SESSION_DRAFTS = 256;
+  var evictedSessionDrafts = Object.create(null);
+  function stashEvictedSessionDraft(id, buf) {
+    if (!id || !buf) return;
+    delete evictedSessionDrafts[id]; // 重新入队时移到表尾,溢出时从表头淘汰
+    var draft = String(buf.composerDraft || "");
+    if (!draft) return;
+    evictedSessionDrafts[id] = draft;
+    var keys = Object.keys(evictedSessionDrafts);
+    if (keys.length > MAX_EVICTED_SESSION_DRAFTS) delete evictedSessionDrafts[keys[0]];
+  }
+  function restoreEvictedSessionDraft(id, buf) {
+    if (!id || !buf || buf.composerDraft) return;
+    var draft = evictedSessionDrafts[id];
+    if (draft) buf.composerDraft = draft;
+  }
   var sessionBufferTouchClock = 0;
   var scheduledRunOwnerTouchClock = 0;
   var suppressNotify = false;
@@ -911,7 +931,10 @@
   }
   function getBuffer(id) {
     if (!id) return null;
-    if (!sessionStates[id]) sessionStates[id] = freshBuffer();
+    if (!sessionStates[id]) {
+      sessionStates[id] = freshBuffer();
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+    }
     return touchSessionBuffer(id, sessionStates[id], id.indexOf("sched-") === 0);
   }
   function isProtectedScheduledBuffer(id, buf) {
@@ -937,12 +960,14 @@
       var id = scheduledIds[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
       delete personaPlaceholderTitles[id];
-      if (window.localStorage) {
-        try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
-      }
+      // scene 事件的 localStorage 缓存是 sidecar 保存失败/离线时的唯一恢复
+      // 副本（savePinvouSceneEventsForSession 的后端失败被有意吞掉，
+      // syncPinvouSceneEventsForSession 靠它兜底重放），容量淘汰不得删键；
+      // 真实会话删除（purgeSessionBuffer）才清理。
       // The owner tombstone has its own bounded LRU and must outlive a
       // presentation-buffer eviction. Otherwise a stale `running` list row can
       // resurrect a run that already emitted chat:done.
@@ -958,8 +983,8 @@
     return buf;
   }
   // 全会话 LRU：与 scheduled 淘汰共用保护谓词（busy/queued/remote turn 不回收），
-  // 仅淘汰空闲 buffer（messages/chatItems 可从磁盘重水化；composerDraft 等
-  // buffer 内草稿会随之丢弃——切走未发送的草稿本就不保证跨淘汰存活）。
+  // 仅淘汰空闲 buffer。messages/chatItems 可从磁盘重水化；composerDraft 等
+  // 不可重水化的草稿先转移到 evictedSessionDrafts 侧表，重建时回填。
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
     var overflow = ids.length - MAX_SESSION_BUFFERS;
@@ -972,18 +997,20 @@
       var id = ids[i];
       var buf = sessionStates[id];
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      stashEvictedSessionDraft(id, buf);
       delete sessionStates[id];
       delete turnUsageDirty[id];
       delete personaPlaceholderTitles[id];
-      if (window.localStorage) {
-        try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
-      }
+      // scene 缓存键在容量淘汰时保留（唯一离线恢复副本），见上方 scheduled
+      // 淘汰处的说明；仅 purgeSessionBuffer（真实会话删除）清理。
       overflow -= 1;
     }
   }
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;
     delete sessionStates[id];
+    // 真实会话删除:任何暂存草稿一并作废,不得回流到同 id 的重建 buffer。
+    delete evictedSessionDrafts[id];
     delete turnUsageDirty[id];
     delete personaPlaceholderTitles[id];
     delete scheduledRunSessionOwners[id];
@@ -1495,8 +1522,12 @@
     if (!buf || (opts && opts.fresh)) {
       buf = sessionStates[id] = freshBuffer();
       // `fresh` is used for a Session this client just created, so its empty
-      // buffer is authoritative rather than an event-created partial cache.
+      // buffer is authoritative rather than an event-created partial cache —
+      // and it must not resurrect a draft stashed from an earlier eviction of
+      // the same (recycled) id. Non-fresh fallback recreates an evicted
+      // buffer, so restore its stashed draft.
       if (opts && opts.fresh) buf.loadedFromDisk = true;
+      else restoreEvictedSessionDraft(id, buf);
     }
     touchSessionBuffer(id, buf, id.indexOf("sched-") === 0);
     loadWorkingSetFrom(buf);
@@ -3334,7 +3365,10 @@
       reportSessionSwitchFailure(new Error(bt("runNoSession")), errorScope);
       return false;
     }
-    if (hydrateLiveSession && !sessionStates[id]) sessionStates[id] = freshBuffer();
+    if (hydrateLiveSession && !sessionStates[id]) {
+      sessionStates[id] = freshBuffer();
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+    }
     var existingBuffer = sessionStates[id];
     if (existingBuffer && (existingBuffer.remoteTurnActive ||
         (!existingBuffer.loadedFromDisk &&
@@ -3464,7 +3498,10 @@
       liveBuffer.sessionRevision = String(saved.transcript_revision || saved.transcriptRevision || "");
       saveWorkingSetTo(liveBuffer);
     } else {
-      loadWorkingSetFrom(sessionStates[id] = freshBuffer());
+      sessionStates[id] = freshBuffer();
+      // 慢路径磁盘重水化不经 getBuffer,淘汰时暂存的草稿须在这里回填。
+      restoreEvictedSessionDraft(id, sessionStates[id]);
+      loadWorkingSetFrom(sessionStates[id]);
       state.messages = Array.isArray(saved.messages) ? saved.messages : [];
       sessionStates[id].loadedFromDisk = true;
       sessionStates[id].sessionRevision = String(saved.transcript_revision || saved.transcriptRevision || "");

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -958,7 +958,8 @@
     return buf;
   }
   // 全会话 LRU：与 scheduled 淘汰共用保护谓词（busy/queued/remote turn 不回收），
-  // 仅淘汰"纯展示缓存"性质的空闲 buffer。
+  // 仅淘汰空闲 buffer（messages/chatItems 可从磁盘重水化；composerDraft 等
+  // buffer 内草稿会随之丢弃——切走未发送的草稿本就不保证跨淘汰存活）。
   function pruneSessionBuffers(keepId) {
     var ids = Object.keys(sessionStates);
     var overflow = ids.length - MAX_SESSION_BUFFERS;
@@ -3445,7 +3446,9 @@
         mergeHydratedArtifacts(saved.artifacts, liveArtifacts),
         state.activeSessionId
       );
-      rerenderFromMessages();
+      // live 注水:toolMeta 可能含在飞工具条目(tool_use 未进 messages),
+      // 保留给后续 chat:tool_end 用。
+      rerenderFromMessages({ keepLiveToolMeta: true });
       if (hasLivePresentation) {
         currentStreamId = mergeHydratedChatItems(liveChatItems, liveCurrentStreamId);
       } else {
@@ -3957,9 +3960,17 @@
   }
 
   // ── Rerender from messages (session restore) ─────────────────────
-  function rerenderFromMessages() {
+  // opts.keepLiveToolMeta: live 会话注水(hydrateLiveSession)时传入 —— 此刻
+  // toolMeta 可能持有在飞工具的条目(tool_use 尚未进 messages),清空会让
+  // 后续 chat:tool_end 拿不到 meta(选择卡卡死/成品卡退化)。
+  function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
+    // 历史 tool_use 的元数据(含 write/patch 的大 args)只服务本次重放期间的
+    // tool_result 回填;实时事件路径插删均衡,但历史写入从不清理,残留会随
+    // 工作集存进 buffer 长期驻留。durable 重放开始即清空(非 live 注水时
+    // 实时条目不存在);重放会为 messages 内的历史 tool_use 重建所需条目。
+    if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     var pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];
     function emitPersonaAt(atOrAfter, isTail) {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -771,6 +771,10 @@
   var scheduledRunOpenInFlight = Object.create(null);
   var MAX_SCHEDULED_SESSION_BUFFERS = 64;
   var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
+  // 全会话缓冲上限：sessionStates 曾只对 scheduled 会话做 64 条 LRU——普通会话
+  // 切过即永久驻留，内存随历史会话数无界增长。普通会话淘汰后重访问走磁盘
+  // 重水化路径（load_session）。
+  var MAX_SESSION_BUFFERS = 96;
   var sessionBufferTouchClock = 0;
   var scheduledRunOwnerTouchClock = 0;
   var suppressNotify = false;
@@ -912,6 +916,7 @@
   function isProtectedScheduledBuffer(id, buf) {
     return id === state.activeSessionId ||
       !!buf.busy ||
+      !!buf.remoteTurnActive ||
       buf.scheduledInitialTurnPhase === "active" ||
       !!(buf.queued && buf.queued.length) ||
       !!(state.scheduledRunContext && state.scheduledRunContext.sessionId === id) ||
@@ -944,7 +949,27 @@
     if (scheduled) buf.scheduledRunSession = true;
     buf.lastTouched = ++sessionBufferTouchClock;
     if (buf.scheduledRunSession) pruneScheduledSessionBuffers(id);
+    pruneSessionBuffers(id);
     return buf;
+  }
+  // 全会话 LRU：与 scheduled 淘汰共用保护谓词（busy/queued/remote turn 不回收），
+  // 仅淘汰"纯展示缓存"性质的空闲 buffer。
+  function pruneSessionBuffers(keepId) {
+    var ids = Object.keys(sessionStates);
+    var overflow = ids.length - MAX_SESSION_BUFFERS;
+    if (overflow <= 0) return;
+    ids.sort(function (left, right) {
+      var delta = (sessionStates[left].lastTouched || 0) - (sessionStates[right].lastTouched || 0);
+      return delta || left.localeCompare(right);
+    });
+    for (var i = 0; i < ids.length && overflow > 0; i++) {
+      var id = ids[i];
+      var buf = sessionStates[id];
+      if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
+      delete sessionStates[id];
+      delete turnUsageDirty[id];
+      overflow -= 1;
+    }
   }
   function purgeSessionBuffer(id) {
     if (typeof id !== "string" || !id) return;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -1483,8 +1483,14 @@
   }
   // 把 active 工作集存好后切到 id 的 buffer(opts.fresh=新建空 buffer)。
   function switchActiveTo(id, opts) {
-    if (state.activeSessionId) saveWorkingSetTo(getBuffer(state.activeSessionId));
+    // Set the new active id before touching the old buffer: the LRU prune
+    // triggered by that touch protects the target via activeSessionId. Touching
+    // the old buffer first (active id still old) could evict an idle target as
+    // the oldest entry, and the freshBuffer() fallback below would silently
+    // show an empty session.
+    var previousActiveId = state.activeSessionId;
     state.activeSessionId = id;
+    if (previousActiveId) saveWorkingSetTo(getBuffer(previousActiveId));
     var buf = sessionStates[id];
     if (!buf || (opts && opts.fresh)) {
       buf = sessionStates[id] = freshBuffer();

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -771,10 +771,11 @@
   var scheduledRunOpenInFlight = Object.create(null);
   var MAX_SCHEDULED_SESSION_BUFFERS = 64;
   var MAX_SCHEDULED_RUN_SESSION_OWNERS = 64;
-  // 全会话缓冲上限：sessionStates 曾只对 scheduled 会话做 64 条 LRU——普通会话
-  // 切过即永久驻留，内存随历史会话数无界增长。普通会话淘汰后重访问走磁盘
-  // 重水化路径（load_session）。
-  var MAX_SESSION_BUFFERS = 96;
+  // 全会话缓冲上限：sessionStates 每条持有完整 messages+chatItems（重会话
+  // 1-4MB/条），曾只对 scheduled 会话做 64 条 LRU——普通会话切过即永久驻留。
+  // 上限取 32：典型用户活跃切换集中在个位数，96×1-4MB 最坏数百 MB 且高水位
+  // 命中率趋近于零；被淘汰会话重访问走 load_session 磁盘重水化，代价仅一次重载。
+  var MAX_SESSION_BUFFERS = 32;
   var sessionBufferTouchClock = 0;
   var scheduledRunOwnerTouchClock = 0;
   var suppressNotify = false;
@@ -938,6 +939,10 @@
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
       delete sessionStates[id];
       delete turnUsageDirty[id];
+      delete personaPlaceholderTitles[id];
+      if (window.localStorage) {
+        try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
+      }
       // The owner tombstone has its own bounded LRU and must outlive a
       // presentation-buffer eviction. Otherwise a stale `running` list row can
       // resurrect a run that already emitted chat:done.
@@ -968,6 +973,10 @@
       if (!buf || id === keepId || isProtectedScheduledBuffer(id, buf)) continue;
       delete sessionStates[id];
       delete turnUsageDirty[id];
+      delete personaPlaceholderTitles[id];
+      if (window.localStorage) {
+        try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
+      }
       overflow -= 1;
     }
   }
@@ -977,6 +986,10 @@
     delete turnUsageDirty[id];
     delete personaPlaceholderTitles[id];
     delete scheduledRunSessionOwners[id];
+    // scene 事件 localStorage 键随会话删除一并清理,避免随历史会话数无界累积。
+    if (window.localStorage) {
+      try { window.localStorage.removeItem(PINVOU_SCENE_EVENTS_STORAGE_PREFIX + id); } catch (_) {}
+    }
     if (state.scheduledRunContext && state.scheduledRunContext.sessionId === id) {
       state.scheduledRunContext = null;
     }

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -45,14 +45,20 @@
     return result;
   }
 
-  // 订阅回调每次通知都会 pick 出全新外层对象：任何一处状态变化（如流式
-  // token）都让所有域订阅者拿到新引用、全量重渲染。逐订阅者缓存上次的
-  // (full, slice)：full 未换引用时复用上次 slice，保持身份稳定。注意这是
-  // 整快照粒度（web 传输层只在全部状态无变更时复用同一 full 引用），弱于
-  // 桌面端 bridge 的按域 revision 缓存：任一域变化仍会让未变域的 slice 换
-  // 新外层对象（内层字段引用仍与 flat 订阅者共享，身份共享契约见
-  // web_bridge_domain_contract 测试，不受影响）。full 由通知方按变更重建，
-  // 同一 full 引用意味着本域字段集合不可能变化。
+  // Subscriber callbacks pick a fresh outer object on every
+  // notification: any state change anywhere (e.g. a streaming token)
+  // hands every domain subscriber a new reference and a full re-render.
+  // Cache the last (full, slice) per subscriber: when full keeps its
+  // reference, reuse the last slice to keep identity stable. Note this
+  // is whole-snapshot granularity (the web transport only reuses the
+  // same full reference when nothing at all changed), weaker than the
+  // desktop bridge's per-domain revision cache: a change in any domain
+  // still swaps the outer object of unchanged domains' slices (inner
+  // field references remain shared with flat subscribers; the identity
+  // sharing contract lives in the web_bridge_domain_contract test and
+  // is unaffected). full is rebuilt by the notifier per change, so the
+  // same full reference implies this domain's field set cannot have
+  // changed.
   function stablePick() {
     var lastFull = null;
     var lastSlice = null;
@@ -86,13 +92,17 @@
 
   function subscribeMany(domains, callback) {
     getMany(domains);
-    // 每个域独立 stable 缓存：stablePick 闭包按 (lastFull,lastSlice) 单槽记忆，
-    // 共用一个实例会在多域间互相覆盖。
+    // One stable cache per domain: the stablePick closure memoizes a
+    // single (lastFull,lastSlice) slot; sharing one instance across
+    // domains would make them overwrite each other.
     var stables = {};
     domains.forEach(function (domainName) { stables[domainName] = stablePick(); });
-    // 合并外层对象同样按 full 引用单槽记忆：订阅方是 React setState 时只能按
-    // 整体身份 bail out，每轮新建合并对象会让无变更通知也触发全量重渲染，
-    // 抵消内层 slice 的身份稳定（消费方见 useBridge.js 的 subscribeMany）。
+    // The combined outer object is likewise memoized on the full
+    // reference in a single slot: a React setState subscriber can only
+    // bail out on whole-object identity, and rebuilding the combined
+    // object every round would make even no-change notifications trigger
+    // full re-renders, cancelling out the inner slices' identity
+    // stability (see useBridge.js's subscribeMany for the consumer).
     var lastFull = null;
     var lastResult = null;
     return flat.subscribe(function (full) {

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -47,10 +47,12 @@
 
   // 订阅回调每次通知都会 pick 出全新外层对象：任何一处状态变化（如流式
   // token）都让所有域订阅者拿到新引用、全量重渲染。逐订阅者缓存上次的
-  // (full, slice)：full 未换引用时复用上次 slice，保持身份稳定（桌面端
-  // bridge 的 revision-cache 同款契约）。full 由通知方按变更重建，同一 full
-  // 引用意味着本域字段集合不可能变化；字段值仍是 full 上的原引用，与 flat
-  // 订阅者共享子树的身份共享契约（见 web_bridge_domain_contract 测试）不受影响。
+  // (full, slice)：full 未换引用时复用上次 slice，保持身份稳定。注意这是
+  // 整快照粒度（web 传输层只在全部状态无变更时复用同一 full 引用），弱于
+  // 桌面端 bridge 的按域 revision 缓存：任一域变化仍会让未变域的 slice 换
+  // 新外层对象（内层字段引用仍与 flat 订阅者共享，身份共享契约见
+  // web_bridge_domain_contract 测试，不受影响）。full 由通知方按变更重建，
+  // 同一 full 引用意味着本域字段集合不可能变化。
   function stablePick() {
     var lastFull = null;
     var lastSlice = null;

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -45,6 +45,23 @@
     return result;
   }
 
+  // 订阅回调每次通知都会 pick 出全新外层对象：任何一处状态变化（如流式
+  // token）都让所有域订阅者拿到新引用、全量重渲染。逐订阅者缓存上次的
+  // (full, slice)：full 未换引用时复用上次 slice，保持身份稳定（桌面端
+  // bridge 的 revision-cache 同款契约）。full 由通知方按变更重建，同一 full
+  // 引用意味着本域字段集合不可能变化；字段值仍是 full 上的原引用，与 flat
+  // 订阅者共享子树的身份共享契约（见 web_bridge_domain_contract 测试）不受影响。
+  function stablePick() {
+    var lastFull = null;
+    var lastSlice = null;
+    return function (full, domainName) {
+      if (full === lastFull) return lastSlice;
+      lastFull = full;
+      lastSlice = Object.freeze(pick(full, domainName));
+      return lastSlice;
+    };
+  }
+
   function get(domainName) {
     return clone(pick(flat.getState(), domainName));
   }
@@ -59,16 +76,21 @@
 
   function subscribe(domainName, callback) {
     get(domainName);
+    var stable = stablePick();
     return flat.subscribe(function (full) {
-      callback(Object.freeze(pick(full, domainName)));
+      callback(stable(full, domainName));
     });
   }
 
   function subscribeMany(domains, callback) {
     getMany(domains);
+    // 每个域独立 stable 缓存：stablePick 闭包按 (lastFull,lastSlice) 单槽记忆，
+    // 共用一个实例会在多域间互相覆盖。
+    var stables = {};
+    domains.forEach(function (domainName) { stables[domainName] = stablePick(); });
     return flat.subscribe(function (full) {
       var result = {};
-      domains.forEach(function (domainName) { Object.assign(result, pick(full, domainName)); });
+      domains.forEach(function (domainName) { Object.assign(result, stables[domainName](full, domainName)); });
       callback(Object.freeze(result));
     });
   }

--- a/pinvou3-app/src/platform/web/bridge/domain-adapter.js
+++ b/pinvou3-app/src/platform/web/bridge/domain-adapter.js
@@ -90,10 +90,19 @@
     // 共用一个实例会在多域间互相覆盖。
     var stables = {};
     domains.forEach(function (domainName) { stables[domainName] = stablePick(); });
+    // 合并外层对象同样按 full 引用单槽记忆：订阅方是 React setState 时只能按
+    // 整体身份 bail out，每轮新建合并对象会让无变更通知也触发全量重渲染，
+    // 抵消内层 slice 的身份稳定（消费方见 useBridge.js 的 subscribeMany）。
+    var lastFull = null;
+    var lastResult = null;
     return flat.subscribe(function (full) {
-      var result = {};
-      domains.forEach(function (domainName) { Object.assign(result, stables[domainName](full, domainName)); });
-      callback(Object.freeze(result));
+      if (full !== lastFull) {
+        var result = {};
+        domains.forEach(function (domainName) { Object.assign(result, stables[domainName](full, domainName)); });
+        lastFull = full;
+        lastResult = Object.freeze(result);
+      }
+      callback(lastResult);
     });
   }
 

--- a/pinvou3-app/src/shared/date-utils.js
+++ b/pinvou3-app/src/shared/date-utils.js
@@ -1,8 +1,9 @@
 
 
-// Intl.DateTimeFormat 构造开销显著，而侧栏每次 App 渲染都会对全部会话调
-// formatSessionDate/formatDateGroupLabel。按 locale|opts 缓存 formatter
-// （键空间封闭：三语言 × 两种 opts）。
+// Intl.DateTimeFormat construction is expensive, and the sidebar calls
+// formatSessionDate/formatDateGroupLabel for every session on each App
+// render. Cache formatters by locale|opts (closed key space: three
+// languages × two opts variants).
 const formatterCache = new Map();
 function cachedFormatter(locale, optsKey, opts) {
   const key = `${locale}|${optsKey}`;

--- a/pinvou3-app/src/shared/date-utils.js
+++ b/pinvou3-app/src/shared/date-utils.js
@@ -1,5 +1,19 @@
 
 
+// Intl.DateTimeFormat 构造开销显著，而侧栏每次 App 渲染都会对全部会话调
+// formatSessionDate/formatDateGroupLabel。按 locale|opts 缓存 formatter
+// （键空间封闭：三语言 × 两种 opts）。
+const formatterCache = new Map();
+function cachedFormatter(locale, optsKey, opts) {
+  const key = `${locale}|${optsKey}`;
+  let fmt = formatterCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, opts);
+    formatterCache.set(key, fmt);
+  }
+  return fmt;
+}
+
 function formatSessionDate(ts, language) {
       if (!ts) return '';
       const d = new Date(typeof ts === 'number' ? ts : ts);
@@ -20,10 +34,9 @@ function formatSessionDate(ts, language) {
       const days = Math.floor(diff / 86400000);
       if (days < 7) return L.daysAgo(days);                               // 2~6 天
       // ≥7 天:日期;跨年带年份(只写月日会有歧义)
-      const opts = d.getFullYear() === now.getFullYear()
-        ? { month: 'short', day: 'numeric' }
-        : { year: 'numeric', month: 'short', day: 'numeric' };
-      return d.toLocaleDateString(L.locale, opts);
+      return d.getFullYear() === now.getFullYear()
+        ? cachedFormatter(L.locale, 'md', { month: 'short', day: 'numeric' }).format(d)
+        : cachedFormatter(L.locale, 'ymd', { year: 'numeric', month: 'short', day: 'numeric' }).format(d);
     }
 
     // 侧栏任务列表按日期堆叠:本地日历日 key(YYYY-MM-DD),无时间戳归 'unknown'
@@ -46,10 +59,9 @@ function formatSessionDate(ts, language) {
       if (key === localDateKey(Date.now() - 86400000)) return L.yesterday;
       const [y, m, d] = key.split('-').map(Number);
       const date = new Date(y, m - 1, d);
-      const opts = y === new Date().getFullYear()
-        ? { month: 'short', day: 'numeric' }
-        : { year: 'numeric', month: 'short', day: 'numeric' };
-      return date.toLocaleDateString(L.locale, opts);
+      return y === new Date().getFullYear()
+        ? cachedFormatter(L.locale, 'md', { month: 'short', day: 'numeric' }).format(date)
+        : cachedFormatter(L.locale, 'ymd', { year: 'numeric', month: 'short', day: 'numeric' }).format(date);
     }
 
 export { formatSessionDate, localDateKey, formatDateGroupLabel };

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -364,9 +364,10 @@ try {
   const loginMod = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'login.rs'), 'utf8');
   const introspectMod = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'introspect.rs'), 'utf8');
   const operationGate = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'operation_gate.rs'), 'utf8');
-  // PR #339 round 9 把活跃时间落盘折进 admit_prompt_turn（operation_gate.rs），
-  // 使 touch 失败无法泄漏已注册的 timing turn；touch 本身仍在
-  // AcpPool::send_message 内、早于 timing 注册与 spawn 的 prompt 任务。
+  // PR #339 round 9 folds the activity persistence into `admit_prompt_turn`
+  // (operation_gate.rs) so a touch failure cannot leak a registered timing
+  // turn; the touch itself still runs inside `AcpPool::send_message`, before
+  // the timing registration and the spawned prompt task.
   assert.ok(/self\.session_store\s+\.touch_activity\(session_id\)/.test(runtime)
     && /admit_prompt_turn\(&runtime\.busy, &runtime\.configuring, session_id, \|\|/s.test(runtime)
     && operationGate.includes('fn admit_prompt_turn')

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -363,7 +363,15 @@ try {
   // 断言需读对应子模块。
   const loginMod = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'login.rs'), 'utf8');
   const introspectMod = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'introspect.rs'), 'utf8');
-  assert.ok(runtime.includes('self.session_store.touch_activity(session_id)'),
+  const operationGate = readFileSync(path.join(root, 'src-tauri', 'src', 'features', 'codex_acp', 'operation_gate.rs'), 'utf8');
+  // PR #339 round 9 把活跃时间落盘折进 admit_prompt_turn（operation_gate.rs），
+  // 使 touch 失败无法泄漏已注册的 timing turn；touch 本身仍在
+  // AcpPool::send_message 内、早于 timing 注册与 spawn 的 prompt 任务。
+  assert.ok(/self\.session_store\s+\.touch_activity\(session_id\)/.test(runtime)
+    && /admit_prompt_turn\(&runtime\.busy, &runtime\.configuring, session_id, \|\|/s.test(runtime)
+    && operationGate.includes('fn admit_prompt_turn')
+    && /if let Err\(error\) = touch_activity\(\) \{\s*busy\.store\(false, Ordering::Release\);/s.test(operationGate)
+    && /touch_activity\(\)[\s\S]*timing::start_turn\(session_id\)/.test(operationGate),
     'an accepted ACP turn must persist the session activity timestamp before it starts');
   assert.ok(runtime.includes('interrupt_orphaned_turns("application_restarted")')
     && runtime.includes('cancel_without_active_prompt')

--- a/pinvou3-app/tests/session_buffer_eviction.test.mjs
+++ b/pinvou3-app/tests/session_buffer_eviction.test.mjs
@@ -16,6 +16,12 @@
  * tauri 侧经 sessions.js factory 注入（同 session_nav_race.test.mjs），
  * web 侧整桥 vm 装载（同 session_nav_race_web.test.mjs）驱动公开 API
  * switchToSession/setComposerDraft/deleteSession 走生产路径。
+ *
+ * 复审追加：
+ * - fresh 物化（ensureSession/persona 加卡）的空 buffer 必须标
+ *   loadedFromDisk，否则带草稿切回时落慢路径被 freshBuffer() 顶替丢草稿；
+ * - personaPlaceholderTitles 是会话元数据，容量淘汰保留、真实删除才清理；
+ * - 超过 64K 字符上限的草稿不入暂存侧表，淘汰后重建 buffer 草稿为空。
  */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -157,7 +163,7 @@ test('tauri 淘汰保护谓词：busy / queued / remote 不回收', () => {
   assert.equal(Object.keys(sessionStates).length, 32);
 });
 
-test('ta purgeSessionBuffer：真实会话删除作废暂存草稿，不回流同 id 重建 buffer', () => {
+test('tauri purgeSessionBuffer：真实会话删除作废暂存草稿，不回流同 id 重建 buffer', () => {
   const { api, state, sessionStates, purgeLog } = loadTauriSessionsFeature();
   for (let i = 1; i <= 33; i++) {
     api.switchActiveTo(`s${i}`, null);
@@ -190,6 +196,91 @@ test('tauri 暂存草稿侧表有界（256）：远超上限的淘汰逐出最�
   assert.equal(api.getBuffer('s1').composerDraft, '', '最早的暂存草稿被侧表上限逐出');
   assert.equal(api.getBuffer('s257').composerDraft, 'draft-257',
     '近期暂存草稿仍在侧表内（侧表非无限，但容量远大于 buffer 上限）');
+});
+
+// ── 复审 BLOCKER：fresh 物化空 buffer 的草稿丢失回归（tauri）─────────
+
+test('tauri fresh 物化空会话带草稿：切走再切回经 switchToSession 不丢草稿', async () => {
+  const { api, state, sessionStates } = loadTauriSessionsFeature({
+    invoke(name, args) {
+      // persona 加卡物化的会话在磁盘上是零消息空会话。
+      if (name === 'load_session') {
+        return Promise.resolve({
+          metadata: { id: args.id, message_count: 0 },
+          messages: [],
+          artifacts: [],
+        });
+      }
+      return Promise.resolve({});
+    },
+  });
+  // persona 加卡物化：switchActiveTo(id, {fresh:true}) 建空 buffer（无 messages）。
+  api.switchActiveTo('persona-1', { fresh: true });
+  state.composerDraft = 'persona-draft'; // 用户输入未发送草稿
+  // 切走：saveWorkingSetTo 把草稿快照进 persona-1 的后台 buffer。
+  api.switchActiveTo('other', null);
+  assert.equal(sessionStates['persona-1'].composerDraft, 'persona-draft', '前置：草稿已快照进 buffer');
+  // 切回：fresh 物化的空 buffer 已标 loadedFromDisk → 快路径命中、草稿保留。
+  // 回归前 buffer 未标，门控拒绝后落慢路径，sessionStates[id] 被
+  // freshBuffer() 顶替且不经侧表暂存，草稿被静默丢弃。
+  assert.equal(await api.switchToSession('persona-1'), true);
+  assert.equal(state.composerDraft, 'persona-draft',
+    'fresh 物化空会话的未发送草稿不得在切回时丢失');
+  assert.equal(sessionStates['persona-1'].loadedFromDisk, true,
+    'fresh 物化的空 buffer 必须标 loadedFromDisk（快路径门控依据）');
+});
+
+// ── 复审：personaPlaceholderTitles 只随真实删除清理 ──────────────────
+
+test('tauri LRU 容量淘汰保留 personaPlaceholderTitles，真实删除才清理', () => {
+  const personaPlaceholderTitles = {};
+  const { api, state } = loadTauriSessionsFeature({ personaPlaceholderTitles });
+  api.switchActiveTo('s1', null);
+  personaPlaceholderTitles.s1 = true; // 加卡占位标题标记
+  state.composerDraft = 'd1';
+  for (let i = 2; i <= 33; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `d${i}`;
+  }
+  assert.equal(personaPlaceholderTitles.s1, true,
+    '容量淘汰不得删除占位标题标记（重水化路径不会恢复它）');
+
+  api.purgeSessionBuffer('s1');
+  assert.equal(personaPlaceholderTitles.s1, undefined,
+    '真实会话删除必须清理占位标题标记');
+});
+
+test('web personaPlaceholderTitles 只在真实删除时清理（源码契约）', () => {
+  const webBridge = read('bridge.js');
+  const bodyOf = signature => {
+    const start = webBridge.indexOf(signature);
+    assert.ok(start > 0, `${signature} 必须存在`);
+    const end = webBridge.indexOf('\n  function ', start + 1);
+    return webBridge.slice(start, end > 0 ? end : undefined);
+  };
+  assert.ok(!/delete personaPlaceholderTitles/.test(bodyOf('function pruneSessionBuffers')),
+    '全会话 LRU 淘汰不得清理 personaPlaceholderTitles');
+  assert.ok(!/delete personaPlaceholderTitles/.test(bodyOf('function pruneScheduledSessionBuffers')),
+    'scheduled LRU 淘汰不得清理 personaPlaceholderTitles');
+  assert.ok(/delete personaPlaceholderTitles\[id\]/.test(bodyOf('function purgeSessionBuffer')),
+    '真实会话删除（purgeSessionBuffer）必须清理 personaPlaceholderTitles');
+});
+
+// ── 复审：64K 草稿字符上限 ────────────────────────────────────────────
+
+test('tauri 超长草稿（>64K）不入暂存侧表：淘汰后重建 buffer 草稿为空', () => {
+  const { api, state, sessionStates } = loadTauriSessionsFeature();
+  api.switchActiveTo('s1', null);
+  // transport 级写入可绕过 Composer 的输入上限，产生超长草稿。
+  state.composerDraft = 'x'.repeat(65537);
+  for (let i = 2; i <= 33; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `d${i}`;
+  }
+  assert.equal(sessionStates.s2.composerDraft, 'd2', '存活 buffer 的小草稿不受影响');
+  // s1 已被淘汰；超长草稿未入侧表，重建 buffer 不回填。
+  assert.equal(api.getBuffer('s1').composerDraft, '',
+    '超过 64K 字符上限的草稿不随淘汰暂存，重建后为空');
 });
 
 // ── P2：scene 缓存键语义（源码契约 + tauri hook reason）────────────
@@ -332,6 +423,20 @@ test('web 34 会话 LRU：淘汰 s1 后重访问，草稿经侧表回填且走�
   assert.equal(loadsAfter, 2, 's1 被淘汰后重访问必须重新水化（重对象确已释放）');
   assert.equal(rt.flat.getComposerDraft(), 'web-unsent-draft',
     '淘汰时的未发送草稿必须经侧表恢复');
+});
+
+test('web 超长草稿（>64K）不入暂存侧表：淘汰重水化后草稿为空', async () => {
+  const rt = bootWebBridge();
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  // transport 级 setter 可绕过 Composer 的输入上限，产生超长草稿。
+  rt.flat.setComposerDraft('x'.repeat(65537));
+  for (let i = 2; i <= 34; i++) {
+    assert.equal(await rt.flat.switchToSession(`s${i}`), true);
+  }
+  // s1 已被容量淘汰；切回重新水化后超长草稿不得回填。
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  assert.equal(rt.flat.getComposerDraft(), '',
+    '超过 64K 字符上限的草稿不随淘汰暂存，重水化后为空');
 });
 
 // ── P2（web）：保存失败 + 淘汰 + 重水化 ────────────────────────────

--- a/pinvou3-app/tests/session_buffer_eviction.test.mjs
+++ b/pinvou3-app/tests/session_buffer_eviction.test.mjs
@@ -1,0 +1,370 @@
+/**
+ * 会话 buffer LRU 淘汰回归测试（PR #339 五审 P1/P2）：
+ *
+ * P1 —— 全会话 LRU 淘汰空闲 buffer 时连同 composerDraft 一起丢弃。磁盘
+ * transcript 只含已提交内容，草稿（Tauri 与 Web 均不落盘）一旦淘汰即从
+ * 「可恢复」变「永久丢失」。修复：淘汰前把不可重水化的轻量草稿转移到
+ * evictedSessionDrafts 侧表（独立上限 256），buffer 重建时回填；真实会话
+ * 删除（purgeSessionBuffer）时作废，不得回流。
+ *
+ * P2 —— LRU 淘汰把 scene 事件的 localStorage 缓存键当会话删除清理。该缓存
+ * 是 sidecar 保存失败/离线时的唯一恢复副本（savePinvouSceneEventsForSession
+ * 的后端失败被有意吞掉，syncPinvouSceneEventsForSession 靠它兜底重放）。
+ * 修复：容量淘汰（reason="evict"）保留缓存键，仅真实会话删除
+ * （reason="delete"）清理。
+ *
+ * tauri 侧经 sessions.js factory 注入（同 session_nav_race.test.mjs），
+ * web 侧整桥 vm 装载（同 session_nav_race_web.test.mjs）驱动公开 API
+ * switchToSession/setComposerDraft/deleteSession 走生产路径。
+ */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
+const webBridgeRoot = path.resolve(here, '..', 'src', 'platform', 'web');
+const read = relativePath => fs.readFileSync(path.join(webBridgeRoot, relativePath), 'utf8');
+
+// ── tauri sessions.js factory 装载 ────────────────────────────────
+
+function loadTauriSessionsFeature(overrides) {
+  const root = { __PINVOU_SHARED_I18N__: {} };
+  const src = fs.readFileSync(path.join(bridgeDir, 'sessions.js'), 'utf8');
+  vm.runInNewContext(src, { window: root, globalThis: root, setTimeout, clearTimeout });
+  const factory = root.__PINVOU_TAURI_BRIDGE_FEATURES__.sessions;
+  const state = {
+    activeSessionId: null,
+    messages: [], chatItems: [], artifacts: [], queued: [],
+    sessions: [], archivedSessions: [],
+    scheduledTaskRecentRuns: [], scheduledTaskRuns: [],
+    modeState: { mode: 'yolo', multiAgent: false },
+    modeDefaults: { work: 'yolo', design: 'yolo' },
+    modeLane: 'work',
+    draftEpoch: 0,
+    composerDraft: '',
+    pendingDraftMultiAgent: false,
+    scheduledRunContext: null,
+    scheduledTaskPendingGuide: null,
+    mountedCollections: [],
+    mountedCollectionsRevision: 0,
+    busy: false,
+    thinking: false,
+    tokens: { input: 0, max: 0 },
+    turnTimeline: [],
+    activeTurnTimelineId: null,
+    personaEvents: [],
+    pinvouReviews: [],
+    pinvouSceneEvents: [],
+    scheduledTaskDraft: null,
+  };
+  const sessionStates = {};
+  const purgeLog = [];
+  const calls = { invoke: [] };
+  const api = factory(Object.assign({
+    state,
+    sessionStates,
+    notify() { calls.notify = (calls.notify || 0) + 1; },
+    listen: null,
+    bt(key) { return key; },
+    onSessionBufferPurged(id, reason) { purgeLog.push({ id, reason }); },
+    addSystemItem(text) { state.chatItems.push({ type: 'system', text }); },
+    addChatItem(item) { state.chatItems.push(item); },
+    timeStr() { return ''; },
+    invoke(name, args) {
+      calls.invoke.push(name);
+      return Promise.resolve({});
+    },
+    runSyncOnSession(sid, fn) { fn(); },
+    persistMessagesFor() {},
+    resetPendingAssistant() {},
+    stopThinking() {},
+    rerenderFromMessages() {},
+    syncModeState() { return Promise.resolve(); },
+    applyAuthoritativeModeState() {},
+    currentDraftModeState() { return { mode: 'yolo', multiAgent: false }; },
+    syncActivePersona() { return Promise.resolve(); },
+    syncMountedCollection() { return Promise.resolve(); },
+    reconcileArtifacts() {},
+    loadSessionModel() { return Promise.resolve(); },
+    clearScheduledTaskSelection() {},
+    invalidateScheduledRecentRunsForSession() {},
+    refreshHistoryListForRun() { return Promise.resolve(); },
+    turnUsageDirty: {},
+    basename(p) { return String(p || '').split('/').pop(); },
+    isAbsPath() { return false; },
+    filterSessionArtifacts(list) { return list; },
+    scheduleShellPoll() {},
+    setScheduledTaskError() {},
+    userMessageDisplayText(t) { return t; },
+    loadMemoryOverview() { return Promise.resolve(); },
+    isScheduledRunSession(id) { return String(id || '').indexOf('sched-') === 0; },
+    invalidateScheduledTaskReads() {},
+    applyScheduledRunViewed() {},
+    loadScheduledTaskRecentRuns() { return Promise.resolve(); },
+    scheduledRunSessionOwners: {},
+    personaPlaceholderTitles: {},
+    currentStreamText: '',
+    currentStreamId: 0,
+    pendingAssistantText: '',
+    pendingAssistantBlocks: [],
+    itemIdSeq: 0,
+    toolMeta: {},
+  }, overrides || {}));
+  return { api, state, sessionStates, purgeLog, calls };
+}
+
+// ── P1：33 会话淘汰后草稿回填（tauri）──────────────────────────────
+
+test('tauri 33 会话 LRU：淘汰最旧空闲 buffer，草稿经侧表回填，buffer 数有界', () => {
+  const { api, state, sessionStates, purgeLog } = loadTauriSessionsFeature();
+  const total = 33;
+  for (let i = 1; i <= total; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    // 切入后输入：离开 s_i 时 saveWorkingSetTo 快照的才是 draft-i（生产语义）。
+    state.composerDraft = `draft-${i}`;
+    state.messages = [{ role: 'user', content: `m${i}` }];
+  }
+  // 第 33 次切换的 touch 使 sessionStates 达到 33 → 淘汰最旧的 s1。
+  assert.equal(purgeLog.filter(e => e.reason === 'evict').length, 1);
+  assert.deepEqual(purgeLog[0], { id: 's1', reason: 'evict' });
+  assert.equal(Object.keys(sessionStates).length, 32, '重对象 buffer 必须有界（≤32）');
+  assert.equal(sessionStates.s1, undefined, '最旧空闲 buffer 必须被淘汰');
+  assert.equal(sessionStates.s2.composerDraft, 'draft-2', '存活 buffer 草稿原样');
+
+  // 重访问 s1：switchActiveTo 重建 buffer（非 fresh）→ 暂存草稿回填。
+  api.switchActiveTo('s1', null);
+  assert.equal(state.composerDraft, 'draft-1', '淘汰时的未发送草稿必须经侧表恢复');
+  assert.equal(sessionStates.s1.composerDraft, 'draft-1');
+  // 重水化语义：新 buffer 不携带旧 messages（由 load_session 慢路径重建）。
+  assert.equal(state.messages.length, 0);
+});
+
+test('tauri 淘汰保护谓词：busy / queued / remote 不回收', () => {
+  const { api, state, sessionStates } = loadTauriSessionsFeature();
+  api.switchActiveTo('s1', null);
+  state.composerDraft = 'd1';
+  state.busy = true; // 回合进行中离开：saveWorkingSetTo 把 busy 快照进 s1 buffer
+  for (let i = 2; i <= 34; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `d${i}`;
+  }
+  assert.notEqual(sessionStates.s1, undefined, 'busy buffer 不得被容量淘汰');
+  assert.equal(sessionStates.s1.busy, true);
+  assert.equal(Object.keys(sessionStates).length, 32);
+});
+
+test('ta purgeSessionBuffer：真实会话删除作废暂存草稿，不回流同 id 重建 buffer', () => {
+  const { api, state, sessionStates, purgeLog } = loadTauriSessionsFeature();
+  for (let i = 1; i <= 33; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `draft-${i}`;
+  }
+  assert.equal(sessionStates.s1, undefined, '前置：s1 已被淘汰且草稿已暂存');
+  assert.deepEqual(purgeLog[0], { id: 's1', reason: 'evict' });
+
+  api.purgeSessionBuffer('s1');
+  assert.deepEqual(purgeLog[purgeLog.length - 1], { id: 's1', reason: 'delete' },
+    '真实删除必须以 delete reason 通知宿主（scene 键清理的依据）');
+  const rebuilt = api.getBuffer('s1');
+  assert.equal(rebuilt.composerDraft, '', '已删除会话的暂存草稿不得回流');
+
+  // 对照：未删除的 s2 暂存草稿仍可回填。
+  api.switchActiveTo('s2', null);
+  assert.equal(state.composerDraft, 'draft-2');
+});
+
+test('tauri 暂存草稿侧表有界（256）：远超上限的淘汰逐出最旧暂存', () => {
+  const { api, state } = loadTauriSessionsFeature();
+  const total = 32 + 257; // 289 个会话 → 257 次淘汰 → 暂存表 257 条超限逐出 s1
+  for (let i = 1; i <= total; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `draft-${i}`;
+  }
+  // 探查本身会触发新一轮淘汰+暂存（挤掉当时的表头），所以只断言两个
+  // 稳定不变量：最早的暂存（s1）已被逐出；近期暂存（第 257 个被淘汰的
+  // s257）仍在表内。二者都不受探查顺序影响。
+  assert.equal(api.getBuffer('s1').composerDraft, '', '最早的暂存草稿被侧表上限逐出');
+  assert.equal(api.getBuffer('s257').composerDraft, 'draft-257',
+    '近期暂存草稿仍在侧表内（侧表非无限，但容量远大于 buffer 上限）');
+});
+
+// ── P2：scene 缓存键语义（源码契约 + tauri hook reason）────────────
+
+test('scene 事件 localStorage 键只在真实会话删除时清理（tauri hook 契约）', () => {
+  const tauriBridge = fs.readFileSync(path.join(bridgeDir, '..', 'bridge.js'), 'utf8');
+  // onSessionBufferPurged 必须按 reason 区分，仅 delete 清理 scene 缓存键。
+  assert.match(tauriBridge, /onSessionBufferPurged: function \(id, reason\)/,
+    'tauri bridge hook 必须接收淘汰原因');
+  const sceneRemoves = tauriBridge.match(/removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX \+ id\)/g) || [];
+  assert.equal(sceneRemoves.length, 1, 'tauri bridge 只应有一处 scene 键清理（hook 内）');
+  const hookBody = tauriBridge.slice(
+    tauriBridge.indexOf('onSessionBufferPurged: function (id, reason)'),
+    tauriBridge.indexOf('onSessionBufferPurged: function (id, reason)') + 900);
+  assert.match(hookBody, /reason === "delete"[\s\S]{0,400}removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX/,
+    'scene 键清理必须被 reason === "delete" 门控');
+
+  // web 桥：两处 LRU 淘汰循环不得清理 scene 键；清理只存在于 purgeSessionBuffer。
+  const webBridge = read('bridge.js');
+  const webSceneRemoves = webBridge.match(/removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX \+ id\)/g) || [];
+  assert.equal(webSceneRemoves.length, 1, 'web bridge 的 scene 键清理只应在 purgeSessionBuffer（真实删除）');
+  const purgeAt = webBridge.indexOf('function purgeSessionBuffer');
+  const pruneAt = webBridge.indexOf('function pruneSessionBuffers');
+  assert.ok(purgeAt > 0 && pruneAt > 0);
+  assert.ok(webSceneRemoves[0] && webBridge.indexOf(webSceneRemoves[0]) > purgeAt,
+    'web scene 键清理必须位于 purgeSessionBuffer 内');
+});
+
+// ── web 桥：整桥装载驱动公开 API ──────────────────────────────────
+
+function bootWebBridge() {
+  const storage = new Map();
+  const localStorage = {
+    getItem(key) { return storage.has(key) ? storage.get(key) : null; },
+    setItem(key, value) { storage.set(key, String(value)); },
+    removeItem(key) { storage.delete(key); },
+  };
+  const documentObject = {
+    readyState: 'loading',
+    addEventListener() {},
+    createElement() { return { click() {}, remove() {}, style: {}, setAttribute() {} }; },
+    body: { appendChild() {} },
+  };
+  const listeners = {};
+  const deferreds = {};
+  const handlers = {};
+  const calls = { invoke: [], chunkLoads: [] };
+  const windowObject = {
+    PinvouPlatform: {
+      kind: 'web',
+      isWeb: true,
+      capabilities: {},
+      can: () => false,
+      canInvoke: () => false,
+      areInvokeCapabilitiesReady: () => true,
+    },
+    __TAURI__: {
+      core: { invoke: (name, args) => {
+        calls.invoke.push(name);
+        if (handlers[name]) return Promise.resolve(handlers[name](args || {}));
+        const d = deferreds[name];
+        if (d && d.promise) return d.promise;
+        return Promise.resolve(null);
+      } },
+      event: { listen: async (name, fn) => { (listeners[name] = listeners[name] || []).push(fn); return function () {}; } },
+      dialog: { open: async () => null },
+    },
+    location: { search: '', href: 'https://example.test/pinvou3/remote/' },
+    localStorage,
+    crypto: { randomUUID: () => '00000000-0000-4000-8000-000000000000' },
+    performance: { now: () => 0 },
+    atob: value => Buffer.from(String(value), 'base64').toString('binary'),
+    btoa: value => Buffer.from(String(value), 'binary').toString('base64'),
+    addEventListener() {},
+    removeEventListener() {},
+    setTimeout,
+    clearTimeout,
+  };
+  const context = vm.createContext({
+    window: windowObject,
+    document: documentObject,
+    navigator: { mediaDevices: null },
+    localStorage,
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    structuredClone,
+    URL,
+    URLSearchParams,
+    Blob,
+    Uint8Array,
+    ArrayBuffer,
+    TextEncoder,
+    TextDecoder,
+  });
+  vm.runInContext(read('bridge.js'), context, { filename: 'platform/web/bridge.js' });
+  const flat = windowObject.TauriBridge;
+  // 冷切换走 loadSessionForClient 的 chunk 协议：单块 eof 返回。
+  handlers.web_access_load_session_chunk = args => {
+    calls.chunkLoads.push(args.id);
+    const saved = {
+      metadata: { id: args.id, title: `会话 ${args.id}`, message_count: 1 },
+      messages: [{ role: 'user', content: `hello ${args.id}` }],
+      transcript_revision: 1,
+      artifacts: [],
+    };
+    const encoded = Buffer.from(JSON.stringify(saved), 'utf8');
+    return {
+      download_id: args.downloadId || args.requestedDownloadId || `dl-${args.id}`,
+      offset: Number(args.offset || 0),
+      total: encoded.length,
+      data_base64: encoded.subarray(Number(args.offset || 0)).toString('base64'),
+      eof: true,
+    };
+  };
+  return {
+    flat, storage, calls, handlers, deferreds,
+    view() { return flat.getState(); },
+  };
+}
+
+// ── P1（web）：33+ 会话淘汰后草稿仍恢复 ────────────────────────────
+
+test('web 34 会话 LRU：淘汰 s1 后重访问，草稿经侧表回填且走磁盘重水化', async () => {
+  const rt = bootWebBridge();
+  // s1 冷加载（慢路径建立 loadedFromDisk buffer）并留下未发送草稿。
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  rt.flat.setComposerDraft('web-unsent-draft');
+  // 再切换 33 个会话：第 34 个会话建立时容量淘汰 s1（最旧空闲）。
+  for (let i = 2; i <= 34; i++) {
+    assert.equal(await rt.flat.switchToSession(`s${i}`), true);
+  }
+  const loadsBefore = rt.calls.chunkLoads.filter(id => id === 's1').length;
+  assert.equal(loadsBefore, 1, '前置：s1 此前只冷加载过一次');
+  // 切回 s1：buffer 已被淘汰 → 必须重新走 chunk 重水化（证明淘汰真实发生）。
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  const loadsAfter = rt.calls.chunkLoads.filter(id => id === 's1').length;
+  assert.equal(loadsAfter, 2, 's1 被淘汰后重访问必须重新水化（重对象确已释放）');
+  assert.equal(rt.flat.getComposerDraft(), 'web-unsent-draft',
+    '淘汰时的未发送草稿必须经侧表恢复');
+});
+
+// ── P2（web）：保存失败 + 淘汰 + 重水化 ────────────────────────────
+
+test('web scene sidecar 保存失败 + 容量淘汰后，localStorage 缓存仍可恢复', async () => {
+  const rt = bootWebBridge();
+  const key = 'pinvou_scene_events_v1:s1';
+  // 模拟「sidecar 尚无数据、后端保存失败」：get 返回空数组、save 拒绝，
+  // localStorage 缓存是唯一副本（savePinvouSceneEventsForSession 的后端
+  // 失败被有意吞掉，留下缓存）。
+  rt.handlers.get_session_pinvou_scene_events = () => [];
+  rt.handlers.save_session_pinvou_scene_events = () => Promise.reject(new Error('offline'));
+  rt.storage.set(key, JSON.stringify([{ pos: 0, scene: 'work:document-writing' }]));
+
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  assert.equal(rt.view().pinvouSceneEvents.length, 1,
+    'sidecar 空 + 保存失败时必须由 localStorage 缓存兜底恢复');
+  assert.equal(rt.storage.has(key), true);
+
+  for (let i = 2; i <= 34; i++) {
+    assert.equal(await rt.flat.switchToSession(`s${i}`), true);
+  }
+  // 容量淘汰不得清理恢复副本。
+  assert.equal(rt.storage.has(key), true,
+    'LRU 容量淘汰不得删除 scene 事件的唯一离线恢复副本');
+  // 淘汰后重水化仍然恢复。
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  assert.equal(rt.view().pinvouSceneEvents.length, 1,
+    '淘汰 + 重水化后 scene 映射必须从缓存恢复');
+
+  // 对照：真实会话删除才清理缓存键。
+  rt.handlers.delete_session = () => ({});
+  assert.equal(await rt.flat.deleteSession('s1'), true);
+  assert.equal(rt.storage.has(key), false,
+    '真实会话删除必须清理 scene 缓存键（防无界累积）');
+});

--- a/pinvou3-app/tests/session_buffer_eviction.test.mjs
+++ b/pinvou3-app/tests/session_buffer_eviction.test.mjs
@@ -1,27 +1,38 @@
 /**
- * 会话 buffer LRU 淘汰回归测试（PR #339 五审 P1/P2）：
+ * Session buffer LRU eviction regression tests (PR #339, round-5 P1/P2):
  *
- * P1 —— 全会话 LRU 淘汰空闲 buffer 时连同 composerDraft 一起丢弃。磁盘
- * transcript 只含已提交内容，草稿（Tauri 与 Web 均不落盘）一旦淘汰即从
- * 「可恢复」变「永久丢失」。修复：淘汰前把不可重水化的轻量草稿转移到
- * evictedSessionDrafts 侧表（独立上限 256），buffer 重建时回填；真实会话
- * 删除（purgeSessionBuffer）时作废，不得回流。
+ * P1 — The all-session LRU evicting an idle buffer used to drop its
+ * composerDraft with it. Disk transcripts hold committed content only and
+ * drafts are never persisted (both tauri and web), so eviction turned a
+ * recoverable draft into permanent loss. Fix: before eviction the
+ * non-rehydratable lightweight draft moves to an evictedSessionDrafts side
+ * table (bounded at 256 entries / 1M chars each) and every buffer-rebuild
+ * path restores it; when a bound would be exceeded the eviction is refused
+ * so the draft stays in the live buffer; real session deletion
+ * (purgeSessionBuffer) invalidates stashed drafts so they never flow back.
  *
- * P2 —— LRU 淘汰把 scene 事件的 localStorage 缓存键当会话删除清理。该缓存
- * 是 sidecar 保存失败/离线时的唯一恢复副本（savePinvouSceneEventsForSession
- * 的后端失败被有意吞掉，syncPinvouSceneEventsForSession 靠它兜底重放）。
- * 修复：容量淘汰（reason="evict"）保留缓存键，仅真实会话删除
- * （reason="delete"）清理。
+ * P2 — LRU eviction used to clean the scene-events localStorage cache key
+ * as if it were session deletion. That cache is the only recovery copy
+ * when the sidecar save fails or we are offline
+ * (savePinvouSceneEventsForSession intentionally swallows backend
+ * failures; syncPinvouSceneEventsForSession replays from it). Fix:
+ * capacity eviction (reason="evict") keeps the key; only real session
+ * deletion (reason="delete") cleans it.
  *
- * tauri 侧经 sessions.js factory 注入（同 session_nav_race.test.mjs），
- * web 侧整桥 vm 装载（同 session_nav_race_web.test.mjs）驱动公开 API
- * switchToSession/setComposerDraft/deleteSession 走生产路径。
+ * The tauri side loads the sessions.js factory (same as
+ * session_nav_race.test.mjs); the web side boots the whole bridge in a vm
+ * (same as session_nav_race_web.test.mjs) and drives the public API
+ * switchToSession/setComposerDraft/deleteSession through production paths.
  *
- * 复审追加：
- * - fresh 物化（ensureSession/persona 加卡）的空 buffer 必须标
- *   loadedFromDisk，否则带草稿切回时落慢路径被 freshBuffer() 顶替丢草稿；
- * - personaPlaceholderTitles 是会话元数据，容量淘汰保留、真实删除才清理；
- * - 超过 64K 字符上限的草稿不入暂存侧表，淘汰后重建 buffer 草稿为空。
+ * Follow-up rounds added:
+ * - fresh materialization (ensureSession/persona card) must mark the empty
+ *   buffer loadedFromDisk, otherwise switching back with a draft falls
+ *   into the slow path and the freshBuffer() replacement drops the draft;
+ * - personaPlaceholderTitles is session metadata: kept on capacity
+ *   eviction, cleaned only on real deletion;
+ * - eviction must never lose a draft: over-cap and capacity-boundary
+ *   drafts are preserved (stash overflow refuses eviction instead of
+ *   silently discarding user input).
  */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
@@ -35,7 +46,7 @@ const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
 const webBridgeRoot = path.resolve(here, '..', 'src', 'platform', 'web');
 const read = relativePath => fs.readFileSync(path.join(webBridgeRoot, relativePath), 'utf8');
 
-// ── tauri sessions.js factory 装载 ────────────────────────────────
+// ── tauri sessions.js factory boot ───────────────────────────────────
 
 function loadTauriSessionsFeature(overrides) {
   const root = { __PINVOU_SHARED_I18N__: {} };
@@ -123,87 +134,122 @@ function loadTauriSessionsFeature(overrides) {
   return { api, state, sessionStates, purgeLog, calls };
 }
 
-// ── P1：33 会话淘汰后草稿回填（tauri）──────────────────────────────
+// ── P1: 33-session eviction restores drafts via the side table (tauri) ──
 
-test('tauri 33 会话 LRU：淘汰最旧空闲 buffer，草稿经侧表回填，buffer 数有界', () => {
+test('tauri 33-session LRU evicts the oldest idle buffer, restores its draft, keeps buffer count bounded', () => {
   const { api, state, sessionStates, purgeLog } = loadTauriSessionsFeature();
   const total = 33;
   for (let i = 1; i <= total; i++) {
     api.switchActiveTo(`s${i}`, null);
-    // 切入后输入：离开 s_i 时 saveWorkingSetTo 快照的才是 draft-i（生产语义）。
+    // Type after switching in: what saveWorkingSetTo snapshots when leaving
+    // s_i is draft-i (production semantics).
     state.composerDraft = `draft-${i}`;
     state.messages = [{ role: 'user', content: `m${i}` }];
   }
-  // 第 33 次切换的 touch 使 sessionStates 达到 33 → 淘汰最旧的 s1。
+  // The 33rd switch's touch brings sessionStates to 33 → evicts oldest s1.
   assert.equal(purgeLog.filter(e => e.reason === 'evict').length, 1);
   assert.deepEqual(purgeLog[0], { id: 's1', reason: 'evict' });
-  assert.equal(Object.keys(sessionStates).length, 32, '重对象 buffer 必须有界（≤32）');
-  assert.equal(sessionStates.s1, undefined, '最旧空闲 buffer 必须被淘汰');
-  assert.equal(sessionStates.s2.composerDraft, 'draft-2', '存活 buffer 草稿原样');
+  assert.equal(Object.keys(sessionStates).length, 32, 'heavy buffers must stay bounded (≤32)');
+  assert.equal(sessionStates.s1, undefined, 'the oldest idle buffer must be evicted');
+  assert.equal(sessionStates.s2.composerDraft, 'draft-2', 'surviving buffers keep their drafts');
 
-  // 重访问 s1：switchActiveTo 重建 buffer（非 fresh）→ 暂存草稿回填。
+  // Revisit s1: switchActiveTo rebuilds the buffer (non-fresh) → the
+  // stashed draft is restored.
   api.switchActiveTo('s1', null);
-  assert.equal(state.composerDraft, 'draft-1', '淘汰时的未发送草稿必须经侧表恢复');
+  assert.equal(state.composerDraft, 'draft-1', 'the unsent draft at eviction time must be restored via the side table');
   assert.equal(sessionStates.s1.composerDraft, 'draft-1');
-  // 重水化语义：新 buffer 不携带旧 messages（由 load_session 慢路径重建）。
+  // Rehydration semantics: the new buffer carries no old messages (the
+  // load_session slow path rebuilds them).
   assert.equal(state.messages.length, 0);
 });
 
-test('tauri 淘汰保护谓词：busy / queued / remote 不回收', () => {
+test('tauri eviction protection predicates: busy / queued / remote buffers are never reclaimed', () => {
   const { api, state, sessionStates } = loadTauriSessionsFeature();
   api.switchActiveTo('s1', null);
   state.composerDraft = 'd1';
-  state.busy = true; // 回合进行中离开：saveWorkingSetTo 把 busy 快照进 s1 buffer
+  state.busy = true; // leaving mid-turn: saveWorkingSetTo snapshots busy into s1's buffer
   for (let i = 2; i <= 34; i++) {
     api.switchActiveTo(`s${i}`, null);
     state.composerDraft = `d${i}`;
   }
-  assert.notEqual(sessionStates.s1, undefined, 'busy buffer 不得被容量淘汰');
+  assert.notEqual(sessionStates.s1, undefined, 'a busy buffer must not be evicted for capacity');
   assert.equal(sessionStates.s1.busy, true);
   assert.equal(Object.keys(sessionStates).length, 32);
 });
 
-test('tauri purgeSessionBuffer：真实会话删除作废暂存草稿，不回流同 id 重建 buffer', () => {
+test('tauri purgeSessionBuffer: real session deletion invalidates stashed drafts so they never flow back', () => {
   const { api, state, sessionStates, purgeLog } = loadTauriSessionsFeature();
   for (let i = 1; i <= 33; i++) {
     api.switchActiveTo(`s${i}`, null);
     state.composerDraft = `draft-${i}`;
   }
-  assert.equal(sessionStates.s1, undefined, '前置：s1 已被淘汰且草稿已暂存');
+  assert.equal(sessionStates.s1, undefined, 'precondition: s1 already evicted and its draft stashed');
   assert.deepEqual(purgeLog[0], { id: 's1', reason: 'evict' });
 
   api.purgeSessionBuffer('s1');
   assert.deepEqual(purgeLog[purgeLog.length - 1], { id: 's1', reason: 'delete' },
-    '真实删除必须以 delete reason 通知宿主（scene 键清理的依据）');
+    'real deletion must notify the host with the delete reason (the scene-key cleanup depends on it)');
   const rebuilt = api.getBuffer('s1');
-  assert.equal(rebuilt.composerDraft, '', '已删除会话的暂存草稿不得回流');
+  assert.equal(rebuilt.composerDraft, '', 'a deleted session\'s stashed draft must not flow back');
 
-  // 对照：未删除的 s2 暂存草稿仍可回填。
+  // Control: s2's stashed draft (not deleted) is still restorable.
   api.switchActiveTo('s2', null);
   assert.equal(state.composerDraft, 'draft-2');
 });
 
-test('tauri 暂存草稿侧表有界（256）：远超上限的淘汰逐出最旧暂存', () => {
+test('tauri oversized drafts never lost: eviction is refused when the stash cannot retain the draft', () => {
+  const { api, state, sessionStates } = loadTauriSessionsFeature();
+  api.switchActiveTo('s1', null);
+  // A transport-level write can bypass the composer input cap, producing an
+  // oversized draft (over the 1M-char stash bound).
+  state.composerDraft = 'x'.repeat(1000001);
+  for (let i = 2; i <= 33; i++) {
+    api.switchActiveTo(`s${i}`, null);
+    state.composerDraft = `d${i}`;
+  }
+  // s1 is oldest and idle, but its oversized draft cannot be safely
+  // stashed: the eviction must be refused so the draft stays in the live
+  // buffer (never silently discarded). s2 becomes the oldest eligible
+  // buffer and is evicted instead.
+  assert.notEqual(sessionStates.s1, undefined,
+    'eviction must be refused when the stash cannot retain the draft');
+  assert.equal(sessionStates.s1.composerDraft, 'x'.repeat(1000001),
+    'the oversized unsent draft must survive in the resident buffer');
+  assert.equal(sessionStates.s2, undefined,
+    'the next eligible buffer (s2) is evicted instead');
+  assert.equal(sessionStates.s3.composerDraft, 'd3', 'surviving buffers keep their small drafts');
+  // The refusal must not wedge the LRU: another eligible session is evicted
+  // instead, keeping the count bounded.
+  assert.equal(Object.keys(sessionStates).length, 32,
+    'the LRU must still evict an eligible buffer to stay bounded');
+});
+
+test('tauri stash capacity boundary: the 257th drafted session keeps its draft (eviction refused, no silent loss)', () => {
   const { api, state } = loadTauriSessionsFeature();
-  const total = 32 + 257; // 289 个会话 → 257 次淘汰 → 暂存表 257 条超限逐出 s1
+  // 32 resident + 257 evictions = 289 sessions: the 257th stash insert
+  // would exceed the 256-entry side table.
+  const total = 32 + 257;
   for (let i = 1; i <= total; i++) {
     api.switchActiveTo(`s${i}`, null);
     state.composerDraft = `draft-${i}`;
   }
-  // 探查本身会触发新一轮淘汰+暂存（挤掉当时的表头），所以只断言两个
-  // 稳定不变量：最早的暂存（s1）已被逐出；近期暂存（第 257 个被淘汰的
-  // s257）仍在表内。二者都不受探查顺序影响。
-  assert.equal(api.getBuffer('s1').composerDraft, '', '最早的暂存草稿被侧表上限逐出');
+  // s1 (oldest, draft already stashed earlier) was evicted; its stash is
+  // still within the 256-entry table and restorable.
+  assert.equal(api.getBuffer('s1').composerDraft, 'draft-1',
+    'the earliest stashed draft is restored when the side table is within its entry bound');
+  // The 257th eviction (s257's) was refused to avoid evicting the oldest
+  // stash entry — the draft survives in the resident buffer.
   assert.equal(api.getBuffer('s257').composerDraft, 'draft-257',
-    '近期暂存草稿仍在侧表内（侧表非无限，但容量远大于 buffer 上限）');
+    'the capacity-boundary draft is preserved (eviction refused rather than silently discarding input)');
 });
 
-// ── 复审 BLOCKER：fresh 物化空 buffer 的草稿丢失回归（tauri）─────────
+// ── Review BLOCKER: fresh materialization draft-loss regression (tauri) ──
 
-test('tauri fresh 物化空会话带草稿：切走再切回经 switchToSession 不丢草稿', async () => {
+test('tauri fresh-materialized empty session with a draft: switching away and back via switchToSession keeps the draft', async () => {
   const { api, state, sessionStates } = loadTauriSessionsFeature({
     invoke(name, args) {
-      // persona 加卡物化的会话在磁盘上是零消息空会话。
+      // A session materialized by equipping a persona card is a zero-message
+      // empty session on disk.
       if (name === 'load_session') {
         return Promise.resolve({
           metadata: { id: args.id, message_count: 0 },
@@ -214,102 +260,115 @@ test('tauri fresh 物化空会话带草稿：切走再切回经 switchToSession 
       return Promise.resolve({});
     },
   });
-  // persona 加卡物化：switchActiveTo(id, {fresh:true}) 建空 buffer（无 messages）。
+  // Persona-card materialization: switchActiveTo(id, {fresh:true}) builds an
+  // empty buffer (no messages).
   api.switchActiveTo('persona-1', { fresh: true });
-  state.composerDraft = 'persona-draft'; // 用户输入未发送草稿
-  // 切走：saveWorkingSetTo 把草稿快照进 persona-1 的后台 buffer。
+  state.composerDraft = 'persona-draft'; // user's unsent draft
+  // Switch away: saveWorkingSetTo snapshots the draft into persona-1's
+  // background buffer.
   api.switchActiveTo('other', null);
-  assert.equal(sessionStates['persona-1'].composerDraft, 'persona-draft', '前置：草稿已快照进 buffer');
-  // 切回：fresh 物化的空 buffer 已标 loadedFromDisk → 快路径命中、草稿保留。
-  // 回归前 buffer 未标，门控拒绝后落慢路径，sessionStates[id] 被
-  // freshBuffer() 顶替且不经侧表暂存，草稿被静默丢弃。
+  assert.equal(sessionStates['persona-1'].composerDraft, 'persona-draft', 'precondition: the draft was snapshotted into the buffer');
+  // Switch back: the fresh empty buffer is marked loadedFromDisk → the fast
+  // path hits and the draft survives. Before the regression fix the buffer
+  // was unmarked, the gate rejected it onto the slow path, sessionStates[id]
+  // was replaced by freshBuffer() without the side-table stash, and the
+  // draft was silently dropped.
   assert.equal(await api.switchToSession('persona-1'), true);
   assert.equal(state.composerDraft, 'persona-draft',
-    'fresh 物化空会话的未发送草稿不得在切回时丢失');
+    'the unsent draft of a fresh-materialized empty session must not be lost on switching back');
   assert.equal(sessionStates['persona-1'].loadedFromDisk, true,
-    'fresh 物化的空 buffer 必须标 loadedFromDisk（快路径门控依据）');
+    'a fresh empty buffer must be marked loadedFromDisk (the fast-path gate depends on it)');
 });
 
-// ── 复审：personaPlaceholderTitles 只随真实删除清理 ──────────────────
+// ── personaPlaceholderTitles cleaned only on real deletion ─────────────
 
-test('tauri LRU 容量淘汰保留 personaPlaceholderTitles，真实删除才清理', () => {
+test('tauri LRU capacity eviction keeps personaPlaceholderTitles; real deletion cleans it', () => {
   const personaPlaceholderTitles = {};
   const { api, state } = loadTauriSessionsFeature({ personaPlaceholderTitles });
   api.switchActiveTo('s1', null);
-  personaPlaceholderTitles.s1 = true; // 加卡占位标题标记
+  personaPlaceholderTitles.s1 = true; // persona-card placeholder title marker
   state.composerDraft = 'd1';
   for (let i = 2; i <= 33; i++) {
     api.switchActiveTo(`s${i}`, null);
     state.composerDraft = `d${i}`;
   }
   assert.equal(personaPlaceholderTitles.s1, true,
-    '容量淘汰不得删除占位标题标记（重水化路径不会恢复它）');
+    'capacity eviction must not delete the placeholder-title marker (rehydration never restores it)');
 
   api.purgeSessionBuffer('s1');
   assert.equal(personaPlaceholderTitles.s1, undefined,
-    '真实会话删除必须清理占位标题标记');
+    'real session deletion must clean the placeholder-title marker');
 });
 
-test('web personaPlaceholderTitles 只在真实删除时清理（源码契约）', () => {
+test('web personaPlaceholderTitles cleaned only on real deletion (source contract)', () => {
   const webBridge = read('bridge.js');
   const bodyOf = signature => {
     const start = webBridge.indexOf(signature);
-    assert.ok(start > 0, `${signature} 必须存在`);
+    assert.ok(start > 0, `${signature} must exist`);
     const end = webBridge.indexOf('\n  function ', start + 1);
     return webBridge.slice(start, end > 0 ? end : undefined);
   };
   assert.ok(!/delete personaPlaceholderTitles/.test(bodyOf('function pruneSessionBuffers')),
-    '全会话 LRU 淘汰不得清理 personaPlaceholderTitles');
+    'the all-session LRU eviction must not clean personaPlaceholderTitles');
   assert.ok(!/delete personaPlaceholderTitles/.test(bodyOf('function pruneScheduledSessionBuffers')),
-    'scheduled LRU 淘汰不得清理 personaPlaceholderTitles');
+    'the scheduled LRU eviction must not clean personaPlaceholderTitles');
   assert.ok(/delete personaPlaceholderTitles\[id\]/.test(bodyOf('function purgeSessionBuffer')),
-    '真实会话删除（purgeSessionBuffer）必须清理 personaPlaceholderTitles');
+    'real session deletion (purgeSessionBuffer) must clean personaPlaceholderTitles');
 });
 
-// ── 复审：64K 草稿字符上限 ────────────────────────────────────────────
+// ── draft stash bounds: eviction is refused instead of losing input ────
 
-test('tauri 超长草稿（>64K）不入暂存侧表：淘汰后重建 buffer 草稿为空', () => {
+test('tauri oversized draft (>1M chars) is never stashed-and-dropped: eviction is refused and the draft survives', () => {
   const { api, state, sessionStates } = loadTauriSessionsFeature();
   api.switchActiveTo('s1', null);
-  // transport 级写入可绕过 Composer 的输入上限，产生超长草稿。
-  state.composerDraft = 'x'.repeat(65537);
+  // A transport-level write can bypass the composer input cap, producing an
+  // oversized draft. It must not be silently lost at eviction time.
+  state.composerDraft = 'y'.repeat(1000001);
   for (let i = 2; i <= 33; i++) {
     api.switchActiveTo(`s${i}`, null);
     state.composerDraft = `d${i}`;
   }
-  assert.equal(sessionStates.s2.composerDraft, 'd2', '存活 buffer 的小草稿不受影响');
-  // s1 已被淘汰；超长草稿未入侧表，重建 buffer 不回填。
-  assert.equal(api.getBuffer('s1').composerDraft, '',
-    '超过 64K 字符上限的草稿不随淘汰暂存，重建后为空');
+  // s1 is the oldest idle buffer but its draft exceeds the stash char
+  // bound: the eviction is refused and the draft stays resident.
+  assert.notEqual(sessionStates.s1, undefined,
+    'a buffer whose draft cannot be safely retained must not be evicted');
+  assert.equal(sessionStates.s1.composerDraft.length, 1000001,
+    'the oversized draft survives in the resident buffer');
+  // The LRU stays bounded by evicting the next eligible session instead.
+  assert.equal(Object.keys(sessionStates).length, 32,
+    'the buffer count stays bounded via other eligible evictions');
 });
 
-// ── P2：scene 缓存键语义（源码契约 + tauri hook reason）────────────
+// ── P2: scene cache key semantics (source contract + tauri hook reason) ──
 
-test('scene 事件 localStorage 键只在真实会话删除时清理（tauri hook 契约）', () => {
+test('scene-events localStorage key cleaned only on real session deletion (tauri hook contract)', () => {
   const tauriBridge = fs.readFileSync(path.join(bridgeDir, '..', 'bridge.js'), 'utf8');
-  // onSessionBufferPurged 必须按 reason 区分，仅 delete 清理 scene 缓存键。
+  // onSessionBufferPurged must distinguish by reason; only delete cleans
+  // the scene cache key.
   assert.match(tauriBridge, /onSessionBufferPurged: function \(id, reason\)/,
-    'tauri bridge hook 必须接收淘汰原因');
+    'the tauri bridge hook must receive the eviction reason');
   const sceneRemoves = tauriBridge.match(/removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX \+ id\)/g) || [];
-  assert.equal(sceneRemoves.length, 1, 'tauri bridge 只应有一处 scene 键清理（hook 内）');
+  assert.equal(sceneRemoves.length, 1, 'the tauri bridge must have exactly one scene-key cleanup (inside the hook)');
   const hookBody = tauriBridge.slice(
     tauriBridge.indexOf('onSessionBufferPurged: function (id, reason)'),
-    tauriBridge.indexOf('onSessionBufferPurged: function (id, reason)') + 900);
-  assert.match(hookBody, /reason === "delete"[\s\S]{0,400}removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX/,
-    'scene 键清理必须被 reason === "delete" 门控');
+    tauriBridge.indexOf('onSessionBufferPurged: function (id, reason)') + 1600);
+  const hookTail = hookBody.slice(hookBody.indexOf('reason === "delete"'));
+  assert.match(hookTail, /removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX/,
+    'the scene-key cleanup must be gated on reason === "delete"');
 
-  // web 桥：两处 LRU 淘汰循环不得清理 scene 键；清理只存在于 purgeSessionBuffer。
+  // Web bridge: neither LRU eviction loop may clean the scene key; cleanup
+  // exists only in purgeSessionBuffer.
   const webBridge = read('bridge.js');
   const webSceneRemoves = webBridge.match(/removeItem\(PINVOU_SCENE_EVENTS_STORAGE_PREFIX \+ id\)/g) || [];
-  assert.equal(webSceneRemoves.length, 1, 'web bridge 的 scene 键清理只应在 purgeSessionBuffer（真实删除）');
+  assert.equal(webSceneRemoves.length, 1, 'the web bridge\'s scene-key cleanup must exist only in purgeSessionBuffer (real deletion)');
   const purgeAt = webBridge.indexOf('function purgeSessionBuffer');
   const pruneAt = webBridge.indexOf('function pruneSessionBuffers');
   assert.ok(purgeAt > 0 && pruneAt > 0);
   assert.ok(webSceneRemoves[0] && webBridge.indexOf(webSceneRemoves[0]) > purgeAt,
-    'web scene 键清理必须位于 purgeSessionBuffer 内');
+    'the web scene-key cleanup must live inside purgeSessionBuffer');
 });
 
-// ── web 桥：整桥装载驱动公开 API ──────────────────────────────────
+// ── web bridge: full-bridge vm boot driving the public API ────────────
 
 function bootWebBridge() {
   const storage = new Map();
@@ -380,11 +439,12 @@ function bootWebBridge() {
   });
   vm.runInContext(read('bridge.js'), context, { filename: 'platform/web/bridge.js' });
   const flat = windowObject.TauriBridge;
-  // 冷切换走 loadSessionForClient 的 chunk 协议：单块 eof 返回。
+  // Cold switches go through loadSessionForClient's chunk protocol: a
+  // single-chunk eof response.
   handlers.web_access_load_session_chunk = args => {
     calls.chunkLoads.push(args.id);
     const saved = {
-      metadata: { id: args.id, title: `会话 ${args.id}`, message_count: 1 },
+      metadata: { id: args.id, title: `session ${args.id}`, message_count: 1 },
       messages: [{ role: 'user', content: `hello ${args.id}` }],
       transcript_revision: 1,
       artifacts: [],
@@ -404,87 +464,98 @@ function bootWebBridge() {
   };
 }
 
-// ── P1（web）：33+ 会话淘汰后草稿仍恢复 ────────────────────────────
+// ── P1 (web): drafts survive 33+ session eviction ─────────────────────
 
-test('web 34 会话 LRU：淘汰 s1 后重访问，草稿经侧表回填且走磁盘重水化', async () => {
+test('web 34-session LRU: evicted s1 revisited — draft restored via the side table with a disk rehydration', async () => {
   const rt = bootWebBridge();
-  // s1 冷加载（慢路径建立 loadedFromDisk buffer）并留下未发送草稿。
+  // s1 cold-loads (slow path builds a loadedFromDisk buffer) and leaves an
+  // unsent draft.
   assert.equal(await rt.flat.switchToSession('s1'), true);
   rt.flat.setComposerDraft('web-unsent-draft');
-  // 再切换 33 个会话：第 34 个会话建立时容量淘汰 s1（最旧空闲）。
+  // Switch through 33 more sessions: the 34th session's creation evicts s1
+  // (oldest idle).
   for (let i = 2; i <= 34; i++) {
     assert.equal(await rt.flat.switchToSession(`s${i}`), true);
   }
   const loadsBefore = rt.calls.chunkLoads.filter(id => id === 's1').length;
-  assert.equal(loadsBefore, 1, '前置：s1 此前只冷加载过一次');
-  // 切回 s1：buffer 已被淘汰 → 必须重新走 chunk 重水化（证明淘汰真实发生）。
+  assert.equal(loadsBefore, 1, 'precondition: s1 was cold-loaded exactly once before');
+  // Switch back to s1: the buffer was evicted → the chunk rehydration must
+  // run again (proving the eviction really happened).
   assert.equal(await rt.flat.switchToSession('s1'), true);
   const loadsAfter = rt.calls.chunkLoads.filter(id => id === 's1').length;
-  assert.equal(loadsAfter, 2, 's1 被淘汰后重访问必须重新水化（重对象确已释放）');
+  assert.equal(loadsAfter, 2, 'a revisited evicted session must rehydrate (heavy objects really released)');
   assert.equal(rt.flat.getComposerDraft(), 'web-unsent-draft',
-    '淘汰时的未发送草稿必须经侧表恢复');
+    'the unsent draft at eviction time must be restored via the side table');
 });
 
-test('web 超长草稿（>64K）不入暂存侧表：淘汰重水化后草稿为空', async () => {
+test('web oversized draft (>1M chars) survives: eviction is refused instead of silently dropping input', async () => {
   const rt = bootWebBridge();
   assert.equal(await rt.flat.switchToSession('s1'), true);
-  // transport 级 setter 可绕过 Composer 的输入上限，产生超长草稿。
-  rt.flat.setComposerDraft('x'.repeat(65537));
+  // A transport-level setter can bypass the composer input cap, producing
+  // an oversized draft. It must not be lost to eviction.
+  rt.flat.setComposerDraft('x'.repeat(1000001));
   for (let i = 2; i <= 34; i++) {
     assert.equal(await rt.flat.switchToSession(`s${i}`), true);
   }
-  // s1 已被容量淘汰；切回重新水化后超长草稿不得回填。
+  // s1 is the oldest idle session but its draft exceeds the stash char
+  // bound: the eviction is refused and the draft survives in the resident
+  // buffer (no rehydration needed, no silent loss).
   assert.equal(await rt.flat.switchToSession('s1'), true);
-  assert.equal(rt.flat.getComposerDraft(), '',
-    '超过 64K 字符上限的草稿不随淘汰暂存，重水化后为空');
+  assert.equal(rt.flat.getComposerDraft(), 'x'.repeat(1000001),
+    'an oversized unsent draft must survive eviction (eviction refused rather than dropped)');
 });
 
-// ── P2（web）：保存失败 + 淘汰 + 重水化 ────────────────────────────
+// ── P2 (web): failed save + eviction + rehydration ─────────────────────
 
-test('web scene sidecar 保存失败 + 容量淘汰后，localStorage 缓存仍可恢复', async () => {
+test('web scene sidecar save failure + capacity eviction: the localStorage cache still recovers', async () => {
   const rt = bootWebBridge();
   const key = 'pinvou_scene_events_v1:s1';
-  // 模拟「sidecar 尚无数据、后端保存失败」：get 返回空数组、save 拒绝，
-  // localStorage 缓存是唯一副本（savePinvouSceneEventsForSession 的后端
-  // 失败被有意吞掉，留下缓存）。
+  // Simulate "sidecar has no data yet and the backend save fails": get
+  // returns an empty array, save rejects, and the localStorage cache is
+  // the only copy (savePinvouSceneEventsForSession intentionally swallows
+  // the backend failure, leaving the cache).
   rt.handlers.get_session_pinvou_scene_events = () => [];
   rt.handlers.save_session_pinvou_scene_events = () => Promise.reject(new Error('offline'));
   rt.storage.set(key, JSON.stringify([{ pos: 0, scene: 'work:document-writing' }]));
 
   assert.equal(await rt.flat.switchToSession('s1'), true);
   assert.equal(rt.view().pinvouSceneEvents.length, 1,
-    'sidecar 空 + 保存失败时必须由 localStorage 缓存兜底恢复');
+    'with an empty sidecar and a failed save, the localStorage cache must back the recovery');
   assert.equal(rt.storage.has(key), true);
 
   for (let i = 2; i <= 34; i++) {
     assert.equal(await rt.flat.switchToSession(`s${i}`), true);
   }
-  // 容量淘汰不得清理恢复副本。
+  // Capacity eviction must not clean the recovery copy.
   assert.equal(rt.storage.has(key), true,
-    'LRU 容量淘汰不得删除 scene 事件的唯一离线恢复副本');
-  // 淘汰后重水化仍然恢复。
+    'LRU capacity eviction must not delete the only offline recovery copy of scene events');
+  // Rehydration after eviction still recovers.
   assert.equal(await rt.flat.switchToSession('s1'), true);
   assert.equal(rt.view().pinvouSceneEvents.length, 1,
-    '淘汰 + 重水化后 scene 映射必须从缓存恢复');
+    'after eviction + rehydration the scene mapping must recover from the cache');
 
-  // 对照：真实会话删除才清理缓存键。
+  // Control: real session deletion cleans the cache key.
   rt.handlers.delete_session = () => ({});
   assert.equal(await rt.flat.deleteSession('s1'), true);
   assert.equal(rt.storage.has(key), false,
-    '真实会话删除必须清理 scene 缓存键（防无界累积）');
+    'real session deletion must clean the scene cache key (preventing unbounded accumulation)');
 });
 
-// ── 计划任务重开：淘汰后 scheduled 打开流程的草稿恢复 ────────────────
-// openScheduledRunChatOnce 两分支（queued/running 的 beginScheduledOpenActivation
-// 与其余的 scheduledRunBuffer）都先经 getBuffer 重建 buffer——回填发生在
-// getBuffer 恢复点（switchToSessionInternal 的 hydrateLive 入口恢复是防御
-// 性兜底，正常调用图不可达）。本测试锁定可达路径：淘汰 → 计划任务重开 →
-// 草稿必须回到可见工作集。
+// ── scheduled-run reopen: draft recovery via the scheduled open flow after eviction ───
 
-test('web 计划任务重开：淘汰后经 scheduled 打开，草稿经 getBuffer 重建回填', async () => {
+// Both openScheduledRunChatOnce branches (beginScheduledOpenActivation for
+// queued/running, scheduledRunBuffer otherwise) rebuild the buffer via
+// getBuffer first — the restore happens at the getBuffer restore point
+// (the switchToSessionInternal hydrateLive entry restore is a defensive
+// backstop, unreachable on the normal call graph). This test pins the
+// reachable path: eviction → scheduled-run reopen → the draft must return
+// to the visible working set.
+
+test('web scheduled-run reopen: after eviction, the scheduled open restores the draft via the getBuffer rebuild', async () => {
   const rt = bootWebBridge();
-  // sched 会话此前被切到过并留下未发送草稿，后被容量淘汰（buffer 无了，
-  // 草稿只剩侧表）。running 运行重开走 hydrateLiveSession: true 路径。
+  // The sched session was visited earlier and left an unsent draft, then
+  // was evicted by capacity (buffer gone, draft only in the side table).
+  // Reopening a running run takes the hydrateLiveSession: true path.
   const sid = 'sched-run-1';
   assert.equal(await rt.flat.switchToSession(sid), true);
   rt.flat.setComposerDraft('sched-live-draft');
@@ -496,28 +567,30 @@ test('web 计划任务重开：淘汰后经 scheduled 打开，草稿经 getBuff
     { id: 'task-1' },
   ), true);
   assert.equal(rt.flat.getComposerDraft(), 'sched-live-draft',
-    '淘汰后计划任务重开（getBuffer 重建）必须回填侧表草稿');
-  assert.equal(rt.view().pinvouSceneEvents.length, 0, '注水成功：会话已打开');
+    'a scheduled-run reopen after eviction (getBuffer rebuild) must restore the side-table draft');
+  assert.equal(rt.view().pinvouSceneEvents.length, 0, 'hydration succeeded: the session is open');
   assert.notEqual(rt.view().activeSessionId, null);
 });
 
-// ── web getBuffer 回填：迟到事件重建 buffer 的恢复点 ─────────────────
+// ── web getBuffer restore: the rebuild point for late events ──────────
 
-test('web 迟到 chat:usage 事件：淘汰后经事件 getBuffer 重建，草稿回填', async () => {
+test('web late chat:usage event: buffer rebuilt by the event via getBuffer, draft restored', async () => {
   const rt = bootWebBridge();
   assert.equal(await rt.flat.switchToSession('s1'), true);
   rt.flat.setComposerDraft('late-event-draft');
   for (let i = 2; i <= 34; i++) {
     assert.equal(await rt.flat.switchToSession(`s${i}`), true);
   }
-  // s1 已被容量淘汰；非回合事件（chat:usage）点名 s1 → onSessionEvent 经
-  // getBuffer 重建空 buffer → 回填暂存草稿。之后切回走快路径，草稿仍在。
+  // s1 was evicted; a non-turn event (chat:usage) naming s1 →
+  // onSessionEvent rebuilds an empty buffer via getBuffer → the stashed
+  // draft is restored. Switching back then takes the fast path with the
+  // draft intact.
   const listeners = rt.listeners && rt.listeners['chat:usage'];
-  assert.ok(Array.isArray(listeners) && listeners.length > 0, 'chat:usage 监听已注册');
+  assert.ok(Array.isArray(listeners) && listeners.length > 0, 'the chat:usage listener is registered');
   for (const fn of listeners) {
     await fn({ event: 'chat:usage', payload: { session_id: 's1', input_tokens: 10 } });
   }
   assert.equal(await rt.flat.switchToSession('s1'), true);
   assert.equal(rt.flat.getComposerDraft(), 'late-event-draft',
-    '迟到事件经 getBuffer 重建 buffer 时必须回填侧表草稿');
+    'a late event rebuilding the buffer via getBuffer must restore the side-table draft');
 });

--- a/pinvou3-app/tests/session_buffer_eviction.test.mjs
+++ b/pinvou3-app/tests/session_buffer_eviction.test.mjs
@@ -308,7 +308,7 @@ function bootWebBridge() {
     };
   };
   return {
-    flat, storage, calls, handlers, deferreds,
+    flat, storage, calls, handlers, deferreds, listeners,
     view() { return flat.getState(); },
   };
 }
@@ -367,4 +367,52 @@ test('web scene sidecar 保存失败 + 容量淘汰后，localStorage 缓存仍�
   assert.equal(await rt.flat.deleteSession('s1'), true);
   assert.equal(rt.storage.has(key), false,
     '真实会话删除必须清理 scene 缓存键（防无界累积）');
+});
+
+// ── 计划任务重开：淘汰后 scheduled 打开流程的草稿恢复 ────────────────
+// openScheduledRunChatOnce 两分支（queued/running 的 beginScheduledOpenActivation
+// 与其余的 scheduledRunBuffer）都先经 getBuffer 重建 buffer——回填发生在
+// getBuffer 恢复点（switchToSessionInternal 的 hydrateLive 入口恢复是防御
+// 性兜底，正常调用图不可达）。本测试锁定可达路径：淘汰 → 计划任务重开 →
+// 草稿必须回到可见工作集。
+
+test('web 计划任务重开：淘汰后经 scheduled 打开，草稿经 getBuffer 重建回填', async () => {
+  const rt = bootWebBridge();
+  // sched 会话此前被切到过并留下未发送草稿，后被容量淘汰（buffer 无了，
+  // 草稿只剩侧表）。running 运行重开走 hydrateLiveSession: true 路径。
+  const sid = 'sched-run-1';
+  assert.equal(await rt.flat.switchToSession(sid), true);
+  rt.flat.setComposerDraft('sched-live-draft');
+  for (let i = 1; i <= 33; i++) {
+    assert.equal(await rt.flat.switchToSession(`s${i}`), true);
+  }
+  assert.equal(await rt.flat.openScheduledRunChat(
+    { sessionId: sid, status: 'running', runId: 'run-1' },
+    { id: 'task-1' },
+  ), true);
+  assert.equal(rt.flat.getComposerDraft(), 'sched-live-draft',
+    '淘汰后计划任务重开（getBuffer 重建）必须回填侧表草稿');
+  assert.equal(rt.view().pinvouSceneEvents.length, 0, '注水成功：会话已打开');
+  assert.notEqual(rt.view().activeSessionId, null);
+});
+
+// ── web getBuffer 回填：迟到事件重建 buffer 的恢复点 ─────────────────
+
+test('web 迟到 chat:usage 事件：淘汰后经事件 getBuffer 重建，草稿回填', async () => {
+  const rt = bootWebBridge();
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  rt.flat.setComposerDraft('late-event-draft');
+  for (let i = 2; i <= 34; i++) {
+    assert.equal(await rt.flat.switchToSession(`s${i}`), true);
+  }
+  // s1 已被容量淘汰；非回合事件（chat:usage）点名 s1 → onSessionEvent 经
+  // getBuffer 重建空 buffer → 回填暂存草稿。之后切回走快路径，草稿仍在。
+  const listeners = rt.listeners && rt.listeners['chat:usage'];
+  assert.ok(Array.isArray(listeners) && listeners.length > 0, 'chat:usage 监听已注册');
+  for (const fn of listeners) {
+    await fn({ event: 'chat:usage', payload: { session_id: 's1', input_tokens: 10 } });
+  }
+  assert.equal(await rt.flat.switchToSession('s1'), true);
+  assert.equal(rt.flat.getComposerDraft(), 'late-event-draft',
+    '迟到事件经 getBuffer 重建 buffer 时必须回填侧表草稿');
 });

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -298,6 +298,20 @@ assert.ok(
   'Web domain adapter must load after the flat transport',
 );
 
+const stableCombined = [];
+const unsubscribeStableCombined = api.state.subscribeMany(['sessions', 'chat'], snapshot => { stableCombined.push(snapshot); });
+api.chat.prefillComposer('stable-combined-identity');
+api.chat.removeQueued('no-such-queued-id');
+assert.equal(stableCombined.length, 2, 'no-change notifications must still reach multi-domain subscribers');
+assert.equal(stableCombined[0], stableCombined[1],
+  'multi-domain combined slices must reuse identity when the transport snapshot is unchanged');
+assert.ok(Object.isFrozen(stableCombined[0]), 'the reused combined slice must stay frozen');
+api.chat.prefillComposer('stable-combined-identity-2');
+assert.equal(stableCombined.length, 3);
+assert.notEqual(stableCombined[1], stableCombined[2], 'a real state change must produce a new combined slice');
+assert.equal(stableCombined[2].composerPrefill.text, 'stable-combined-identity-2');
+unsubscribeStableCombined();
+
 invokeResponse = async command => command === 'web_access_ingest_file' ? new Date(0) : null;
 await assert.rejects(api.attachments.addAttachmentByPath('/tmp/non-plain.txt'), /only supports arrays and plain objects/);
 const nonPlainAttachment = flat.getState().attachments.at(-1);


### PR DESCRIPTION
## Background

A whole-repository memory audit (React frontend, Tauri bridge layer, src-tauri Rust, and the CodeWhale submodule as a read-only sweep) looking for memory leaks and object-reuse opportunities, following the Tauri 2 / React 18 / tokio / reqwest best practices for this stack. This PR lands every fix that is safe and behavior-preserving. CodeWhale findings are intentionally **not** fixed here (upstream-first fork policy); they are listed below for follow-up.

## Changes

### Unbounded growth (P0)
- **Session working-set buffers** (`tauri/bridge/sessions.js`, `web/bridge.js`): only scheduled sessions had an LRU; every normal session's buffer (messages, rendered chatItems, artifacts) stayed resident for the app lifetime. Added an all-session LRU (cap 32) on both bridges, protecting active/busy/queued/remote-turn buffers; evicted buffers rehydrate from disk on next access (the existing `load_session` path), and unsent composer drafts survive eviction via a bounded side table (fifth pass).
- **`render_artifact_visual` cache** (`app/commands/artifacts.rs`): multi-MB preview payloads (30-page PDF data URIs, inlined-image HTML) cached by `path|mtime` forever — every artifact rewrite created a new key. Now an LRU with 16 entries / 96 MiB budget; same-path stale keys yield on insert.
- **KnowledgeView preview cache** (`KnowledgeView.jsx`): ref cache of base64 images and full-document HTML capped at 48 entries.
- **Startup timing entries** (`index.html`): the inline startup recorder appended entries forever (every tab switch); keeps the last 64 with the flush cursor kept consistent.

### Structural leaks (P1)
- **Transcript sanitization rules** (`assistant/engine.rs`, `engine_pool.rs`): one rule per turn holding the full raw prompt plus a display clone accumulated for the engine's lifetime (~2× prompt size × turns). After a successful `SyncSession` resync (the reseeded history is already sanitized) stale rules are pruned while the in-flight reservation's rule is retained; stale rules are also pruned on engine reclaim so they no longer outlive the engine in `turn_lifecycles` until session delete. Regression test locks the production shape (stale rules cleared while a reservation is held).
- **Timing turn queue** (`assistant/timing.rs`): unsubmitted-cancel paths left stale turn ids that the next `finish_turn` misattributed to an old turn. Finish now pops from the tail and clears the queue; `clear_session` added and wired into session deletion.
- **ACP tools map** (`codex_acp/events.rs`): tool calls whose first notification was already terminal were inserted but never removed (holding full `raw_input`/`raw_output`); removed on terminal notification.
- **Web domain-adapter snapshot identity** (`web/bridge/domain-adapter.js`): every notify built fresh slices for all domain subscribers, re-rendering them on any state change (e.g. every streaming token). Slices are now cached per subscriber keyed on the transport snapshot reference, preserving the flat/domain subtree-sharing contract (`web_bridge_domain_contract` test).
- **Unix zombie children** (`platform/os/posix.rs` + macOS/Linux callers): `open`/`xdg-open`/`notify-send` were spawned without `wait`, leaving one zombie per invocation. New shared detached-reaper helper (fallback to synchronous wait), with unit tests.
- **Client reuse**: shared `SystemCredentialStore` handle in the assistant bridge (previously rebuilt per call, discarding its backend cache several times per turn); shared `reqwest::Client` for monitor model probes (previously a fresh client every 1 Hz poll) and the IMA connector, with timeouts moved to per-request.

### Hygiene (P2/P3)
- Notification dedup set bounded per session (keys pruned by session prefix; same-key replay still deduped).
- Credential `delete` now removes the value-cache entry and per-key lock registration instead of leaving `None` placeholders that accumulate with dynamic keys.
- `modeStateEpochs` entries purged together with session buffers via a new host hook.
- SearchView date-group refs deleted on unmount (no more detached DOM nodes).
- Cached `Intl.DateTimeFormat` instances in `date-utils.js` (sidebar formats every session per render).
- Pet window: 600 ms tick skips state updates when derived activities are unchanged; `PetActivityBody` memoized (avoids re-running markdown+sanitize per card per tick); `dismissActivity` reuses `refresh` (drops a duplicate derive/sort per tick).

## Verification
- `cargo test --lib`: **1396 passed / 0 failed** (3 new tests; 2 existing contract tests updated to the intentionally changed behavior: credential delete no longer leaves a cached `None`; notification dedup keeps only the latest key per session).
- Frontend `npm test`: **zero new failures** vs the pre-existing sandbox baseline (5 failures exist on clean `main` in this environment).
- `python3 scripts/architecture-guard.py`: passes.
- Commit message passes `scripts/validate-commit-msg.py --range main HEAD`.
- Note for reviewers: local builds of the CodeWhale `tui` crate hit a known rustc SIGBUS under incremental compilation (compiler crash, pre-existing); tests were run with `CARGO_INCREMENTAL=0`.

## Known risks
- Session-buffer LRU could evict a background session's in-memory working set that is not busy/queued/remote-active; reopening rehydrates committed content from disk (one-time reload). Unsent composer drafts (not on disk) are preserved across eviction via a bounded stash restored on every rebuild path (fifth pass), and the scene-events localStorage recovery copy is kept on eviction (cleaned only on real session delete). Protected classes are never evicted.
- Transcript-rule pruning assumes a resynced engine never sees pre-sanitization raw prompts again — this holds because persistence writes sanitized messages (`forwarder.rs` sanitize-before-persist), and is locked by a regression test.
- The notification-set semantics change means a stale duplicate of an *older* turn's terminal event (after a newer turn completed in the same session) would notify again; real duplicates always follow the same turn, which is still deduped.
- Shared process-lifetime `reqwest` clients (monitor probes, IMA connector) snapshot the system-proxy configuration at first use (`system-proxy` reads env/SCDynamicStore at build time); a proxy toggled mid-session is not picked up until restart, and a client build failure is cached for the process lifetime. This matches the repo's existing persistent clients (behavior_telemetry, codex_acp latest); per-request timeouts are preserved.
- Eviction never drops a draft (eighth pass): stashes are capped at 256 entries / 1M chars per draft, and when either bound would be exceeded the eviction itself is refused so the buffer stays resident — the worst case degrades to main's no-eviction behavior rather than data loss. In that pathological regime (>256 drafted evicted sessions or a >1M-char transport-bypass draft) the buffer LRU can exceed its 32-entry cap.

## Out of scope (follow-ups)
- CodeWhale submodule findings (upstream-first): unbounded `acp_server` sessions/messages maps, `core` ThreadManager/JobManager growth, static PTY `SESSIONS` registry, xai OAuth crash leftovers, lane registry pruning, execpolicy per-call prefix clones, catalog re-parsing.
- In-repo items needing product decisions or redesign: scheduled-turn panic-safety registration, ACP prompt watchdog, `login_agent` panic latch, feishu authorize poll blocking a spawn_blocking thread, knowledge `search_vec` full-collection load, marketplace uninstall keeping uploaded package dirs.

## Second pass: cache capacity & necessity audit (9c69b3b8)

A dedicated 12-sweep cache audit (capacity lens: is every bound reasonable; necessity lens: should the cache exist at all) over the frontend bridges, src-tauri, and CodeWhale. Findings that touched this PR's own caches plus small same-area gaps are fixed here; bigger items are listed under follow-ups.

- **toolMeta** (tauri bridge): historical tool_use metadata written during `rerenderFromMessages` was never cleared and rode into session buffers (write/patch args can be hundreds of KB per tool call). Cleared at replay start; the live-event path was already insert/delete balanced.
- **outPreviewCache** (KnowledgeView): count-only cap missed the byte axis — 48 multi-MB office HTML entries could reach hundreds of MB. Added a 32 MiB cumulative budget with insertion-order eviction (count cap kept as secondary axis).
- **MAX_SESSION_BUFFERS 96 → 32** (both bridges): heavy sessions run 1–4 MB each and real switching hot sets are single-digit; 96 paid worst-case hundreds of MB for near-zero hit rate beyond ~20. Eviction falls back to one-time disk rehydrate.
- **Prune-path gaps**: scheduled-buffer LRU skipped the `onSessionBufferPurged` hook (leaked `modeStateEpochs` keys); both LRU loops missed `personaPlaceholderTitles`; scene-events localStorage keys removed on real session deletion only (tauri purge hook reason `delete`, web `purgeSessionBuffer`); LRU eviction keeps the key as the offline recovery copy (corrected in the fifth pass).
- **visual_cache**: key now uses millisecond mtime (same-second atomic rewrites previously returned a stale preview); added unit tests for same-path eviction, entry cap, and byte budget (previously zero coverage).
- **pending_user_input** cleared on session delete alongside timing/turn-capture cleanup.

Verification for this pass: `cargo test --lib` 1399 passed / 0 failed (3 new visual_cache tests); frontend `npm test` zero new failures vs baseline; architecture-guard passes.

Notable audit verdicts kept as-is (documented rationale, no change): remote_control rpc_cache/journal/ledger (disjoint contracts, all axes enforced); credential VALUE_CACHE staleness trade-off (macOS Keychain reprompt storm, #175) — external-keychain-edit staleness flagged for follow-up; secrets FileKeyringStore no-cache (multi-process freshness); connectors CLI probes no-cache (freshness-by-design); knowledge per-scan index rebuild (correctness-required).


## Third pass: independent re-review fixes (30b17a1f)

An independent adversarial re-review (13 subagent sweeps + manual verification) confirmed the P0 leaks and landed the following fixes on top:

- **Fast-path gate hardened** (`tauri/bridge/sessions.js`): dropped the `chatItems` clause. A non-turn event (e.g. `chat:compaction`) recreating an empty buffer via `getBuffer` only writes a system chatItem without setting busy or messages; admitting such a buffer on the fast path showed a history-less view with no self-heal. The gate is now `loadedFromDisk || busy || remoteTurnActive || messages.length` (matching the web bridge's durable-fallback design).
- **`switchActiveTo` eviction race** (both bridges): the new active id is committed *before* touching the old buffer; with the old ordering the touch-triggered LRU prune could evict an idle target mid-switch (active id still pointed at the old session) and the `freshBuffer()` fallback silently showed an empty session.
- **Transcript rule pruning made effective**: the `state.active` bail was a no-op on every interactive path (chat/edit/remote all `reserve()` before spawn). Replaced with a retain that keeps only the in-flight reservation's rule, plus a prune on engine reclaim (rules previously survived the engine in `turn_lifecycles` until session delete).
- **`KEY_LOCKS` deregistration race** (`platform/credential_store.rs`): delete now deregisters the per-key lock only when no other thread still holds the handle (`Arc::strong_count == 2`), so a concurrent get/set can no longer build a second lock and lose mutual exclusion (which could leave the cache serving a deleted credential for the process lifetime).
- **visual cache key parsing**: `rsplit_once('|')` — filenames may legally contain `|`, and left-splitting evicted unrelated entries.
- **PetWindow `sameActivities`** now compares `body` — copy-derived bodies change on language switch without any event field changing, so cards previously stayed in the previous language.
- **domain-adapter comment** accurately scopes the stablePick cache (whole-snapshot granularity, weaker than the desktop per-domain revision cache).
- `cargo fmt` on `model_probe.rs`/`ima.rs` (the previous head would have failed the rust-lint gate).

Verification: `cargo test --lib` green (one pre-existing `runtime_bundle` flaky passes in isolation); `npm test` 5 failures identical to the pre-PR sandbox baseline; `architecture-guard` passes; commit range passes `validate-commit-msg.py --range main HEAD` (the earlier "review findings" commit title was rebuilt to meet the 50-char gate).

## Fifth pass: eviction data-loss fixes (b448455b)

Review round on the rewritten head found two data-loss defects in the eviction paths, both fixed and covered by `tests/session_buffer_eviction.test.mjs` (7 tests; 6 fail on the pre-fix head):

- **Unsent composer drafts lost on eviction** (both bridges): eviction dropped idle working sets wholesale, but drafts live only in memory (neither bridge persists them; the disk transcript holds committed content only). Eviction now stashes non-empty drafts into a bounded side table (256 entries, short strings only) and every rebuild path restores it — `getBuffer`, `switchActiveTo` non-fresh fallback, slow-path disk rehydrate, and the `hydrateLiveSession` entry. Real session deletion (`purgeSessionBuffer`) invalidates the stash so it never flows back into a recycled session id. Heavy buffers (messages/chatItems/artifacts) are still released on eviction; re-visits rehydrate from disk (verified by chunk-transport reload counting in the web test).
- **Scene-events recovery copy deleted on eviction** (both bridges): `savePinvouSceneEventsForSession` swallows backend save failures by design and `syncPinvouSceneEventsForSession` relies on the localStorage cache to replay, so eviction deleting the key could permanently drop the scene mapping after one failed save. Eviction no longer removes the key; the tauri purge hook now distinguishes `reason` (`evict` vs `delete`) and only `delete` cleans it, matching the web bridge where cleanup lives solely in `purgeSessionBuffer`.

Verification: new eviction suite 7/7 green (6 red on pre-fix head, confirming discrimination); targeted suites around the touched paths (`session_nav_race`, `session_nav_race_web`, `pinvou_scene_sidecar`, `scheduled_race`, `scheduled_tasks_unit`, `web_bridge_domain_contract`, …) all green; the 5 sandbox `npm test` failures are byte-identical on the pre-fix head (pre-existing dist/ environment failures); `architecture-guard` and the commit-message gate pass.



## Sixth pass: review follow-ups (c0e6c9c0, rebased again onto `main` after #305 landed — see 73fbb103; rebased once more onto #344's markdown-only `main` advance, conflict-free)

A sixth independent audit sweep (rebased onto `main` 322b7855, conflict-free) landed the following:

- **Draft stash byte bound (both bridges)**: the side table documented "short strings only" but enforced nothing; external transport callers (`prefillComposer`/`setComposerText`) bypass the composer's input limit, so 256 unbounded strings could re-introduce the retained-memory leak this PR removes. Stashes are now capped at 64K chars — longer drafts keep the old drop-on-eviction behavior.
- **Missed same-class zombie spawn**: the agent-login browser launch (`open_agent_login_url`) spawned without reaping, three lines above the already-fixed `open_target` fallback. Now routed through the shared posix reaper, exposed as a cross-platform `platform::os::spawn_detached_and_reap` (unix reaps via the detached thread; Windows has no zombie contract).
- **Discriminating timing tests**: the tail-pop/queue-clear/clear_session semantics previously had zero tests that could fail on regression — reverting the fix passed the whole suite. Two new tests lock attribution to the newest queued turn and clear_session silencing late finishes.
- **Eviction suite gaps closed**: scheduled-run reopen after eviction and late `chat:usage` `getBuffer` rebuild now both assert draft restoration (mutation-verified: removing the web `getBuffer` restore fails the scheduled-reopen test). The `hydrateLiveSession`-entry restore is confirmed defensive (both `openScheduledRunChatOnce` branches rebuild via `getBuffer` first) and documented as such.

Follow-ups identified by the audit and intentionally not fixed here: reader-window `PENDING_OPEN` backlog bound (small entries, low rate), connector cancel/timeout `kill()` without `wait()`, retention deletion path not clearing the new process-level maps, `model_endpoint.rs` per-probe clients (manual cadence), and extracting the duplicated bridge LRU/draft-stash core into `shared/` (established window-global script pattern exists).

Rebase note (73fbb103): #305 restructured `timing.rs` around `finish_turn_internal` with benchmark-hook observation params but kept FIFO queue pops; the tail-pop semantics is ported into that structure (observation accessors now read the queue back so observations land on the live turn), and #305's queue-ordering test is adapted to the tail-pop attribution while keeping its double-finish protection intent. `cargo test --lib` after the rebase: 1405 passed (same pre-existing `runtime_bundle` flaky).

Verification for this pass: `cargo test --lib` 1377 passed (1 pre-existing `runtime_bundle` flaky, green in isolation); `node --test` 243/250 with the 5 failures byte-identical to the pre-PR sandbox baseline (dist not built in this environment); `cargo fmt`, architecture-guard, and the commit-message gate pass.



## Eighth pass: review round 7 — draft-loss elimination + English comments (0fb5494, 106485e8)

Addressing @zhuowp's round-7 review (both blockers confirmed valid):

- **P1 — the stash bounds themselves could still lose drafts.** The 64K cap also sat *below* the composer's actual 100K input cap, so legal UI drafts between 64K and 100K were silently dropped; and the 257th drafted session's draft was dropped at eviction. Both bridges now refuse the eviction when the stash cannot safely retain the draft (buffer stays resident, draft survives); the char cap rises to 1M (10x the composer input cap). Tests assert recovery for oversized and capacity-boundary drafts, mutation-verified (reverting either refusal turns the suite red).
- **P2 — all 460+ PR-added Chinese comment blocks and test diagnostics translated to English** (Rust platform/feature layers, both bridges, frontend components, eviction suite). Pre-existing localized strings only moved by refactors (ima/linux/macos error strings) are exempt per the existing-history policy and untouched.

Verification for this pass: `cargo test --lib` 1415 passed / 0 failed (one known `runtime_bundle` flake, green in isolation); eviction suite 15/15; `test:node` 258 pass / 5 fail byte-identical to the pre-PR baseline; `cargo fmt --check`, architecture guard, fork-guard --fast, commit-message gate all pass.




## Ninth pass: review round 8 — atomic admission across the activity touch (e3129ff8)

Addressing the round-8 reviews from @JensenChen28 and @zhuowp (same P1, confirmed valid):

- **P1 — a `touch_activity` failure after admission leaked the timing registration.** The round-7 fix registered the turn inside the admitted section but before the fallible activity touch, so a touch failure released `busy` while leaving both halves of the registration behind (the queue entry and the persisted `user_start` event) with no spawned task to ever finish them. `begin_prompt_turn` is now `admit_prompt_turn(busy, configuring, session_id, touch_activity)`: busy admission → activity touch inside the admitted section (failure rolls the slot back) → timing registration immediately before `tokio::spawn`. All round-7 invariants are preserved (registration still precedes the spawned prompt; busy-rejected submits still never enqueue ghost turns).
- **Failure-injection regression** `activity_touch_failure_releases_slot_and_defers_registration`: an injected touch failure propagates, releases busy, leaves no queue entry, persists no lifecycle event, and the next submit is admitted and paired exactly once. Mutation-verified both directions (registration moved back before the touch → red; busy rollback dropped → red).

Rebase note (e3129ff8): `main` advanced to 01ba9bf0 (marketplace skill lifecycle, #345) with zero file overlap against this PR; rebase was conflict-free.

Verification for this pass: `cargo test --lib` 1445 passed / 0 failed / 12 ignored; `cargo fmt --check`, architecture guard, fork-guard --fast, and the commit-message gate pass; `session_buffer_eviction` + `session_nav_race`(+`_web`) 30/30.



**CI follow-up (adecd749):** the `adecd749` push additionally updates the Wave-2 literal contract assertion in `tests/codex_acp_timeline.test.mjs` ("an accepted ACP turn must persist the session activity timestamp before it starts", from #89) to the admission-gate shape: the touch now runs inside the `admit_prompt_turn` closure, and the assertion verifies across both `mod.rs` and `operation_gate.rs` that it still precedes the timing registration and the spawned prompt, that its failure rolls the busy slot back, and that no `begin_prompt_turn` shape remains. Mutation-verified (reversing the touch/registration order turns it red).


**Round-9 follow-up (1411ea5a):** the round-9 contract-explanation comment in `tests/codex_acp_timeline.test.mjs` is translated to English per the PR-added-comments rule (assertions unchanged, contract test green).
