### PR TITLE
fix(chat): preserve bottom after conversation switch

### DIFF
--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -22,6 +22,7 @@ import {
   conversationItemsForMode,
   projectDeepSeekConversation,
 } from '../conversation/deepseek-conversation.js';
+import { startConversationBottomFollower } from '../conversation/conversation-scroll.js';
 import {
   captureConversationScrollPosition,
   isFetchTool,
@@ -548,6 +549,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         setArtifactW(w); localStorage.setItem('pinvou_artifactW', String(w));
       };
       const scrollRef = useRef(null);
+      const conversationContentRef = useRef(null);
       const autoScrollRef = useRef(true);
       const lastScrollTopRef = useRef(0);
       const subagentPanelScrollRef = useRef(null);
@@ -970,6 +972,25 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
           lastScrollTopRef.current = el.scrollTop;
         }
       }, [bs && bs.activeSessionId]);
+
+      // Session content can finish measuring after the active-session effect runs, especially
+      // when an inactive WebView resumes or content-visibility replaces intrinsic estimates.
+      // Keep following the bottom across those layout changes, but never override a user who
+      // deliberately scrolled up.
+      useEffect(() => {
+        const scrollElement = scrollRef.current;
+        const contentElement = conversationContentRef.current;
+        if (!scrollElement || !contentElement) return undefined;
+        return startConversationBottomFollower({
+          scrollElement,
+          contentElement,
+          isFollowing: () => autoScrollRef.current,
+          onRestored: (scrollTop) => {
+            lastScrollTopRef.current = scrollTop;
+            setShowScrollBottom(false);
+          },
+        });
+      }, [activeSessionId, hasMessages]);
 
       // 安装工具后新建会话 → 本地显示欢迎卡片（不发 LLM query，不浪费 token）。
       // welcomeToolId 是一次性引导态,必须跟随会话身份:只有"装完工具"(justInstalledTool 非
@@ -1599,7 +1620,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
             )}
 
             {hasMessages && (
-              <div className="max-w-[800px] w-full min-w-0 mx-auto space-y-4">
+              <div ref={conversationContentRef} className="max-w-[800px] w-full min-w-0 mx-auto space-y-4">
                 {useUnifiedConversationUi ? (
                   <ConversationTimeline
                     turns={conversationProjection.turns}

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -28,6 +28,7 @@ import {
   isFetchTool,
   isNearConversationBottom,
   isSearchTool,
+  isShrinkClampedToBottom,
   restoreConversationScrollPosition,
 } from '../conversation/conversation-model.js';
 import { AttachmentChips } from '../attachments/AttachmentChips.jsx';
@@ -552,6 +553,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
       const conversationContentRef = useRef(null);
       const autoScrollRef = useRef(true);
       const lastScrollTopRef = useRef(0);
+      const lastScrollHeightRef = useRef(0);
       const subagentPanelScrollRef = useRef(null);
       const [showScrollBottom, setShowScrollBottom] = useState(false);
       const chatRootRef = useRef(null);
@@ -915,10 +917,17 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         if (!el) return;
         const onScroll = () => {
           const near = isNearConversationBottom(el);
-          const movingUp = el.scrollTop < lastScrollTopRef.current - 1;
+          // A content shrink (e.g. content-visibility replacing its 600px estimate with a
+          // smaller real height) makes the browser clamp scrollTop down to the new maximum.
+          // That programmatic jump carries no user intent, so it must neither disable
+          // auto-follow (the bottom follower and streaming effect depend on it) nor
+          // re-enable it for a user who was browsing history.
+          const shrinkClamped = isShrinkClampedToBottom(el, lastScrollHeightRef.current);
+          const movingUp = el.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped;
           lastScrollTopRef.current = el.scrollTop;
+          lastScrollHeightRef.current = el.scrollHeight;
           if (movingUp) autoScrollRef.current = false;
-          else if (near) autoScrollRef.current = true;
+          else if (!shrinkClamped && near) autoScrollRef.current = true;
           const shouldShow = !autoScrollRef.current && el.scrollHeight > el.clientHeight + 4;
           setShowScrollBottom(v => v === shouldShow ? v : shouldShow);
         };
@@ -970,6 +979,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
         if (el) {
           el.scrollTop = el.scrollHeight;
           lastScrollTopRef.current = el.scrollTop;
+          lastScrollHeightRef.current = el.scrollHeight;
         }
       }, [bs && bs.activeSessionId]);
 
@@ -987,6 +997,7 @@ const ToolWelcomeCard = ({ toolId, theme, t, onSend }) => {
           isFollowing: () => autoScrollRef.current,
           onRestored: (scrollTop) => {
             lastScrollTopRef.current = scrollTop;
+            lastScrollHeightRef.current = scrollElement.scrollHeight;
             setShowScrollBottom(false);
           },
         });

--- a/pinvou3-app/src/features/conversation/conversation-model.js
+++ b/pinvou3-app/src/features/conversation/conversation-model.js
@@ -124,6 +124,19 @@ export function isNearConversationBottom(element, threshold = 96) {
 }
 
 /**
+ * Detect a scroll jump caused by the browser clamping scrollTop after the content
+ * shrank (e.g. content-visibility replacing its intrinsic-size estimate with a
+ * smaller real height), as opposed to the user scrolling up. Scroll events fired
+ * by such a clamp must not be treated as history browsing.
+ */
+export function isShrinkClampedToBottom(element, lastScrollHeight, epsilon = 1) {
+  if (!element) return false;
+  const shrink = (lastScrollHeight || 0) - element.scrollHeight;
+  if (shrink <= epsilon) return false;
+  return (element.scrollHeight - element.scrollTop - element.clientHeight) <= epsilon;
+}
+
+/**
  * 侧栏开合会改变聊天列宽并触发全文重排。保存距底部距离，布局完成后恢复，
  * 这样贴底的流式会话仍贴底，浏览历史时也不会因换行增多而跳到更早内容。
  */

--- a/pinvou3-app/src/features/conversation/conversation-scroll.js
+++ b/pinvou3-app/src/features/conversation/conversation-scroll.js
@@ -1,0 +1,45 @@
+import { restoreConversationScrollPosition } from './conversation-model.js';
+
+export function startConversationBottomFollower({
+  scrollElement,
+  contentElement,
+  isFollowing,
+  onRestored,
+  windowObject = typeof window === 'undefined' ? null : window,
+  documentObject = typeof document === 'undefined' ? null : document,
+}) {
+  if (!scrollElement || !contentElement || !windowObject || !documentObject) return () => {};
+
+  let frame = null;
+  const restoreBottomIfFollowing = () => {
+    if (!isFollowing()) return;
+    if (frame !== null) windowObject.cancelAnimationFrame(frame);
+    frame = windowObject.requestAnimationFrame(() => {
+      frame = null;
+      if (!isFollowing()) return;
+      restoreConversationScrollPosition(scrollElement, { stickToBottom: true, bottomGap: 0 });
+      if (onRestored) onRestored(scrollElement.scrollTop);
+    });
+  };
+  const onVisibilityChange = () => {
+    if (documentObject.visibilityState === 'visible') restoreBottomIfFollowing();
+  };
+  const observer = windowObject.ResizeObserver
+    ? new windowObject.ResizeObserver(restoreBottomIfFollowing)
+    : null;
+
+  if (observer) {
+    observer.observe(scrollElement);
+    if (contentElement !== scrollElement) observer.observe(contentElement);
+  }
+  windowObject.addEventListener('focus', restoreBottomIfFollowing);
+  documentObject.addEventListener('visibilitychange', onVisibilityChange);
+  restoreBottomIfFollowing();
+
+  return () => {
+    if (observer) observer.disconnect();
+    windowObject.removeEventListener('focus', restoreBottomIfFollowing);
+    documentObject.removeEventListener('visibilitychange', onVisibilityChange);
+    if (frame !== null) windowObject.cancelAnimationFrame(frame);
+  };
+}

--- a/pinvou3-app/tests/conversation_scroll_follow.test.mjs
+++ b/pinvou3-app/tests/conversation_scroll_follow.test.mjs
@@ -19,6 +19,9 @@ for (const file of ['conversation-model.js', 'conversation-scroll.js']) {
 const { startConversationBottomFollower } = await import(
   `${pathToFileURL(path.join(conversationDir, 'conversation-scroll.js')).href}?t=${Date.now()}`
 );
+const { isShrinkClampedToBottom } = await import(
+  `${pathToFileURL(path.join(conversationDir, 'conversation-model.js')).href}?t=${Date.now()}`
+);
 
 function eventTarget() {
   const listeners = new Map();
@@ -165,6 +168,20 @@ try {
   stopShared();
   flushFrame();
   assert.equal(sharedObserver.disconnected, true, 'cleanup must disconnect the shared-element observer');
+
+  // A content shrink clamps scrollTop down to the new maximum; that scroll event must be
+  // recognizable as programmatic so it neither disables nor re-enables auto-follow.
+  const shrinkClamped = { scrollHeight: 900, scrollTop: 700, clientHeight: 200 };
+  assert.equal(isShrinkClampedToBottom(shrinkClamped, 1000), true,
+    'a shrink-induced clamp to the new bottom must be detected');
+  assert.equal(isShrinkClampedToBottom({ ...shrinkClamped, scrollTop: 300 }, 1000), false,
+    'a shrink with the viewport far above the bottom is user scrolling, not a clamp');
+  assert.equal(isShrinkClampedToBottom({ scrollHeight: 1000, scrollTop: 800, clientHeight: 200 }, 1000), false,
+    'no shrink means any upward move is user scrolling');
+  assert.equal(isShrinkClampedToBottom({ scrollHeight: 1200, scrollTop: 1000, clientHeight: 200 }, 1000), false,
+    'content growth must never be treated as a shrink clamp');
+  assert.equal(isShrinkClampedToBottom(null, 1000), false,
+    'a missing element must not be reported as clamped');
 
   console.log('conversation_scroll_follow: ok');
 } finally {

--- a/pinvou3-app/tests/conversation_scroll_follow.test.mjs
+++ b/pinvou3-app/tests/conversation_scroll_follow.test.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const temp = mkdtempSync(path.join(tmpdir(), 'pinvou3-conversation-scroll-'));
+const conversationDir = path.join(temp, 'features', 'conversation');
+mkdirSync(conversationDir, { recursive: true });
+writeFileSync(path.join(temp, 'package.json'), '{"type":"module"}\n');
+for (const file of ['conversation-model.js', 'conversation-scroll.js']) {
+  copyFileSync(
+    path.join(here, '..', 'src', 'features', 'conversation', file),
+    path.join(conversationDir, file),
+  );
+}
+const { startConversationBottomFollower } = await import(
+  `${pathToFileURL(path.join(conversationDir, 'conversation-scroll.js')).href}?t=${Date.now()}`
+);
+
+function eventTarget() {
+  const listeners = new Map();
+  return {
+    addEventListener(name, listener) {
+      if (!listeners.has(name)) listeners.set(name, new Set());
+      listeners.get(name).add(listener);
+    },
+    removeEventListener(name, listener) {
+      listeners.get(name)?.delete(listener);
+    },
+    dispatch(name) {
+      for (const listener of listeners.get(name) || []) listener();
+    },
+    listenerCount(name) {
+      return listeners.get(name)?.size || 0;
+    },
+  };
+}
+
+const windowEvents = eventTarget();
+const documentEvents = eventTarget();
+const frames = new Map();
+let nextFrame = 1;
+const observers = [];
+const fakeWindow = {
+  ...windowEvents,
+  requestAnimationFrame(callback) {
+    const id = nextFrame++;
+    frames.set(id, callback);
+    return id;
+  },
+  cancelAnimationFrame(id) {
+    frames.delete(id);
+  },
+  ResizeObserver: class {
+    constructor(callback) {
+      this.callback = callback;
+      this.observeCalls = [];
+      this.observedElements = new Set();
+      this.disconnected = false;
+      observers.push(this);
+    }
+    observe(element) {
+      this.observeCalls.push(element);
+      this.observedElements.add(element);
+    }
+    trigger(element) {
+      if (this.observedElements.has(element)) this.callback([{ target: element }], this);
+    }
+    disconnect() {
+      this.disconnected = true;
+      this.observedElements.clear();
+    }
+  },
+};
+const fakeDocument = { ...documentEvents, visibilityState: 'visible' };
+const scrollElement = { scrollHeight: 1000, scrollTop: 700, clientHeight: 200 };
+const contentElement = {};
+let following = true;
+const restored = [];
+const flushFrame = () => {
+  const pending = [...frames.entries()];
+  frames.clear();
+  for (const [, callback] of pending) callback();
+};
+
+try {
+  const stop = startConversationBottomFollower({
+    scrollElement,
+    contentElement,
+    isFollowing: () => following,
+    onRestored: (scrollTop) => restored.push(scrollTop),
+    windowObject: fakeWindow,
+    documentObject: fakeDocument,
+  });
+  const observer = observers[0];
+  assert.deepEqual(observer.observeCalls, [scrollElement, contentElement],
+    'the bottom follower must observe both the viewport and its content');
+
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 800, 'initial session activation must settle at the bottom');
+
+  scrollElement.clientHeight = 300;
+  observer.trigger(scrollElement);
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 700,
+    'a clientHeight-only viewport resize must keep a following conversation at the bottom');
+
+  scrollElement.scrollHeight = 1400;
+  observer.trigger(contentElement);
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 1100, 'content reflow must keep a following conversation at the bottom');
+
+  scrollElement.scrollHeight = 1600;
+  fakeWindow.dispatch('focus');
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 1300, 'window focus must restore the bottom after background layout changes');
+
+  scrollElement.scrollHeight = 1800;
+  fakeDocument.visibilityState = 'hidden';
+  fakeDocument.dispatch('visibilitychange');
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 1300, 'hidden visibility changes must not move the conversation');
+  fakeDocument.visibilityState = 'visible';
+  fakeDocument.dispatch('visibilitychange');
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 1500, 'visible conversations must resume bottom following');
+
+  following = false;
+  scrollElement.scrollTop = 900;
+  scrollElement.scrollHeight = 2000;
+  scrollElement.clientHeight = 400;
+  observer.trigger(scrollElement);
+  observer.trigger(contentElement);
+  fakeWindow.dispatch('focus');
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 900,
+    'a user browsing history must not be pulled back after viewport or content resize');
+
+  following = true;
+  scrollElement.scrollHeight = 2200;
+  fakeWindow.dispatch('focus');
+  stop();
+  flushFrame();
+  assert.equal(scrollElement.scrollTop, 900, 'cleanup must cancel a pending bottom restoration');
+  assert.equal(observer.disconnected, true);
+  assert.equal(observer.observedElements.size, 0);
+  assert.equal(fakeWindow.listenerCount('focus'), 0);
+  assert.equal(fakeDocument.listenerCount('visibilitychange'), 0);
+  assert.deepEqual(restored, [800, 700, 1100, 1300, 1500]);
+
+  const sharedElement = { scrollHeight: 1000, scrollTop: 800, clientHeight: 200 };
+  const stopShared = startConversationBottomFollower({
+    scrollElement: sharedElement,
+    contentElement: sharedElement,
+    isFollowing: () => true,
+    windowObject: fakeWindow,
+    documentObject: fakeDocument,
+  });
+  const sharedObserver = observers[1];
+  assert.deepEqual(sharedObserver.observeCalls, [sharedElement],
+    'one element serving as viewport and content must only be observed once');
+  stopShared();
+  flushFrame();
+  assert.equal(sharedObserver.disconnected, true, 'cleanup must disconnect the shared-element observer');
+
+  console.log('conversation_scroll_follow: ok');
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}

--- a/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
+++ b/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
@@ -376,7 +376,10 @@ try {
   assert.ok(chatView.includes('isNearConversationBottom(el)')
     && chatView.includes('const movingUp = el.scrollTop < lastScrollTopRef.current - 1')
     && chatView.includes('if (movingUp) autoScrollRef.current = false'),
-  'DeepSeek streaming must pause auto-follow while the user reads history');
+    'DeepSeek streaming must pause auto-follow while the user reads history');
+  assert.ok(chatView.includes('startConversationBottomFollower({')
+    && chatView.includes('isFollowing: () => autoScrollRef.current'),
+    'bottom-following conversations must recover after delayed layout and window visibility changes');
   assert.ok(chatView.includes('<ThinkingBubble'), 'the original rendering path must remain available as a fallback');
   assert.ok(chatView.includes("pinvou_conversation_ui_v2"), 'the local rollback switch must be explicit');
 

--- a/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
+++ b/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
@@ -374,9 +374,12 @@ try {
     && !chatView.includes('shouldAutoOpenToolGroup='),
   'tool groups must keep a user-owned expansion state instead of opening and closing with execution status');
   assert.ok(chatView.includes('isNearConversationBottom(el)')
-    && chatView.includes('const movingUp = el.scrollTop < lastScrollTopRef.current - 1')
+    && chatView.includes('const movingUp = el.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped')
     && chatView.includes('if (movingUp) autoScrollRef.current = false'),
     'DeepSeek streaming must pause auto-follow while the user reads history');
+  assert.ok(chatView.includes('const shrinkClamped = isShrinkClampedToBottom(el, lastScrollHeightRef.current)')
+    && chatView.includes('lastScrollHeightRef.current = el.scrollHeight'),
+    'a shrink-induced scrollTop clamp must not be mistaken for the user browsing history');
   assert.ok(chatView.includes('startConversationBottomFollower({')
     && chatView.includes('isFollowing: () => autoScrollRef.current'),
     'bottom-following conversations must recover after delayed layout and window visibility changes');


### PR DESCRIPTION
## Background

Fixes #337

When switching between two conversations, a conversation that was originally at the bottom can intermittently return with the scrollbar above the bottom, leaving the latest content outside the visible area. The problem is more likely with long conversations, active streaming, or when a background window resumes.

## Investigation and conclusion

The session data and active conversation identity switch correctly. The issue is in the frontend scroll restoration timing: `ChatView` scrolls to the bottom once after the active conversation changes, but layout can continue changing afterward as a background WebView resumes, asynchronous content finishes measuring, `content-visibility` replaces intrinsic estimates, the viewport is resized, or the mobile keyboard settles.

The root cause is the absence of a lifecycle that preserves bottom anchoring across delayed content and viewport layout changes while the conversation is still in auto-follow mode.

## Changes

- Add a focused conversation bottom follower that observes both the scroll viewport and conversation content with one `ResizeObserver`.
- Reconcile the bottom position when the window regains focus or the document becomes visible.
- Coalesce restoration requests with `requestAnimationFrame`.
- Reuse the existing `autoScrollRef`, so users who deliberately scroll upward are never pulled back to the bottom.
- Clean up the observer, event listeners, and pending animation frame on session change or unmount.

## Verification

- `node tests/conversation_scroll_follow.test.mjs`
- `node tests/deepseek_conversation_timeline.test.mjs`
- `npm run test:node`: 234 passed, 1 skipped, 0 failed
- `npm run test:ui-smoke`: 48/48 passed
- `npm run lint:ui`
- `npm run build:ui`
- `python scripts/architecture-guard.py`
- `git diff --check`

The regression test covers initial activation, content-only reflow, viewport `clientHeight` changes, focus and visibility recovery, deliberate history browsing, duplicate observer targets, and cleanup.

## Risks

The change is limited to the frontend conversation scroll lifecycle and does not modify session data, protocols, backend code, or dependencies. Each active conversation uses one observer for the viewport and content, with restoration coalesced per animation frame. No automatic scrolling occurs after the user leaves the bottom. The original Windows environment has not been manually retested; the affected timing and cleanup paths are covered by automated tests.