### PR TITLE
feat(visualizer): require persistent labels

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/SKILL.md
+++ b/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/SKILL.md
@@ -26,6 +26,7 @@ description: 当用户要求数据可视化、做图表、生成看板、数据�
 - 直接在聊天正文粘贴完整 HTML，而没有写 `.html` 文件和展示 artifact。
 - `<canvas>` 缺少 `role="img"`、`aria-label` 或 fallback text。
 - 使用默认 Chart.js legend，而没有自定义 HTML legend。
+- 图表数值只出现在 hover tooltip 中，画布上没有常驻数值标签。
 - 使用彩虹渐变 KPI、重阴影、发光、深色 hero、emoji 或营销页式大标题。
 - HTML/CSS/JS 中出现 `<!-- comments -->`、`/* comments */` 或独立行 `// comments`。
 - `scripts/validate_visualizer_html.py` 返回失败。
@@ -62,7 +63,6 @@ Pinvou 的聊天正文会转义或清理 `<script>`，所以不要把带 Chart.j
 - 不要编造真实业务数据。缺数据时先询问，或明确生成空模板/示例模板。
 - 用户给出 Excel、CSV、JSON、表格或明细数据时，先做必要聚合，再写入图表。
 - 所有展示数字都要四舍五入到合理精度。
-- 图表默认常驻显示关键数值标签；hover tooltip 可以保留，但不能作为唯一的数值展示方式。
 - 图表解释写在普通回复中；HTML 产物内部只放视觉元素、必要标题、图例和简短标签。
 
 ## HTML 产物硬规则
@@ -70,7 +70,7 @@ Pinvou 的聊天正文会转义或清理 `<script>`，所以不要把带 Chart.j
 - 使用 Chart.js UMD：`https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js`。
 - 每个 `<canvas>` 必须有 `role="img"`、描述性 `aria-label` 和 fallback text。
 - 默认 legend 必须关闭，使用自定义 HTML legend。
-- 默认在图表关键数据点上常驻显示数值标签，不只依赖 hover tooltip；柱状图显示在柱体末端或顶部，折线图显示在关键节点附近，饼图/环图显示分类占比。若数据点过密导致重叠，只显示首尾、峰值、谷值或 Top N，并在图例、KPI 或标题旁保留完整口径。
+- 默认在图表关键数据点上常驻显示数值标签，不只依赖 hover tooltip；柱状图显示在柱体末端或顶部，折线图显示在关键节点附近，饼图/环图显示分类占比。数据密集时只显示首尾、峰值、谷值或 Top N 等关键标签，避免重叠；完整数值保留在图例或 KPI 卡中。
 - canvas 外层 wrapper 设置高度，canvas 本身不直接设置高度。
 - Chart.js 配置里使用硬编码 hex，不使用 CSS 变量。
 - 页面视觉要扁平、紧凑、无渐变背景、无阴影、无深色外层容器。

--- a/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/SKILL.md
+++ b/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/SKILL.md
@@ -17,6 +17,7 @@ description: 当用户要求数据可视化、做图表、生成看板、数据�
 - 每个 `<canvas>` 都有 `role="img"`、描述性 `aria-label` 和 fallback text。
 - Chart.js 默认 legend 关闭，并使用自定义 HTML legend。
 - 数据先聚合再入图，展示数字经过合理四舍五入。
+- 图表关键数值常驻显示，不只依赖 hover tooltip；数据密集时显示首尾、峰值、谷值或 Top N 等关键标签。
 
 ## 失败判定
 如果发生以下任一情况，必须重写产物再交付：
@@ -61,6 +62,7 @@ Pinvou 的聊天正文会转义或清理 `<script>`，所以不要把带 Chart.j
 - 不要编造真实业务数据。缺数据时先询问，或明确生成空模板/示例模板。
 - 用户给出 Excel、CSV、JSON、表格或明细数据时，先做必要聚合，再写入图表。
 - 所有展示数字都要四舍五入到合理精度。
+- 图表默认常驻显示关键数值标签；hover tooltip 可以保留，但不能作为唯一的数值展示方式。
 - 图表解释写在普通回复中；HTML 产物内部只放视觉元素、必要标题、图例和简短标签。
 
 ## HTML 产物硬规则
@@ -68,6 +70,7 @@ Pinvou 的聊天正文会转义或清理 `<script>`，所以不要把带 Chart.j
 - 使用 Chart.js UMD：`https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js`。
 - 每个 `<canvas>` 必须有 `role="img"`、描述性 `aria-label` 和 fallback text。
 - 默认 legend 必须关闭，使用自定义 HTML legend。
+- 默认在图表关键数据点上常驻显示数值标签，不只依赖 hover tooltip；柱状图显示在柱体末端或顶部，折线图显示在关键节点附近，饼图/环图显示分类占比。若数据点过密导致重叠，只显示首尾、峰值、谷值或 Top N，并在图例、KPI 或标题旁保留完整口径。
 - canvas 外层 wrapper 设置高度，canvas 本身不直接设置高度。
 - Chart.js 配置里使用硬编码 hex，不使用 CSS 变量。
 - 页面视觉要扁平、紧凑、无渐变背景、无阴影、无深色外层容器。

--- a/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/references/visualizer-design-system.md
+++ b/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/references/visualizer-design-system.md
@@ -136,13 +136,13 @@ Use these placement rules when drawing Chart.js value labels:
 
 - Vertical bars: positive labels sit above the bar; negative labels sit below the bar. Pull labels inward near chart edges.
 - Horizontal bars: positive labels sit after the bar end; negative labels sit before the bar end. Move labels inside the bar when outside space is tight.
-- Line charts: show every point only when the series is short. For dense series, label endpoints, peaks, troughs, important thresholds, or Top N values with 6-8px spacing from the point.
+- Line charts: show every point only when the series is short; keep labels 6-8px away from the point.
 - Area charts: follow line chart labeling, and avoid covering the main filled trend shape.
 - Doughnut and pie charts: show percentage or Top N labels. Do not force persistent labels on tiny slices; put those values in the custom legend instead.
 - Scatter and bubble charts: label the selected business metric, usually `y`, and keep labels outside the marker when practical.
 - Multi-dataset charts: label the primary dataset by default. If labeling every dataset would clutter the chart, use the custom legend and tooltip for secondary datasets.
 - Format every label with `Intl.NumberFormat`, `Math.round()`, or `.toFixed(n)`, matching the metric type and keeping labels compact.
-- Use at least 11px text, weight 400 or 500, and hardcoded neutral hex colors in canvas drawing code.
+- Use at least 11px text, weight 400 or 500, and hardcoded neutral hex from the c-gray scale (such as #5F5E5A or #444441) in canvas drawing code.
 
 ### Legends
 Always disable the default legend and use custom HTML:

--- a/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/references/visualizer-design-system.md
+++ b/pinvou3-app/src-tauri/resources/common/skill-marketplace/visualizer/references/visualizer-design-system.md
@@ -126,6 +126,23 @@ Use Chart.js UMD from cdnjs:
 - Bubble/scatter charts should pad the scale range about 10% beyond the data range.
 - 12 categories or fewer: set `scales.x.ticks: { autoSkip: false, maxRotation: 45 }`.
 - Negative currency values: `-$5M`, not `$-5M`.
+- Show persistent value labels by default instead of relying only on hover tooltips. Use a small custom Chart.js plugin, usually with `afterDatasetsDraw`, to draw rounded values near bars, points, or segments.
+- Keep hover tooltips available for detail, but do not make hover the only way to see chart values.
+- Extract label values according to the dataset shape. Numeric arrays can use the numeric value directly; scatter data should read `{x,y}` and usually label `y`; bubble data should read `{x,y,r}` and label the business metric or `y`. Never pass an object directly into `Math.round()`.
+- For dense series, label only endpoints, peaks, troughs, important thresholds, or Top N values to avoid overlap.
+
+### Persistent value labels
+Use these placement rules when drawing Chart.js value labels:
+
+- Vertical bars: positive labels sit above the bar; negative labels sit below the bar. Pull labels inward near chart edges.
+- Horizontal bars: positive labels sit after the bar end; negative labels sit before the bar end. Move labels inside the bar when outside space is tight.
+- Line charts: show every point only when the series is short. For dense series, label endpoints, peaks, troughs, important thresholds, or Top N values with 6-8px spacing from the point.
+- Area charts: follow line chart labeling, and avoid covering the main filled trend shape.
+- Doughnut and pie charts: show percentage or Top N labels. Do not force persistent labels on tiny slices; put those values in the custom legend instead.
+- Scatter and bubble charts: label the selected business metric, usually `y`, and keep labels outside the marker when practical.
+- Multi-dataset charts: label the primary dataset by default. If labeling every dataset would clutter the chart, use the custom legend and tooltip for secondary datasets.
+- Format every label with `Intl.NumberFormat`, `Math.round()`, or `.toFixed(n)`, matching the metric type and keeping labels compact.
+- Use at least 11px text, weight 400 or 500, and hardcoded neutral hex colors in canvas drawing code.
 
 ### Legends
 Always disable the default legend and use custom HTML:


### PR DESCRIPTION
## Background

Visualizer artifacts generated with Chart.js could hide chart values behind hover-only tooltips. That makes key numbers harder to scan in reports, screenshots, and non-hover contexts.

## Changes

- Require persistent key value labels in the visualizer skill success criteria and hard rules.
- Add Chart.js design guidance for custom persistent value-label plugins.
- Document placement rules for bars, lines, area charts, doughnut/pie charts, scatter/bubble charts, and dense datasets.
- Keep hover tooltips available for details, but prevent them from being the only value display.

## Verification

- `git diff --check`
- `python scripts/architecture-guard.py`
- Validated two temporary visualizer HTML fixtures with `validate_visualizer_html.py` before cleanup.
- Started the desktop app successfully after initializing the Windows ONNX runtime.

## Known Risks

- This is a skill guidance and design-system documentation change; it does not add automated enforcement for value-label drawing in the validator.
- `cargo test visualizer --no-run` was attempted after syncing latest `origin/main`, but local compilation did not complete: `rustc` remained in the `codewhale_tui` compile unit for an extended period and reached about 11.6 GB memory usage, so the command was stopped to avoid tying up the machine.