### PR TITLE
fix(marketplace): harden skill package lifecycle

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -460,15 +460,24 @@ pub(super) fn uninstall_marketplace_tool_sync(tool_id: &str) -> Result<(), Strin
             }
         }
     }
-    // 联动:删配套技能(best-effort,删不掉不影响 MCP 卸载)。必须先于
-    // `mgr.uninstall` 执行:技能落盘目录按 `skill_owner_package` 条件认领推导
-    // (包本体已装才归 `bundles/<pkg>/skills/`),MCP 先卸则认领翻转、技能卸载
-    // 会按「独立纯技能包」算错目录并报「非市场安装」静默残留(gongwen 先卸 →
-    // government-writing 删不掉的顺序依赖 bug)。
+    // 联动:删配套技能。必须先于 `mgr.uninstall` 执行:技能落盘目录按
+    // `skill_owner_package` 条件认领推导(包本体已装才归 `bundles/<pkg>/skills/`),
+    // MCP 先卸则认领翻转、技能卸载会按「独立纯技能包」算错目录并报「非市场安装」
+    // 静默残留(gongwen 先卸 → government-writing 删不掉的顺序依赖 bug)。
+    // Companion teardown must also *succeed* before the MCP record is removed:
+    // read-time scope normalization maps skill id -> package id one-way, so a
+    // failed companion delete followed by MCP removal flips the claim back to
+    // the skill name and the stored package-level disabled/hidden entries stop
+    // matching — a user-disabled/hidden skill would be re-materialized into
+    // sessions with its scripts outside the execpolicy deny rules. Abort on
+    // failure (same discipline as the install path's abort-on-delete-failure):
+    // the MCP stays installed, the claim stays stable, and the user can retry.
     for sid in companions {
-        let _ = crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new()
-            .uninstall(&sid);
-        // 已卸载技能从两个 scope 禁用集清除残留。
+        crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new()
+            .uninstall(&sid)
+            .map_err(|e| format!("联动卸载配套技能 '{sid}' 失败（已中止工具卸载，请重试）: {e}"))?;
+        // Scope entries are cleared only after the skill is actually gone —
+        // otherwise a still-installed skill would be silently re-enabled.
         crate::features::marketplace::skill_scope::remove_skill_from_disabled_scopes(&sid);
     }
     mgr.uninstall(tool_id)?;

--- a/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/marketplace.rs
@@ -460,16 +460,20 @@ pub(super) fn uninstall_marketplace_tool_sync(tool_id: &str) -> Result<(), Strin
             }
         }
     }
-    mgr.uninstall(tool_id)?;
-    // 已卸载的连接器从两个 scope 的禁用集移除(避免残留 id)。
-    crate::features::marketplace::remove_connector_from_disabled_scopes(tool_id);
-    // 联动:删配套技能(best-effort,删不掉不影响 MCP 卸载)。
+    // 联动:删配套技能(best-effort,删不掉不影响 MCP 卸载)。必须先于
+    // `mgr.uninstall` 执行:技能落盘目录按 `skill_owner_package` 条件认领推导
+    // (包本体已装才归 `bundles/<pkg>/skills/`),MCP 先卸则认领翻转、技能卸载
+    // 会按「独立纯技能包」算错目录并报「非市场安装」静默残留(gongwen 先卸 →
+    // government-writing 删不掉的顺序依赖 bug)。
     for sid in companions {
         let _ = crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new()
             .uninstall(&sid);
         // 已卸载技能从两个 scope 禁用集清除残留。
         crate::features::marketplace::skill_scope::remove_skill_from_disabled_scopes(&sid);
     }
+    mgr.uninstall(tool_id)?;
+    // 已卸载的连接器从两个 scope 的禁用集移除(避免残留 id)。
+    crate::features::marketplace::remove_connector_from_disabled_scopes(tool_id);
     Ok(())
 }
 // ---------------------------------------------------------------------------

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -584,29 +584,30 @@ fn mcp_install_links_companion_skills() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
-/// 卸载顺序回归：MCP 已装时 companion 技能落盘在 `bundles/<pkg>/skills/`（条件认领，
-/// `skill_owner_package` 以包本体安装态判定归属）。若先卸 MCP 本体再删 companion，
-/// 认领翻转、技能卸载按「独立纯技能包」算错目录而静默残留（gongwen 先卸 →
-/// government-writing 删不掉）。命令层必须先删 companion 再卸 MCP。
+/// 卸载回归：MCP 已装时 companion 技能落盘在 `bundles/<pkg>/skills/`（条件认领，
+/// `skill_owner_package` 以包本体安装态判定归属）。本测试锁定的是**物理扫描
+/// 删除路径**（技能卸载按实际物理位置找包目录副本并删除），而非直接证明调用
+/// 顺序——顺序依赖的正确性由该扫描路径在认领仍有效时能找到副本来体现
+/// （gongwen 先卸 → government-writing 删不掉的回归）。
 #[test]
-fn mcp_uninstall_removes_companion_skills_before_teardown() {
+fn mcp_uninstall_removes_companion_skills_from_package_dir() {
     let _g = crate::platform::paths::tests::ENV_LOCK
         .lock()
         .unwrap_or_else(|p| p.into_inner());
-    let root = std::env::temp_dir().join(format!(
-        "pinvou3-companion-unlink-test-{}",
-        std::process::id()
-    ));
-    let previous = std::env::var("PINVOU3_HOME").ok();
-    let _ = std::fs::remove_dir_all(&root);
-    std::fs::create_dir_all(&root).unwrap();
-    std::env::set_var("PINVOU3_HOME", &root);
+    let _home = TempPinvou3Home::new("companion-unlink");
 
     let mgr = crate::features::marketplace::MarketplaceManager::new();
     let skill_mgr = crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new();
-    // 复刻命令层安装路径：装 MCP → 联动装 companion 技能（gongwen 已装 →
-    // government-writing 认领进 bundles/gongwen/skills/）。
-    mgr.install("gongwen", &std::collections::HashMap::new())
+    // 复刻命令层安装路径的**安装态**而不跑真实 install 管线（`mgr.install`
+    // 会真实执行 pip install python-docx，邻测 mcp_install_links_companion_skills
+    // 因此也不调它）：条件认领（bundle_installed）只查 BundleStore 记录。
+    crate::features::marketplace::store::BundleStore::new()
+        .upsert(
+            crate::features::marketplace::store::BundleRecord::installed_now(
+                "gongwen".to_string(),
+                crate::features::marketplace::store::BundleSource::Preset,
+            ),
+        )
         .unwrap();
     for sid in mgr.companion_skills("gongwen") {
         skill_mgr.install(&sid).unwrap();
@@ -630,12 +631,63 @@ fn mcp_uninstall_removes_companion_skills_before_teardown() {
             .any(|s| s.id == "government-writing" && s.installed),
         "卸 MCP 后 companion 技能不得仍为已装态"
     );
+}
 
-    match previous {
-        Some(value) => std::env::set_var("PINVOU3_HOME", value),
-        None => std::env::remove_var("PINVOU3_HOME"),
-    }
-    let _ = std::fs::remove_dir_all(&root);
+/// Claim-flip guard (safety-relevant): if the companion skill cannot be
+/// deleted, the MCP uninstall must abort and leave the MCP record in place.
+/// Read-time scope normalization maps skill id -> package id one-way; removing
+/// the MCP record after a failed companion delete would flip the claim back to
+/// the skill name, orphaning the stored package-level disabled/hidden entries
+/// and re-materializing a user-disabled skill into sessions. The scope entries
+/// must also stay untouched while the skill is still installed.
+#[test]
+fn mcp_uninstall_aborts_when_companion_uninstall_fails() {
+    let _g = crate::platform::paths::tests::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let _home = TempPinvou3Home::new("companion-abort");
+
+    // gongwen installed (store record drives the conditional claim).
+    crate::features::marketplace::store::BundleStore::new()
+        .upsert(
+            crate::features::marketplace::store::BundleRecord::installed_now(
+                "gongwen".to_string(),
+                crate::features::marketplace::store::BundleSource::Preset,
+            ),
+        )
+        .unwrap();
+    // Failure injection without platform-specific permission tricks: the
+    // companion exists only as an *unmarked* legacy flat dir, which skill
+    // uninstall refuses to delete ("非市场安装" protection).
+    let legacy = crate::platform::paths::bundle_skills_dir().join("government-writing");
+    std::fs::create_dir_all(&legacy).unwrap();
+    std::fs::write(
+        legacy.join("SKILL.md"),
+        "---\nname: government-writing\n---\n",
+    )
+    .unwrap();
+    // The package-level disable entry (normalized to the package id while the
+    // claim holds) must survive the abort.
+    crate::features::marketplace::save_disabled_bundles(&["government-writing".to_string()]);
+
+    let err = uninstall_marketplace_tool_sync("gongwen").unwrap_err();
+    assert!(
+        err.contains("government-writing"),
+        "中止错误应点名失败的配套技能，实际: {err}"
+    );
+    assert!(
+        crate::features::marketplace::store::BundleStore::new()
+            .get("gongwen")
+            .unwrap()
+            .is_some(),
+        "companion 卸载失败时 MCP 记录必须保留（认领不得翻转）"
+    );
+    assert!(legacy.join("SKILL.md").is_file(), "保护对象目录不得被动");
+    assert_eq!(
+        crate::features::marketplace::load_disabled_bundles(),
+        vec!["gongwen".to_string()],
+        "companion 卸载失败时禁用集条目不得清除（仍在装的技能不得被重新启用）"
+    );
 }
 
 #[test]

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -584,6 +584,60 @@ fn mcp_install_links_companion_skills() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// 卸载顺序回归：MCP 已装时 companion 技能落盘在 `bundles/<pkg>/skills/`（条件认领，
+/// `skill_owner_package` 以包本体安装态判定归属）。若先卸 MCP 本体再删 companion，
+/// 认领翻转、技能卸载按「独立纯技能包」算错目录而静默残留（gongwen 先卸 →
+/// government-writing 删不掉）。命令层必须先删 companion 再卸 MCP。
+#[test]
+fn mcp_uninstall_removes_companion_skills_before_teardown() {
+    let _g = crate::platform::paths::tests::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let root = std::env::temp_dir().join(format!(
+        "pinvou3-companion-unlink-test-{}",
+        std::process::id()
+    ));
+    let previous = std::env::var("PINVOU3_HOME").ok();
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    std::env::set_var("PINVOU3_HOME", &root);
+
+    let mgr = crate::features::marketplace::MarketplaceManager::new();
+    let skill_mgr = crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new();
+    // 复刻命令层安装路径：装 MCP → 联动装 companion 技能（gongwen 已装 →
+    // government-writing 认领进 bundles/gongwen/skills/）。
+    mgr.install("gongwen", &std::collections::HashMap::new())
+        .unwrap();
+    for sid in mgr.companion_skills("gongwen") {
+        skill_mgr.install(&sid).unwrap();
+    }
+    let skill_dir = crate::platform::paths::bundles_root()
+        .join("gongwen")
+        .join("skills")
+        .join("government-writing");
+    assert!(skill_dir.is_dir(), "companion 技能应随包装入包目录");
+
+    uninstall_marketplace_tool_sync("gongwen").unwrap();
+
+    assert!(
+        !skill_dir.exists(),
+        "卸 MCP 后 companion 技能目录不得残留（顺序依赖回归）"
+    );
+    assert!(
+        !skill_mgr
+            .list_skills()
+            .iter()
+            .any(|s| s.id == "government-writing" && s.installed),
+        "卸 MCP 后 companion 技能不得仍为已装态"
+    );
+
+    match previous {
+        Some(value) => std::env::set_var("PINVOU3_HOME", value),
+        None => std::env::remove_var("PINVOU3_HOME"),
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn file_url_from_path_encodes_local_artifact_paths() {
     let tmp = std::env::temp_dir().join(format!("pinvou3 file-url test {}", std::process::id()));

--- a/pinvou3-app/src-tauri/src/features/marketplace/mcp_catalog.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mcp_catalog.rs
@@ -147,7 +147,15 @@ pub fn release_package(id: &str) -> Result<Option<String>, String> {
             return Err(e);
         }
     };
-    let _ = std::fs::remove_dir_all(&mcp_dir);
+    // 删旧目录不得吞错误：Windows 文件锁导致删一半时若继续 rename 必然失败，
+    // 且暂存被清理后盘上只剩残缺的旧目录（静默损坏残留）。失败即中止并保留
+    // 原目录现状，下个启动周期重试收敛。
+    if mcp_dir.exists() {
+        std::fs::remove_dir_all(&mcp_dir).map_err(|e| {
+            let _ = std::fs::remove_dir_all(&staged);
+            format!("清理旧包目录失败（已中止，原目录可能部分删除）: {e}")
+        })?;
+    }
     std::fs::rename(&staged, &mcp_dir).map_err(|e| {
         let _ = std::fs::remove_dir_all(&staged);
         format!("释放包资源: {e}")

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -731,10 +731,8 @@ mod tests {
             let new_dir = mcp_catalog::package_mcp_dir(id);
             std::fs::create_dir_all(&new_dir).unwrap();
             assert!(migrate_mcp_json_paths().unwrap());
-            let mcp: serde_json::Value = serde_json::from_str(
-                &std::fs::read_to_string(&mcp_path).unwrap(),
-            )
-            .unwrap();
+            let mcp: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&mcp_path).unwrap()).unwrap();
             let command = mcp["servers"][id]["command"].as_str().unwrap();
             assert!(
                 command.starts_with(&*new_dir.to_string_lossy()),

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -127,6 +127,12 @@ pub fn migrate_mcp_json_paths() -> Result<bool, String> {
     for id in ids {
         let old_dir = paths::bundle_mcp_servers_dir().join(&id);
         let new_dir = mcp_catalog::package_mcp_dir(&id);
+        // 新目录不存在（自定义 MCP 搬迁 kept/重释放被跳过）时不重写：否则
+        // mcp.json 指向不存在的新路径，工具静默死掉且读路径无旧布局回退（G4）。
+        // 搬迁/重释放成功后的下一轮启动再重写（本函数幂等）。
+        if !new_dir.is_dir() {
+            continue;
+        }
         // 兼容两种分隔符的历史写法（Windows 原生 `\` 与 `/`）
         let old_spellings = [
             old_dir.to_string_lossy().replace('\\', "/"),
@@ -694,6 +700,47 @@ mod tests {
             }
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// G4 回归：mcp.json 路径重写以新目录存在为前提——自定义 MCP 搬迁 kept
+    /// （新目录不存在）时保留旧路径，不得把条目改指到不存在的目录（否则工具
+    /// 静默死掉且读路径无旧布局回退）；新目录出现后下一轮再重写（幂等）。
+    #[test]
+    fn migrate_mcp_json_paths_skips_missing_target_dir() {
+        with_temp_home(|| {
+            let id = "custom-weather";
+            let old_dir = paths::bundle_mcp_servers_dir().join(id);
+            std::fs::create_dir_all(&old_dir).unwrap();
+            let mcp_path = paths::mcp_config_path();
+            std::fs::create_dir_all(mcp_path.parent().unwrap()).unwrap();
+            let old_text = old_dir.to_string_lossy().replace('\\', "/");
+            std::fs::write(
+                &mcp_path,
+                format!(
+                    r#"{{"servers":{{"{id}":{{"command":"{old_text}/run.cmd","args":["{old_text}/server.py"]}}}}}}"#
+                ),
+            )
+            .unwrap();
+
+            // 新目录不存在：不重写、旧路径保留
+            assert!(!migrate_mcp_json_paths().unwrap());
+            let content = std::fs::read_to_string(&mcp_path).unwrap();
+            assert!(content.contains(&old_text), "新目录缺失时旧路径应保留");
+
+            // 新目录出现（搬迁成功）：重写指向新目录
+            let new_dir = mcp_catalog::package_mcp_dir(id);
+            std::fs::create_dir_all(&new_dir).unwrap();
+            assert!(migrate_mcp_json_paths().unwrap());
+            let mcp: serde_json::Value = serde_json::from_str(
+                &std::fs::read_to_string(&mcp_path).unwrap(),
+            )
+            .unwrap();
+            let command = mcp["servers"][id]["command"].as_str().unwrap();
+            assert!(
+                command.starts_with(&*new_dir.to_string_lossy()),
+                "重写后应指向新包目录，实际: {command}"
+            );
+        });
     }
 
     async fn with_temp_home_async<F, Fut>(f: F)

--- a/pinvou3-app/src-tauri/src/features/marketplace/plugin_import.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/plugin_import.rs
@@ -796,6 +796,38 @@ pub fn import_plugin_package(
             ));
         }
     }
+    // Preset/companion/cross-package skill name collisions are rejected up
+    // front, consistent with the two skill_marketplace channels (which sweep
+    // duplicate copies after install — this pipeline never sweeps, so without
+    // a guard a collision would escalate from "shadowed" to "swept away").
+    // Self-claim is allowed (owner == this package id, e.g. a combo package
+    // whose mcp manifest declares its own skill as companion on reimport).
+    for skill_name in &skills {
+        if crate::features::marketplace::skill_marketplace::is_preset_skill_name(skill_name) {
+            return Err(format!(
+                "技能 '{skill_name}' 与市场预置技能冲突，请改用其它名称"
+            ));
+        }
+        let owner = crate::features::marketplace::bundle::skill_owner_package(skill_name);
+        if owner != *skill_name && owner != id {
+            return Err(format!(
+                "技能 '{skill_name}' 已被包 '{owner}' 的配套技能占用，请改用其它名称"
+            ));
+        }
+        if let Some(other) =
+            crate::features::marketplace::skill_marketplace::foreign_skill_copies_under(
+                &crate::platform::paths::bundles_root(),
+                skill_name,
+                &id,
+            )
+            .into_iter()
+            .next()
+        {
+            return Err(format!(
+                "技能 '{skill_name}' 已存在于包 '{other}'，请先卸载该包或改用其它名称"
+            ));
+        }
+    }
     // 技能组件一致性（plugin-package-spec §8 承诺的导入校验）：组件 id 必须与
     // SKILL.md frontmatter 的 `name` 一致——不一致会被注册表当两套技能处理。
     // 必读必验（四轮评审 M-3）：SKILL.md 缺失或读取失败一律响亮拒收，不再
@@ -1827,6 +1859,103 @@ mod tests {
         );
         assert!(
             !dir.join("bundles").join("greet").exists(),
+            "拒收不得落盘包目录"
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("PINVOU3_HOME", v),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Upload-side collision guard (review MINOR): a skill component named
+    /// like a preset skill is rejected up front — the preset pipeline owns the
+    /// name and its sweep/rehome lifecycle would destroy the uploaded copy.
+    #[test]
+    fn import_rejects_preset_skill_name_collision() {
+        use std::io::Write;
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "pinvou-preset-collision-{}-{}",
+            std::process::id(),
+            crate::platform::paths::tests::unique_suffix()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &dir);
+
+        let zip_path = dir.join("skill.zip");
+        {
+            let f = std::fs::File::create(&zip_path).unwrap();
+            let mut zw = zip::ZipWriter::new(f);
+            let opts = zip::write::SimpleFileOptions::default();
+            zw.start_file("skills/visualizer/SKILL.md", opts).unwrap();
+            zw.write_all(b"---\nname: visualizer\n---\n# hi").unwrap();
+            zw.finish().unwrap();
+        }
+        let err = import_plugin_package(&zip_path.to_string_lossy(), "skill.zip").unwrap_err();
+        assert!(
+            err.contains("预置技能冲突"),
+            "预置技能撞名应拒收，实际: {err}"
+        );
+        assert!(
+            !dir.join("bundles").join("visualizer").exists(),
+            "拒收不得落盘包目录"
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("PINVOU3_HOME", v),
+            None => std::env::remove_var("PINVOU3_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Upload-side collision guard (review MINOR): a skill component whose
+    /// name is already on disk under another package is rejected up front —
+    /// this pipeline never sweeps, and the other package's copy must survive.
+    #[test]
+    fn import_rejects_skill_name_owned_by_another_package() {
+        use std::io::Write;
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let dir = std::env::temp_dir().join(format!(
+            "pinvou-foreign-skill-{}-{}",
+            std::process::id(),
+            crate::platform::paths::tests::unique_suffix()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::var("PINVOU3_HOME").ok();
+        std::env::set_var("PINVOU3_HOME", &dir);
+
+        // Existing plugin package owning skill "foo".
+        let foreign = dir.join("bundles/other-pkg/skills/foo");
+        std::fs::create_dir_all(&foreign).unwrap();
+        std::fs::write(foreign.join("SKILL.md"), "---\nname: foo\n---\n").unwrap();
+        std::fs::write(dir.join("bundles/other-pkg/plugin.json"), "{}").unwrap();
+
+        let zip_path = dir.join("skill.zip");
+        {
+            let f = std::fs::File::create(&zip_path).unwrap();
+            let mut zw = zip::ZipWriter::new(f);
+            let opts = zip::write::SimpleFileOptions::default();
+            zw.start_file("skills/foo/SKILL.md", opts).unwrap();
+            zw.write_all(b"---\nname: foo\n---\n# hi").unwrap();
+            zw.finish().unwrap();
+        }
+        let err = import_plugin_package(&zip_path.to_string_lossy(), "skill.zip").unwrap_err();
+        assert!(
+            err.contains("已存在于包 'other-pkg'"),
+            "跨包撞名应拒收，实际: {err}"
+        );
+        assert!(foreign.join("SKILL.md").is_file(), "外来包副本不得被动");
+        assert!(
+            !dir.join("bundles").join("foo").exists(),
             "拒收不得落盘包目录"
         );
 

--- a/pinvou3-app/src-tauri/src/features/marketplace/scope.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/scope.rs
@@ -90,7 +90,11 @@ fn load_disabled_bundles_file_locked() -> DisabledBundlesFile {
 /// 误写入的带前缀 id；本文件按裸包 id 匹配，读者在此统一归一）。返回是否剥出过前缀。
 fn strip_skill_prefixes(file: &mut DisabledBundlesFile) -> bool {
     let mut stripped = false;
-    for ids in file.scopes.values_mut().chain(file.hidden_scopes.values_mut()) {
+    for ids in file
+        .scopes
+        .values_mut()
+        .chain(file.hidden_scopes.values_mut())
+    {
         for id in ids.iter_mut() {
             if let Some(s) = id.strip_prefix("skill:") {
                 *id = s.to_string();
@@ -615,10 +619,7 @@ mod tests {
     #[test]
     fn load_normalizes_stale_skill_id_after_claim_flip() {
         with_temp_home(|| {
-            save_disabled_bundles_for(
-                ConnectorScope::Plain,
-                &["government-writing".to_string()],
-            );
+            save_disabled_bundles_for(ConnectorScope::Plain, &["government-writing".to_string()]);
             save_hidden_bundles_for(ConnectorScope::Plain, &["government-writing".to_string()]);
             assert_eq!(
                 load_disabled_bundles_for(ConnectorScope::Plain),

--- a/pinvou3-app/src-tauri/src/features/marketplace/scope.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/scope.rs
@@ -86,11 +86,11 @@ fn load_disabled_bundles_file_locked() -> DisabledBundlesFile {
     file
 }
 
-/// 防御：剥除所有 scope 禁用集里的 `skill:` 前缀（旧前端 bug 窗口期误写入的带前缀
-/// id；本文件按裸包 id 匹配，读者在此统一归一）。返回是否剥出过前缀。
+/// 防御：剥除所有 scope 禁用集与不可见集里的 `skill:` 前缀（旧前端 bug 窗口期
+/// 误写入的带前缀 id；本文件按裸包 id 匹配，读者在此统一归一）。返回是否剥出过前缀。
 fn strip_skill_prefixes(file: &mut DisabledBundlesFile) -> bool {
     let mut stripped = false;
-    for ids in file.scopes.values_mut() {
+    for ids in file.scopes.values_mut().chain(file.hidden_scopes.values_mut()) {
         for id in ids.iter_mut() {
             if let Some(s) = id.strip_prefix("skill:") {
                 *id = s.to_string();
@@ -106,6 +106,21 @@ fn strip_skill_prefixes(file: &mut DisabledBundlesFile) -> bool {
 fn to_package_id(raw: &str) -> String {
     let stripped = raw.strip_prefix("skill:").unwrap_or(raw);
     skill_owner_package(stripped)
+}
+
+/// 读时归一：存储条目按**当前**认领状态重映射为包 id 并去重（保序）。
+/// 认领（`skill_owner_package`）随安装态时变：条目可能在 companion MCP 未装时
+/// 按独立技能 id 落库，MCP 后装则认领翻转到包 id——只在写时归一会让用户的
+/// 「关/隐藏」在认领翻转后静默失效（F4）；读时归一让门控跟随技能本体。
+fn normalize_stored_pkg_ids(ids: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(ids.len());
+    for id in ids {
+        let pkg = to_package_id(id);
+        if !out.iter().any(|x| x == &pkg) {
+            out.push(pkg);
+        }
+    }
+    out
 }
 
 /// 首启迁移：读旧 `disabled_connectors.json` + `disabled_skills.json`（各兼容三种
@@ -281,11 +296,14 @@ pub fn load_disabled_bundles_for(scope: ConnectorScope) -> Vec<String> {
 fn resolve_scope_disabled_ids(file: &DisabledBundlesFile, scope: ConnectorScope) -> Vec<String> {
     let key = scope.as_str();
     if file.initialized.contains(key) {
-        return file.scopes.get(key).cloned().unwrap_or_default();
+        return normalize_stored_pkg_ids(&file.scopes.get(key).cloned().unwrap_or_default());
     }
     match scope.pack_default_policy() {
-        PackDefaultPolicy::AllowAll => file.scopes.get(key).cloned().unwrap_or_default(),
+        PackDefaultPolicy::AllowAll => {
+            normalize_stored_pkg_ids(&file.scopes.get(key).cloned().unwrap_or_default())
+        }
         PackDefaultPolicy::DenyAll => {
+            // 现算分支：已按当前认领推导包 id，无需再归一。
             let mut ids: Vec<String> = MarketplaceManager::new().installed_ids();
             ids.extend(builtin_cli_bundle_ids().map(str::to_string));
             for skill_id in SkillMarketplaceManager::new().installed_skill_ids() {
@@ -318,10 +336,13 @@ pub fn save_disabled_bundles_for(scope: ConnectorScope, ids: &[String]) {
 /// 不决定 on/off。
 pub fn load_hidden_bundles_for(scope: ConnectorScope) -> Vec<String> {
     let file = load_disabled_bundles_file();
-    file.hidden_scopes
-        .get(scope.as_str())
-        .cloned()
-        .unwrap_or_default()
+    normalize_stored_pkg_ids(
+        &file
+            .hidden_scopes
+            .get(scope.as_str())
+            .cloned()
+            .unwrap_or_default(),
+    )
 }
 
 /// 写某 scope 被「不可见」的包 id 列表（不参与 DenyAll 默认，显式写入才隐藏）。
@@ -584,6 +605,48 @@ mod tests {
             assert_eq!(
                 load_disabled_bundles_for(ConnectorScope::Plain),
                 vec!["visualizer".to_string(), "gongwen".to_string()]
+            );
+        });
+    }
+
+    /// F4 回归：条目在 companion MCP 未装时按独立技能 id 落库；MCP 后装 →
+    /// 认领翻转到包 id。读时归一（`normalize_stored_pkg_ids`）须让「关/隐藏」
+    /// 跟随技能本体，否则用户的禁用/隐藏态在认领翻转后静默失效。
+    #[test]
+    fn load_normalizes_stale_skill_id_after_claim_flip() {
+        with_temp_home(|| {
+            save_disabled_bundles_for(
+                ConnectorScope::Plain,
+                &["government-writing".to_string()],
+            );
+            save_hidden_bundles_for(ConnectorScope::Plain, &["government-writing".to_string()]);
+            assert_eq!(
+                load_disabled_bundles_for(ConnectorScope::Plain),
+                vec!["government-writing".to_string()]
+            );
+            assert_eq!(
+                load_hidden_bundles_for(ConnectorScope::Plain),
+                vec!["government-writing".to_string()]
+            );
+
+            // 后装 gongwen → 认领翻转 government-writing → gongwen
+            crate::features::marketplace::store::BundleStore::new()
+                .upsert(
+                    crate::features::marketplace::store::BundleRecord::installed_now(
+                        "gongwen".to_string(),
+                        crate::features::marketplace::store::BundleSource::Preset,
+                    ),
+                )
+                .unwrap();
+            assert_eq!(
+                load_disabled_bundles_for(ConnectorScope::Plain),
+                vec!["gongwen".to_string()],
+                "认领翻转后读时归一应把禁用条目重映射到包 id"
+            );
+            assert_eq!(
+                load_hidden_bundles_for(ConnectorScope::Plain),
+                vec!["gongwen".to_string()],
+                "认领翻转后读时归一应把隐藏条目重映射到包 id"
             );
         });
     }

--- a/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
@@ -457,7 +457,10 @@ impl SkillMarketplaceManager {
 
     /// 落盘后清扫同名技能的其余物理副本，保证一个技能只有一份市场副本：
     /// 其余 `bundles/*/skills/<name>`（滞留/双份）与带市场标记的旧扁平目录
-    /// 一律删除；无标记旧扁平是内置/手放保护对象（extraction 清理契约），不动。
+    /// 一律删除。Unmarked legacy flat dirs are not touched here — but note
+    /// `bundle/skills/` is a builtin-managed area, not protected user storage:
+    /// its unmarked residue is converged by self-heal step 4, and hand-placed
+    /// user skills belong in `~/.pinvou3/user/skills/`.
     fn sweep_duplicate_skill_dirs(&self, skill_name: &str, keep: &Path) {
         for dir in self.package_candidate_dirs(skill_name) {
             if dir == *keep || !dir.is_dir() {
@@ -502,17 +505,45 @@ impl SkillMarketplaceManager {
     ///    整段跳过（fail-closed：登记丢失时不得误删用户安装）。
     /// 3. **瘫记录清理**：Upload 记录但任何候选位置都找不到目录 → 内容不可
     ///    再生，记录即死配置，删除（Preset/Builtin 保留：可重释放/再装）。
-    /// 4. **内置释放目录收敛**：`bundle/skills/` 下无市场标记、无记录、且不在
-    ///    当前构建内嵌内置集 `builtin_released` 的目录 → 残旧删除。其它发行版
-    ///    内嵌同名技能（如集团版 eip）时它在其内置集内，自然保留——这正是
-    ///    与「按名单清理」的本质区别。带标记目录留给布局迁移处理。
+    /// 4. **Builtin-release convergence**: unmarked, unrecorded dirs under
+    ///    `bundle/skills/` that are not in this build's embedded builtin set
+    ///    `builtin_released` are deleted as stale residue. Another edition
+    ///    embedding a same-named skill (e.g. the group edition's eip) keeps it
+    ///    via its own builtin set — the essential difference from a name-list
+    ///    cleanup. Marked dirs are left to the layout migration.
+    ///    `bundle/skills/` is a builtin-managed area, not user storage:
+    ///    hand-placed user skills belong in `~/.pinvou3/user/skills/`.
+    ///
+    /// **Package-layout ownership guard** (applies to steps 1-3): a package dir
+    /// carrying `plugin.json` (always landed by `plugin_import`) or an `mcp/`
+    /// sibling owns its whole `skills/` subtree — plugin packages may contain
+    /// multiple skills whose names differ from the single registered package
+    /// id, and pure-MCP uploads have no skill dir at all. Name-based
+    /// rehome/orphan/stale-record heuristics must never touch package-owned
+    /// content, otherwise user uploads are destroyed within two launches.
     pub fn self_heal_skills(&self, builtin_released: &[&str]) -> SkillSelfHealReport {
         let mut report = SkillSelfHealReport::default();
-        let records = self.bundle_store.records().ok();
-        if records.is_none() {
-            // fail-closed：登记读不出时只做不依赖登记的错位归位
-            log::warn!("[skill-marketplace] BundleStore 不可读，自愈仅执行认领错位归位");
-        }
+        // Fail-closed when the store is unreadable OR missing: a missing
+        // bundles.json yields an empty record set that is indistinguishable
+        // from "everything is an orphan" — with user content on disk, steps
+        // 2-4 would mass-delete it. (Startup runs import_legacy before
+        // self-heal, so a missing file means the registry was lost, not that
+        // nothing was ever installed.)
+        let records = if self.bundle_store.file_path().is_file() {
+            match self.bundle_store.records() {
+                Ok(recs) => Some(recs),
+                Err(_) => {
+                    // fail-closed：登记读不出时只做不依赖登记的错位归位
+                    log::warn!("[skill-marketplace] BundleStore 不可读，自愈仅执行认领错位归位");
+                    None
+                }
+            }
+        } else {
+            log::warn!(
+                "[skill-marketplace] bundles.json 缺失，自愈仅执行认领错位归位（fail-closed）"
+            );
+            None
+        };
 
         // 1 + 2：扫描 bundles/<pkg>/skills/<name>。本轮归位落入的目标目录跳过
         // 当轮孤儿判定（read_dir 顺序不定，归位目标可能在本轮稍后被扫到；
@@ -521,7 +552,17 @@ impl SkillMarketplaceManager {
         if let Ok(pkgs) = std::fs::read_dir(&self.packages_root) {
             for pkg_entry in pkgs.flatten() {
                 let pkg = pkg_entry.file_name().to_string_lossy().into_owned();
-                let skills_dir = pkg_entry.path().join("skills");
+                let pkg_path = pkg_entry.path();
+                // Package-layout ownership guard: plugin-import packages
+                // (plugin.json) and MCP-bearing packages (mcp/ sibling) own
+                // their skills/ subtree regardless of skill dir names —
+                // multi-skill packages and plugin.json id != skill name layouts
+                // register only one record (the package id), so the name-based
+                // heuristics below would rehome/delete user content.
+                if pkg_path.join("plugin.json").is_file() || pkg_path.join("mcp").is_dir() {
+                    continue;
+                }
+                let skills_dir = pkg_path.join("skills");
                 let Ok(rd) = std::fs::read_dir(&skills_dir) else {
                     continue;
                 };
@@ -550,7 +591,9 @@ impl SkillMarketplaceManager {
                             match staged_ok.then(|| std::fs::rename(&dir, &dest)) {
                                 Some(Ok(())) => {
                                     rehomed_this_run.push(dest);
-                                    report.rehomed.push(format!("{pkg}/{name} → {owner}/{name}"));
+                                    report
+                                        .rehomed
+                                        .push(format!("{pkg}/{name} → {owner}/{name}"));
                                 }
                                 _ => log::warn!(
                                     "[skill-marketplace] 错位技能归位失败（{} → {}），下个启动周期重试",
@@ -585,7 +628,15 @@ impl SkillMarketplaceManager {
                 if !matches!(record.source, super::store::BundleSource::Upload(_)) {
                     continue;
                 }
+                // Package-layout ownership guard: plugin_import registers one
+                // record per package whose id is the package id — not
+                // necessarily a skill dir name (multi-skill packages,
+                // plugin.json id != skill names, pure-MCP uploads with no
+                // skills/ at all). The existing package dir is the content
+                // proof; only a record with neither skill dir nor package dir
+                // is stale.
                 if self.find_skill_dir(&record.id).is_none()
+                    && !self.packages_root.join(&record.id).is_dir()
                     && self.bundle_store.remove(&record.id).is_ok()
                 {
                     report.removed_stale_records.push(record.id.clone());
@@ -635,7 +686,11 @@ impl SkillMarketplaceManager {
     /// 卸载:按**实际物理位置**删除（不按认领现算——认领随安装态时变，现算
     /// 会在认领翻转后算错目录、把滞留副本判成"非市场安装"，F1/F3）：
     /// - `bundles/*/skills/<name>` 全部候选副本（按包聚合布局 = 市场属主证明）；
-    /// - 旧扁平布局残留要求带 `.installed-from` 标记才删（保护内置/手放目录）；
+    /// - legacy flat-layout residue is deleted only when it carries the
+    ///   `.installed-from` marker. Unmarked `bundle/skills/` dirs are refused
+    ///   here — that area is builtin-managed (unmarked residue there is
+    ///   converged by self-heal step 4), and hand-placed user skills belong
+    ///   in `~/.pinvou3/user/skills/`;
     /// - 目录已不存在（外部删除/安装中途失败）时仍删 BundleStore 记录——记录
     ///   即安装态登记，删记录不以目录存在为前提，否则卡成永远"已安装"的瘫记录。
     pub fn uninstall(&self, skill_id: &str) -> Result<(), String> {
@@ -765,6 +820,29 @@ impl SkillMarketplaceManager {
         if RETIRED_SKILL_NAMES.contains(&name.as_str()) {
             return Err(format!("技能名 '{name}' 与已下线内置冲突,拒绝"));
         }
+        // Preset/companion name collisions are rejected up front: the market
+        // lifecycle (post-install sweep, claim-driven rehome in self-heal)
+        // owns these names, so an uploaded copy would be shadowed or swept
+        // away (review: collision must not escalate from shadowed to swept).
+        if is_preset_skill_name(&name) {
+            return Err(format!("技能名 '{name}' 与市场预置技能冲突，请改名后重试"));
+        }
+        let owner = super::bundle::skill_owner_package(&name);
+        if owner != name {
+            return Err(format!(
+                "技能名 '{name}' 已被包 '{owner}' 的配套技能占用，请改名后重试"
+            ));
+        }
+        // A copy under another package dir would be swept by the post-install
+        // dedupe below — destroying that package's component. Reject instead.
+        if let Some(other) = foreign_skill_copies_under(&self.packages_root, &name, &name)
+            .into_iter()
+            .next()
+        {
+            return Err(format!(
+                "技能 '{name}' 已存在于包 '{other}'，请先卸载该包或改名后重试"
+            ));
+        }
 
         // pass2:写出 skill_root 子树到 staged（上传技能独立成包：bundles/<name>/skills/）
         let dest = self.packages_root.join(&name).join("skills").join(&name);
@@ -879,7 +957,10 @@ impl SkillMarketplaceManager {
     ///   退役技能会永久残留并被物化进会话（五轮评审必修 3）；
     /// - CLI companion（无标记，内置清单目录名）：连接器当前可见才移动；不可见 =
     ///   断开后的残留，按门控语义删除（immutable 资源，重连重解包，无用户数据）；
-    /// - 无标记的其它目录（内置释放技能 visual-design、手放目录）→ 不动；
+    /// - other unmarked dirs (builtin-released skills like visual-design) →
+    ///   untouched here; stale unmarked residue in `bundle/skills/` is
+    ///   converged by self-heal step 4. `bundle/skills/` is not user storage —
+    ///   hand-placed user skills belong in `~/.pinvou3/user/skills/`;
     /// - 目标已存在或 rename 失败 → 保留旧位置并 warn（读路径 `find_skill_dir`
     ///   对旧位置有回退，迁移下个启动周期自愈）。
     pub fn migrate_flat_skills_layout(&self) -> SkillsMigrationReport {
@@ -1024,7 +1105,10 @@ pub struct SkillsMigrationReport {
     pub moved: Vec<String>,
     /// 连接器不可见而按门控语义删除的 CLI companion 残留
     pub removed_stale: Vec<String>,
-    /// 未动：内置释放技能 / 手放目录 / 迁移失败保留旧位置
+    /// Untouched: builtin-released skills / migration-failed dirs kept at the
+    /// old location. (`bundle/skills/` unmarked residue is converged by
+    /// self-heal step 4; hand-placed user skills belong in
+    /// `~/.pinvou3/user/skills/`.)
     pub kept: Vec<String>,
 }
 
@@ -1348,6 +1432,43 @@ pub(crate) fn is_safe_skill_name(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Whether `skill_name` collides with a preset skill (embedded marketplace
+/// manifest, by frontmatter/dir name). Upload channels must reject such names
+/// up front: the preset install pipeline owns the name and its sweep/rehome
+/// lifecycle would destroy or absorb the uploaded copy.
+/// `pub(crate)`: the unified plugin import pipeline applies the same check.
+pub(crate) fn is_preset_skill_name(skill_name: &str) -> bool {
+    preset_manifests()
+        .iter()
+        .any(|m| m.skill_name == skill_name)
+}
+
+/// On-disk copies of `skill_name` under `<packages_root>/*/skills/` whose
+/// package dir name differs from `own_pkg` (staging dirs like `<id>.tmp` /
+/// `<id>.old` are excluded by the component-id check). Upload channels use
+/// this to reject cross-package name collisions up front: another package's
+/// copy must never be silently shadowed or swept away.
+/// `pub(crate)`: the unified plugin import pipeline applies the same check.
+pub(crate) fn foreign_skill_copies_under(
+    packages_root: &Path,
+    skill_name: &str,
+    own_pkg: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(packages_root) {
+        for entry in entries.flatten() {
+            let pkg = entry.file_name().to_string_lossy().into_owned();
+            if pkg == own_pkg || !super::plugin_import::is_safe_component_id(&pkg) {
+                continue;
+            }
+            if entry.path().join("skills").join(skill_name).is_dir() {
+                out.push(pkg);
+            }
+        }
+    }
+    out
 }
 
 /// 把任意字符串（文件名 stem 等）净化为合法技能名：非 `[a-zA-Z0-9_-]` 字符 → `-`，
@@ -1758,6 +1879,228 @@ mod tests {
         assert!(embedded.exists(), "内嵌集内目录应保留");
         assert!(marked.exists(), "带市场标记目录应留给布局迁移");
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Plugin-package layouts (plugin_import): one BundleStore record per
+    /// package whose id need not equal any skill dir name. self_heal must
+    /// leave package-owned content untouched on every launch — no rehome, no
+    /// orphan deletion, no stale-record removal — otherwise multi-skill
+    /// packages, id != skill name packages, and pure-MCP uploads lose user
+    /// content within two launches (review BLOCKER).
+    #[test]
+    fn self_heal_preserves_plugin_package_layouts() {
+        let tmp = fresh_dir("heal_plugin_layout");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        let write_skill = |pkg: &str, name: &str| {
+            let dir = tmp.join("bundles").join(pkg).join("skills").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("---\nname: {name}\n---\n")).unwrap();
+            dir
+        };
+        let upload_record = |id: &str| {
+            store
+                .upsert(
+                    crate::features::marketplace::store::BundleRecord::installed_now(
+                        id.to_string(),
+                        crate::features::marketplace::store::BundleSource::Upload(
+                            "pkg.zip".to_string(),
+                        ),
+                    ),
+                )
+                .unwrap();
+        };
+        // 1) Multi-skill package, record id = first skill name.
+        let alpha = write_skill("alpha", "alpha");
+        let beta = write_skill("alpha", "beta");
+        std::fs::write(tmp.join("bundles/alpha/plugin.json"), "{}").unwrap();
+        upload_record("alpha");
+        // 2) plugin.json id != skill component names.
+        let gamma = write_skill("combo", "gamma");
+        let delta = write_skill("combo", "delta");
+        std::fs::write(tmp.join("bundles/combo/plugin.json"), "{}").unwrap();
+        upload_record("combo");
+        // 3) Pure-MCP upload (no skills/ subtree at all).
+        let mcp_manifest = tmp.join("bundles/puremcp/mcp/manifest.json");
+        std::fs::create_dir_all(mcp_manifest.parent().unwrap()).unwrap();
+        std::fs::write(&mcp_manifest, "{}").unwrap();
+        std::fs::write(tmp.join("bundles/puremcp/plugin.json"), "{}").unwrap();
+        upload_record("puremcp");
+
+        for round in 1..=2 {
+            let report = mgr.self_heal_skills(&["visual-design"]);
+            assert!(alpha.join("SKILL.md").is_file(), "round {round}: alpha");
+            assert!(beta.join("SKILL.md").is_file(), "round {round}: beta");
+            assert!(gamma.join("SKILL.md").is_file(), "round {round}: gamma");
+            assert!(delta.join("SKILL.md").is_file(), "round {round}: delta");
+            assert!(mcp_manifest.is_file(), "round {round}: pure-MCP manifest");
+            assert!(
+                report.rehomed.is_empty()
+                    && report.deduped.is_empty()
+                    && report.removed_orphan_dirs.is_empty()
+                    && report.removed_stale_records.is_empty(),
+                "round {round}: package-owned content must be untouched: {report:?}"
+            );
+            for id in ["alpha", "combo", "puremcp"] {
+                assert!(
+                    store.get(id).unwrap().is_some(),
+                    "round {round}: package record {id} must survive"
+                );
+            }
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// MCP-bearing package without plugin.json (preset MCP release layout):
+    /// its skills/ subtree is package-owned even when the claim no longer
+    /// resolves (store record gone) — fail closed, leave content in place
+    /// instead of rehoming it into a phantom standalone package.
+    #[test]
+    fn self_heal_keeps_skills_under_mcp_bearing_package() {
+        let tmp = fresh_dir("heal_mcp_sibling");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        // Unrelated record so bundles.json exists (record-dependent steps run).
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "unrelated".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("x.zip".to_string()),
+                ),
+            )
+            .unwrap();
+        let skill = tmp.join("bundles/gongwen/skills/ghost-helper");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(skill.join("SKILL.md"), "---\nname: ghost-helper\n---\n").unwrap();
+        std::fs::create_dir_all(tmp.join("bundles/gongwen/mcp")).unwrap();
+        std::fs::write(tmp.join("bundles/gongwen/mcp/manifest.json"), "{}").unwrap();
+
+        for round in 1..=2 {
+            let report = mgr.self_heal_skills(&["visual-design"]);
+            assert!(
+                skill.join("SKILL.md").is_file(),
+                "round {round}: skill under mcp-bearing package must stay put"
+            );
+            assert!(
+                !tmp.join("bundles/ghost-helper").exists(),
+                "round {round}: must not rehome into a phantom standalone package"
+            );
+            assert!(
+                report.rehomed.is_empty() && report.removed_orphan_dirs.is_empty(),
+                "round {round}: {report:?}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A missing bundles.json must not be treated as an empty registry: with
+    /// the store file absent, self-heal skips the record-dependent steps
+    /// (orphan/stale/converge) instead of mass-deleting unregistered skills.
+    #[test]
+    fn self_heal_fail_closed_when_store_file_missing() {
+        let tmp = fresh_dir("heal_no_store");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let orphan = tmp.join("bundles/orphan-skill/skills/orphan-skill");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("SKILL.md"), "---\nname: orphan-skill\n---\n").unwrap();
+        let stale_builtin = tmp.join("bundle/skills/old-thing");
+        std::fs::create_dir_all(&stale_builtin).unwrap();
+        std::fs::write(
+            stale_builtin.join("SKILL.md"),
+            "---\nname: old-thing\n---\n",
+        )
+        .unwrap();
+
+        let report = mgr.self_heal_skills(&["visual-design"]);
+        assert!(orphan.exists(), "store 缺失时孤儿判定不得执行");
+        assert!(stale_builtin.exists(), "store 缺失时内置收敛不得执行");
+        assert!(report.removed_orphan_dirs.is_empty());
+        assert!(report.removed_stale_records.is_empty());
+        assert!(report.converged_builtin_dirs.is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Upload channels reject preset/companion/cross-package name collisions
+    /// up front instead of shadowing or sweeping package-owned copies
+    /// (review MINOR: collision must not escalate from shadowed to swept).
+    #[test]
+    fn import_rejects_colliding_skill_names() {
+        use std::io::Write;
+        let tmp = fresh_dir("import_collision");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let write_zip = |file: &str, name: &str| {
+            let zip_path = tmp.join(file);
+            let f = std::fs::File::create(&zip_path).unwrap();
+            let mut zw = zip::ZipWriter::new(f);
+            let opts = zip::write::SimpleFileOptions::default();
+            zw.start_file("s/SKILL.md", opts).unwrap();
+            zw.write_all(format!("---\nname: {name}\n---\n# hi").as_bytes())
+                .unwrap();
+            zw.finish().unwrap();
+            zip_path
+        };
+
+        // Preset skill name → reject.
+        let zip_path = write_zip("preset.zip", "visualizer");
+        let err = mgr.import_package(zip_path.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("预置技能冲突"), "实际: {err}");
+
+        // Skill already on disk under another package dir → reject (the
+        // post-install sweep would otherwise destroy that package's copy).
+        let foreign = tmp.join("bundles/other-pkg/skills/taken-skill");
+        std::fs::create_dir_all(&foreign).unwrap();
+        std::fs::write(foreign.join("SKILL.md"), "---\nname: taken-skill\n---\n").unwrap();
+        let zip_path = write_zip("taken.zip", "taken-skill");
+        let err = mgr.import_package(zip_path.to_str().unwrap()).unwrap_err();
+        assert!(err.contains("已存在于包 'other-pkg'"), "实际: {err}");
+        assert!(foreign.join("SKILL.md").is_file(), "外来副本不得被动");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Companion-claimed name collision (claim depends on install state, so
+    /// this test needs an env-isolated home with an installed MCP package
+    /// whose manifest declares the skill as companion).
+    #[test]
+    fn import_rejects_companion_claimed_skill_name() {
+        use std::io::Write;
+        with_temp_home(|| {
+            let home = paths::pinvou3_home();
+            // Installed custom MCP package claiming "helper-skill" as companion.
+            let manifest_dir = home.join("bundles/custom-mcp/mcp");
+            std::fs::create_dir_all(&manifest_dir).unwrap();
+            std::fs::write(
+                manifest_dir.join("manifest.json"),
+                r#"{"id":"custom-mcp","name":"x","description":"d","version":"1.0.0","icon":"","category":"office","mcp_tools":[],"command":"python","args":["server.py"],"companion_skills":["helper-skill"]}"#,
+            )
+            .unwrap();
+            crate::features::marketplace::store::BundleStore::new()
+                .upsert(
+                    crate::features::marketplace::store::BundleRecord::installed_now(
+                        "custom-mcp".to_string(),
+                        crate::features::marketplace::store::BundleSource::Upload(
+                            "x.zip".to_string(),
+                        ),
+                    ),
+                )
+                .unwrap();
+            let zip_path = home.join("companion.zip");
+            {
+                let f = std::fs::File::create(&zip_path).unwrap();
+                let mut zw = zip::ZipWriter::new(f);
+                let opts = zip::write::SimpleFileOptions::default();
+                zw.start_file("s/SKILL.md", opts).unwrap();
+                zw.write_all(b"---\nname: helper-skill\n---\n# hi").unwrap();
+                zw.finish().unwrap();
+            }
+            let mgr = SkillMarketplaceManager::new();
+            let err = mgr.import_package(zip_path.to_str().unwrap()).unwrap_err();
+            assert!(
+                err.contains("配套技能占用"),
+                "companion 撞名应拒收，实际: {err}"
+            );
+        });
     }
 
     /// 预置 pptx 从嵌入资源落盘 → list 反映 installed → 卸载删目录的全链路。

--- a/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
@@ -203,12 +203,20 @@ impl SkillMarketplaceManager {
     }
 
     /// 测试用：三套根都指到同一临时目录下，不碰真实 ~/.pinvou3。
+    /// 认领（`skill_owner_package` → `bundle_installed`）经全局 env 读家目录，
+    /// 须持 ENV_LOCK 与 env-mutating 测试串行——否则并行窗口内认领翻转，
+    /// `package_skill_dir` 推导结果不稳定（测试间互相制造 flaky）。
     #[cfg(test)]
-    fn with_roots(dir: PathBuf) -> Self {
-        Self {
-            packages_root: dir.join("bundles"),
-            legacy_skills_dir: dir.join("bundle/skills"),
-            bundle_store: super::store::BundleStore::with_file(dir.join("bundles.json")),
+    fn with_roots(dir: PathBuf) -> LockedSkillManager {
+        LockedSkillManager {
+            _guard: crate::platform::paths::tests::ENV_LOCK
+                .lock()
+                .unwrap_or_else(|p| p.into_inner()),
+            inner: Self {
+                packages_root: dir.join("bundles"),
+                legacy_skills_dir: dir.join("bundle/skills"),
+                bundle_store: super::store::BundleStore::with_file(dir.join("bundles.json")),
+            },
         }
     }
 
@@ -221,15 +229,16 @@ impl SkillMarketplaceManager {
             .join(skill_name)
     }
 
-    /// 已装技能目录定位：新布局（按包聚合 `bundles/<pkg>/skills/<name>`）优先；
-    /// 旧扁平布局 `bundle/skills/<name>` 回退读取——一次性迁移
+    /// 已装技能目录定位：认领包目录 → 其余 `bundles/*/skills/<name>` 滞留副本
+    /// （认领翻转/迁移失败留下的，see `package_candidate_dirs`）→ 旧扁平布局
+    /// `bundle/skills/<name>` 回退读取——一次性迁移
     /// （`migrate_flat_skills_layout`）失败或目标已存在时保留旧位置，读路径在此
-    /// 兜底，避免迁移失败后 is_installed / list / uninstall 与技能失联（迁移
-    /// 下个启动周期自愈）。
+    /// 兜底，避免迁移失败/认领翻转后 is_installed / list / uninstall 与技能失联。
     pub(crate) fn find_skill_dir(&self, skill_name: &str) -> Option<PathBuf> {
-        let new_path = self.package_skill_dir(skill_name);
-        if new_path.is_dir() {
-            return Some(new_path);
+        for cand in self.package_candidate_dirs(skill_name) {
+            if cand.is_dir() {
+                return Some(cand);
+            }
         }
         let legacy_path = self.legacy_skills_dir.join(skill_name);
         if legacy_path.is_dir() {
@@ -398,11 +407,22 @@ impl SkillMarketplaceManager {
             }
         };
 
-        let _ = std::fs::remove_dir_all(&dest);
+        // 与 mcp_catalog::release_package 同一纪律：删旧目录失败即中止（吞错误
+        // 会让"删一半"的残缺目录静默残留，rename 也必然失败）。
+        if dest.exists() {
+            std::fs::remove_dir_all(&dest).map_err(|e| {
+                let _ = std::fs::remove_dir_all(&staged);
+                format!("清理旧技能目录失败（已中止，原目录可能部分删除）: {e}")
+            })?;
+        }
         std::fs::rename(&staged, &dest).map_err(|e| {
             let _ = std::fs::remove_dir_all(&staged);
             format!("落盘: {e}")
         })?;
+
+        // 一个技能只留一份市场副本：清扫认领翻转滞留/双份安装的其余物理副本
+        // （F2：独立安装后又装 companion MCP；F3：迁移 kept 留下的双份）。
+        self.sweep_duplicate_skill_dirs(m.skill_name, &dest);
 
         // 登记（预置 source=Preset + 内容指纹；更新走同一 install 管线，
         // upsert_preserving 保留首次安装时间）。失败只记日志，目录落盘仍是权威。
@@ -418,8 +438,207 @@ impl SkillMarketplaceManager {
         Ok(())
     }
 
-    /// 卸载:删包目录内的技能目录（包目录 = 市场属主证明，无需再验标记）；
-    /// 旧扁平布局残留要求带 `.installed-from` 标记才删（保护内置/手放目录）。
+    /// `bundles/*/skills/<name>` 的全部候选（认领目录 + 其余包目录下的滞留
+    /// 副本）。认领（`skill_owner_package`）随安装态时变，认领翻转/迁移失败/
+    /// 双份安装都会留下与现算认领不一致的物理副本（F1/F2）；按包聚合布局本身
+    /// 即市场属主契约，扫描只用于定位/删除市场副本，不碰用户目录。
+    fn package_candidate_dirs(&self, skill_name: &str) -> Vec<PathBuf> {
+        let mut out = vec![self.package_skill_dir(skill_name)];
+        if let Ok(entries) = std::fs::read_dir(&self.packages_root) {
+            for entry in entries.flatten() {
+                let cand = entry.path().join("skills").join(skill_name);
+                if cand.is_dir() && !out.contains(&cand) {
+                    out.push(cand);
+                }
+            }
+        }
+        out
+    }
+
+    /// 落盘后清扫同名技能的其余物理副本，保证一个技能只有一份市场副本：
+    /// 其余 `bundles/*/skills/<name>`（滞留/双份）与带市场标记的旧扁平目录
+    /// 一律删除；无标记旧扁平是内置/手放保护对象（extraction 清理契约），不动。
+    fn sweep_duplicate_skill_dirs(&self, skill_name: &str, keep: &Path) {
+        for dir in self.package_candidate_dirs(skill_name) {
+            if dir == *keep || !dir.is_dir() {
+                continue;
+            }
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                log::warn!("[skill-marketplace] 清扫重复技能副本失败（{}）: {e}", dir.display());
+                continue;
+            }
+            if let Some(skills_parent) = dir.parent() {
+                let _ = std::fs::remove_dir(skills_parent); // 仅空目录能删掉
+                if let Some(pkg_dir) = skills_parent.parent() {
+                    let _ = std::fs::remove_dir(pkg_dir);
+                }
+            }
+        }
+        let legacy = self.legacy_skills_dir.join(skill_name);
+        if legacy != *keep && legacy.is_dir() && legacy.join(INSTALLED_FROM_MARKER).is_file() {
+            if let Err(e) = std::fs::remove_dir_all(&legacy) {
+                log::warn!(
+                    "[skill-marketplace] 清扫旧布局技能副本失败（{}）: {e}",
+                    legacy.display()
+                );
+            }
+        }
+    }
+
+    /// 自愈对账（名称无关，按**归属证明**判定残旧；各发行版构建自动适配——
+    /// 判定只依赖「本构建内嵌什么 / 登记在册什么 / CLI 门控静态所有什么」，
+    /// 不使用任何硬编码技能名单）。启动路径在技能布局迁移之后、CLI gates 之前
+    /// 调用。返回报告供启动标记观测。
+    ///
+    /// 1. **认领错位归位**：`bundles/<pkg>/skills/<name>` 的活认领（
+    ///    `skill_owner_package`，随安装态时变）≠ pkg → 正确位置已有副本则去重
+    ///    删除（按包聚合布局 = 市场属主契约），无则移动归位（保留用户安装；
+    ///    rename 失败保留，下个启动周期重试）。
+    /// 2. **孤儿副本清理**：`bundles/` 下技能目录无 BundleStore 记录、非预置
+    ///    技能（可重释放）、非 CLI 门控静态所有 → 残旧删除。store 不可读 →
+    ///    整段跳过（fail-closed：登记丢失时不得误删用户安装）。
+    /// 3. **瘫记录清理**：Upload 记录但任何候选位置都找不到目录 → 内容不可
+    ///    再生，记录即死配置，删除（Preset/Builtin 保留：可重释放/再装）。
+    /// 4. **内置释放目录收敛**：`bundle/skills/` 下无市场标记、无记录、且不在
+    ///    当前构建内嵌内置集 `builtin_released` 的目录 → 残旧删除。其它发行版
+    ///    内嵌同名技能（如集团版 eip）时它在其内置集内，自然保留——这正是
+    ///    与「按名单清理」的本质区别。带标记目录留给布局迁移处理。
+    pub fn self_heal_skills(&self, builtin_released: &[&str]) -> SkillSelfHealReport {
+        let mut report = SkillSelfHealReport::default();
+        let records = self.bundle_store.records().ok();
+        if records.is_none() {
+            // fail-closed：登记读不出时只做不依赖登记的错位归位
+            log::warn!("[skill-marketplace] BundleStore 不可读，自愈仅执行认领错位归位");
+        }
+
+        // 1 + 2：扫描 bundles/<pkg>/skills/<name>。本轮归位落入的目标目录跳过
+        // 当轮孤儿判定（read_dir 顺序不定，归位目标可能在本轮稍后被扫到；
+        // 无记录的归位副本留给下轮对账，不在同轮边搬边删）。
+        let mut rehomed_this_run: Vec<PathBuf> = Vec::new();
+        if let Ok(pkgs) = std::fs::read_dir(&self.packages_root) {
+            for pkg_entry in pkgs.flatten() {
+                let pkg = pkg_entry.file_name().to_string_lossy().into_owned();
+                let skills_dir = pkg_entry.path().join("skills");
+                let Ok(rd) = std::fs::read_dir(&skills_dir) else {
+                    continue;
+                };
+                for entry in rd.flatten() {
+                    let dir = entry.path();
+                    if !dir.is_dir() {
+                        continue;
+                    }
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if !is_safe_skill_name(&name) {
+                        continue;
+                    }
+                    let owner = super::bundle::skill_owner_package(&name);
+                    if owner != pkg {
+                        // 1. 错位归位/去重
+                        let dest = self.packages_root.join(&owner).join("skills").join(&name);
+                        if dest.is_dir() {
+                            if std::fs::remove_dir_all(&dir).is_ok() {
+                                report.deduped.push(format!("{pkg}/{name}"));
+                            }
+                        } else {
+                            let staged_ok = dest
+                                .parent()
+                                .map(|p| std::fs::create_dir_all(p).is_ok())
+                                .unwrap_or(false);
+                            match staged_ok.then(|| std::fs::rename(&dir, &dest)) {
+                                Some(Ok(())) => {
+                                    rehomed_this_run.push(dest);
+                                    report.rehomed.push(format!("{pkg}/{name} → {owner}/{name}"));
+                                }
+                                _ => log::warn!(
+                                    "[skill-marketplace] 错位技能归位失败（{} → {}），下个启动周期重试",
+                                    dir.display(),
+                                    dest.display()
+                                ),
+                            }
+                        }
+                        continue;
+                    }
+                    // 2. 孤儿（无记录 + 非预置 + 非 CLI 静态所有 + 非本轮归位）
+                    if let Some(recs) = &records {
+                        if !self.has_install_record(recs, &name)
+                            && self.preset_by_skill_name(&name).is_none()
+                            && super::bundle::cli_bundle_of_skill(&name).is_none()
+                            && !rehomed_this_run.iter().any(|d| d == &dir)
+                            && std::fs::remove_dir_all(&dir).is_ok()
+                        {
+                            report.removed_orphan_dirs.push(format!("{pkg}/{name}"));
+                        }
+                    }
+                }
+                // 清理腾空的 skills/ 与包目录（仅空目录能删掉）
+                let _ = std::fs::remove_dir(&skills_dir);
+                let _ = std::fs::remove_dir(pkg_entry.path());
+            }
+        }
+
+        if let Some(recs) = &records {
+            // 3. 瘫记录（Upload 且无目录）
+            for record in recs {
+                if !matches!(record.source, super::store::BundleSource::Upload(_)) {
+                    continue;
+                }
+                if self.find_skill_dir(&record.id).is_none()
+                    && self.bundle_store.remove(&record.id).is_ok()
+                {
+                    report.removed_stale_records.push(record.id.clone());
+                }
+            }
+
+            // 4. 内置释放目录收敛
+            if let Ok(rd) = std::fs::read_dir(&self.legacy_skills_dir) {
+                for entry in rd.flatten() {
+                    let dir = entry.path();
+                    if !dir.is_dir() {
+                        continue;
+                    }
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if !is_safe_skill_name(&name)
+                        || builtin_released.contains(&name.as_str())
+                        || dir.join(INSTALLED_FROM_MARKER).is_file()
+                        || self.has_install_record(recs, &name)
+                    {
+                        continue;
+                    }
+                    if std::fs::remove_dir_all(&dir).is_ok() {
+                        report.converged_builtin_dirs.push(name);
+                    }
+                }
+            }
+        }
+
+        report
+    }
+
+    /// 技能是否有安装登记：记录 id = 目录名（上传/同名预置），或预置 id 与
+    /// 技能名异名（如 tencent-docs-skill ↔ tencent-docs）时按预置 id 命中。
+    fn has_install_record(
+        &self,
+        records: &[super::store::BundleRecord],
+        skill_name: &str,
+    ) -> bool {
+        records.iter().any(|r| r.id == skill_name)
+            || self
+                .preset_by_skill_name(skill_name)
+                .is_some_and(|m| records.iter().any(|r| r.id == m.id))
+    }
+
+    fn preset_by_skill_name(&self, skill_name: &str) -> Option<&'static SkillManifest> {
+        preset_manifests()
+            .iter()
+            .find(|m| m.skill_name == skill_name)
+    }
+
+    /// 卸载:按**实际物理位置**删除（不按认领现算——认领随安装态时变，现算
+    /// 会在认领翻转后算错目录、把滞留副本判成"非市场安装"，F1/F3）：
+    /// - `bundles/*/skills/<name>` 全部候选副本（按包聚合布局 = 市场属主证明）；
+    /// - 旧扁平布局残留要求带 `.installed-from` 标记才删（保护内置/手放目录）；
+    /// - 目录已不存在（外部删除/安装中途失败）时仍删 BundleStore 记录——记录
+    ///   即安装态登记，删记录不以目录存在为前提，否则卡成永远"已安装"的瘫记录。
     pub fn uninstall(&self, skill_id: &str) -> Result<(), String> {
         // 预置 id(pua/nuwa) → skill_name;上传技能 id 即目录名本身。
         let dir_name = self
@@ -429,27 +648,30 @@ impl SkillMarketplaceManager {
         if !is_safe_skill_name(&dir_name) {
             return Err(format!("非法技能名 '{dir_name}'"));
         }
-        let dir = self.package_skill_dir(&dir_name);
-        if !dir.is_dir() {
-            // 旧布局残留（迁移未跑/失败）：沿用标记保护语义删除
-            let legacy = self.legacy_skills_dir.join(&dir_name);
-            if legacy.is_dir() && legacy.join(INSTALLED_FROM_MARKER).is_file() {
-                std::fs::remove_dir_all(&legacy).map_err(|e| format!("删除失败: {e}"))?;
-                if let Err(e) = self.bundle_store.remove(skill_id) {
-                    log::warn!("[skill-marketplace] bundles.json 镜像删除失败（uninstall {skill_id}）: {e}");
+        let legacy = self.legacy_skills_dir.join(&dir_name);
+        let mut deleted_any = false;
+        for dir in self.package_candidate_dirs(&dir_name) {
+            if !dir.is_dir() {
+                continue;
+            }
+            std::fs::remove_dir_all(&dir).map_err(|e| format!("删除失败: {e}"))?;
+            deleted_any = true;
+            // 清理腾空的父目录（skills/ 空 → 删；独立包的 bundles/<id>/ 空 → 删；
+            // companion 的包目录还装着 MCP 资源，非空自然保留）
+            if let Some(skills_parent) = dir.parent() {
+                let _ = std::fs::remove_dir(skills_parent); // 仅空目录能删掉
+                if let Some(pkg_dir) = skills_parent.parent() {
+                    let _ = std::fs::remove_dir(pkg_dir);
                 }
-                return Ok(());
             }
-            return Err(format!("技能 '{dir_name}' 非市场安装(不在包目录),拒绝删除"));
         }
-        std::fs::remove_dir_all(&dir).map_err(|e| format!("删除失败: {e}"))?;
-        // 清理腾空的父目录（skills/ 空 → 删；独立包的 bundles/<id>/ 空 → 删；
-        // companion 的包目录还装着 MCP 资源，非空自然保留）
-        if let Some(skills_parent) = dir.parent() {
-            let _ = std::fs::remove_dir(skills_parent); // 仅空目录能删掉
-            if let Some(pkg_dir) = skills_parent.parent() {
-                let _ = std::fs::remove_dir(pkg_dir);
-            }
+        if legacy.is_dir() && legacy.join(INSTALLED_FROM_MARKER).is_file() {
+            std::fs::remove_dir_all(&legacy).map_err(|e| format!("删除失败: {e}"))?;
+            deleted_any = true;
+        }
+        if !deleted_any && legacy.is_dir() {
+            // 只剩无标记旧扁平目录：内置/手放保护对象，维持拒绝语义且不动记录。
+            return Err(format!("技能 '{dir_name}' 非市场安装(不在包目录),拒绝删除"));
         }
         // 镜像删除（预置 id 即记录 id；上传技能 id = 目录名，与 install 的登记口径一致）。
         if let Err(e) = self.bundle_store.remove(skill_id) {
@@ -621,11 +843,19 @@ impl SkillMarketplaceManager {
             }
         };
 
-        let _ = std::fs::remove_dir_all(&dest);
+        // 与 preset install 同一纪律：删旧目录失败即中止，不留"删一半"残缺目录。
+        if dest.exists() {
+            std::fs::remove_dir_all(&dest).map_err(|e| {
+                let _ = std::fs::remove_dir_all(&staged);
+                format!("清理旧技能目录失败（已中止，原目录可能部分删除）: {e}")
+            })?;
+        }
         std::fs::rename(&staged, &dest).map_err(|e| {
             let _ = std::fs::remove_dir_all(&staged);
             format!("落盘: {e}")
         })?;
+        // 一个技能只留一份市场副本：清扫认领翻转滞留/双份安装的其余物理副本。
+        self.sweep_duplicate_skill_dirs(&name, &dest);
         // 登记（上传 source=Upload(zip 展示名) + 内容指纹，记录 id = 落盘技能名，
         // 与 import_legacy 的反推口径一致；`.installed-from` 标记已退役）。失败只记日志。
         let mut record = super::store::BundleRecord::installed_now(
@@ -799,6 +1029,22 @@ pub struct SkillsMigrationReport {
     pub kept: Vec<String>,
 }
 
+/// 自愈对账报告（启动标记/日志观测用），见
+/// [`SkillMarketplaceManager::self_heal_skills`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SkillSelfHealReport {
+    /// 认领错位后移动归位的 `<旧pkg>/<name> → <认领pkg>/<name>`
+    pub rehomed: Vec<String>,
+    /// 认领错位且正确位置已有副本，去重删除的 `<pkg>/<name>`
+    pub deduped: Vec<String>,
+    /// 无记录、非预置、非 CLI 静态所有的孤儿副本 `<pkg>/<name>`
+    pub removed_orphan_dirs: Vec<String>,
+    /// 任何位置都找不到目录的 Upload 瘫记录 id
+    pub removed_stale_records: Vec<String>,
+    /// 内置释放目录收敛删除的残旧目录名
+    pub converged_builtin_dirs: Vec<String>,
+}
+
 // 辅助 ------------------------------------------------------------------------
 
 /// 迁移期 companion 归属映射：扫描旧布局 `bundle/mcp-servers/<id>/manifest.json`
@@ -836,14 +1082,35 @@ fn legacy_companion_owners() -> std::collections::HashMap<String, String> {
     map
 }
 
+/// `with_roots` 的返回包装：持有 ENV_LOCK 的 manager，经 Deref 透明调用方法，
+/// guard 随测试绑定结束自动释放。
+#[cfg(test)]
+struct LockedSkillManager {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    inner: SkillMarketplaceManager,
+}
+
+#[cfg(test)]
+impl std::ops::Deref for LockedSkillManager {
+    type Target = SkillMarketplaceManager;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
 /// 收集嵌入资源子树的 `(相对路径, 内容)` 列表,供更新检测比对。
-/// 口径与 [`extract_embedded_subdir`] 一致:strip `source_dir` 前缀、跳过 SOURCE.md。
+/// 口径与 [`extract_embedded_subdir`] 一致:strip `source_dir` 前缀、跳过 SOURCE.md、
+/// 跳过 `__pycache__`/`*.pyc`——否则构建期混入的 pyc 会让内嵌指纹永远 ≠ 落盘
+/// 指纹，`update_available` 幽灵常亮（G6）。
 fn collect_embedded_files(dir: &Dir<'_>, source_dir: &str, out: &mut Vec<(String, Vec<u8>)>) {
     let prefix = format!("{source_dir}/");
     for file in dir.files() {
         let p = file.path().to_string_lossy();
         let rel = p.strip_prefix(&prefix).unwrap_or(&p);
         if Path::new(rel).file_name().and_then(|s| s.to_str()) == Some("SOURCE.md") {
+            continue;
+        }
+        if is_python_cache_path(Path::new(rel)) {
             continue;
         }
         out.push((rel.to_string(), file.contents().to_vec()));
@@ -1250,6 +1517,229 @@ mod tests {
             .list_skills()
             .iter()
             .any(|s| s.id == "government-writing" && !s.installed));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// F1 回归：认领翻转后的滞留副本（物理在 `bundles/<其他包>/skills/<name>`，
+    /// 与现算认领目录不一致）必须可按实际物理位置删除并清除记录——旧实现按
+    /// 认领现算目录，判「非市场安装」让残留永驻且持续物化进会话。
+    #[test]
+    fn uninstall_removes_stranded_claim_mismatch_copy() {
+        let tmp = fresh_dir("stranded");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let stranded = tmp.join("bundles/gongwen/skills/ghost-writer");
+        std::fs::create_dir_all(&stranded).unwrap();
+        std::fs::write(stranded.join("SKILL.md"), "---\nname: ghost-writer\n---\n").unwrap();
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "ghost-writer".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("x.zip".to_string()),
+                ),
+            )
+            .unwrap();
+        // 现算认领目录（未知技能 owner=自身）并不存在——旧实现在此报错
+        assert!(!mgr.package_skill_dir("ghost-writer").is_dir());
+        // find_skill_dir 应能定位滞留副本（可见、可管）
+        assert_eq!(mgr.find_skill_dir("ghost-writer"), Some(stranded.clone()));
+
+        mgr.uninstall("ghost-writer").unwrap();
+        assert!(!stranded.exists(), "滞留副本应被删除");
+        assert!(
+            !tmp.join("bundles/gongwen").exists(),
+            "腾空的包目录应被清理"
+        );
+        assert!(
+            store.get("ghost-writer").unwrap().is_none(),
+            "记录应同步删除"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// 瘫记录回归：目录已不存在（外部删除/安装中途失败）时卸载仍须删记录——
+    /// 记录即安装态登记，删记录不以目录存在为前提，否则卡成永远「已安装」。
+    #[test]
+    fn uninstall_removes_record_when_dir_missing() {
+        let tmp = fresh_dir("ghostrec");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "ghost-skill".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("x.zip".to_string()),
+                ),
+            )
+            .unwrap();
+        mgr.uninstall("ghost-skill").unwrap();
+        assert!(store.get("ghost-skill").unwrap().is_none());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// 保护契约回归：只剩无标记旧扁平目录（内置/手放）时仍拒绝删除。
+    #[test]
+    fn uninstall_still_protects_unmarked_legacy_dir() {
+        let tmp = fresh_dir("protect_unmarked");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let legacy = tmp.join("bundle/skills/hand-placed");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("SKILL.md"), "---\nname: hand-placed\n---\n").unwrap();
+        assert!(mgr.uninstall("hand-placed").is_err(), "无标记旧扁平应拒绝");
+        assert!(legacy.join("SKILL.md").is_file(), "保护对象不得被动");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// F2/F3 回归：install 落盘后清扫同名其余物理副本（滞留包目录 + 带标记
+    /// 旧扁平），保证一个技能只有一份市场副本；无标记旧扁平（内置/手放）不动。
+    #[test]
+    fn install_sweeps_duplicate_copies() {
+        let tmp = fresh_dir("sweep");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let stray = tmp.join("bundles/stray-pkg/skills/government-writing");
+        std::fs::create_dir_all(&stray).unwrap();
+        std::fs::write(
+            stray.join("SKILL.md"),
+            "---\nname: government-writing\n---\nstray",
+        )
+        .unwrap();
+        let legacy = tmp.join("bundle/skills/government-writing");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("SKILL.md"),
+            "---\nname: government-writing\n---\nlegacy",
+        )
+        .unwrap();
+        std::fs::write(
+            legacy.join(".installed-from"),
+            "pinvou3-marketplace:government-writing",
+        )
+        .unwrap();
+
+        mgr.install("government-writing").unwrap();
+        let dest = mgr.package_skill_dir("government-writing");
+        assert!(dest.join("SKILL.md").is_file());
+        assert!(!stray.exists(), "滞留副本应被清扫");
+        assert!(!legacy.exists(), "带标记旧扁平副本应被清扫");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// 自愈对账回归：认领错位目录归位（无正确副本 → 移动保留用户安装；
+    /// 有正确副本 → 去重删除）。判定名称无关，纯归属证明驱动。
+    #[test]
+    fn self_heal_rehomes_and_dedupes_claim_mismatch() {
+        let tmp = fresh_dir("heal_rehome");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        // ghost-skill 活认领 = 自身（未知技能），物理在 wrong-pkg 下 = 错位
+        let stray = tmp.join("bundles/wrong-pkg/skills/ghost-skill");
+        std::fs::create_dir_all(&stray).unwrap();
+        std::fs::write(stray.join("SKILL.md"), "---\nname: ghost-skill\n---\n").unwrap();
+        // dup-skill 同样错位，且正确位置已有副本
+        let dup_stray = tmp.join("bundles/wrong-pkg/skills/dup-skill");
+        std::fs::create_dir_all(&dup_stray).unwrap();
+        std::fs::write(dup_stray.join("SKILL.md"), "---\nname: dup-skill\n---\nstray").unwrap();
+        let dup_right = tmp.join("bundles/dup-skill/skills/dup-skill");
+        std::fs::create_dir_all(&dup_right).unwrap();
+        std::fs::write(dup_right.join("SKILL.md"), "---\nname: dup-skill\n---\nright").unwrap();
+        // 正确位置副本需有登记（生产语义：已装技能必有记录），否则它自身即孤儿
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "dup-skill".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("x.zip".to_string()),
+                ),
+            )
+            .unwrap();
+
+        let report = mgr.self_heal_skills(&["visual-design"]);
+        let rightful = tmp.join("bundles/ghost-skill/skills/ghost-skill");
+        assert!(rightful.join("SKILL.md").is_file(), "错位副本应归位");
+        assert!(!stray.exists(), "原错位目录应消失");
+        assert_eq!(report.rehomed.len(), 1);
+        assert!(!dup_stray.exists(), "有正确副本的错位副本应去重删除");
+        assert_eq!(
+            std::fs::read_to_string(dup_right.join("SKILL.md")).unwrap(),
+            "---\nname: dup-skill\n---\nright",
+            "正确位置副本内容应保持"
+        );
+        assert_eq!(report.deduped.len(), 1);
+        assert!(!tmp.join("bundles/wrong-pkg").exists(), "腾空包目录应清理");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// 自愈对账回归：孤儿副本（无记录/非预置/非 CLI 静态所有）删除；有记录、
+    /// 预置名、CLI 静态所有的目录保留；Upload 瘫记录删除；内置释放目录收敛
+    /// （无标记/无记录/不在内嵌集 → 删；内嵌集内与带标记 → 留）。
+    #[test]
+    fn self_heal_cleans_orphans_stale_records_and_builtin_residue() {
+        let tmp = fresh_dir("heal_clean");
+        let mgr = SkillMarketplaceManager::with_roots(tmp.clone());
+        let store =
+            crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
+        let write_skill = |pkg: &str, name: &str| {
+            let dir = tmp.join("bundles").join(pkg).join("skills").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("SKILL.md"), format!("---\nname: {name}\n---\n")).unwrap();
+            dir
+        };
+        // 孤儿（无记录、非预置、非 CLI）→ 删
+        let orphan = write_skill("orphan-skill", "orphan-skill");
+        // 有记录 → 留
+        let recorded = write_skill("recorded-skill", "recorded-skill");
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "recorded-skill".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("x.zip".to_string()),
+                ),
+            )
+            .unwrap();
+        // 预置名无记录（可重释放）→ 留
+        let preset_dir = write_skill("visualizer", "visualizer");
+        // CLI 静态所有（lark-doc 属 feishu 门控）→ 留
+        let cli_dir = write_skill("feishu", "lark-doc");
+        // Upload 瘫记录（无目录）→ 删记录
+        store
+            .upsert(
+                crate::features::marketplace::store::BundleRecord::installed_now(
+                    "ghost-upload".to_string(),
+                    crate::features::marketplace::store::BundleSource::Upload("y.zip".to_string()),
+                ),
+            )
+            .unwrap();
+        // 内置释放目录：残旧（无标记/无记录/非内嵌）→ 删；内嵌集内 → 留；带标记 → 留
+        let stale_builtin = tmp.join("bundle/skills/old-thing");
+        std::fs::create_dir_all(&stale_builtin).unwrap();
+        std::fs::write(stale_builtin.join("SKILL.md"), "---\nname: old-thing\n---\n").unwrap();
+        let embedded = tmp.join("bundle/skills/visual-design");
+        std::fs::create_dir_all(&embedded).unwrap();
+        std::fs::write(embedded.join("SKILL.md"), "---\nname: visual-design\n---\n").unwrap();
+        let marked = tmp.join("bundle/skills/marked-thing");
+        std::fs::create_dir_all(&marked).unwrap();
+        std::fs::write(marked.join("SKILL.md"), "---\nname: marked-thing\n---\n").unwrap();
+        std::fs::write(marked.join(".installed-from"), "pinvou3-marketplace:marked-thing").unwrap();
+
+        let report = mgr.self_heal_skills(&["visual-design"]);
+        assert!(!orphan.exists(), "孤儿副本应删除");
+        assert!(report.removed_orphan_dirs.contains(&"orphan-skill/orphan-skill".to_string()));
+        assert!(recorded.exists(), "有记录副本应保留");
+        assert!(preset_dir.exists(), "预置名副本应保留（可重释放）");
+        assert!(cli_dir.exists(), "CLI 静态所有副本应保留");
+        assert!(
+            store.get("ghost-upload").unwrap().is_none(),
+            "Upload 瘫记录应删除"
+        );
+        assert!(
+            store.get("recorded-skill").unwrap().is_some(),
+            "有目录的 Upload 记录应保留"
+        );
+        assert!(!stale_builtin.exists(), "内置释放目录残旧应收敛删除");
+        assert!(embedded.exists(), "内嵌集内目录应保留");
+        assert!(marked.exists(), "带市场标记目录应留给布局迁移");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
@@ -464,7 +464,10 @@ impl SkillMarketplaceManager {
                 continue;
             }
             if let Err(e) = std::fs::remove_dir_all(&dir) {
-                log::warn!("[skill-marketplace] 清扫重复技能副本失败（{}）: {e}", dir.display());
+                log::warn!(
+                    "[skill-marketplace] 清扫重复技能副本失败（{}）: {e}",
+                    dir.display()
+                );
                 continue;
             }
             if let Some(skills_parent) = dir.parent() {
@@ -616,11 +619,7 @@ impl SkillMarketplaceManager {
 
     /// 技能是否有安装登记：记录 id = 目录名（上传/同名预置），或预置 id 与
     /// 技能名异名（如 tencent-docs-skill ↔ tencent-docs）时按预置 id 命中。
-    fn has_install_record(
-        &self,
-        records: &[super::store::BundleRecord],
-        skill_name: &str,
-    ) -> bool {
+    fn has_install_record(&self, records: &[super::store::BundleRecord], skill_name: &str) -> bool {
         records.iter().any(|r| r.id == skill_name)
             || self
                 .preset_by_skill_name(skill_name)
@@ -1639,10 +1638,18 @@ mod tests {
         // dup-skill 同样错位，且正确位置已有副本
         let dup_stray = tmp.join("bundles/wrong-pkg/skills/dup-skill");
         std::fs::create_dir_all(&dup_stray).unwrap();
-        std::fs::write(dup_stray.join("SKILL.md"), "---\nname: dup-skill\n---\nstray").unwrap();
+        std::fs::write(
+            dup_stray.join("SKILL.md"),
+            "---\nname: dup-skill\n---\nstray",
+        )
+        .unwrap();
         let dup_right = tmp.join("bundles/dup-skill/skills/dup-skill");
         std::fs::create_dir_all(&dup_right).unwrap();
-        std::fs::write(dup_right.join("SKILL.md"), "---\nname: dup-skill\n---\nright").unwrap();
+        std::fs::write(
+            dup_right.join("SKILL.md"),
+            "---\nname: dup-skill\n---\nright",
+        )
+        .unwrap();
         // 正确位置副本需有登记（生产语义：已装技能必有记录），否则它自身即孤儿
         let store =
             crate::features::marketplace::store::BundleStore::with_file(tmp.join("bundles.json"));
@@ -1714,18 +1721,28 @@ mod tests {
         // 内置释放目录：残旧（无标记/无记录/非内嵌）→ 删；内嵌集内 → 留；带标记 → 留
         let stale_builtin = tmp.join("bundle/skills/old-thing");
         std::fs::create_dir_all(&stale_builtin).unwrap();
-        std::fs::write(stale_builtin.join("SKILL.md"), "---\nname: old-thing\n---\n").unwrap();
+        std::fs::write(
+            stale_builtin.join("SKILL.md"),
+            "---\nname: old-thing\n---\n",
+        )
+        .unwrap();
         let embedded = tmp.join("bundle/skills/visual-design");
         std::fs::create_dir_all(&embedded).unwrap();
         std::fs::write(embedded.join("SKILL.md"), "---\nname: visual-design\n---\n").unwrap();
         let marked = tmp.join("bundle/skills/marked-thing");
         std::fs::create_dir_all(&marked).unwrap();
         std::fs::write(marked.join("SKILL.md"), "---\nname: marked-thing\n---\n").unwrap();
-        std::fs::write(marked.join(".installed-from"), "pinvou3-marketplace:marked-thing").unwrap();
+        std::fs::write(
+            marked.join(".installed-from"),
+            "pinvou3-marketplace:marked-thing",
+        )
+        .unwrap();
 
         let report = mgr.self_heal_skills(&["visual-design"]);
         assert!(!orphan.exists(), "孤儿副本应删除");
-        assert!(report.removed_orphan_dirs.contains(&"orphan-skill/orphan-skill".to_string()));
+        assert!(report
+            .removed_orphan_dirs
+            .contains(&"orphan-skill/orphan-skill".to_string()));
         assert!(recorded.exists(), "有记录副本应保留");
         assert!(preset_dir.exists(), "预置名副本应保留（可重释放）");
         assert!(cli_dir.exists(), "CLI 静态所有副本应保留");

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/extraction.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/extraction.rs
@@ -123,6 +123,23 @@ impl Pinvou3Bundle {
                 migration.kept.len()
             ),
         );
+        // 自愈对账：认领错位归位/去重、孤儿副本、瘫记录、内置释放目录残旧收敛。
+        // 名称无关（按归属证明判定，各发行版构建自动适配），排在布局迁移之后
+        // （旧扁平目录已搬完）、gates 之前（CLI 静态所有目录不受影响）。
+        let heal = crate::features::marketplace::skill_marketplace::SkillMarketplaceManager::new()
+            .self_heal_skills(Self::BUILTIN_RELEASED_SKILL_DIRS);
+        crate::platform::startup::mark_with_detail(
+            "rust",
+            "bundle_extract:skills_self_heal:done",
+            &format!(
+                "rehomed={} deduped={} orphan={} stale_records={} converged={}",
+                heal.rehomed.len(),
+                heal.deduped.len(),
+                heal.removed_orphan_dirs.len(),
+                heal.removed_stale_records.len(),
+                heal.converged_builtin_dirs.len()
+            ),
+        );
         // 飞书 / 企微 / 钉钉鉴权 CLI 不得阻塞 Tauri setup。启动阶段只沿用上次落盘的完整
         // 技能目录作为缓存；React 首屏提交后调用 refresh_connector_auth_gates 并行
         // 实时探测，再按真实状态修正目录。bundle 升级时仅刷新当前可见的缓存目录。
@@ -319,6 +336,11 @@ impl Pinvou3Bundle {
                 crate::features::marketplace::remove_connector_from_disabled_scopes(tool_id);
 
                 let _ = std::fs::remove_dir_all(paths::bundle_mcp_servers_dir().join(tool_id));
+                // 按包聚合新布局的退役残留：`migrate_custom_mcp_layout` 会先把旧目录
+                // 搬进 bundles/<id>/mcp/，而 uninstall 的 can_redeliver=false 规则
+                // （非内嵌 id 不可重释放）保留包目录——不删则 manifest 存活、退役
+                // 工具以「自定义 MCP 卡」复活（G8a）。Upload 保护已在上方判定。
+                let _ = std::fs::remove_dir_all(paths::bundles_root().join(tool_id));
             }
         }
         Ok(())
@@ -331,6 +353,11 @@ impl Pinvou3Bundle {
     /// contains 级探测——宁可误报(多跑一次幂等清理)也不漏报(残留永驻)。
     fn marketplace_tool_residue_present(tool_id: &str) -> bool {
         if paths::bundle_mcp_servers_dir().join(tool_id).exists() {
+            return true;
+        }
+        // 新布局包目录（含迁移搬入的 bundles/<id>/mcp/）也是残留面——否则只剩
+        // 它时探测漏报，退役工具的 manifest 会以自定义 MCP 卡复活。
+        if paths::bundles_root().join(tool_id).exists() {
             return true;
         }
         let home = paths::pinvou3_home();
@@ -369,6 +396,13 @@ impl Pinvou3Bundle {
             None => true,
         }
     }
+
+    /// 当前构建内嵌释放到 `bundle/skills/` 的内置技能目录集合——与
+    /// [`Self::write_builtin_skills`] 的释放面保持一致。自愈对账
+    /// （`self_heal_skills` 第 4 步）以此为「本构建内嵌什么」的判定基准：
+    /// 不在集内且无归属证明的目录判残旧收敛；其它发行版构建内嵌更多技能
+    /// 时扩充本常量即可，天然保留。
+    pub(crate) const BUILTIN_RELEASED_SKILL_DIRS: &[&str] = &["visual-design"];
 
     /// 解包内嵌的内置 skills 到 pinvou3 单一来源 `bundle/skills`。v0.9 clean re-fork
     /// 后 catalogue 与 `load_skill` 都只扫描此目录，不再写 `~/.agents/skills`。
@@ -681,6 +715,18 @@ impl Pinvou3Bundle {
                     if crate::features::marketplace::mcp_catalog::spec_for(&record.id).is_none() {
                         continue; // 非内嵌包（自定义/上传），无内嵌资源可校验
                     }
+                    // 上传/未知来源的记录即使 id 撞内嵌目录也不得重释放：重释放
+                    // 以嵌入资源为基准覆盖包目录（release_package 先删后建），对
+                    // 用户内容即数据销毁。镜像卸载路径 source_may_be_upload 的
+                    // fail-closed 口径（六轮评审 R1），只放行预置/内置来源。
+                    if !should_ensure_embedded_release(record) {
+                        log::warn!(
+                            "[runtime-bundle] 跳过非预置来源记录的内嵌重释放（{}，source={:?}）",
+                            record.id,
+                            record.source
+                        );
+                        continue;
+                    }
                     if let Err(e) =
                         crate::features::marketplace::mcp_catalog::ensure_package_released(
                             &record.id,
@@ -726,5 +772,37 @@ impl Pinvou3Bundle {
         }
         std::fs::write(path, contents)?;
         Ok(true)
+    }
+}
+
+/// 内嵌重释放放行判定（G1）：仅预置/内置来源。上传/未知来源即使 id 撞内嵌
+/// 目录也不得重释放——重释放以嵌入资源为基准覆盖包目录（`release_package`
+/// 先删后建），对用户内容即数据销毁。镜像卸载路径 `source_may_be_upload`
+/// 的 fail-closed 口径（六轮评审 R1）。
+fn should_ensure_embedded_release(
+    record: &crate::features::marketplace::store::BundleRecord,
+) -> bool {
+    matches!(
+        record.source,
+        crate::features::marketplace::store::BundleSource::Preset
+            | crate::features::marketplace::store::BundleSource::Builtin
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    /// G1 回归：上传来源记录不得进入内嵌重释放（防用户内容被嵌入资源覆盖）。
+    #[test]
+    fn embedded_release_skips_non_preset_sources() {
+        use crate::features::marketplace::store::{BundleRecord, BundleSource};
+        let preset = BundleRecord::installed_now("weather".to_string(), BundleSource::Preset);
+        let builtin = BundleRecord::installed_now("weather".to_string(), BundleSource::Builtin);
+        let upload = BundleRecord::installed_now(
+            "weather".to_string(),
+            BundleSource::Upload("x.zip".to_string()),
+        );
+        assert!(super::should_ensure_embedded_release(&preset));
+        assert!(super::should_ensure_embedded_release(&builtin));
+        assert!(!super::should_ensure_embedded_release(&upload));
     }
 }

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/extraction.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/extraction.rs
@@ -305,6 +305,9 @@ impl Pinvou3Bundle {
             // 退役 id 保护（二轮评审）：`bundles/` 已是用户上传落盘区，用户可能上传过
             // 同名包——其 Upload 记录存在时跳过整段清理（不删登记、不删 mcp.json），
             // 只清理确定无主的内嵌退役残留。
+            // Fail-closed like the uninstall path's `source_may_be_upload`: an
+            // unreadable store means "may be an upload" → skip the cleanup
+            // entirely (its last step deletes `bundles/<id>` wholesale).
             let user_uploaded = crate::features::marketplace::store::BundleStore::new()
                 .records()
                 .map(|records| {
@@ -316,7 +319,7 @@ impl Pinvou3Bundle {
                             )
                     })
                 })
-                .unwrap_or(false);
+                .unwrap_or(true);
             if !user_uploaded {
                 // 廉价残留探测:所有清理面都干净时直接返回——uninstall 会无条件重写
                 // installed.json / mcp.json 并访问系统 keyring,不值得每次启动都实例化
@@ -402,6 +405,11 @@ impl Pinvou3Bundle {
     /// （`self_heal_skills` 第 4 步）以此为「本构建内嵌什么」的判定基准：
     /// 不在集内且无归属证明的目录判残旧收敛；其它发行版构建内嵌更多技能
     /// 时扩充本常量即可，天然保留。
+    /// Binding tests (same pattern as `wecom_skill_dirs_match_embedded_resources`):
+    /// `builtin_released_skill_dirs_match_embedded_resources` and
+    /// `write_builtin_skills_releases_exactly_the_listed_dirs` — a builtin
+    /// skill added to `write_builtin_skills` without extending this constant
+    /// would be written and self-heal-deleted in the same run.
     pub(crate) const BUILTIN_RELEASED_SKILL_DIRS: &[&str] = &["visual-design"];
 
     /// 解包内嵌的内置 skills 到 pinvou3 单一来源 `bundle/skills`。v0.9 clean re-fork
@@ -804,5 +812,53 @@ mod tests {
         assert!(super::should_ensure_embedded_release(&preset));
         assert!(super::should_ensure_embedded_release(&builtin));
         assert!(!super::should_ensure_embedded_release(&upload));
+    }
+
+    /// G1 loop wiring: `write_mcp_servers` must actually consult
+    /// `should_ensure_embedded_release` — an installed Upload record whose id
+    /// collides with an embedded spec keeps its on-disk package untouched.
+    /// (The predicate-only test above stays green even if the loop's guard
+    /// `continue` is removed; this one fails.)
+    #[test]
+    fn write_mcp_servers_never_releases_over_upload_records() {
+        use crate::features::marketplace::store::{BundleRecord, BundleSource};
+        let _g = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = std::env::temp_dir().join(format!(
+            "pinvou3-g1-wiring-{}-{}",
+            std::process::id(),
+            crate::platform::paths::tests::unique_suffix()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::env::set_var("PINVOU3_HOME", &tmp);
+        let bundle = super::Pinvou3Bundle::paths();
+
+        // Installed Upload record colliding with the embedded spec id "weather".
+        crate::features::marketplace::store::BundleStore::new()
+            .upsert(BundleRecord::installed_now(
+                "weather".to_string(),
+                BundleSource::Upload("weather.zip".to_string()),
+            ))
+            .unwrap();
+        // User content in the package dir — must survive write_mcp_servers.
+        let pkg_mcp = crate::platform::paths::bundles_root()
+            .join("weather")
+            .join("mcp");
+        std::fs::create_dir_all(&pkg_mcp).unwrap();
+        std::fs::write(pkg_mcp.join("server.py"), "USER CODE").unwrap();
+        std::fs::write(pkg_mcp.join("manifest.json"), "{}").unwrap();
+
+        bundle.write_mcp_servers().unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(pkg_mcp.join("server.py")).unwrap(),
+            "USER CODE",
+            "上传包目录不得被内嵌重释放覆盖"
+        );
+
+        std::env::remove_var("PINVOU3_HOME");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -165,6 +165,13 @@ pub fn instructions_code_md(workspace_hint: &str) -> String {
 const VISUAL_DESIGN_SKILL_MD: &str =
     include_str!("../../../../resources/common/bundle/builtin-skills/visual-design/SKILL.md");
 
+/// Test-only view of the embedded builtin-skill resource tree: binds
+/// `Pinvou3Bundle::BUILTIN_RELEASED_SKILL_DIRS` to the actual resources
+/// (same pattern as `wecom_skill_dirs_match_embedded_resources`).
+#[cfg(test)]
+static BUILTIN_SKILLS_DIR: Dir<'_> =
+    include_dir!("$CARGO_MANIFEST_DIR/resources/common/bundle/builtin-skills");
+
 /// pinvou3 版 base prompt，编译期内嵌。通过底座 `prompts::set_base_prompt_override`
 /// 注入，替换底座的上游 `BASE_PROMPT`。这样 pinvou3 的 prompt 定制活在 app,
 /// CodeWhale submodule 的 base.md 回退上游原文（fork drift 归零）。
@@ -810,6 +817,66 @@ mod tests {
         cleanup(&tmp);
     }
 
+    /// `BUILTIN_RELEASED_SKILL_DIRS` must mirror the embedded builtin-skills
+    /// resource tree (same pattern as `wecom_skill_dirs_match_embedded_resources`):
+    /// a builtin skill added without extending the constant would be written by
+    /// every launch and deleted by self-heal step 4 in the same run — silently
+    /// invisible forever.
+    #[test]
+    fn builtin_released_skill_dirs_match_embedded_resources() {
+        let mut embedded: Vec<&str> = BUILTIN_SKILLS_DIR
+            .dirs()
+            .map(|d| d.path().to_str().expect("目录名应为 UTF-8"))
+            .collect();
+        embedded.sort_unstable();
+        let mut listed = Pinvou3Bundle::BUILTIN_RELEASED_SKILL_DIRS.to_vec();
+        listed.sort_unstable();
+        assert_eq!(
+            embedded, listed,
+            "BUILTIN_RELEASED_SKILL_DIRS 与 bundle/builtin-skills 实际目录不一致"
+        );
+        for d in listed {
+            assert!(
+                BUILTIN_SKILLS_DIR
+                    .get_file(format!("{d}/SKILL.md"))
+                    .is_some(),
+                "builtin-skills/{d} 缺 SKILL.md"
+            );
+        }
+    }
+
+    /// The other divergence direction: `write_builtin_skills` must release
+    /// exactly the dirs listed in `BUILTIN_RELEASED_SKILL_DIRS` — a skill added
+    /// to the write path without extending the constant would be converged
+    /// away by self-heal step 4 on the same launch.
+    #[test]
+    fn write_builtin_skills_releases_exactly_the_listed_dirs() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir();
+        std::env::set_var("PINVOU3_HOME", &tmp);
+        let bundle = Pinvou3Bundle::paths();
+
+        bundle.write_builtin_skills().unwrap();
+
+        let mut written: Vec<String> = std::fs::read_dir(&bundle.skills_dir)
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().is_dir())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        written.sort_unstable();
+        let mut listed: Vec<String> = Pinvou3Bundle::BUILTIN_RELEASED_SKILL_DIRS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        listed.sort_unstable();
+        assert_eq!(
+            written, listed,
+            "write_builtin_skills 的释放面与 BUILTIN_RELEASED_SKILL_DIRS 不一致"
+        );
+        cleanup(&tmp);
+    }
+
     /// include_dir! 内嵌树中的 `__pycache__/` 与 `*.pyc` 不得物化到用户 bundle
     /// (在仓库里直接运行技能脚本会产生这些编译缓存,详见 extract_dir 文档注释)。
     /// 覆盖实际走 extract_dir 的两棵树(lark skills 与 dws);构建机存在 pycache 时
@@ -1014,6 +1081,38 @@ mod tests {
                 .join("installed.json")
                 .exists(),
             "无残留时不应触发 uninstall(其必写 installed.json)"
+        );
+        cleanup(&tmp);
+    }
+
+    /// G8a Upload protection must be fail-closed like the uninstall path's
+    /// `source_may_be_upload`: an unreadable BundleStore means "may be an
+    /// upload" → skip the whole retired-tool cleanup (its last step deletes
+    /// `bundles/<id>` wholesale, which is user content for an upload).
+    #[test]
+    fn cleanup_removed_marketplace_tools_fail_closed_on_unreadable_store() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempdir();
+        std::env::set_var("PINVOU3_HOME", &tmp);
+        paths::ensure_dirs().unwrap();
+        let bundle = Pinvou3Bundle::paths();
+
+        // Corrupt (unparseable) bundles.json.
+        let store_file = paths::pinvou3_home()
+            .join("marketplace")
+            .join("bundles.json");
+        std::fs::create_dir_all(store_file.parent().unwrap()).unwrap();
+        std::fs::write(&store_file, "{ not valid json !!!").unwrap();
+        // Residue that would otherwise be cleaned (new-layout package dir).
+        let pkg_dir = paths::bundles_root().join("data_analysis");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(pkg_dir.join("plugin.json"), "{}").unwrap();
+
+        bundle.cleanup_removed_marketplace_tools().unwrap();
+
+        assert!(
+            pkg_dir.join("plugin.json").is_file(),
+            "store 不可读时退役清理必须 fail-closed（跳过），不得删包目录"
         );
         cleanup(&tmp);
     }

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1039,15 +1039,16 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         if (mcpId) {
           const mcpBs = bundleStates[mcpId];
           const mcpInstalled = mcpBs ? mcpBs.installed : !!toolStates[mcpId];
-          // MCP 未装但技能独立已装（历史遗留/单独安装）→ 卡也显示已装，
-          // 动作走技能级（卸载按实际物理位置删除，G3）；MCP 已装则跟随包态。
+          // 安装态：MCP 或技能任一已装即显示已装（G3：独立安装的 companion
+          // 技能可见可管）。动作始终跟随所属 MCP 包 readiness——配置字段
+          // （配置/连接按钮）只有包级 readiness 知道，技能级给不出。
           const skillBs = s.backendId ? bundleStates[s.backendId] : null;
           const skillInstalled = skillBs ? skillBs.installed : (be ? be.installed : false);
           return {
             ...s,
             installed: mcpInstalled || skillInstalled,
             updateAvailable,
-            actions: mcpInstalled ? actionsOf(mcpBs) : actionsOf(skillBs),
+            actions: actionsOf(mcpBs),
           };
         }
         const bs = s.backendId ? bundleStates[s.backendId] : null;
@@ -1074,14 +1075,13 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const mcpEntry = mcpId
             ? (tsToolsData.find(t => t.backendId === mcpId) || tsToolWelcomeData.find(t => t.backendId === mcpId))
             : null;
-          // 安装态/动作：MCP 已装 → 跟随所属包（统一 readiness，store 真相源）；
-          // MCP 未装但技能独立已装 → 跟随技能自身（G3：独立安装的 companion
-          // 技能可見、可卸载）；独立技能读自身 readiness；缺失回退技能后端状态位。
+          // 安装态：MCP 或技能任一已装即显示已装（G3：独立安装的 companion
+          // 技能可見、可卸载）。动作始终跟随所属 MCP 包 readiness——配置/连接
+          // 按钮依赖包级配置字段（如腾讯文档 Token），技能级 readiness 给不出。
           const mcpBs = mcpId ? bundleStates[mcpId] : null;
           const skillBs = bundleStates[x.id];
           const mcpInstalled = mcpId ? (mcpBs ? mcpBs.installed : !!toolStates[mcpId]) : false;
           const skillInstalled = skillBs ? skillBs.installed : !!x.installed;
-          const stateBs = mcpInstalled ? mcpBs : skillBs;
           return localizeSkill({
             id: 'mcp-skill-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || '',
             // 有配套 MCP(companion)的卡 = 工具包:徽标与分组归 bundle,安装态跟随 MCP
@@ -1092,7 +1092,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             icon: tsSkillIconByName[x.icon] || Package, color: x.color || 'bg-gradient-to-b from-slate-400 to-slate-600',
             installed: mcpId ? (mcpInstalled || skillInstalled) : skillInstalled,
             updateAvailable: !!x.update_available,
-            actions: actionsOf(stateBs),          });
+            actions: mcpId ? actionsOf(mcpBs) : actionsOf(skillBs),          });
         });
       const uploadedSkills = skillBackend.filter(x => x.user_uploaded).map(x => ({
         id: 'up-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || storeCopy.uploadedSkill,

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1040,15 +1040,17 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const mcpBs = bundleStates[mcpId];
           const mcpInstalled = mcpBs ? mcpBs.installed : !!toolStates[mcpId];
           // 安装态：MCP 或技能任一已装即显示已装（G3：独立安装的 companion
-          // 技能可见可管）。动作始终跟随所属 MCP 包 readiness——配置字段
-          // （配置/连接按钮）只有包级 readiness 知道，技能级给不出。
+          // 技能可见可管）。动作与安装态同源拆分：MCP 已装、或两者皆未装（安装
+          // 入口始终路由到所属 MCP 包）走包级 readiness——配置字段（配置/连接
+          // 按钮）只有包级 readiness 知道；仅技能独立已装（G3 混合态）改走技能级
+          // readiness 给出卸载入口，与 handleAction 的技能级卸载分流一致。
           const skillBs = s.backendId ? bundleStates[s.backendId] : null;
           const skillInstalled = skillBs ? skillBs.installed : (be ? be.installed : false);
           return {
             ...s,
             installed: mcpInstalled || skillInstalled,
             updateAvailable,
-            actions: actionsOf(mcpBs),
+            actions: (!mcpInstalled && skillInstalled) ? actionsOf(skillBs) : actionsOf(mcpBs),
           };
         }
         const bs = s.backendId ? bundleStates[s.backendId] : null;
@@ -1076,8 +1078,11 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             ? (tsToolsData.find(t => t.backendId === mcpId) || tsToolWelcomeData.find(t => t.backendId === mcpId))
             : null;
           // 安装态：MCP 或技能任一已装即显示已装（G3：独立安装的 companion
-          // 技能可見、可卸载）。动作始终跟随所属 MCP 包 readiness——配置/连接
-          // 按钮依赖包级配置字段（如腾讯文档 Token），技能级 readiness 给不出。
+          // 技能可見、可卸载）。动作与安装态同源拆分：MCP 已装、或两者皆未装
+          // （安装入口始终路由到所属 MCP 包）走包级 readiness——配置/连接按钮
+          // 依赖包级配置字段（如腾讯文档 Token），技能级 readiness 给不出；仅
+          // 技能独立已装（G3 混合态）改走技能级 readiness 给出卸载入口，
+          // 与 handleAction 的技能级卸载分流一致。
           const mcpBs = mcpId ? bundleStates[mcpId] : null;
           const skillBs = bundleStates[x.id];
           const mcpInstalled = mcpId ? (mcpBs ? mcpBs.installed : !!toolStates[mcpId]) : false;
@@ -1092,7 +1097,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             icon: tsSkillIconByName[x.icon] || Package, color: x.color || 'bg-gradient-to-b from-slate-400 to-slate-600',
             installed: mcpId ? (mcpInstalled || skillInstalled) : skillInstalled,
             updateAvailable: !!x.update_available,
-            actions: mcpId ? actionsOf(mcpBs) : actionsOf(skillBs),          });
+            actions: mcpId
+              ? ((!mcpInstalled && skillInstalled) ? actionsOf(skillBs) : actionsOf(mcpBs))
+              : actionsOf(skillBs),          });
         });
       const uploadedSkills = skillBackend.filter(x => x.user_uploaded).map(x => ({
         id: 'up-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || storeCopy.uploadedSkill,

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -646,8 +646,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       // 据此动态合成卡片（安装时显示、卸载后消失），不依赖前端硬编码。
       const [toolBackend, setToolBackend] = useState([]);
       const [toolAuthStates, setToolAuthStates] = useState({});
-      // 配套技能 id → 所属 MCP id(由 list_marketplace_tools 的 companion_skills 反建,manifest 单一真源)。
-      // 有配套 MCP 的技能卡据此把状态/装卸联动到该 MCP,避免命名不一致(government-writing↔gongwen)时状态分叉。
+      // 配套技能 id → 所属 MCP id(由 list_marketplace_tools 的 companion_skills 反建,manifest 单一真源;
+      // 只认领已装 MCP,与后端 skill_owner_package 条件认领同口径)。
+      // 有配套 MCP 且已装的技能卡据此把状态/装卸联动到该 MCP,避免命名不一致(government-writing↔gongwen)时状态分叉。
       const [skillToMcp, setSkillToMcp] = useState({});
       const [busyId, setBusyId] = useState(null);
       const busyRef = useRef(null); // 拖放 controller 经 ref 读最新 busyId(闭包不刷新)
@@ -710,10 +711,10 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const toggleModeVisibility = (id, mode, checked) => {
         if (!canMutateToolStore || !visibilityLoaded || !id) return;
         // 可见性按包 id 落库（后端 save_hidden_bundles_for 经 to_package_id 归一为包
-        // id，scope.rs；get_bundle_visibility 原样返回包 id）：companion 技能卡
-        // （government-writing→gongwen 等）先经 skillToMcp 映射为所属 MCP 包 id——
-        // 与安装态联动同一映射源（manifest companion_skills 反建，不随安装态变化），
-        // 否则写技能 id、读回包 id，勾选永不命中（五轮评审）。
+        // id，scope.rs；读回经 normalize_stored_pkg_ids 按当前认领再归一）：companion
+        // 技能卡（government-writing→gongwen 等）先经 skillToMcp 映射为所属 MCP 包
+        // id（只认领已装 MCP，与后端条件认领同口径）；MCP 未装时按技能 id 直接落库，
+        // 读回归一后仍能命中。
         const pkgId = skillToMcp[id] || id;
         const prev = hiddenByModeRef.current;
         const next = new Set(prev[mode] || []);
@@ -763,10 +764,15 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         try {
           const list = await invokeTauri('list_marketplace_tools');
           const states = {};
-          const s2m = {}; // 配套技能 → 所属 MCP(manifest companion_skills 反建,单一真源)
+          const s2m = {}; // 配套技能 → 所属 MCP(manifest companion_skills 反建,单一真源)。
+          // 与后端条件认领同口径（skill_owner_package 以包本体安装态判定归属）：
+          // 只认领**已装** MCP 的配套技能。无条件认领会让独立安装的 companion
+          // 技能卡跟随未装 MCP 显示「未安装」、无卸载入口，且点安装被路由去装
+          // MCP 从而制造双份副本（G3/F2）。可见性读写在后端读时归一（scope.rs
+          // normalize_stored_pkg_ids），不依赖本映射的安装态无关性。
           list.forEach(t => {
             states[t.id] = t.installed;
-            (t.companion_skills || []).forEach(sid => { s2m[sid] = t.id; });
+            if (t.installed) (t.companion_skills || []).forEach(sid => { s2m[sid] = t.id; });
           });
           setToolStates(states);
           setSkillToMcp(s2m);

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -647,8 +647,8 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const [toolBackend, setToolBackend] = useState([]);
       const [toolAuthStates, setToolAuthStates] = useState({});
       // 配套技能 id → 所属 MCP id(由 list_marketplace_tools 的 companion_skills 反建,manifest 单一真源;
-      // 只认领已装 MCP,与后端 skill_owner_package 条件认领同口径)。
-      // 有配套 MCP 且已装的技能卡据此把状态/装卸联动到该 MCP,避免命名不一致(government-writing↔gongwen)时状态分叉。
+      // 映射与安装态无关)。「安装」始终走组合包(装 MCP 联动装技能);卡片安装态/卸载/可见性
+      // 按 MCP 是否已装分流,与后端条件认领(skill_owner_package)对齐。
       const [skillToMcp, setSkillToMcp] = useState({});
       const [busyId, setBusyId] = useState(null);
       const busyRef = useRef(null); // 拖放 controller 经 ref 读最新 busyId(闭包不刷新)
@@ -712,10 +712,14 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         if (!canMutateToolStore || !visibilityLoaded || !id) return;
         // 可见性按包 id 落库（后端 save_hidden_bundles_for 经 to_package_id 归一为包
         // id，scope.rs；读回经 normalize_stored_pkg_ids 按当前认领再归一）：companion
-        // 技能卡（government-writing→gongwen 等）先经 skillToMcp 映射为所属 MCP 包
-        // id（只认领已装 MCP，与后端条件认领同口径）；MCP 未装时按技能 id 直接落库，
-        // 读回归一后仍能命中。
-        const pkgId = skillToMcp[id] || id;
+        // 技能卡（government-writing→gongwen 等）在 MCP 已装时映射为所属包 id；
+        // MCP 未装（技能独立态）时按技能 id 直接落库——与后端条件认领同口径。
+        const companionMcpId = skillToMcp[id];
+        const companionBs = companionMcpId ? bundleStates[companionMcpId] : null;
+        const companionInstalled = companionMcpId
+          ? (companionBs ? companionBs.installed : !!toolStates[companionMcpId])
+          : false;
+        const pkgId = companionInstalled ? companionMcpId : id;
         const prev = hiddenByModeRef.current;
         const next = new Set(prev[mode] || []);
         // 恢复可见时同时删包 id 与原始技能 id：兼容历史版本按独立技能 id 落库的
@@ -765,14 +769,13 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const list = await invokeTauri('list_marketplace_tools');
           const states = {};
           const s2m = {}; // 配套技能 → 所属 MCP(manifest companion_skills 反建,单一真源)。
-          // 与后端条件认领同口径（skill_owner_package 以包本体安装态判定归属）：
-          // 只认领**已装** MCP 的配套技能。无条件认领会让独立安装的 companion
-          // 技能卡跟随未装 MCP 显示「未安装」、无卸载入口，且点安装被路由去装
-          // MCP 从而制造双份副本（G3/F2）。可见性读写在后端读时归一（scope.rs
-          // normalize_stored_pkg_ids），不依赖本映射的安装态无关性。
+          // 映射与安装态无关：组合包语义要求 companion 卡的「安装」始终路由到
+          // 所属 MCP（装 MCP 联动装技能）；「卸载」与卡片安装态在下游按 MCP
+          // 是否已装分流（MCP 已装 → 包级卸载；仅技能独立已装 → 技能级卸载，
+          // 后端 uninstall 按实际物理位置删除，G3）。
           list.forEach(t => {
             states[t.id] = t.installed;
-            if (t.installed) (t.companion_skills || []).forEach(sid => { s2m[sid] = t.id; });
+            (t.companion_skills || []).forEach(sid => { s2m[sid] = t.id; });
           });
           setToolStates(states);
           setSkillToMcp(s2m);
@@ -1035,11 +1038,16 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         const mcpId = skillToMcp[s.backendId] || null;
         if (mcpId) {
           const mcpBs = bundleStates[mcpId];
+          const mcpInstalled = mcpBs ? mcpBs.installed : !!toolStates[mcpId];
+          // MCP 未装但技能独立已装（历史遗留/单独安装）→ 卡也显示已装，
+          // 动作走技能级（卸载按实际物理位置删除，G3）；MCP 已装则跟随包态。
+          const skillBs = s.backendId ? bundleStates[s.backendId] : null;
+          const skillInstalled = skillBs ? skillBs.installed : (be ? be.installed : false);
           return {
             ...s,
-            installed: mcpBs ? mcpBs.installed : !!toolStates[mcpId],
+            installed: mcpInstalled || skillInstalled,
             updateAvailable,
-            actions: actionsOf(mcpBs),
+            actions: mcpInstalled ? actionsOf(mcpBs) : actionsOf(skillBs),
           };
         }
         const bs = s.backendId ? bundleStates[s.backendId] : null;
@@ -1066,9 +1074,14 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const mcpEntry = mcpId
             ? (tsToolsData.find(t => t.backendId === mcpId) || tsToolWelcomeData.find(t => t.backendId === mcpId))
             : null;
-          // 安装态/动作：companion 卡跟随所属 MCP 包（统一 readiness，store 真相源）；
-          // 独立技能读自身 readiness；缺失回退技能后端状态位。
-          const stateBs = mcpId ? bundleStates[mcpId] : bundleStates[x.id];
+          // 安装态/动作：MCP 已装 → 跟随所属包（统一 readiness，store 真相源）；
+          // MCP 未装但技能独立已装 → 跟随技能自身（G3：独立安装的 companion
+          // 技能可見、可卸载）；独立技能读自身 readiness；缺失回退技能后端状态位。
+          const mcpBs = mcpId ? bundleStates[mcpId] : null;
+          const skillBs = bundleStates[x.id];
+          const mcpInstalled = mcpId ? (mcpBs ? mcpBs.installed : !!toolStates[mcpId]) : false;
+          const skillInstalled = skillBs ? skillBs.installed : !!x.installed;
+          const stateBs = mcpInstalled ? mcpBs : skillBs;
           return localizeSkill({
             id: 'mcp-skill-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || '',
             // 有配套 MCP(companion)的卡 = 工具包:徽标与分组归 bundle,安装态跟随 MCP
@@ -1077,7 +1090,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
             companionBundle: !!mcpId,
             version: '—', latency: storeCopy.localLatency, desc: x.description || '',
             icon: tsSkillIconByName[x.icon] || Package, color: x.color || 'bg-gradient-to-b from-slate-400 to-slate-600',
-            installed: stateBs ? stateBs.installed : (mcpId ? !!toolStates[mcpId] : !!x.installed),
+            installed: mcpId ? (mcpInstalled || skillInstalled) : skillInstalled,
             updateAvailable: !!x.update_available,
             actions: actionsOf(stateBs),          });
         });
@@ -1680,13 +1693,20 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       // 安装/卸载入口
       const handleAction = async (backendId, isInstalled) => {
         if (!canMutateToolStore) return;
-        // 有配套 MCP 的技能(公文=gongwen、PPT=pptx,manifest companion_skills 声明)→ 改走该
-        // MCP 装卸,skill 作为 companion 随 MCP 联动(两卡同步);
+        // 有配套 MCP 的技能(公文=gongwen、PPT=pptx,manifest companion_skills 声明)：
+        // - 安装 → 始终改走所属 MCP 安装（组合包语义：装 MCP 联动装 companion 技能）;
+        // - 卸载 → MCP 已装走包级卸载（companion 随包联动删除）;MCP 未装但技能
+        //   独立已装（历史遗留/单独安装）走技能级卸载（后端按实际物理位置删除,G3）;
         // 纯技能(无配套 MCP:如 visualizer、上传技能)才走 handleSkillAction。
         // 用 skillCards(含后端合成卡与 userUploaded 卡)而非静态 tsSkillsData 判定——
         // 静态卡已删除且上传技能不在静态表里,漏判会落到通用工具分支报「未知工具」。
-
-        if (skillToMcp[backendId]) backendId = skillToMcp[backendId];
+        const companionMcpId = skillToMcp[backendId];
+        if (companionMcpId) {
+          const mcpBs = bundleStates[companionMcpId];
+          const mcpInstalled = mcpBs ? mcpBs.installed : !!toolStates[companionMcpId];
+          if (isInstalled && !mcpInstalled) return handleSkillAction(backendId, isInstalled);
+          backendId = companionMcpId;
+        }
         else if (skillCards.some(s => s.backendId === backendId) && !tsToolsData.some(t => t.backendId === backendId)) return handleSkillAction(backendId, isInstalled);
         const requestedTool = findLocalizedTool(backendId);
         if (!externalAuthAvailable && isRestrictedExternalAuthTool(requestedTool)) return;

--- a/pinvou3-app/tests/tool_store_smoke.js
+++ b/pinvou3-app/tests/tool_store_smoke.js
@@ -46,7 +46,9 @@ function injectSource() {
     const OAUTH_SERVERS={'yuandian-mcp':'yuandian_mcp','canva-mcp':'canva_mcp',qcc:'qcc-company'};
     const BLOCKING_INSTALL_OAUTH_TOOLS=new Set(['yuandian-mcp','canva-mcp']);
     const state=window.__TOOL_STORE_TEST__={
-      installed:{},skills:{visualizer:false},connected:{feishu:false,wecom:false,dingtalk:false,tmeet:false,ima:false},
+      // government-writing 初始为独立已装（MCP gongwen 未装）:覆盖 G3 混合态——
+      // companion 卡动作须来自技能级 readiness(卸载),首个用例卸载后回到未装态。
+      installed:{},skills:{visualizer:false,'government-writing':true},connected:{feishu:false,wecom:false,dingtalk:false,tmeet:false,ima:false},
       oauthAuth:{},oauthRequests:{},finishOAuthInstall:null,calls:[],obsidianChecks:0,composerChanged:0,failVisibility:false,
       hidden:{plain:[],code:[]}
     };
@@ -54,7 +56,8 @@ function injectSource() {
     window.__TAURI_EVENT_HANDLERS__={};
     const tools=()=>Object.entries(TOOL_META).map(([id,[name,companions]])=>({id,name,description:'test',version:'1.0.0',icon:'',category:'test',installed:!!state.installed[id],companion_skills:companions}));
     const skills=()=>[
-      {id:'government-writing',title:'党政机关公文写作',installed:!!state.installed.gongwen,user_uploaded:false},
+      // companion 技能安装态 = 所属 MCP 已装 或 技能独立已装（G3 混合态）。
+      {id:'government-writing',title:'党政机关公文写作',installed:!!(state.installed.gongwen||state.skills['government-writing']),user_uploaded:false},
       {id:'visualizer',title:'数据分析可视化',installed:!!state.skills.visualizer,user_uploaded:false},
       // pptx:真实预置技能(组合包化),卡片由后端数据合成,安装态跟随同名 MCP
       {id:'pptx',title:'PPT 生成',subtitle:'本地直出可编辑 PowerPoint',description:'本地直出可编辑 .pptx',icon:'Presentation',color:'bg-gradient-to-b from-orange-400 to-rose-500',installed:!!state.installed.pptx,user_uploaded:false},
@@ -153,7 +156,7 @@ function injectSource() {
             return Promise.resolve(mk(c,true,null,c?[act('uninstall')]:[act('install')]));
           }
           if(id==='government-writing'){
-            const c=!!state.installed.gongwen;
+            const c=!!(state.installed.gongwen||state.skills['government-writing']);
             return Promise.resolve(mk(c,true,null,c?[act('uninstall')]:[act('install')]));
           }
           if(TOOL_META[id]){
@@ -302,6 +305,28 @@ async function visibilityBox(page, cardText, modeLabel, click) {
     text: document.body.innerText.slice(0, 240),
   })).then(detail => JSON.stringify({ detail: JSON.parse(detail), errors: errors.slice(0, 5) }));
   rec('工具商店真实页面加载', toolStoreLoaded, navDebug);
+
+  // G3 混合态（评审 MAJOR1）：MCP(gongwen)未装、companion 技能(government-writing)
+  // 独立已装——卡片动作须来自技能级 readiness（卸载入口），而非未装 MCP 的
+  // 安装/配置；旧实现两者并存（卡片「已安装」却只剩「安装」按钮）。
+  await search(page,'党政机关公文写作');
+  rec('混合态 companion 卡展示技能级卸载入口',await page.evaluate(()=>{
+    const btns=[...document.querySelectorAll('button')].filter(b=>b.getAttribute('data-tool-id')==='government-writing');
+    return btns.some(b=>(b.textContent||'').trim()==='卸载')
+      &&!btns.some(b=>['安装','配置'].includes((b.textContent||'').trim()));
+  }));
+  await action(page,'党政机关公文写作','卸载','government-writing'); await dismiss(page);
+  rec('混合态卸载走技能级卸载命令',await page.evaluate(()=>{
+    const state=window.__TOOL_STORE_TEST__;
+    return state.calls.some(x=>x.cmd==='uninstall_marketplace_skill'&&x.args.skillId==='government-writing')
+      &&!state.calls.some(x=>x.cmd==='uninstall_marketplace_tool'&&x.args.toolId==='gongwen')
+      &&state.skills['government-writing']===false;
+  }));
+  await search(page,'党政机关公文写作');
+  rec('混合态卸载后卡片回退包级安装入口',await page.evaluate(()=>{
+    const btns=[...document.querySelectorAll('button')].filter(b=>b.getAttribute('data-tool-id')==='government-writing');
+    return btns.some(b=>(b.textContent||'').trim()==='安装');
+  }));
 
   await action(page,'高德天气','配置','weather');
   rec('高德天气安装前展示必填 Key 配置',await page.evaluate(()=>{


### PR DESCRIPTION
## Background

After the capability-bundle unification landed on main (#302), an audit of the bundle-aggregated skill/plugin lifecycle found residue, toggle-loss, and data-corruption paths. This PR hardens that lifecycle. The unified bundle model, plugin import pipeline, and plugin-center frontend are already on main and are not part of this diff.

## Changes

- **Uninstall correctness**: companion skills are deleted before MCP teardown (the conditional claim flips once the MCP record is gone, so the old order computed the wrong dir); `uninstall()` probes physical locations instead of recomputing the claim; BundleStore records are removed even when the dir is already gone; duplicate physical copies are swept after install/import.
- **Toggle governance**: disabled/hidden package ids are normalized at read time so toggles follow the skill when the conditional claim flips on companion MCP install; `skill:` prefixes are stripped in `hidden_scopes` as well.
- **Release/update safety**: embedded re-release is restricted to Preset/Builtin records (upload/custom records with catalog-id collisions are never overwritten); removal of the old package dir before rename fails loudly; retired-tool cleanup and residue probing cover the `bundles/<id>` layout (data_analysis ghost card); the embedded fingerprint baseline excludes `__pycache__`/`*.pyc`.
- **Startup self-heal** (provenance-based, no name lists): rehome/dedupe claim-mismatched package skill dirs, remove orphan dirs with no record/preset/CLI ownership, drop stale Upload records without content, and converge the builtin skills dir — all under a **package-layout ownership guard** (plugin.json present, `mcp/` sibling, or `bundles/<record.id>/` exists) so plugin-import packages, multi-skill packages, id!=skill-name layouts, and pure-MCP uploads are never rehomed, orphan-deleted, or unregistered.
- **Import guards**: preset skill names, companion-claimed names, and skill names owned by another package dir are rejected up front in both the skill_marketplace and plugin_import channels.
- **Frontend**: companion cards claim skills only for installed MCPs; install always routes to the owner MCP; actions follow the owner bundle (package-level readiness carries configure/connect) except in the mixed state (MCP not installed, companion skill standalone-installed), where skill readiness provides the uninstall entry.
- **Review hardening** (second pass): companion uninstall failure aborts the tool uninstall before the MCP record is removed, and disabled-scope cleanup only runs after the companion is actually deleted (no claim flip, no silent re-enable); G8a upload protection is fail-closed; `BUILTIN_RELEASED_SKILL_DIRS` is bound to the embedded resources and to `write_builtin_skills` by two equivalence tests; self-heal treats a missing `bundles.json` like an unreadable store (fail-closed); comment contract for unmarked `bundle/skills/` dirs unified — user skills belong in `~/.pinvou3/user/skills/`.

## Verification

- `cargo test --lib`: 1430 passed, 5 failed — all five reproduce identically on the main baseline on this machine (codex_acp attachment `$HOME`/path-projection cases and a parallel flake that passes in isolation); none are introduced here. Run before the final rebase; that rebase only advanced the base past #320/#349 with no conflicts in the touched files.
- Frontend (local Windows + Chrome, fresh `build:ui`): `test:tool-store` 51/51 (48 existing + 3 new mixed-state assertions), grouping, import, drop-contract, composer suites, and ui-smoke all green; `lint:ui` clean; `architecture-guard` clean.

## Known risks

- End-to-end installation of a real third-party zip package is covered by mock smoke tests only, not by manual installs.
