### PR TITLE
fix(codex): preserve selected model label on first native turn

### DIFF
--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -62,6 +62,7 @@ import {
 } from './code-permission-state.js';
 import {
   canApplyNativeControlsRefresh,
+  claimNativeControlsRefreshId,
   finalizePreparedSessionCreation,
   resolveNativeModelId,
 } from './native-session-handoff.js';
@@ -1199,7 +1200,9 @@ export function CodexAcpView({
   // refreshNativeControls 请求序号：快速切会话时多个 get_* invoke 并发在途，
   // 后发起的请求应胜出。没有它，先发起的慢响应会晚返回并把控件值/归属 ref 覆盖
   // 成旧会话——mode chip 随即显示全局 fallback 而非新会话实测值（串台/陈旧覆盖，
-  // 与聊天页 modeState epoch 修复同款竞态）。
+  // 与聊天页 modeState epoch 修复同款竞态）。序号只对发起时仍归属当前会话的请求
+  // 发放（claimNativeControlsRefreshId）：已切走的陈旧请求反正会被归属检查丢弃，
+  // 占用序号反而会把当前会话在途的权威刷新顶成过期且无人补发。
   const nativeControlsRequestRef = useRef(0);
   // code 会话权限模式全局偏好（{ last_mode, yolo_confirmed }，null=未拉到）：
   // 驱动草稿态/刷新途中的默认 mode 展示，以及首次切 yolo 的一次性确认门。
@@ -1460,8 +1463,15 @@ export function CodexAcpView({
 
   /// 拉取原生会话的模型/知识库/模式状态（全部 per-session 命令，显式 sessionId）。
   async function refreshNativeControls(sessionId) {
-    const requestId = nativeControlsRequestRef.current + 1;
-    nativeControlsRequestRef.current = requestId;
+    // 发起时已不归属当前会话的刷新注定被提交前的归属检查丢弃，不得占用序号——
+    // 否则它会把当前会话在途的权威刷新顶成过期且无人补发（跨会话抢占）。
+    const claimed = claimNativeControlsRefreshId({
+      sessionId,
+      activeId: activeIdRef.current,
+      latestRequestId: nativeControlsRequestRef.current,
+    });
+    nativeControlsRequestRef.current = claimed.latestRequestId;
+    const requestId = claimed.requestId;
     const [modelId, mountedId, modeState] = await Promise.all([
       invoke('get_session_model_id', { sessionId }).catch(() => null),
       invoke('session_mounted_collection', { sessionId }).catch(() => null),

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -2650,6 +2650,10 @@ export function CodexAcpView({
           acpSendOperationTracker.switchSession(targetId);
           operation = beginAcpSendOperation(targetId);
         }
+        // Activation invalidates the draft-scoped operation token. Report preparation
+        // failures only after rebinding to the created session so the visible error path
+        // remains current and the user's message is restored for retry in this session.
+        if (created.preparationError) throw created.preparationError;
         // prepareSession has already persisted the draft controls before loadSession,
         // and the authoritative load now owns the displayed values. Clear only after
         // that handoff completes so the selected model label remains stable.

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -61,6 +61,11 @@ import {
   resolveNativeModeValue,
 } from './code-permission-state.js';
 import {
+  canApplyNativeControlsRefresh,
+  finalizePreparedSessionCreation,
+  resolveNativeModelId,
+} from './native-session-handoff.js';
+import {
   ConversationActivityIndicator,
   ConversationMarkdown,
   ConversationTurn,
@@ -1234,11 +1239,13 @@ export function CodexAcpView({
   });
   const nativeModelChoices = visibleUserModels((bs && bs.savedModels) || [])
     .map(model => ({ value: model.id, name: selectorMainLabel(model, t) || model.id }));
-  const nativeSessionModelId = activeId
-    ? (nativeControlsSessionRef.current === activeId
-      ? nativeControls.modelId
-      : (nativeDraftControlsHandoff?.modelId || null))
-    : (nativeDraftControls.modelId || null);
+  const nativeSessionModelId = resolveNativeModelId({
+    activeId,
+    controlsSessionId: nativeControlsSessionRef.current,
+    controlsModelId: nativeControls.modelId,
+    draftModelId: nativeDraftControls.modelId,
+    handoffModelId: nativeDraftControlsHandoff?.modelId,
+  });
   const nativeMountedId = activeId
     ? (nativeControlsSessionRef.current === activeId
       ? nativeControls.mountedId
@@ -1469,7 +1476,12 @@ export function CodexAcpView({
       multiAgentAvailable: Boolean(modeState && modeState.multi_agent_available),
     };
     // 请求期间可能切换会话；旧响应不得覆盖新会话的模型/模式/多智能体展示。
-    if (requestId !== nativeControlsRequestRef.current || sessionId !== activeIdRef.current) {
+    if (!canApplyNativeControlsRefresh({
+      requestId,
+      latestRequestId: nativeControlsRequestRef.current,
+      sessionId,
+      activeId: activeIdRef.current,
+    })) {
       return controls;
     }
     setNativeControls(controls);
@@ -1857,20 +1869,22 @@ export function CodexAcpView({
       current === requestedWorkspaceHandle ? null : current
     ));
     await refreshSessions();
-    // Native first-send controls must exist before the session is exposed and loaded.
-    // Otherwise loadSession observes the unbound default, and its local state update can
-    // race the later model write while the parent is still committing activeId.
-    if (prepareSession) await prepareSession(metadata.id);
-    if (!shouldActivate()) {
-      const info = requestedAgentId === 'pinvou'
+    // Persist native controls before the first load. If persistence fails after the
+    // backend session exists, still activate and load it before surfacing the error;
+    // the restored composer can then retry in that session instead of creating another.
+    return finalizePreparedSessionCreation({
+      sessionId: metadata.id,
+      prepareSession,
+      shouldActivate,
+      activateSession: sessionId => {
+        skipNextActiveLoadRef.current = sessionId;
+        if (onActiveSessionChange) onActiveSessionChange(sessionId);
+      },
+      loadSession,
+      loadInactiveSessionInfo: requestedAgentId === 'pinvou'
         ? null
-        : await getAcpSessionInfo(metadata.id);
-      return { id: metadata.id, info, activated: false };
-    }
-    skipNextActiveLoadRef.current = metadata.id;
-    if (onActiveSessionChange) onActiveSessionChange(metadata.id);
-    const info = await loadSession(metadata.id);
-    return { id: metadata.id, info, activated: true };
+        : getAcpSessionInfo,
+    });
   }
 
   function beginDraft(

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1080,9 +1080,13 @@ export function CodexAcpView({
   const draftEpochRef = useRef(draftEpoch);
   const activeIdRef = useRef(activeId);
   const lastActiveSessionIdRef = useRef(activeId);
-  activeIdRef.current = activeId;
   if (activeId) lastActiveSessionIdRef.current = activeId;
   useLayoutEffect(() => {
+    // loadSession may optimistically point this ref at a just-created session before
+    // the parent commits activeId. Do not overwrite that handoff from an intermediate
+    // render carrying the old prop; layout effects still update ordinary session switches
+    // before async responses can commit.
+    activeIdRef.current = activeId;
     acpConfigOperationTracker.switchSession(activeId);
     acpSendOperationTracker.switchSession(activeId || DRAFT_ATTACHMENT_KEY);
   }, [acpConfigOperationTracker, acpSendOperationTracker, activeId]);
@@ -1181,12 +1185,17 @@ export function CodexAcpView({
     multiAgentAvailable: false,
   });
   const [nativeDraftControls, setNativeDraftControls] = useState({});
+  // First-send session creation persists draft controls before activation. Keep the
+  // staged values associated with that exact session until its authoritative load
+  // completes so the selector never falls back to a different global model in between.
+  const nativeDraftControlsHandoffRef = useRef(null);
   // nativeControls 的会话归属：切会话后、refresh 返回前不展示上一会话的控件值。
   const nativeControlsSessionRef = useRef(null);
   // refreshNativeControls 请求序号：快速切会话时多个 get_* invoke 并发在途，
   // 后发起的请求应胜出。没有它，先发起的慢响应会晚返回并把控件值/归属 ref 覆盖
   // 成旧会话——mode chip 随即显示全局 fallback 而非新会话实测值（串台/陈旧覆盖，
   // 与聊天页 modeState epoch 修复同款竞态）。
+  const nativeControlsRequestRef = useRef(0);
   // code 会话权限模式全局偏好（{ last_mode, yolo_confirmed }，null=未拉到）：
   // 驱动草稿态/刷新途中的默认 mode 展示，以及首次切 yolo 的一次性确认门。
   const [codePermPrefs, setCodePermPrefs] = useState(null);
@@ -1212,23 +1221,33 @@ export function CodexAcpView({
     .find(turn => turn.status === 'running') || null;
   // 原生车道底栏控件的展示值（归属保护：refresh 返回前按默认/暂存显示；
   // 默认 = 全局 code_last_mode，从未用过 code 模式 → Plan 只读）。
+  const nativeDraftControlsHandoff = nativeDraftControlsHandoffRef.current?.sessionId === activeId
+    ? nativeDraftControlsHandoffRef.current.controls
+    : null;
   const nativeModeValue = resolveNativeModeValue({
     activeId,
     controlsSessionId: nativeControlsSessionRef.current,
     controlsMode: nativeControls.mode,
     draftMode: nativeDraftControls.mode,
+    handoffMode: nativeDraftControlsHandoff?.mode,
     prefs: codePermPrefs,
   });
   const nativeModelChoices = visibleUserModels((bs && bs.savedModels) || [])
     .map(model => ({ value: model.id, name: selectorMainLabel(model, t) || model.id }));
   const nativeSessionModelId = activeId
-    ? (nativeControlsSessionRef.current === activeId ? nativeControls.modelId : null)
+    ? (nativeControlsSessionRef.current === activeId
+      ? nativeControls.modelId
+      : (nativeDraftControlsHandoff?.modelId || null))
     : (nativeDraftControls.modelId || null);
   const nativeMountedId = activeId
-    ? (nativeControlsSessionRef.current === activeId ? nativeControls.mountedId : null)
+    ? (nativeControlsSessionRef.current === activeId
+      ? nativeControls.mountedId
+      : (nativeDraftControlsHandoff?.mountedId ?? null))
     : (nativeDraftControls.mountedId ?? null);
   const nativeMultiAgentSelected = activeId
-    ? (nativeControlsSessionRef.current === activeId && Boolean(nativeControls.multiAgent))
+    ? (nativeControlsSessionRef.current === activeId
+      ? Boolean(nativeControls.multiAgent)
+      : Boolean(nativeDraftControlsHandoff?.multiAgent))
     : Boolean(nativeDraftControls.multiAgent);
   // Existing sessions use the backend SessionPolicy result. A Pinvou draft is
   // known to become a native Code session, so it may stage the same control
@@ -1434,6 +1453,8 @@ export function CodexAcpView({
 
   /// 拉取原生会话的模型/知识库/模式状态（全部 per-session 命令，显式 sessionId）。
   async function refreshNativeControls(sessionId) {
+    const requestId = nativeControlsRequestRef.current + 1;
+    nativeControlsRequestRef.current = requestId;
     const [modelId, mountedId, modeState] = await Promise.all([
       invoke('get_session_model_id', { sessionId }).catch(() => null),
       invoke('session_mounted_collection', { sessionId }).catch(() => null),
@@ -1448,7 +1469,9 @@ export function CodexAcpView({
       multiAgentAvailable: Boolean(modeState && modeState.multi_agent_available),
     };
     // 请求期间可能切换会话；旧响应不得覆盖新会话的模型/模式/多智能体展示。
-    if (sessionId !== activeIdRef.current) return controls;
+    if (requestId !== nativeControlsRequestRef.current || sessionId !== activeIdRef.current) {
+      return controls;
+    }
     setNativeControls(controls);
     nativeControlsSessionRef.current = sessionId;
     return controls;
@@ -1471,10 +1494,17 @@ export function CodexAcpView({
   /// 草稿态暂存的控件选择在新会话上应用；失败报错不静默（逐个应用，多智能体最后）。
   /// 任一步失败即整体失败：清空暂存并上抛，由 sendNative 外层 catch 兜住（会话已创建，
   /// 保留半份暂存会在下次创建会话时把过期的部分选择悄悄应用，形成孤儿暂存）。
-  async function applyNativeDraftControls(sessionId, staged) {
+  function clearNativeDraftControls(staged) {
+    setNativeDraftControls(current => current === staged ? {} : current);
+    if (nativeDraftControlsHandoffRef.current?.controls === staged) {
+      nativeDraftControlsHandoffRef.current = null;
+    }
+  }
+
+  async function persistNativeDraftControls(sessionId, staged) {
     const hasMultiAgentSelection = Object.prototype.hasOwnProperty.call(staged, 'multiAgent');
     const hasStaged = staged.modelId || staged.mountedId != null || staged.mode || hasMultiAgentSelection;
-    if (!hasStaged) return;
+    if (!hasStaged) return false;
     try {
       if (staged.modelId) {
         await invoke('set_session_model', { sessionId, modelId: staged.modelId });
@@ -1495,19 +1525,13 @@ export function CodexAcpView({
           enabled: Boolean(staged.multiAgent),
         });
       }
-      setNativeDraftControls(current => current === staged ? {} : current);
     } catch (err) {
       // 会话已经创建且部分配置可能已生效：清空暂存避免未来复用过期选择，
       // 错误继续上抛，由 sendNative 的 catch 提示用户并恢复输入框文本。
-      setNativeDraftControls(current => current === staged ? {} : current);
+      clearNativeDraftControls(staged);
       throw err;
     }
-    // 暂存落地后必须再刷新一次实测值：会话物化时 effect 触发的
-    // refreshNativeControls 通常在暂存应用链（mode 排最后）落地前就带着
-    // 后端默认值返回了，chip 停在旧 mode（如 plan），要重进对话才刷新。
-    // 此处以应用后的实测值收口；refreshNativeControls 的请求序号保证在途
-    // 旧读返回时被丢弃，不会反向覆盖。
-    await refreshNativeControls(sessionId);
+    return true;
   }
 
   /// 切模型：set_session_model 会 evict 该会话 engine，lane busy 时由控件禁用兜底。
@@ -1815,7 +1839,7 @@ export function CodexAcpView({
     }
   }
 
-  async function createSession({ shouldActivate = () => true } = {}) {
+  async function createSession({ shouldActivate = () => true, prepareSession = null } = {}) {
     const requestedWorkspacePath = draftWorkspacePath;
     const requestedWorkspaceHandle = draftWorkspaceHandle;
     const requestedAgentId = draftAgentId;
@@ -1833,6 +1857,10 @@ export function CodexAcpView({
       current === requestedWorkspaceHandle ? null : current
     ));
     await refreshSessions();
+    // Native first-send controls must exist before the session is exposed and loaded.
+    // Otherwise loadSession observes the unbound default, and its local state update can
+    // race the later model write while the parent is still committing activeId.
+    if (prepareSession) await prepareSession(metadata.id);
     if (!shouldActivate()) {
       const info = requestedAgentId === 'pinvou'
         ? null
@@ -2582,6 +2610,7 @@ export function CodexAcpView({
     const workspaceReferencesAtSend = workspaceReferences;
     const nativeDraftControlsAtSend = nativeDraftControls;
     let targetId = activeId;
+    const materializingDraft = !targetId;
     let operation = beginAcpSendOperation(targetId);
     if (!operation) return;
     setError('');
@@ -2589,18 +2618,28 @@ export function CodexAcpView({
       if (!targetId) {
         const created = await createSession({
           shouldActivate: () => canApplyAcpSendOperation(operation),
+          prepareSession: async sessionId => {
+            const prepared = await persistNativeDraftControls(
+              sessionId,
+              nativeDraftControlsAtSend,
+            );
+            if (prepared) {
+              nativeDraftControlsHandoffRef.current = {
+                sessionId,
+                controls: nativeDraftControlsAtSend,
+              };
+            }
+          },
         });
         targetId = created.id;
         if (created.activated && activeIdRef.current === targetId) {
           acpSendOperationTracker.switchSession(targetId);
           operation = beginAcpSendOperation(targetId);
         }
-        // 草稿态暂存的模型/知识库/模式/多智能体选择先落到新会话（失败会显式报错）。
-        await applyNativeDraftControls(targetId, nativeDraftControlsAtSend);
-        // createSession 内的首次 load 发生在草稿控件落盘之前；若用户在草稿态
-        // 开启了多智能体，那次 load 读到的是旧的 false。首条消息发送前必须
-        // 再读一次后端权威状态，保证输入框开关及时反映刚落盘的会话配置。
-        await refreshNativeControls(targetId);
+        // prepareSession has already persisted the draft controls before loadSession,
+        // and the authoritative load now owns the displayed values. Clear only after
+        // that handoff completes so the selected model label remains stable.
+        clearNativeDraftControls(nativeDraftControlsAtSend);
         setAttachmentDrafts(current => transferAcpDraftItems(
           current,
           DRAFT_ATTACHMENT_KEY,
@@ -2655,6 +2694,7 @@ export function CodexAcpView({
         reference => reference,
       ));
     } catch (err) {
+      if (materializingDraft) clearNativeDraftControls(nativeDraftControlsAtSend);
       if (canApplyAcpSendOperation(operation)) {
         showError(err);
         setDraft(message);

--- a/pinvou3-app/src/features/codex/code-permission-state.js
+++ b/pinvou3-app/src/features/codex/code-permission-state.js
@@ -27,7 +27,8 @@ export function needsYoloConfirmation(prefs) {
 }
 
 /// 底栏 mode chip 的展示值：会话控件已按 sessionId 归属刷新 → 用会话实测值；
-/// 刷新途中 / 草稿态 → 全局默认（draft 有用户暂存选择时优先暂存）。
+/// 刷新途中 → 首发物化交接值（handoffMode，无交接则全局默认）；
+/// 草稿态 → 全局默认（draft 有用户暂存选择时优先暂存）。
 export function resolveNativeModeValue({
   activeId,
   controlsSessionId,

--- a/pinvou3-app/src/features/codex/code-permission-state.js
+++ b/pinvou3-app/src/features/codex/code-permission-state.js
@@ -28,9 +28,17 @@ export function needsYoloConfirmation(prefs) {
 
 /// 底栏 mode chip 的展示值：会话控件已按 sessionId 归属刷新 → 用会话实测值；
 /// 刷新途中 / 草稿态 → 全局默认（draft 有用户暂存选择时优先暂存）。
-export function resolveNativeModeValue({ activeId, controlsSessionId, controlsMode, draftMode, prefs }) {
+export function resolveNativeModeValue({
+  activeId,
+  controlsSessionId,
+  controlsMode,
+  draftMode,
+  handoffMode,
+  prefs,
+}) {
   const fallback = nativeModeFallback(prefs);
   if (activeId && controlsSessionId === activeId && controlsMode) return controlsMode;
+  if (activeId && handoffMode) return handoffMode;
   if (activeId) return fallback;
   return draftMode || fallback;
 }

--- a/pinvou3-app/src/features/codex/native-session-handoff.js
+++ b/pinvou3-app/src/features/codex/native-session-handoff.js
@@ -1,4 +1,7 @@
-// Pure state and lifecycle helpers for materializing a native Code draft into a session.
+// Pure helpers for the native Code session lifecycle: display resolution for the
+// draft→session activation handoff, issue/commit gating for native control
+// refreshes across session switches, and the creation pipeline that persists
+// draft controls before a new session is exposed and loaded.
 
 export function resolveNativeModelId({
   activeId,

--- a/pinvou3-app/src/features/codex/native-session-handoff.js
+++ b/pinvou3-app/src/features/codex/native-session-handoff.js
@@ -45,7 +45,7 @@ export async function finalizePreparedSessionCreation({
   activateSession(sessionId);
   const info = await loadSession(sessionId);
   // Preparation can partially persist controls before failing. Loading the created
-  // session first preserves that state and gives a retry a stable session target.
-  if (preparationError) throw preparationError;
-  return { id: sessionId, info, activated: true };
+  // session first preserves that state and gives a retry a stable session target. Return
+  // the error so the caller can rebind session-scoped operation state before reporting it.
+  return { id: sessionId, info, activated: true, preparationError };
 }

--- a/pinvou3-app/src/features/codex/native-session-handoff.js
+++ b/pinvou3-app/src/features/codex/native-session-handoff.js
@@ -12,6 +12,18 @@ export function resolveNativeModelId({
   return draftModelId || null;
 }
 
+// Issues the sequence number for a control refresh. A refresh aimed at a session
+// other than the active one is certain to be dropped by canApplyNativeControlsRefresh,
+// so it must not consume a sequence number: otherwise a late request for a stale
+// session (e.g. fired after an awaited control mutation) would supersede the active
+// session's in-flight authoritative refresh, leaving its controls stuck on fallback
+// values with no replacement request.
+export function claimNativeControlsRefreshId({ sessionId, activeId, latestRequestId }) {
+  if (sessionId !== activeId) return { requestId: 0, latestRequestId };
+  const requestId = latestRequestId + 1;
+  return { requestId, latestRequestId: requestId };
+}
+
 export function canApplyNativeControlsRefresh({
   requestId,
   latestRequestId,

--- a/pinvou3-app/src/features/codex/native-session-handoff.js
+++ b/pinvou3-app/src/features/codex/native-session-handoff.js
@@ -1,0 +1,51 @@
+// Pure state and lifecycle helpers for materializing a native Code draft into a session.
+
+export function resolveNativeModelId({
+  activeId,
+  controlsSessionId,
+  controlsModelId,
+  draftModelId,
+  handoffModelId,
+}) {
+  if (activeId && controlsSessionId === activeId) return controlsModelId || null;
+  if (activeId) return handoffModelId || null;
+  return draftModelId || null;
+}
+
+export function canApplyNativeControlsRefresh({
+  requestId,
+  latestRequestId,
+  sessionId,
+  activeId,
+}) {
+  return requestId === latestRequestId && sessionId === activeId;
+}
+
+export async function finalizePreparedSessionCreation({
+  sessionId,
+  prepareSession,
+  shouldActivate,
+  activateSession,
+  loadSession,
+  loadInactiveSessionInfo,
+}) {
+  let preparationError = null;
+  try {
+    if (prepareSession) await prepareSession(sessionId);
+  } catch (err) {
+    preparationError = err;
+  }
+
+  if (!shouldActivate()) {
+    if (preparationError) throw preparationError;
+    const info = loadInactiveSessionInfo ? await loadInactiveSessionInfo(sessionId) : null;
+    return { id: sessionId, info, activated: false };
+  }
+
+  activateSession(sessionId);
+  const info = await loadSession(sessionId);
+  // Preparation can partially persist controls before failing. Loading the created
+  // session first preserves that state and gives a retry a stable session target.
+  if (preparationError) throw preparationError;
+  return { id: sessionId, info, activated: true };
+}

--- a/pinvou3-app/tests/code_permission_state.test.mjs
+++ b/pinvou3-app/tests/code_permission_state.test.mjs
@@ -53,6 +53,11 @@ try {
     activeId: 's2', controlsSessionId: 's1', controlsMode: 'plan', draftMode: null,
     prefs: { last_mode: 'yolo', yolo_confirmed: true },
   }), 'yolo');
+  // 首发物化中的新会话使用与该会话绑定的 handoff，不能闪成全局默认。
+  assert.equal(resolveNativeModeValue({
+    activeId: 's2', controlsSessionId: null, controlsMode: 'plan', draftMode: null,
+    handoffMode: 'yolo', prefs: null,
+  }), 'yolo');
   // 草稿态：无暂存 → 全局默认（首次 Plan / 跟随 last_mode）；有暂存 → 暂存优先。
   assert.equal(resolveNativeModeValue({
     activeId: null, controlsSessionId: null, controlsMode: 'plan', draftMode: null, prefs: null,

--- a/pinvou3-app/tests/code_permission_state.test.mjs
+++ b/pinvou3-app/tests/code_permission_state.test.mjs
@@ -18,6 +18,10 @@ copyFileSync(
   path.join(root, 'src', 'features', 'codex', 'code-permission-state.js'),
   path.join(temp, 'codex', 'code-permission-state.js'),
 );
+copyFileSync(
+  path.join(root, 'src', 'features', 'codex', 'native-session-handoff.js'),
+  path.join(temp, 'codex', 'native-session-handoff.js'),
+);
 
 try {
   const {
@@ -26,6 +30,11 @@ try {
     needsYoloConfirmation,
     resolveNativeModeValue,
   } = await import(`${pathToFileURL(path.join(temp, 'codex', 'code-permission-state.js')).href}?t=${Date.now()}`);
+  const {
+    canApplyNativeControlsRefresh,
+    finalizePreparedSessionCreation,
+    resolveNativeModelId,
+  } = await import(`${pathToFileURL(path.join(temp, 'codex', 'native-session-handoff.js')).href}?t=${Date.now()}`);
 
   // ── 全局默认 mode 解析 ─────────────────────────────────────────
   assert.equal(CODE_MODE_FALLBACK, 'plan', '兜底必须是只读方向 Plan');
@@ -72,10 +81,99 @@ try {
   }), 'plan');
 
   // ── CodexAcpView.jsx 接线契约 ──────────────────────────────────
+  // A staged model must remain visible throughout delayed activation. A late control
+  // response from the previous request cannot replace the authoritative new-session value.
+  let controls = { sessionId: 'old-session', modelId: 'model-b' };
+  const handoff = { sessionId: 'new-session', modelId: 'model-a' };
+  assert.equal(resolveNativeModelId({
+    activeId: null,
+    controlsSessionId: controls.sessionId,
+    controlsModelId: controls.modelId,
+    draftModelId: 'model-a',
+    handoffModelId: null,
+  }), 'model-a');
+  assert.equal(resolveNativeModelId({
+    activeId: handoff.sessionId,
+    controlsSessionId: controls.sessionId,
+    controlsModelId: controls.modelId,
+    draftModelId: null,
+    handoffModelId: handoff.modelId,
+  }), 'model-a');
+
+  const applyRefresh = ({ requestId, latestRequestId, sessionId, modelId }) => {
+    if (!canApplyNativeControlsRefresh({
+      requestId,
+      latestRequestId,
+      sessionId,
+      activeId: handoff.sessionId,
+    })) return false;
+    controls = { sessionId, modelId };
+    return true;
+  };
+  assert.equal(applyRefresh({
+    requestId: 2,
+    latestRequestId: 2,
+    sessionId: handoff.sessionId,
+    modelId: 'model-a',
+  }), true);
+  assert.equal(applyRefresh({
+    requestId: 1,
+    latestRequestId: 2,
+    sessionId: handoff.sessionId,
+    modelId: null,
+  }), false);
+  assert.equal(resolveNativeModelId({
+    activeId: handoff.sessionId,
+    controlsSessionId: controls.sessionId,
+    controlsModelId: controls.modelId,
+    draftModelId: null,
+    handoffModelId: handoff.modelId,
+  }), 'model-a');
+
+  // Preparation can fail after the backend session exists. Activate and load that same
+  // session before rethrowing so the restored composer retries there, not in a duplicate.
+  {
+    const preparationError = new Error('model persistence failed');
+    const calls = [];
+    let activeSessionId = null;
+    await assert.rejects(
+      finalizePreparedSessionCreation({
+        sessionId: 'new-session',
+        prepareSession: async sessionId => {
+          calls.push(`prepare:${sessionId}`);
+          throw preparationError;
+        },
+        shouldActivate: () => {
+          calls.push('should-activate');
+          return true;
+        },
+        activateSession: sessionId => {
+          calls.push(`activate:${sessionId}`);
+          activeSessionId = sessionId;
+        },
+        loadSession: async sessionId => {
+          calls.push(`load:${sessionId}`);
+          return null;
+        },
+        loadInactiveSessionInfo: null,
+      }),
+      error => error === preparationError,
+    );
+    assert.equal(activeSessionId, 'new-session');
+    assert.deepEqual(calls, [
+      'prepare:new-session',
+      'should-activate',
+      'activate:new-session',
+      'load:new-session',
+    ]);
+  }
+
   const view = readFileSync(path.join(root, 'src', 'features', 'codex', 'CodexAcpView.jsx'), 'utf8');
   assert.match(view, /invoke\('get_code_permission_prefs'\)/, '启动/切换拉取全局 code 权限偏好');
   assert.match(view, /invoke\('confirm_code_yolo'\)/, '确认卡【确认】写全局标志');
   assert.match(view, /resolveNativeModeValue\(/, 'chip 展示值经纯逻辑解析');
+  assert.match(view, /resolveNativeModelId\(/, 'native model display must use the tested handoff resolver');
+  assert.match(view, /finalizePreparedSessionCreation\(/, 'native session creation must use the tested preparation lifecycle');
   assert.match(view, /data-testid="native-yolo-confirm"/, 'yolo 确认卡渲染');
   assert.match(view, /needsYoloConfirmation\(prefs\)/, '切 yolo 前过确认门');
   assert.doesNotMatch(view, /mountedId: null, mode: 'yolo'/, '不再写死 yolo 初始 mode');

--- a/pinvou3-app/tests/code_permission_state.test.mjs
+++ b/pinvou3-app/tests/code_permission_state.test.mjs
@@ -36,6 +36,7 @@ try {
   } = await import(`${pathToFileURL(path.join(temp, 'codex', 'code-permission-state.js')).href}?t=${Date.now()}`);
   const {
     canApplyNativeControlsRefresh,
+    claimNativeControlsRefreshId,
     finalizePreparedSessionCreation,
     resolveNativeModelId,
   } = await import(`${pathToFileURL(path.join(temp, 'codex', 'native-session-handoff.js')).href}?t=${Date.now()}`);
@@ -137,7 +138,34 @@ try {
     handoffModelId: handoff.modelId,
   }), 'model-a');
 
-  // Preparation can fail after the backend session exists. This exercises the integration
+  // ── 请求序号发放：陈旧会话的刷新不得占用序号 ─────────────────────
+  // 发起时已不归属当前会话的刷新注定被归属检查丢弃；若它占用序号，会把当前会话
+  // 在途的权威刷新顶成过期且无人补发，控件卡死在全局兜底（跨会话抢占回归）。
+  {
+    let latest = 0;
+    // 当前会话 B 的权威刷新正常领取序号。
+    let claim = claimNativeControlsRefreshId({ sessionId: 'B', activeId: 'B', latestRequestId: latest });
+    latest = claim.latestRequestId;
+    assert.equal(claim.requestId, 1);
+    // 用户在 accept_plan 在途期间从 A 切到 B；A 的陈旧刷新晚发起，不得顶掉序号。
+    const stale = claimNativeControlsRefreshId({ sessionId: 'A', activeId: 'B', latestRequestId: latest });
+    assert.equal(stale.requestId, 0, 'stale-session refresh must not claim a sequence number');
+    assert.equal(stale.latestRequestId, 1, 'stale-session refresh must not supersede the active request');
+    // B 的在途刷新返回后仍可提交；陈旧请求提交时被拒绝。
+    assert.equal(canApplyNativeControlsRefresh({
+      requestId: 1, latestRequestId: stale.latestRequestId, sessionId: 'B', activeId: 'B',
+    }), true);
+    assert.equal(canApplyNativeControlsRefresh({
+      requestId: stale.requestId, latestRequestId: stale.latestRequestId, sessionId: 'A', activeId: 'B',
+    }), false);
+    // 同会话内仍保持后发胜出：B 再次刷新领取新序号，旧响应被丢弃。
+    claim = claimNativeControlsRefreshId({ sessionId: 'B', activeId: 'B', latestRequestId: stale.latestRequestId });
+    assert.equal(claim.requestId, 2);
+    assert.equal(canApplyNativeControlsRefresh({
+      requestId: 1, latestRequestId: claim.latestRequestId, sessionId: 'B', activeId: 'B',
+    }), false);
+  }
+
   // between creation and the real operation tracker: activation invalidates the draft token,
   // then sendNative-style rebinding makes the visible error path current again.
   {

--- a/pinvou3-app/tests/code_permission_state.test.mjs
+++ b/pinvou3-app/tests/code_permission_state.test.mjs
@@ -22,6 +22,10 @@ copyFileSync(
   path.join(root, 'src', 'features', 'codex', 'native-session-handoff.js'),
   path.join(temp, 'codex', 'native-session-handoff.js'),
 );
+copyFileSync(
+  path.join(root, 'src', 'features', 'codex', 'acp-session-operation.js'),
+  path.join(temp, 'codex', 'acp-session-operation.js'),
+);
 
 try {
   const {
@@ -35,6 +39,9 @@ try {
     finalizePreparedSessionCreation,
     resolveNativeModelId,
   } = await import(`${pathToFileURL(path.join(temp, 'codex', 'native-session-handoff.js')).href}?t=${Date.now()}`);
+  const { createAcpSessionOperationTracker } = await import(
+    `${pathToFileURL(path.join(temp, 'codex', 'acp-session-operation.js')).href}?t=${Date.now()}`
+  );
 
   // ── 全局默认 mode 解析 ─────────────────────────────────────────
   assert.equal(CODE_MODE_FALLBACK, 'plan', '兜底必须是只读方向 Plan');
@@ -130,36 +137,50 @@ try {
     handoffModelId: handoff.modelId,
   }), 'model-a');
 
-  // Preparation can fail after the backend session exists. Activate and load that same
-  // session before rethrowing so the restored composer retries there, not in a duplicate.
+  // Preparation can fail after the backend session exists. This exercises the integration
+  // between creation and the real operation tracker: activation invalidates the draft token,
+  // then sendNative-style rebinding makes the visible error path current again.
   {
     const preparationError = new Error('model persistence failed');
     const calls = [];
+    const visibleErrors = [];
+    const tracker = createAcpSessionOperationTracker('draft');
+    let operation = tracker.begin('draft', 'send');
     let activeSessionId = null;
-    await assert.rejects(
-      finalizePreparedSessionCreation({
-        sessionId: 'new-session',
-        prepareSession: async sessionId => {
-          calls.push(`prepare:${sessionId}`);
-          throw preparationError;
-        },
-        shouldActivate: () => {
-          calls.push('should-activate');
-          return true;
-        },
-        activateSession: sessionId => {
-          calls.push(`activate:${sessionId}`);
-          activeSessionId = sessionId;
-        },
-        loadSession: async sessionId => {
-          calls.push(`load:${sessionId}`);
-          return null;
-        },
-        loadInactiveSessionInfo: null,
-      }),
-      error => error === preparationError,
-    );
+    const created = await finalizePreparedSessionCreation({
+      sessionId: 'new-session',
+      prepareSession: async sessionId => {
+        calls.push(`prepare:${sessionId}`);
+        throw preparationError;
+      },
+      shouldActivate: () => {
+        calls.push('should-activate');
+        return tracker.isCurrent(operation);
+      },
+      activateSession: sessionId => {
+        calls.push(`activate:${sessionId}`);
+        activeSessionId = sessionId;
+        tracker.switchSession(sessionId);
+      },
+      loadSession: async sessionId => {
+        calls.push(`load:${sessionId}`);
+        return null;
+      },
+      loadInactiveSessionInfo: null,
+    });
+    assert.equal(tracker.isCurrent(operation), false, 'activation invalidates the draft operation');
+    if (created.activated && activeSessionId === created.id) {
+      tracker.switchSession(created.id);
+      operation = tracker.begin(created.id, 'send');
+    }
+    try {
+      if (created.preparationError) throw created.preparationError;
+    } catch (err) {
+      if (tracker.isCurrent(operation)) visibleErrors.push(err);
+    }
     assert.equal(activeSessionId, 'new-session');
+    assert.equal(operation.sessionId, 'new-session');
+    assert.deepEqual(visibleErrors, [preparationError]);
     assert.deepEqual(calls, [
       'prepare:new-session',
       'should-activate',
@@ -174,6 +195,11 @@ try {
   assert.match(view, /resolveNativeModeValue\(/, 'chip 展示值经纯逻辑解析');
   assert.match(view, /resolveNativeModelId\(/, 'native model display must use the tested handoff resolver');
   assert.match(view, /finalizePreparedSessionCreation\(/, 'native session creation must use the tested preparation lifecycle');
+  assert.match(
+    view,
+    /operation = beginAcpSendOperation\(targetId\);[\s\S]{0,500}if \(created\.preparationError\) throw created\.preparationError;/,
+    'native preparation errors must surface only after the send operation is rebound',
+  );
   assert.match(view, /data-testid="native-yolo-confirm"/, 'yolo 确认卡渲染');
   assert.match(view, /needsYoloConfirmation\(prefs\)/, '切 yolo 前过确认门');
   assert.doesNotMatch(view, /mountedId: null, mode: 'yolo'/, '不再写死 yolo 初始 mode');

--- a/pinvou3-app/tests/code_permission_state.test.mjs
+++ b/pinvou3-app/tests/code_permission_state.test.mjs
@@ -164,10 +164,16 @@ try {
     assert.equal(canApplyNativeControlsRefresh({
       requestId: 1, latestRequestId: claim.latestRequestId, sessionId: 'B', activeId: 'B',
     }), false);
+    // 序号虽是最新，但会话不归属当前：归属检查必须独立承重，不能只靠序号差异。
+    assert.equal(canApplyNativeControlsRefresh({
+      requestId: 3, latestRequestId: 3, sessionId: 'A', activeId: 'B',
+    }), false, 'a current sequence number must not let a stale session commit');
   }
 
-  // between creation and the real operation tracker: activation invalidates the draft token,
-  // then sendNative-style rebinding makes the visible error path current again.
+  // Preparation can fail after the backend session exists. This exercises the
+  // integration between creation and the real operation tracker: activation
+  // invalidates the draft token, then sendNative-style rebinding makes the
+  // visible error path current again.
   {
     const preparationError = new Error('model persistence failed');
     const calls = [];
@@ -217,6 +223,56 @@ try {
     ]);
   }
 
+  // ── finalize 非激活分支与异常传播 ─────────────────────────────────
+  {
+    const calls = [];
+    const created = await finalizePreparedSessionCreation({
+      sessionId: 's9',
+      prepareSession: async () => { calls.push('prepare'); },
+      shouldActivate: () => { calls.push('should-activate'); return false; },
+      activateSession: () => { throw new Error('must not activate'); },
+      loadSession: async () => { throw new Error('must not load'); },
+      loadInactiveSessionInfo: async id => { calls.push(`info:${id}`); return { id }; },
+    });
+    assert.deepEqual(created, { id: 's9', info: { id: 's9' }, activated: false });
+    assert.deepEqual(calls, ['prepare', 'should-activate', 'info:s9'],
+      'non-activation must not activate or load, only fetch inactive info');
+    const prepErr = new Error('prepare failed before activation check');
+    await assert.rejects(finalizePreparedSessionCreation({
+      sessionId: 's9',
+      prepareSession: async () => { throw prepErr; },
+      shouldActivate: () => false,
+      activateSession: () => {},
+      loadSession: async () => null,
+      loadInactiveSessionInfo: null,
+    }), prepErr, 'prepare failure with no activation must throw directly');
+    const loadErr = new Error('load failed after activation');
+    await assert.rejects(finalizePreparedSessionCreation({
+      sessionId: 's9',
+      prepareSession: null,
+      shouldActivate: () => true,
+      activateSession: () => {},
+      loadSession: async () => { throw loadErr; },
+      loadInactiveSessionInfo: null,
+    }), loadErr, 'load failures must propagate to the caller');
+  }
+
+  // ── 权威控件 vs handoff 优先级（用不同值区分分支） ────────────────
+  // 权威刷新按归属提交后，即使残留 handoff 也必须用实测值；无 handoff 且
+  // 控件归属过期时显示空，绝不显示上一会话的值。
+  assert.equal(resolveNativeModelId({
+    activeId: 's1', controlsSessionId: 's1', controlsModelId: 'model-b',
+    draftModelId: null, handoffModelId: 'model-a',
+  }), 'model-b', 'session-owned authoritative model must beat the stale handoff');
+  assert.equal(resolveNativeModelId({
+    activeId: 's1', controlsSessionId: 'old', controlsModelId: 'model-b',
+    draftModelId: null, handoffModelId: null,
+  }), null, 'no handoff + stale controls must show null, never the previous session model');
+  assert.equal(resolveNativeModeValue({
+    activeId: 's1', controlsSessionId: 's1', controlsMode: 'plan',
+    draftMode: null, handoffMode: 'yolo', prefs: null,
+  }), 'plan', 'session-owned authoritative mode must beat the stale handoff');
+
   const view = readFileSync(path.join(root, 'src', 'features', 'codex', 'CodexAcpView.jsx'), 'utf8');
   assert.match(view, /invoke\('get_code_permission_prefs'\)/, '启动/切换拉取全局 code 权限偏好');
   assert.match(view, /invoke\('confirm_code_yolo'\)/, '确认卡【确认】写全局标志');
@@ -225,8 +281,29 @@ try {
   assert.match(view, /finalizePreparedSessionCreation\(/, 'native session creation must use the tested preparation lifecycle');
   assert.match(
     view,
-    /operation = beginAcpSendOperation\(targetId\);[\s\S]{0,500}if \(created\.preparationError\) throw created\.preparationError;/,
+    /operation = beginAcpSendOperation\(targetId\);[\s\S]{0,800}if \(created\.preparationError\) throw created\.preparationError;/,
     'native preparation errors must surface only after the send operation is rebound',
+  );
+  // activeIdRef 只允许在 layout effect 内重指：渲染期赋值会被携带旧 prop 的中间
+  // 渲染打回旧值，吞掉 loadSession 的乐观交接（首发标签闪回全局兜底的根因之一）。
+  assert.equal((view.match(/activeIdRef\.current = activeId;/g) || []).length, 1,
+    'activeIdRef must be assigned from the prop exactly once');
+  assert.ok(
+    view.indexOf('activeIdRef.current = activeId;') > view.indexOf('useLayoutEffect(() => {')
+      && view.indexOf('activeIdRef.current = activeId;') < view.indexOf('acpConfigOperationTracker.switchSession'),
+    'activeIdRef must only be re-pointed inside the layout effect so optimistic handoffs survive intermediate renders',
+  );
+  const clearNativeDraft = view.indexOf('function clearNativeDraftControls(staged)');
+  assert.ok(
+    clearNativeDraft >= 0
+      && view.indexOf('setNativeDraftControls(current => current === staged ? {} : current)', clearNativeDraft) > clearNativeDraft
+      && view.indexOf('nativeDraftControlsHandoffRef.current = null;', clearNativeDraft) > clearNativeDraft,
+    'clearing draft controls must stay identity-guarded and must drop the matching handoff',
+  );
+  assert.ok(
+    view.includes(': (nativeDraftControlsHandoff?.mountedId ?? null)')
+      && view.includes(': Boolean(nativeDraftControlsHandoff?.multiAgent)'),
+    'knowledge and multi-agent display must keep the same activation handoff as model/mode',
   );
   assert.match(view, /data-testid="native-yolo-confirm"/, 'yolo 确认卡渲染');
   assert.match(view, /needsYoloConfirmation\(prefs\)/, '切 yolo 前过确认门');

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -730,27 +730,34 @@ try {
     && !codexView.includes('bridge.interaction.')
     && !codexView.includes('bridge.chat.'),
   'the code lane must never call bridge chat-active-bound methods for composer controls');
-  const nativeDraftApplyStart = codexView.indexOf('async function applyNativeDraftControls(sessionId, staged)');
+  const nativeDraftApplyStart = codexView.indexOf('async function persistNativeDraftControls(');
   const nativeDraftMultiAgent = codexView.indexOf("invoke('set_multi_agent_mode'", nativeDraftApplyStart);
-  const nativeDraftClear = codexView.indexOf('setNativeDraftControls(current => current === staged ? {} : current)', nativeDraftMultiAgent);
+  const nativeCreateStart = codexView.indexOf('async function createSession({');
+  const nativeCreatePrepare = codexView.indexOf('if (prepareSession) await prepareSession(metadata.id)', nativeCreateStart);
+  const nativeCreateLoad = codexView.indexOf('const info = await loadSession(metadata.id)', nativeCreateStart);
   const nativeSendCreate = codexView.indexOf('const created = await createSession({', codexView.indexOf('async function sendNative'));
-  const nativeSendApply = codexView.indexOf('await applyNativeDraftControls(targetId, nativeDraftControlsAtSend)', nativeSendCreate);
+  const nativeSendPrepare = codexView.indexOf('prepareSession: async sessionId => {', nativeSendCreate);
+  const nativeSendApply = codexView.indexOf('const prepared = await persistNativeDraftControls(', nativeSendPrepare);
+  const nativeSendClear = codexView.indexOf('clearNativeDraftControls(nativeDraftControlsAtSend)', nativeSendApply);
   assert.ok(codexView.includes('nativeDraftControls')
     && nativeDraftApplyStart >= 0
     && nativeDraftMultiAgent > nativeDraftApplyStart
-    && nativeDraftClear > nativeDraftMultiAgent
+    && nativeCreatePrepare > nativeCreateStart
+    && nativeCreatePrepare < nativeCreateLoad
     && nativeSendCreate >= 0
-    && nativeSendApply > nativeSendCreate,
-  'draft-state control selections, including multi-agent mode, must be applied after session creation and before first send');
+    && nativeSendPrepare > nativeSendCreate
+    && nativeSendApply > nativeSendPrepare
+    && nativeSendClear > nativeSendApply,
+  'draft-state control selections, including multi-agent mode, must be persisted before the first session load and cleared only after handoff');
   assert.ok(
-    nativeSendApply < codexView.indexOf('await refreshNativeControls(targetId)', nativeSendApply)
-      && codexView.indexOf('await refreshNativeControls(targetId)', nativeSendApply)
-        < codexView.indexOf("await invoke('chat'", nativeSendApply),
-    'a newly created native session must refresh authoritative multi-agent state after applying draft controls and before its first turn',
+    codexView.includes('nativeDraftControlsHandoffRef.current?.sessionId === activeId')
+      && codexView.includes('nativeDraftControlsHandoff?.modelId || null')
+      && nativeSendApply < codexView.indexOf("await invoke('chat'", nativeSendApply),
+    'a newly created native session must retain its selected model during the activation handoff and before its first turn',
   );
   assert.ok(codexView.includes('nativeControlsSessionRef.current === activeId'),
   'session control state must be scoped to its owning session to avoid cross-session flashes');
-  assert.ok(/refreshNativeControls\(sessionId\)[\s\S]{0,900}sessionId !== activeIdRef\.current[\s\S]{0,100}return controls/.test(codexView),
+  assert.ok(/refreshNativeControls\(sessionId\)[\s\S]{0,1200}requestId !== nativeControlsRequestRef\.current \|\| sessionId !== activeIdRef\.current[\s\S]{0,100}return controls/.test(codexView),
   'an async control refresh from the previous native session must not overwrite the newly selected session');
   assert.ok(chatView.includes("from './composer-controls.jsx'")
     && !chatView.includes('const ComposerKbSelector = ')

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -733,8 +733,9 @@ try {
   const nativeDraftApplyStart = codexView.indexOf('async function persistNativeDraftControls(');
   const nativeDraftMultiAgent = codexView.indexOf("invoke('set_multi_agent_mode'", nativeDraftApplyStart);
   const nativeCreateStart = codexView.indexOf('async function createSession({');
-  const nativeCreatePrepare = codexView.indexOf('if (prepareSession) await prepareSession(metadata.id)', nativeCreateStart);
-  const nativeCreateLoad = codexView.indexOf('const info = await loadSession(metadata.id)', nativeCreateStart);
+  const nativeCreateFinalize = codexView.indexOf('return finalizePreparedSessionCreation({', nativeCreateStart);
+  const nativeCreatePrepare = codexView.indexOf('prepareSession,', nativeCreateFinalize);
+  const nativeCreateLoad = codexView.indexOf('loadSession,', nativeCreateFinalize);
   const nativeSendCreate = codexView.indexOf('const created = await createSession({', codexView.indexOf('async function sendNative'));
   const nativeSendPrepare = codexView.indexOf('prepareSession: async sessionId => {', nativeSendCreate);
   const nativeSendApply = codexView.indexOf('const prepared = await persistNativeDraftControls(', nativeSendPrepare);
@@ -742,7 +743,8 @@ try {
   assert.ok(codexView.includes('nativeDraftControls')
     && nativeDraftApplyStart >= 0
     && nativeDraftMultiAgent > nativeDraftApplyStart
-    && nativeCreatePrepare > nativeCreateStart
+    && nativeCreateFinalize > nativeCreateStart
+    && nativeCreatePrepare > nativeCreateFinalize
     && nativeCreatePrepare < nativeCreateLoad
     && nativeSendCreate >= 0
     && nativeSendPrepare > nativeSendCreate
@@ -751,13 +753,15 @@ try {
   'draft-state control selections, including multi-agent mode, must be persisted before the first session load and cleared only after handoff');
   assert.ok(
     codexView.includes('nativeDraftControlsHandoffRef.current?.sessionId === activeId')
-      && codexView.includes('nativeDraftControlsHandoff?.modelId || null')
+      && codexView.includes('handoffModelId: nativeDraftControlsHandoff?.modelId')
       && nativeSendApply < codexView.indexOf("await invoke('chat'", nativeSendApply),
     'a newly created native session must retain its selected model during the activation handoff and before its first turn',
   );
   assert.ok(codexView.includes('nativeControlsSessionRef.current === activeId'),
   'session control state must be scoped to its owning session to avoid cross-session flashes');
-  assert.ok(/refreshNativeControls\(sessionId\)[\s\S]{0,1200}requestId !== nativeControlsRequestRef\.current \|\| sessionId !== activeIdRef\.current[\s\S]{0,100}return controls/.test(codexView),
+  assert.ok(codexView.includes('canApplyNativeControlsRefresh({')
+    && codexView.includes('latestRequestId: nativeControlsRequestRef.current')
+    && codexView.includes('activeId: activeIdRef.current'),
   'an async control refresh from the previous native session must not overwrite the newly selected session');
   assert.ok(chatView.includes("from './composer-controls.jsx'")
     && !chatView.includes('const ComposerKbSelector = ')

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -763,6 +763,10 @@ try {
     && codexView.includes('latestRequestId: nativeControlsRequestRef.current')
     && codexView.includes('activeId: activeIdRef.current'),
   'an async control refresh from the previous native session must not overwrite the newly selected session');
+  assert.ok(codexView.includes('claimNativeControlsRefreshId({')
+    && codexView.indexOf('claimNativeControlsRefreshId({')
+      < codexView.indexOf('canApplyNativeControlsRefresh({'),
+  'a refresh aimed at a stale session must not claim a sequence number and supersede the active session refresh');
   assert.ok(chatView.includes("from './composer-controls.jsx'")
     && !chatView.includes('const ComposerKbSelector = ')
     && !chatView.includes('const ComposerModeChip = ')


### PR DESCRIPTION
## Background

On the first turn of a new Pinvou native Code conversation, the model selector could change from the selected model to the empty fallback label even though the backend continued using the selected model. The initial session load raced the draft-control persistence and active-session handoff.

## Changes

- Persist native draft controls before exposing and loading the newly created session.
- Preserve model, knowledge, mode, and multi-agent display values during the exact session activation handoff.
- Move active-session ref synchronization to the layout phase so an intermediate render cannot overwrite the optimistic session target.
- Add request ordering to native control refreshes so stale responses cannot overwrite newer state.
- Add regression coverage for first-load ordering and handoff display behavior.

## Verification

- node --test: 5 related test files passed
- python scripts/architecture-guard.py
- git diff --check

## Known risks

- A full Vite build was not run locally because pinvou3-app dependencies are not installed in this checkout. CI remains the authoritative full build verification.