### PR TITLE
fix(bundle): emit JSON deny reason in MCP introspection hook

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/bundle/deny_sensitive_paths.ps1
+++ b/pinvou3-app/src-tauri/resources/common/bundle/deny_sensitive_paths.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = "Stop"
+﻿$ErrorActionPreference = "Stop"
 
 $toolName = if ($env:DEEPSEEK_TOOL_NAME) { $env:DEEPSEEK_TOOL_NAME } else { "unknown" }
 $argsText = if ($env:DEEPSEEK_TOOL_ARGS) { $env:DEEPSEEK_TOOL_ARGS } else { "" }
@@ -118,6 +118,25 @@ if ($toolName -like "exec_shell*" -or $toolName -eq "code_execution") {
         if ($haystack.Contains($pattern.ToLowerInvariant())) {
             Deny-SensitivePath $pattern
         }
+    }
+}
+
+# 与 deny_sensitive_paths.sh 规则 5 对等：技能型连接器（企微/飞书/钉钉/腾讯会议）
+# 无 MCP schema，模型调 list_mcp_resources* 自省必然失败并误判「没连上」。
+# 拦掉并把纠正回传：上游 fold_tool_call_before_results 在 exit 2 时只从 stdout 的
+# 单行 JSON {"decision":"deny","reason":...} 取 reason 喂回模型（非 JSON = 通用文案），
+# 文案刻意不回显连接器名、不列举技能/CLI 名（disable 感知审计，泄漏面 2）。
+if ($toolName -eq "list_mcp_resources" -or $toolName -eq "list_mcp_resource_templates") {
+    if ($argsText -match "wecom|weixin|wework|feishu|lark|dingtalk|dingding|dws|tmeet|tencent[\s_\-]?meeting|企微|企业微信|微信|飞书|钉钉|腾讯会议") {
+        $denyJson = '{"decision":"deny","reason":"该名称不是 MCP server（无 MCP schema），无法用 list_mcp_resources 自省。若它是技能型连接器，请用 load_skill 加载其对应技能后按技能说明使用。连接状态以工具面板为准，自省失败不代表未连接。"}'
+        # 经标准输出流写 UTF-8 无 BOM：上游按 UTF-8 解码 stdout 且 serde_json 拒绝
+        # BOM 前缀；PS 5.1 控制台默认 ANSI(GBK)，WriteLine 会把中文转成乱码。
+        # 不设 [Console]::OutputEncoding：无控制台句柄的宿主里 setter 会抛，
+        # $ErrorActionPreference=Stop 下脚本退出 1 → 所有工具调用被 fail-closed。
+        $stdout = New-Object System.IO.StreamWriter([Console]::OpenStandardOutput(), (New-Object System.Text.UTF8Encoding($false)))
+        $stdout.WriteLine($denyJson)
+        $stdout.Flush()
+        exit 2
     }
 }
 

--- a/pinvou3-app/src-tauri/resources/common/bundle/deny_sensitive_paths.sh
+++ b/pinvou3-app/src-tauri/resources/common/bundle/deny_sensitive_paths.sh
@@ -96,18 +96,20 @@ if [[ "$TOOL" == "exec_shell"* ]]; then
 fi
 
 # 5) 技能型连接器被误当 MCP 自省：企微/飞书/钉钉/腾讯会议是「技能型连接器」
-#    （wecomcli-* / lark-* / dws / tmeet-skill，
-#    无 MCP schema），模型却可能对它们调 list_mcp_resources / list_mcp_resource_templates
+#    （无 MCP schema），模型却可能对它们调 list_mcp_resources / list_mcp_resource_templates
 #    去自省能力 → 必然失败 → 误判「没连上」，甚至谎称缺技能。这里拦掉并把纠正回传：
-#    deny 文案走 **stdout 首行**（fold_tool_call_before_results 在 exit 2 时取 stdout 首行
-#    作 deny_reason，喂回模型当 tool 失败原因），引导模型改用 load_skill。
+#    fold_tool_call_before_results 在 exit 2 时只从 stdout 的 JSON {"decision":"deny",
+#    "reason":...} 取 reason 喂回模型（非 JSON stdout = passthrough，reason 落为通用
+#    文案），所以必须输出单行 JSON，引导模型改用 load_skill。
 #    取代原 bundle/instructions.md 常驻那条软纪律：零常驻 prompt + 现场硬反馈对小模型更准。
+#    文案刻意不回显连接器名、不列举技能/CLI 名：模型问一个不应连带知道全部，
+#    且对「已禁用」的连接器不确认其存在（disable 感知审计，泄漏面 2）。
 if [[ "$TOOL" == "list_mcp_resources" || "$TOOL" == "list_mcp_resource_templates" ]]; then
     # 关键词覆盖模型可能传的各种写法:英文 wecom/weixin/wework、中文全称「企业微信」
     # (注意「企微」子串不含在「企业微信」里,必须显式列全称)、feishu/lark/飞书、
     # 以及 dingtalk/dingding/dws/钉钉、tmeet/tencent meeting/腾讯会议。
     if [[ "$ARGS" =~ (wecom|weixin|wework|feishu|lark|dingtalk|dingding|dws|tmeet|tencent[[:space:]_-]?meeting|企微|企业微信|微信|飞书|钉钉|腾讯会议) ]]; then
-        echo "企微/飞书/钉钉/腾讯会议不是 MCP server（无 schema），是技能型连接器：请改用 load_skill 加载 wecomcli-* / lark-* / dws / tmeet-skill 技能，再按技能说明跑 wecom-cli / lark-cli / dws / tmeet。连接状态以工具面板为准，自省失败不代表未连接。"
+        echo '{"decision":"deny","reason":"该名称不是 MCP server（无 MCP schema），无法用 list_mcp_resources 自省。若它是技能型连接器，请用 load_skill 加载其对应技能后按技能说明使用。连接状态以工具面板为准，自省失败不代表未连接。"}'
         exit 2
     fi
 fi


### PR DESCRIPTION
## Background

Rule 5 of the `deny_sensitive_paths` ToolCallBefore hook (split out from #347 per review) assumed a "first stdout line becomes the deny reason" contract that does not exist in the pinned engine. `fold_tool_call_before_results` (`CodeWhale/crates/tui/src/core/engine/turn_loop.rs`) only reads a **JSON `reason` field** from hook stdout on exit 2 (`parse_tool_call_before_stdout`, `hooks/executor.rs`); non-JSON stdout is a legacy passthrough and the model receives an opaque generic deny. The plain-text `echo` was dead code and the `load_skill` redirect — the entire point of the rule — never reached the model.

Separately, the old deny text named all four skill-type connectors and their skill/CLI ids verbatim, confirming product structure — and, for a disabled connector, its existence — to the model (disable perception audit, leak surface 2).

## Changes

- `deny_sensitive_paths.sh`: rule 5 now emits a single-line `{"decision":"deny","reason":"…"}` before `exit 2`. The message is generic (no connector names, no skill/CLI enumeration) and survives `sanitize_hook_denial_reason` (one line, 120 chars, under the 240-char cap).
- `deny_sensitive_paths.ps1`: adds the missing parity rule (the Windows twin had no rule 5 at all). The JSON is written through a `StreamWriter` with `UTF8Encoding($false)` — the engine decodes stdout as UTF-8 and `serde_json` rejects a BOM preamble, while the PS 5.1 console default (ANSI/GBK) would mangle the Chinese text. `[Console]::OutputEncoding` is deliberately **not** set: in hosts without a console handle the setter throws, and under `$ErrorActionPreference = "Stop"` the script would exit 1 and fail-close every tool call on the machine. The file is saved as UTF-8 with BOM so PS 5.1 parses the non-ASCII content.

## Verification

- Executed both hooks directly: a matching `list_mcp_resources` call (`企业微信`) exits 2 with valid single-line JSON on stdout — verified on bash and on Windows PowerShell 5.1 (stdout starts with `{"d`, no BOM, Chinese intact); a non-matching server exits 0.
- No Rust test asserts on script contents; scripts are embedded via `include_str!` and extracted verbatim, so the BOM round-trips to `~/.pinvou3/bundle/`.

## Known scope notes

- Rules 1–4 (and the ps1 `Deny-SensitivePath`) still send their reasons to stderr, so the model sees the generic deny there too — pre-existing, intentionally left out of this PR to keep the diff minimal.
