### PR TITLE
fix(sidebar): close two code-mode lifecycle gaps

### DIFF
--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -1191,10 +1191,12 @@ function workspaceDisplayName(path) {
       async function handleOpenScheduledRunShortcut(run) {
         if (!run || !run.sessionId) return;
         // A scheduled-run session is a normal chat: both the fallback and the
-        // successful-open branches land on the scheduled view, so exit code mode once at
-        // the entry — otherwise a regular session shows behind a code-only session list.
-        setCodeModeOn(false);
+        // successful-open branches land on the scheduled view, so each branch
+        // exits code mode right before navigating. Clearing once at the entry
+        // would also clear it when the open fails, leaving an active code
+        // session behind the standard sidebar and New chat creating plain drafts.
         if (!bridge.available || !bridge.scheduled.openScheduledRunChat) {
+          setCodeModeOn(false);
           setCurrentView('scheduled');
           closeMobileSidebar();
           return;
@@ -1205,7 +1207,10 @@ function workspaceDisplayName(path) {
           model: run.taskModel || null,
         };
         const opened = await bridge.scheduled.openScheduledRunChat(run, task);
-        if (opened) setCurrentView('scheduled');
+        if (opened) {
+          setCodeModeOn(false);
+          setCurrentView('scheduled');
+        }
       }
 
       function handleNewChat(installedToolId, forceMode) {
@@ -1232,6 +1237,11 @@ function workspaceDisplayName(path) {
           setCodexDraftEpoch(value => value + 1);
           setCurrentView('codex');
         } else {
+          // Every landing here is a normal chat (tool intent, forceMode='chat',
+          // code mode off, or codex unsupported on this host). createNewSession
+          // nulls activeSessionId, so the bridge sync guard cannot heal a stale
+          // codeModeOn afterwards — clear it here.
+          setCodeModeOn(false);
           if (bridge.available) bridge.sessions.createNewSession();
           setCurrentView('chat');
         }

--- a/pinvou3-app/tests/code_mode_exit_contract.test.mjs
+++ b/pinvou3-app/tests/code_mode_exit_contract.test.mjs
@@ -40,18 +40,31 @@ assertClearBefore(
   'bridge composerPrefill',
 );
 
-// 3. Scheduled-run shortcut: both the unavailable-bridge fallback and the
-// successful openScheduledRunChat branch land on the scheduled view showing a
-// regular conversation, so the mode is cleared once at the entry.
+// 3. Scheduled-run shortcut: the unavailable-bridge fallback and the
+// successful openScheduledRunChat branch each land on the scheduled view
+// showing a regular conversation, so each branch clears the mode right
+// before navigating. The entry must NOT clear unconditionally: when the open
+// fails the user is still on the active code session, and an entry-side clear
+// would leave it behind the standard sidebar.
 {
-  const body = windowFrom('async function handleOpenScheduledRunShortcut(run)', 1200);
-  assertClearBefore(body, 'scheduled', 'handleOpenScheduledRunShortcut');
-  const firstNav = body.indexOf("setCurrentView('scheduled')");
+  const head = windowFrom('async function handleOpenScheduledRunShortcut(run)', 700);
+  const fallbackAt = head.indexOf('if (!bridge.available || !bridge.scheduled.openScheduledRunChat)');
+  assert.ok(fallbackAt > -1, 'handleOpenScheduledRunShortcut: fallback branch marker not found');
   assert.ok(
-    body.includes("setCurrentView('scheduled')", firstNav + 1),
-    'handleOpenScheduledRunShortcut: expected both branches covered by the shared entry-point clear',
+    !head.slice(0, fallbackAt).includes('setCodeModeOn(false)'),
+    'handleOpenScheduledRunShortcut: entry must not clear code mode — the failed-open path stays on the active code session',
   );
 }
+assertClearBefore(
+  windowFrom('if (!bridge.available || !bridge.scheduled.openScheduledRunChat)'),
+  'scheduled',
+  'scheduled-run shortcut fallback branch',
+);
+assertClearBefore(
+  windowFrom('const opened = await bridge.scheduled.openScheduledRunChat(run, task);'),
+  'scheduled',
+  'scheduled-run shortcut open branch',
+);
 
 // 4. Pet scheduled notice: opening the run chat lands on the scheduled view.
 assertClearBefore(
@@ -77,6 +90,32 @@ assertClearBefore(
   windowFrom("if (!SCHEDULED_TASKS_ENTRY_ENABLED && currentView === 'scheduled')"),
   'chat',
   'retired scheduled entry fallback',
+);
+
+// 7. New chat: the non-codex branch of handleNewChat lands on a normal chat
+// draft. This covers the tool-intent path (tool store "new chat with this
+// tool") that force-skips the codex draft even while code mode is on, plus
+// forceMode='chat' call sites — the highest-traffic exit path of the mode.
+assertClearBefore(
+  windowFrom("// Every landing here is a normal chat (tool intent, forceMode='chat',", 600),
+  'chat',
+  'handleNewChat normal-chat branch',
+);
+
+// 8. Session list: opening a normal chat session is the baseline exit path.
+assertClearBefore(
+  windowFrom('async function handleSwitchSession(id)', 500),
+  'chat',
+  'handleSwitchSession',
+);
+
+// 9. navigateFromScheduledRun('chat') serves the collapsed-rail "current chat"
+// and the mobile bottom tab — the round-2 P1 fix site. The navigation uses a
+// variable, so pin the guard line itself instead of a clear-before-nav order.
+assert.match(
+  main,
+  /setCurrentView\(nextView\);[\s\S]{0,300}if \(nextView === 'chat'\) setCodeModeOn\(false\);/,
+  "navigateFromScheduledRun('chat'): navigating back to chat must exit code mode",
 );
 
 console.log('code mode exit contract tests passed');


### PR DESCRIPTION
Follow-up to #326 (merged as acc587bd3). A round-4 review of the mode lifecycle that PR establishes found two defects; the merge landed before this fix could be pushed onto the original branch, so they are on `main` today. Both are small, surgical fixes plus contract-test coverage.

## Defect 1 — tool-intent New chat leaks code mode (P1)

`handleNewChat`'s non-codex branch (tool-store "new chat with this tool", `forceMode='chat'`, code mode off, or codex unsupported on this host) landed on a normal chat **without clearing `codeModeOn`**.

Repro: enter code mode → tool store → install a tool → click "new chat with this tool". The visible page becomes a normal `ChatView`, but the sidebar stays code-filtered (the active session is not listed/highlighted) and later bare New-chat clicks silently create codex drafts — exactly the invariant violation #326 set out to eliminate.

There is no self-heal: `createNewSession()` nulls `activeSessionId`, and the bridge-sync guard (`if (bs.activeSessionId && ...)`) never fires on null.

**Fix**: clear the mode in the branch (the comment explains why every landing there is a normal chat and why the sync guard cannot heal it).

## Defect 2 — scheduled-run shortcut clears code mode on failed open (P2)

`handleOpenScheduledRunShortcut` cleared `codeModeOn` unconditionally at the entry, but the failed-open path (`openScheduledRunChat` returns false, e.g. RPC/relay failure) never navigates away. The user stays on the active code session while the sidebar switches back to the standard list and New chat starts creating plain drafts — the inverse-direction leak.

**Fix**: move the clear into both branches (fallback and successful open), mirroring the existing pet-navigation shape.

## Tests

`tests/code_mode_exit_contract.test.mjs`:

- The shortcut is now pinned as per-branch clears **plus** an entry-must-not-clear assertion.
- Three previously unpinned exit sites are now covered: `handleNewChat`'s normal-chat branch, `handleSwitchSession` (the baseline exit path), and `navigateFromScheduledRun('chat')` (the round-2 P1 fix site).

## Verification

- `npm test` (pinvou3-app): 267/267 pass.
- `npx eslint` on touched files and `npm run lint:ui`: clean.
- `npm run build:ui`: clean.
- `python3 scripts/architecture-guard.py`: passed.
- Mutation checks (each turns the contract red, restore turns it green): remove the P1 clear; remove the open-branch clear; reintroduce the entry-side clear.

Reviewed in coordination with the author's rounds 1-3 on #326; the root cause, scope, and non-goals are unchanged.