### PR TITLE
feat(tool-store): group unknown-category items as Other

### DIFF
--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1111,9 +1111,10 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           return localizeSkill({
             id: 'mcp-skill-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || '',
             // 有配套 MCP(companion)的卡 = 工具包:徽标与分组归 bundle,安装态跟随 MCP。
-            // category 'skill' 仅作类型维度标记(getToolTypeGroup 据此归 Skill 组);
-            // 业务维度由 getToolBusinessGroup 统一落「其它」——无 MCP 归属可跟随的
-            // 独立技能业务分类未知(初步设计,见 tool-common 注释)。
+            // 业务类 category 跟随 companion MCP(mcpEntry 查 tsToolsData/tsToolWelcomeData);
+            // 查不到 MCP 或其无 category 时标 'skill'——仅作类型维度标记
+            // (getToolTypeGroup 据此归 Skill 组),业务维度由 getToolBusinessGroup
+            // 落「其他」(初步设计,见 tool-common 注释)。
             category: mcpEntry ? (mcpEntry.category || 'skill') : 'skill',
             type: mcpId ? ((storeCopy.typeGroups || {}).bundle || 'Bundle') : 'Skill',
             companionBundle: !!mcpId,
@@ -1127,7 +1128,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         });
       const uploadedSkills = skillBackend.filter(x => x.user_uploaded).map(x => ({
         id: 'up-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || storeCopy.uploadedSkill,
-        // 用户上传技能无业务归属元数据,业务分组落「其它」;类型分组仍按 userUploaded 归 Skill。
+        // 用户上传技能无业务归属元数据,业务分组落「其他」;类型分组仍按 userUploaded 归 Skill。
         category: 'other', type: 'Skill', version: '—', latency: storeCopy.localLatency, desc: x.description || '',
         icon: Package, color: 'bg-gradient-to-b from-slate-400 to-slate-600', installed: true, userUploaded: true,
         actions: actionsOf(bundleStates[x.id]),

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1029,7 +1029,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const bs = bundleStates[x.id] || null;
           const base = {
             id: 'mcp-' + x.id, backendId: x.id, title: x.name || x.id, subtitle: '',
-            category: 'life', type: 'MCP Server', mcpServer: true,
+            category: 'other', type: 'MCP Server', mcpServer: true,
             version: x.version ? `v${String(x.version).replace(/^v/i, '')}` : '—',
             latency: storeCopy.localLatency, desc: x.description || '',
             icon: Server, color: 'bg-gradient-to-b from-slate-400 to-slate-600',
@@ -1110,7 +1110,10 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           const skillInstalled = skillBs ? skillBs.installed : !!x.installed;
           return localizeSkill({
             id: 'mcp-skill-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || '',
-            // 有配套 MCP(companion)的卡 = 工具包:徽标与分组归 bundle,安装态跟随 MCP
+            // 有配套 MCP(companion)的卡 = 工具包:徽标与分组归 bundle,安装态跟随 MCP。
+            // category 'skill' 仅作类型维度标记(getToolTypeGroup 据此归 Skill 组);
+            // 业务维度由 getToolBusinessGroup 统一落「其它」——无 MCP 归属可跟随的
+            // 独立技能业务分类未知(初步设计,见 tool-common 注释)。
             category: mcpEntry ? (mcpEntry.category || 'skill') : 'skill',
             type: mcpId ? ((storeCopy.typeGroups || {}).bundle || 'Bundle') : 'Skill',
             companionBundle: !!mcpId,
@@ -1124,7 +1127,8 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         });
       const uploadedSkills = skillBackend.filter(x => x.user_uploaded).map(x => ({
         id: 'up-' + x.id, backendId: x.id, title: x.title, subtitle: x.subtitle || storeCopy.uploadedSkill,
-        category: 'skill', type: 'Skill', version: '—', latency: storeCopy.localLatency, desc: x.description || '',
+        // 用户上传技能无业务归属元数据,业务分组落「其它」;类型分组仍按 userUploaded 归 Skill。
+        category: 'other', type: 'Skill', version: '—', latency: storeCopy.localLatency, desc: x.description || '',
         icon: Package, color: 'bg-gradient-to-b from-slate-400 to-slate-600', installed: true, userUploaded: true,
         actions: actionsOf(bundleStates[x.id]),
       }));
@@ -1145,7 +1149,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       const typeLabel = id => ((storeCopy.typeGroups || {})[id]) || id;
       const primaryGroupOf = groupBy === 'type' ? typeGroupOf : getToolBusinessGroup;
       const sectionGroupOf = groupBy === 'type' ? getToolBusinessGroup : typeGroupOf;
-      const sectionOrder = groupBy === 'type' ? [...TOOL_BUSINESS_GROUPS, 'skill'] : TOOL_TYPE_GROUPS;
+      // 业务分区顺序即 TOOL_BUSINESS_GROUPS('skill' 已不再是业务分组——仅标 'skill'
+      // 的条目由 getToolBusinessGroup 落 'other';类型维度仍有 Skill 组)。
+      const sectionOrder = groupBy === 'type' ? TOOL_BUSINESS_GROUPS : TOOL_TYPE_GROUPS;
       const sectionLabelOf = groupBy === 'type' ? catLabel : typeLabel;
       // 二级筛选 chips:第一项恒为「全部」,其余只展示当前列表里有内容的组。
       // eslint-disable-next-line react-hooks/exhaustive-deps -- groupChips is rebuilt on every render; using it as the dep of the effect below is the existing contract, and useMemo would change list render behavior

--- a/pinvou3-app/src/features/tools/tool-common.jsx
+++ b/pinvou3-app/src/features/tools/tool-common.jsx
@@ -696,7 +696,7 @@ const AcFmtIcon = FileTypeIcon;
     // 注:pptx 不在此——它是「PPT 生成」MCP 的同名 companion 技能,卡片由后端
     // list_marketplace_skills 数据合成(见 ToolStoreView 的 companionSkillCards)。
     const tsSkillsData = [
-      { id: 's5', title: '视觉设计', subtitle: '设计系统直出网页 / banner / 海报 / 简历', category: 'skill', type: 'Skill', version: '内置', latency: '本地', desc: '内置自动技能:模型按需自动加载,以设计系统级审美直出网页 / banner / 海报 / 简历等。无需安装、随时可用。', icon: Palette, color: 'bg-gradient-to-b from-pink-400 to-fuchsia-600', installed: true, authRequired: false, builtin: true },
+      { id: 's5', title: '视觉设计', subtitle: '设计系统直出网页 / banner / 海报 / 简历', category: 'other', type: 'Skill', version: '内置', latency: '本地', desc: '内置自动技能:模型按需自动加载,以设计系统级审美直出网页 / banner / 海报 / 简历等。无需安装、随时可用。', icon: Palette, color: 'bg-gradient-to-b from-pink-400 to-fuchsia-600', installed: true, authRequired: false, builtin: true },
     ];
 
     // 后端合成技能卡的补充展示数据(按 backendId 取):
@@ -709,6 +709,7 @@ const AcFmtIcon = FileTypeIcon;
       { id: 'dev', label: '研发' },
       { id: 'finance', label: '金融数据' },
       { id: 'life', label: '生活实用' },
+      { id: 'other', label: '其它' },
       { id: 'skill', label: '技能' },
     ];
 
@@ -732,12 +733,15 @@ const AcFmtIcon = FileTypeIcon;
       if (tool.oauthMcp || tool.mcpServer || /mcp/i.test(tool.type || '')) return 'mcp';
       return 'api';
     };
-    // 业务分组:直接取条目 category(数据即业务类 id);技能卡单列 'skill',不参与业务分类。
-    const TOOL_BUSINESS_GROUPS = ['collab', 'docs', 'dev', 'finance', 'life'];
+    // 业务分组:直接取条目 category(数据即业务类 id)。无明确业务归属的条目
+    // (自定义上传 MCP、用户上传技能、内置视觉设计,以及 category 缺失/无法识别/
+    // 仅标 'skill' 的——'skill' 是类型而非业务类)一律落 'other' 单列「其它」,
+    // 不再兜底 'life'——未知条目错挂「生活实用」比单列「其它」更难发现。
+    // (初步设计:后续若给技能/插件补业务元数据,再把可识别者移出 'other'。)
+    const TOOL_BUSINESS_GROUPS = ['collab', 'docs', 'dev', 'finance', 'life', 'other'];
     const getToolBusinessGroup = (tool) => {
-      if (!tool) return 'life';
-      if (tool.category === 'skill') return 'skill';
-      return TOOL_BUSINESS_GROUPS.includes(tool.category) ? tool.category : 'life';
+      if (!tool) return 'other';
+      return TOOL_BUSINESS_GROUPS.includes(tool.category) ? tool.category : 'other';
     };
 
     // eslint-disable-next-line sonarjs/cognitive-complexity -- tool-card action buttons render many branches; legacy view; tracked separately

--- a/pinvou3-app/src/features/tools/tool-common.jsx
+++ b/pinvou3-app/src/features/tools/tool-common.jsx
@@ -709,8 +709,7 @@ const AcFmtIcon = FileTypeIcon;
       { id: 'dev', label: '研发' },
       { id: 'finance', label: '金融数据' },
       { id: 'life', label: '生活实用' },
-      { id: 'other', label: '其它' },
-      { id: 'skill', label: '技能' },
+      { id: 'other', label: '其他' },
     ];
 
     // ── 列表视图双维度分组(纯函数,ToolStoreView 消费;分支互斥、按优先级短路) ──
@@ -719,7 +718,8 @@ const AcFmtIcon = FileTypeIcon;
     const TOOL_TYPE_GROUPS = ['bundle', 'mcp', 'skill', 'cli', 'api', 'upcoming'];
     const getToolTypeGroup = (tool, bundleMcpIds) => {
       if (!tool) return 'upcoming';
-      // companion 合成卡优先判 bundle:卡面 category 恒为 skill,须先于 skill 规则短路
+      // companion 合成卡优先判 bundle:其 category 可为 'skill'(独立技能)或
+      // companion MCP 的业务类,不能靠 category 值判型,须按 companionBundle 标志短路
       if (tool.companionBundle) return 'bundle';
       // mcpServer/oauthMcp 显式标记位须先于 userUploaded/skill 分支（二轮评审：
       // 自定义上传的 MCP 卡同时带 userUploaded + mcpServer，旧顺序被错归为 Skill 组）。
@@ -735,8 +735,8 @@ const AcFmtIcon = FileTypeIcon;
     };
     // 业务分组:直接取条目 category(数据即业务类 id)。无明确业务归属的条目
     // (自定义上传 MCP、用户上传技能、内置视觉设计,以及 category 缺失/无法识别/
-    // 仅标 'skill' 的——'skill' 是类型而非业务类)一律落 'other' 单列「其它」,
-    // 不再兜底 'life'——未知条目错挂「生活实用」比单列「其它」更难发现。
+    // 仅标 'skill' 的——'skill' 是类型而非业务类)一律落 'other' 单列「其他」,
+    // 不再兜底 'life'——未知条目错挂「生活实用」比单列「其他」更难发现。
     // (初步设计:后续若给技能/插件补业务元数据,再把可识别者移出 'other'。)
     const TOOL_BUSINESS_GROUPS = ['collab', 'docs', 'dev', 'finance', 'life', 'other'];
     const getToolBusinessGroup = (tool) => {

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -827,7 +827,7 @@ visualizer: { title:'Data Visualization', subtitle:'Chart.js dashboards / chart 
 'skill-author': { title:'Skill Creation', subtitle:'Turn a one-line description into a proper SKILL.md skill', desc:'Turn a user\'s one-line description into a usable skill (SKILL.md directory): generate the name/description/instructions, and validate naming and structure. When a deliverable uploadable package is wanted, it can continue with the "Plugin Package Standardization" rules to add plugin.json and an icon, export a standard package, then ask the user whether to install.', latency:'Local' },
 s5: { title:'Visual Design', subtitle:'Design-system-grade webpages / banners / posters / resumes', desc:'Built-in automatic skill: the model loads it on demand to produce webpages, banners, posters, resumes, and more with design-system-grade aesthetics. No installation needed—always available.', version:'Built-in', latency:'Local' },
   },
-  categories: { all:'All', collab:'Collaboration', docs:'Docs & Knowledge', dev:'Development', finance:'Financial Data', life:'Daily Life', other:'Other', skill:'Skills' },
+  categories: { all:'All', collab:'Collaboration', docs:'Docs & Knowledge', dev:'Development', finance:'Financial Data', life:'Daily Life', other:'Other' },
 } });
 
 Object.assign(dictEn.uiToolStore, {

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -827,7 +827,7 @@ visualizer: { title:'Data Visualization', subtitle:'Chart.js dashboards / chart 
 'skill-author': { title:'Skill Creation', subtitle:'Turn a one-line description into a proper SKILL.md skill', desc:'Turn a user\'s one-line description into a usable skill (SKILL.md directory): generate the name/description/instructions, and validate naming and structure. When a deliverable uploadable package is wanted, it can continue with the "Plugin Package Standardization" rules to add plugin.json and an icon, export a standard package, then ask the user whether to install.', latency:'Local' },
 s5: { title:'Visual Design', subtitle:'Design-system-grade webpages / banners / posters / resumes', desc:'Built-in automatic skill: the model loads it on demand to produce webpages, banners, posters, resumes, and more with design-system-grade aesthetics. No installation needed—always available.', version:'Built-in', latency:'Local' },
   },
-  categories: { all:'All', collab:'Collaboration', docs:'Docs & Knowledge', dev:'Development', finance:'Financial Data', life:'Daily Life', skill:'Skills' },
+  categories: { all:'All', collab:'Collaboration', docs:'Docs & Knowledge', dev:'Development', finance:'Financial Data', life:'Daily Life', other:'Other', skill:'Skills' },
 } });
 
 Object.assign(dictEn.uiToolStore, {

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -830,7 +830,7 @@ visualizer: { title:'データ分析の可視化', subtitle:'Chart.js ダッシ�
 'skill-author': { title:'スキル作成', subtitle:'一言の説明から、きちんとした SKILL.md スキルを生成', desc:'ユーザーの一言の説明を、使えるスキル（SKILL.md ディレクトリ）に変えます：name / description / 本文の指示を生成し、命名と構造を検証します。アップロード可能なパッケージとして納品したい場合は、続けて「プラグインパッケージ標準化」のルールで plugin.json とアイコンを補い、標準パッケージを書き出して、最後にユーザーへインストールするか尋ねます。', latency:'ローカル' },
 s5: { title:'ビジュアルデザイン', subtitle:'デザインシステム級の Web ページ / バナー / ポスター / レジュメを直接生成', desc:'内蔵の自動スキル：モデルが必要に応じて自動で読み込み、デザインシステム級の美観で Web ページ / バナー / ポスター / レジュメなどを直接生成します。インストール不要でいつでも利用できます。', version:'内蔵', latency:'ローカル' },
   },
-  categories: { all:'すべて', collab:'連携・コラボ', docs:'ドキュメント・ナレッジ', dev:'開発', finance:'金融データ', life:'生活・実用', skill:'スキル' },
+  categories: { all:'すべて', collab:'連携・コラボ', docs:'ドキュメント・ナレッジ', dev:'開発', finance:'金融データ', life:'生活・実用', other:'その他', skill:'スキル' },
 } });
 
 Object.assign(dictJa.uiToolStore, {

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -830,7 +830,7 @@ visualizer: { title:'データ分析の可視化', subtitle:'Chart.js ダッシ�
 'skill-author': { title:'スキル作成', subtitle:'一言の説明から、きちんとした SKILL.md スキルを生成', desc:'ユーザーの一言の説明を、使えるスキル（SKILL.md ディレクトリ）に変えます：name / description / 本文の指示を生成し、命名と構造を検証します。アップロード可能なパッケージとして納品したい場合は、続けて「プラグインパッケージ標準化」のルールで plugin.json とアイコンを補い、標準パッケージを書き出して、最後にユーザーへインストールするか尋ねます。', latency:'ローカル' },
 s5: { title:'ビジュアルデザイン', subtitle:'デザインシステム級の Web ページ / バナー / ポスター / レジュメを直接生成', desc:'内蔵の自動スキル：モデルが必要に応じて自動で読み込み、デザインシステム級の美観で Web ページ / バナー / ポスター / レジュメなどを直接生成します。インストール不要でいつでも利用できます。', version:'内蔵', latency:'ローカル' },
   },
-  categories: { all:'すべて', collab:'連携・コラボ', docs:'ドキュメント・ナレッジ', dev:'開発', finance:'金融データ', life:'生活・実用', other:'その他', skill:'スキル' },
+  categories: { all:'すべて', collab:'連携・コラボ', docs:'ドキュメント・ナレッジ', dev:'開発', finance:'金融データ', life:'生活・実用', other:'その他' },
 } });
 
 Object.assign(dictJa.uiToolStore, {

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -862,7 +862,7 @@ visualizer: { title:'数据分析可视化', subtitle:'Chart.js 仪表盘 / 图�
 'skill-author': { title:'技能创建', subtitle:'用户描述一句话，生成规范的 SKILL.md 技能', desc:'把用户的一句话描述变成一个可用的技能（SKILL.md 目录）：生成 name/description/正文指令，校验命名与结构；需要交付成可上传插件包时，可继续按「插件包标准化」规则补 plugin.json、图标并导出标准包，最后询问用户是否安装。', latency:'本地' },
 s5: { title:'视觉设计', subtitle:'设计系统直出网页 / banner / 海报 / 简历', desc:'内置自动技能:模型按需自动加载,以设计系统级审美直出网页 / banner / 海报 / 简历等。无需安装、随时可用。', version:'内置', latency:'本地' },
   },
-  categories: { all:'全部', collab:'沟通协作', docs:'文档知识', dev:'研发', finance:'金融数据', life:'生活实用', other:'其它', skill:'技能' },
+  categories: { all:'全部', collab:'沟通协作', docs:'文档知识', dev:'研发', finance:'金融数据', life:'生活实用', other:'其他' },
 } });
 
 

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -862,7 +862,7 @@ visualizer: { title:'数据分析可视化', subtitle:'Chart.js 仪表盘 / 图�
 'skill-author': { title:'技能创建', subtitle:'用户描述一句话，生成规范的 SKILL.md 技能', desc:'把用户的一句话描述变成一个可用的技能（SKILL.md 目录）：生成 name/description/正文指令，校验命名与结构；需要交付成可上传插件包时，可继续按「插件包标准化」规则补 plugin.json、图标并导出标准包，最后询问用户是否安装。', latency:'本地' },
 s5: { title:'视觉设计', subtitle:'设计系统直出网页 / banner / 海报 / 简历', desc:'内置自动技能:模型按需自动加载,以设计系统级审美直出网页 / banner / 海报 / 简历等。无需安装、随时可用。', version:'内置', latency:'本地' },
   },
-  categories: { all:'全部', collab:'沟通协作', docs:'文档知识', dev:'研发', finance:'金融数据', life:'生活实用', skill:'技能' },
+  categories: { all:'全部', collab:'沟通协作', docs:'文档知识', dev:'研发', finance:'金融数据', life:'生活实用', other:'其它', skill:'技能' },
 } });
 
 

--- a/pinvou3-app/tests/tool_store_grouping_smoke.js
+++ b/pinvou3-app/tests/tool_store_grouping_smoke.js
@@ -110,11 +110,13 @@ async function clickChip(page, text) {
     }));
     rec('点击「全部」chip 复位', await clickExact(page, '全部'));
     await sleep(300);
-    // 主维度=类型 → 下方按业务分区
+    // 主维度=类型 → 下方按业务分区。业务归属未知的条目(内置视觉设计/独立技能/
+    // 自定义上传 MCP)落「其它」分区;「技能」不再是业务分区(仅作类型维度组)。
     const sectionsByType = await page.evaluate(() => [...document.querySelectorAll('h3')].map(h => (h.textContent || '').trim()));
-    for (const label of ['沟通协作', '文档知识', '金融数据', '生活实用', '技能']) {
+    for (const label of ['沟通协作', '文档知识', '金融数据', '生活实用', '其它']) {
       rec(`按类型时业务分区「${label}」渲染`, sectionsByType.includes(label));
     }
+    rec('按类型时业务分区不含「技能」', !sectionsByType.includes('技能'));
 
     // 数量徽标 == 分区内实际渲染条目数(分区内工具卡标题同为 h3,故条目数 = h3 总数 - 1)
     const badgeSections = await page.evaluate(() => [...document.querySelectorAll('div.items-baseline')].map(head => ({
@@ -153,7 +155,7 @@ async function clickChip(page, text) {
     rec('点击「按业务」segment', await clickExact(page, '按业务'));
     await sleep(300);
     const bizChips = await page.evaluate(() => [...document.querySelectorAll('button')].map(b => (b.textContent || '').trim()));
-    for (const label of ['全部', '沟通协作', '文档知识', '研发', '金融数据', '生活实用']) {
+    for (const label of ['全部', '沟通协作', '文档知识', '研发', '金融数据', '生活实用', '其它']) {
       rec(`业务维度 chip「${label}」渲染`, bizChips.includes(label));
     }
     rec('业务维度 chip 不含「技能」', !bizChips.includes('技能'));

--- a/pinvou3-app/tests/tool_store_grouping_smoke.js
+++ b/pinvou3-app/tests/tool_store_grouping_smoke.js
@@ -111,11 +111,12 @@ async function clickChip(page, text) {
     rec('点击「全部」chip 复位', await clickExact(page, '全部'));
     await sleep(300);
     // 主维度=类型 → 下方按业务分区。业务归属未知的条目(内置视觉设计/独立技能/
-    // 自定义上传 MCP)落「其它」分区;「技能」不再是业务分区(仅作类型维度组)。
+    // 自定义上传 MCP)落「其他」分区;「技能」不再是业务分区(仅作类型维度组)。
     const sectionsByType = await page.evaluate(() => [...document.querySelectorAll('h3')].map(h => (h.textContent || '').trim()));
-    for (const label of ['沟通协作', '文档知识', '金融数据', '生活实用', '其它']) {
+    for (const label of ['沟通协作', '文档知识', '金融数据', '生活实用', '其他']) {
       rec(`按类型时业务分区「${label}」渲染`, sectionsByType.includes(label));
     }
+    // 「技能」标签已随业务维度的 skill 伪分组一并移除,不得再出现在业务分区
     rec('按类型时业务分区不含「技能」', !sectionsByType.includes('技能'));
 
     // 数量徽标 == 分区内实际渲染条目数(分区内工具卡标题同为 h3,故条目数 = h3 总数 - 1)
@@ -155,7 +156,7 @@ async function clickChip(page, text) {
     rec('点击「按业务」segment', await clickExact(page, '按业务'));
     await sleep(300);
     const bizChips = await page.evaluate(() => [...document.querySelectorAll('button')].map(b => (b.textContent || '').trim()));
-    for (const label of ['全部', '沟通协作', '文档知识', '研发', '金融数据', '生活实用', '其它']) {
+    for (const label of ['全部', '沟通协作', '文档知识', '研发', '金融数据', '生活实用', '其他']) {
       rec(`业务维度 chip「${label}」渲染`, bizChips.includes(label));
     }
     rec('业务维度 chip 不含「技能」', !bizChips.includes('技能'));


### PR DESCRIPTION
## What changed and why

Business grouping in the tool store previously fell back to `life` for unrecognized categories and listed skills under a `skill` pseudo-group. That left several kinds of entries without a meaningful business landing:

- user-uploaded skills
- custom uploaded (user-installed) MCP servers
- the built-in visual-design skill (s5)
- standalone synthesized skill cards with no companion MCP to inherit a category from
- any entry with a missing or unrecognized `category`

This PR adds an `other` business group (`TOOL_BUSINESS_GROUPS`, `tsCategories`, and the zh/en/ja `storeData.categories` entries: 其它 / Other / その他). `getToolBusinessGroup` now lands everything outside the known business ids into `other`, including entries merely tagged `skill` — a type, not a business category.

This is a preliminary design: once skills/plugins carry real business metadata, recognizable entries can move out of Other.

## Affected features, compatibility, risks

- Tool store business view (`ToolStoreView` "by business" grouping + filter chips): the `skill` business pseudo-section is gone; the entries above now appear under **Other**. No behavior change otherwise — empty groups are not rendered.
- Type view ("by type") is unchanged: `userUploaded`, `builtin`, and `category === 'skill'` markers still route cards to the Skill type group. Synthesized standalone skill cards intentionally keep `category: 'skill'` purely as a type marker; the business view maps them to Other via `getToolBusinessGroup`.
- Frontend-only change; no Rust, persistence, or API changes. i18n parity maintained (zh/en/ja).

## Tests actually run

- `npm run build:ui` — pass
- `npm run lint:ui` — pass
- `npm run test:node` — 260 tests, 258 pass; 1 failure is the pre-existing Windows-only path bug in `tests/i18n_lazy_language_gate.test.mjs` (`pathToFileURL(URL.pathname)` produces `D:\D:\...`), unrelated to this change and reproducible on `main`
- `node tests/settings_ui_smoke.js` — 67/67 pass
- `py -3 scripts/architecture-guard.py` — pass
- `./scripts/fork-guard.sh --fast` — pass

## Environment limitations

- Local `python3`/`python` on this Windows machine are Microsoft Store stubs; the architecture guard was run via `py -3` instead.
- Manual UI verification done in `tauri dev`: unknown-category entries render under 其它 in the business view.