### PR TITLE
chore(codewhale): sync r11 public baseline

### DIFF
--- a/docs/fork-modifications.en.md
+++ b/docs/fork-modifications.en.md
@@ -1,6 +1,6 @@
 # CodeWhale Fork Modification Register
 
-> Updated: 2026-08-25. Public maintenance baseline: upstream `v0.9.5` r10. Canonical Chinese register: [`docs/fork-modifications.md`](fork-modifications.md). This English page is a condensed summary; the Chinese version is the complete, authoritative register.
+> Updated: 2026-08-27. Public maintenance baseline: upstream `v0.9.5` r11. Canonical Chinese register: [`docs/fork-modifications.md`](fork-modifications.md). This English page is a condensed summary; the Chinese version is the complete, authoritative register.
 >
 > 2026-08-22 corrections: (1) the parent gitlink bump from r6 (`3bbf8421`) to r7 happened in parent PR #285 (`95502ac8`), not in PR #302 — PR #302 started from a pre-#285 main and merged without touching the gitlink; PR #305 later advanced the published baseline to r8. (2) PR #302 (capability-bundle unification, parent commit `c75f2fb2`) updated the parent-side scope model — the single `disabled_bundles.json` (package id × mode, plus `hidden_scopes`) replaced the separate `disabled_connectors.json` / `disabled_skills.json` files.
 
@@ -9,13 +9,20 @@
 | Item | Value |
 |---|---|
 | Upstream | `v0.9.5` at `853cb707bbcf4f7dc4268fba6d811e0d04083f9c` |
-| Public maintenance branch | `Pinvou/CodeWhale:pinvou3-clean` at `feb8761ae` (`pinvou-v0.9.5-r10`) |
-| Merged fixes | `Pinvou/CodeWhale#9`, `#11`, `#12`, `#13`, `#15`, `#16`, `#17`, and `#19` are merged |
-| Published status | `pinvou3-clean`, `pinvou-v0.9.5-r10`, and the parent gitlink resolve to `feb8761aeda31749f3d54c6e1f8ef460540567a1`; `r1` through `r10` remain immutable historical tags |
+| Public maintenance branch | `Pinvou/CodeWhale:pinvou3-clean` at `0d89a31be` (`pinvou-v0.9.5-r11`) |
+| Merged fixes | Existing `#9`, `#11`, `#12`, `#13`, `#15`, `#16`, `#17`, and `#19`, plus r11 PRs `#18`, `#21`, `#22`, `#25`, `#26`, `#27`, `#29`, and `#30`, are merged |
+| Published status | `pinvou3-clean`, `pinvou-v0.9.5-r11`, and the parent gitlink resolve to `0d89a31be016457c180501417dd2c0f34ce844a6`; `r1` through `r11` remain immutable historical tags |
 | Previous baseline backup | Tag `pinvou-v0.9.0-r4` and branch `backup/pinvou3-clean-v0.9.0-r4`, both at `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` |
-| Drift | Published r10 baseline: 64 files, `+5612/-702` |
+| Drift | Published r11 baseline: 96 files, `+7840/-980`; r10→r11 is 48 files, `+2242/-292` |
 | Organization | Four current long-lived topics; PR #13 removes the product-specific orchestration topic |
-| Guard inventory | Published r10 has 41 CodeWhale `forkguard_*` tests, plus two generic tool-compatibility regressions and parent fingerprints/behavior tests |
+| Guard inventory | Published r11 has 56 CodeWhale `forkguard_*` tests, plus generic tool/route compatibility regressions and parent fingerprints/behavior tests |
+
+### r11 provider, MCP, steer, and platform boundaries (published)
+
+- CodeWhale PRs #18, #21, #22, #25, #26, #27, #29, and #30 are published at `0d89a31be016457c180501417dd2c0f34ce844a6`. Strict-direct providers accept a wire-model casing difference only when exactly one owned model row proves the match; the parent adds a GLM bridge regression from a lowercase saved value to canonical `GLM-5.2`.
+- Explicit route output ceilings now constrain request budgets. Moonshot omits only incompatible tools, emits one user-visible diagnostic per turn, and rejects a named `tool_choice` when its target was omitted. Host MCP secret resolution avoids process-environment writes, while denied servers disappear consistently from the pool, catalog, direct calls, reloads, and subagent inheritance.
+- `withdraw_steer` returns `SteerWithdrawal` to distinguish withdrawn, committed, and missing input. Windows Shell output uses incremental UTF-8 decoding across polls, and dependency updates address the h2/lru advisories. r11 adds 15 `forkguard_*` regressions, raising the total from 41 to 56 without creating a new long-lived topic.
+- r11 adds 48 files and `+2242/-292` over r10. Provider projection, host MCP policy, steer lifecycle, and cross-platform Shell decoding remain generic upstream candidates.
 
 ### r10 fixed-sampling and compaction-usage boundaries (published)
 
@@ -48,8 +55,8 @@ CodeWhale PR #15 combined candidate `1eca6103a` with security follow-ups `169c24
 
 PR #13 was squash-merged as `a36e6cd533024cfe5724bae21875aea42b2ed87a` and published as immutable tag `pinvou-v0.9.5-r7`. It removes product-specific orchestration while preserving canonical registry prompt text and alias-aware Custom SubAgent allowlist resolution.
 
-1. **Host embedding and routing boundary** — `331cb1594688c723d98499d9ca11f05af291b599`, `2eceab4e19cb0b15576c09d5b89e0d8bc42e11fd` (`Pinvou/CodeWhale#11`), `a36e6cd533024cfe5724bae21875aea42b2ed87a` (`Pinvou/CodeWhale#13`), `8aa5f77d35ac1d00d1f444193543307a7e9b391c` (`Pinvou/CodeWhale#16`), `07d183e350ce4a1ed4f91bdfa1875c996e710d2b` (`Pinvou/CodeWhale#17`), and `feb8761aeda31749f3d54c6e1f8ef460540567a1` (`Pinvou/CodeWhale#19`). Exposes only the library modules and narrow host seams needed for Fleet roster loading, live-worker projection, resolved routes, runtime snapshots/recovery, bulk cancellation, terminal facts, reliable steer ownership, authoritative edit-target classification, exact provider sampling compatibility, and complete post-compaction usage estimation. Edit rejection cannot call the provider or mutate history, and the app reconciles an optimistic edit from the durable transcript. Fixed-sampling compatibility is limited to the exact Kimi Code membership model roster and exact `deepseek-v4-flash` Responses route; the Chat dialect preserves its documented contract, and gateways plus other models remain untouched. `CompactionCompleted` carries the canonical complete post-compaction input estimate so hosts can refresh and persist usage without duplicating engine token accounting.
-2. **Tool compatibility and command-execution safety** — `595adce47e2d1bcf895d7bfd6426c074eb969324`, `3bbf8421ebdb16bff71f83dac4d42c8fb65f0f02` (`Pinvou/CodeWhale#12`), `a36e6cd533024cfe5724bae21875aea42b2ed87a` (`Pinvou/CodeWhale#13`), `d127aed113529dc93754d044b9f352e9746f6b83` (`Pinvou/CodeWhale#15`), and the Shell-cancellation boundary in `8aa5f77d35ac1d00d1f444193543307a7e9b391c` (`Pinvou/CodeWhale#16`). Adds host `extra_tools`, dynamic `SetDisallowedTools`, file-size enforcement, fail-closed multiline command safety, schema-bound JSON-container repair, provider-role-safe continuations, canonical registry instructions, and alias-aware Custom SubAgent allowlists while reusing upstream `allowed_tools`. Cancellation terminates only foreground Shell work owned by the current turn instead of relying on dropped futures. The r8 extension layers an exact catalog/final-dispatch policy, trusted-root replacement, latched control-plane denial, hook opt-in, restricted log/audit redaction, and deferral of idle child/Shell continuations until an explicit replacement-authority message, while preserving the legacy `None` path. The parent GAIA integration explicitly requires read-only dispatch, projects the model-visible `File` schema to read/list/search actions, repeats the read-only check before final execution, and projects `Bash` into the hardened read-only Shell context. These generic seams remain prioritized for upstreaming; Pinvou's GAIA profiles stay app-owned.
+1. **Host embedding and routing boundary** — the established T1 commits through `feb8761aeda31749f3d54c6e1f8ef460540567a1` (`#19`), plus `485884913308cdf7564bc60da2e416be637083b5` (`#21`), `04e109af4b4786a0d49fbbeefdd77af15a9f495e` (`#22`), `69ed3bfbdb314f901d4cf4120f1caaaf0b6aa529` (`#30`), and `0d89a31be016457c180501417dd2c0f34ce844a6` (`#18`). Exposes narrow host seams for routing, runtime snapshots/recovery, reliable steer ownership and withdrawal, edit-target classification, provider compatibility, and post-compaction usage estimation. Explicit route ceilings constrain request budgets; strict-direct casing recovery requires one unambiguous owned model row. Edit rejection cannot call the provider or mutate history, and gateways plus ambiguous models remain untouched.
+2. **Tool compatibility and command-execution safety** — the established T2 commits through the Shell-cancellation boundary in `8aa5f77d35ac1d00d1f444193543307a7e9b391c` (`#16`), plus `44730dfe596b70f86ae2f928959877a3e3f494e4` (`#27`), `665b46cd9e67326459223aa662931bd36d726004` (`#29`), `04e109af4b4786a0d49fbbeefdd77af15a9f495e` (`#22`), `4831c3797b76485a912b056c76a4cff22f0a2863` (`#25`), and `e68a185c2ba07f327bd8b63bbfea6a70a96f33ea` (`#26`). Adds exact catalog/final-dispatch policy, read-only projections, per-tool Moonshot schema degradation with a visible diagnostic, process-local MCP secret resolution, pool-side denied-server sealing, and incremental Windows Shell decoding. These generic seams remain prioritized for upstreaming; Pinvou's GAIA profiles stay app-owned.
 3. **Embedded context and Skill sources** — `5a9f52941b83452c1e8b76c2d679bac315edcf70`. Seals ambient project authority, scans only the explicit Skill root, filters disabled Skills, preserves up to 100 KiB only for the Permissions fragment, and excludes internal reminders from Working Set extraction.
 4. **Automation and runtime lifecycle** — `fc84f7d3e5dca0e3db404d43e218597764129f9b`. Preserves stable conversation/thread identity, v4 task compatibility, anchored schedules, no-backfill/no-overlap behavior, and terminal-only cleanup.
 
@@ -65,8 +72,8 @@ Pinvou's product tool allowlist, connector state, UI, workspace selection, bundl
 ## Verification
 
 - CodeWhale format and locked library check pass.
-- All 41 CodeWhale `forkguard_*` tests pass for the published r10 baseline, including the four fixed-sampling and compaction-estimate regressions from `Pinvou/CodeWhale#19`.
-- Parent `./scripts/fork-guard.sh` passes with 21 app forkguard tests; both admitted-display edit-target regressions pass separately.
+- All 56 CodeWhale `forkguard_*` tests pass for the published r11 baseline, including the 15 route, Moonshot, MCP, steer, and Shell regressions added after r10.
+- Parent `./scripts/fork-guard.sh` passes with the app forkguard suite, including the strict-direct GLM casing bridge regression; both admitted-display edit-target regressions pass separately.
 - The Tauri/Web scheduled-task unit harness, architecture guard, version check, CI-policy tests, and strict public-submodule verifier pass.
 - Full product results are recorded in `docs/codewhale-upgrade-0.9.0-to-0.9.5.md`.
 

--- a/docs/fork-modifications.md
+++ b/docs/fork-modifications.md
@@ -4,19 +4,26 @@
 > 基线、主题边界、守护指纹和同步结论以本文与 `docs/fork-policy.md` 为准。
 > English: [`docs/fork-modifications.en.md`](fork-modifications.en.md)
 
-## 0. 当前状态（2026-08-25 · v0.9.5 r10 四主题公开基线）
+## 0. 当前状态（2026-08-27 · v0.9.5 r11 四主题公开基线）
 
 | 项 | 当前值 |
 |---|---|
 | 上游基线 | tag `v0.9.5`，commit `853cb707bbcf4f7dc4268fba6d811e0d04083f9c` |
-| 公开维护分支 | `Pinvou/CodeWhale:pinvou3-clean`，head `feb8761ae` |
-| 已合并修复 | `Pinvou/CodeWhale#9`、`#11`、`#12`、`#13`、`#15`、`#16`、`#17`、`#19` 已合并；公开维护分支固定于 `pinvou-v0.9.5-r10` |
-| 发布状态 | `pinvou3-clean`、`pinvou-v0.9.5-r10` 与父仓 gitlink 均指向 `feb8761aeda31749f3d54c6e1f8ef460540567a1`；`r1` 至 `r10` 保持不可变 |
+| 公开维护分支 | `Pinvou/CodeWhale:pinvou3-clean`，head `0d89a31be` |
+| 已合并修复 | 既有 `#9`、`#11`、`#12`、`#13`、`#15`、`#16`、`#17`、`#19`，以及 r11 的 `#18`、`#21`、`#22`、`#25`、`#26`、`#27`、`#29`、`#30` 均已合并；公开维护分支固定于 `pinvou-v0.9.5-r11` |
+| 发布状态 | `pinvou3-clean`、`pinvou-v0.9.5-r11` 与父仓 gitlink 均指向 `0d89a31be016457c180501417dd2c0f34ce844a6`；`r1` 至 `r11` 保持不可变 |
 | 旧基线备份 | tag `pinvou-v0.9.0-r4` + branch `backup/pinvou3-clean-v0.9.0-r4`，均指向 `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` |
 | 组织方式 | 从 `v0.9.5` clean re-fork 的 4 个当前长期主题；专用编排主题由 PR #13 整体撤销 |
-| drift | r10 公开基线 `64 files changed, +5612/-702`；净增 4910 行 |
-| 守护 | r10 为 41 条 CodeWhale `forkguard_*` 行为测试 + 2 条通用工具兼容回归 + 父仓指纹/行为测试 |
-| 父仓适配 | gitlink、`Cargo.lock`、`EngineConfig` v0.9.5 字段适配、拒绝编辑的终态/权威历史对账，以及压缩后用量即时刷新与持久化回填 |
+| drift | r11 公开基线 `96 files changed, +7840/-980`；净增 6860 行；r10→r11 为 `48 files changed, +2242/-292` |
+| 守护 | r11 为 56 条 CodeWhale `forkguard_*` 行为测试 + 通用工具/路由兼容回归 + 父仓指纹/行为测试 |
+| 父仓适配 | gitlink、`Cargo.lock`、`EngineConfig` v0.9.5 字段适配、拒绝编辑的终态/权威历史对账、压缩后用量即时刷新与持久化回填，以及严格直连模型大小写桥接回归 |
+
+### r11 Provider、MCP、steer 与平台边界（已发布）
+
+- CodeWhale PR #18、#21、#22、#25、#26、#27、#29 与 #30 以 `0d89a31be016457c180501417dd2c0f34ce844a6` 汇入公开 r11。严格直连 provider 仅在唯一自有模型行可确认时容忍 wire model 大小写差异；父仓补充 GLM 小写保存值到 canonical `GLM-5.2` 路由的桥接回归。
+- 显式 route 输出上限在请求预算层生效；Moonshot 对不兼容工具逐个省略，并对用户发出每轮一次的可见诊断，具名 `tool_choice` 指向被省略工具时明确拒绝。MCP 密钥由宿主 resolver 提供且不写进进程环境；被禁用 server 在 pool、catalog、直接调用、reload、子智能体继承等入口统一表现为不可见。
+- `withdraw_steer` 返回 `SteerWithdrawal`，区分撤回、已提交和不存在；Windows Shell 输出使用跨 poll 的增量 UTF-8 解码，依赖更新修复 h2/lru 公告。r11 新增 15 条 `forkguard_*`，总数从 41 增至 56，未增加长期 fork 主题。
+- r11 相对 r10 为 `48 files changed, +2242/-292`。其中 provider projection、MCP host policy、steer lifecycle 和跨平台 shell 解码均是可复用底座能力，后续继续以通用设计优先回馈上游。
 
 ### r10 固定采样与压缩用量边界（已发布）
 
@@ -76,18 +83,20 @@
 
 ### T1：宿主嵌入与路由边界
 
-- **commits**：`331cb1594688c723d98499d9ca11f05af291b599`、`2eceab4e19cb0b15576c09d5b89e0d8bc42e11fd`（`Pinvou/CodeWhale#11`）、`a36e6cd533024cfe5724bae21875aea42b2ed87a`（`Pinvou/CodeWhale#13`）、`8aa5f77d35ac1d00d1f444193543307a7e9b391c`（`Pinvou/CodeWhale#16`）、`07d183e350ce4a1ed4f91bdfa1875c996e710d2b`（`Pinvou/CodeWhale#17`）、`feb8761aeda31749f3d54c6e1f8ef460540567a1`（`Pinvou/CodeWhale#19`）。
-- **公开规模**：r8 前置规模为 10 文件、`+394/-31`；r9 的可靠插入与编辑边界、r10 的固定采样与压缩用量边界增量按上节整体登记。
+- **commits**：`331cb1594688c723d98499d9ca11f05af291b599`、`2eceab4e19cb0b15576c09d5b89e0d8bc42e11fd`（`#11`）、`a36e6cd533024cfe5724bae21875aea42b2ed87a`（`#13`）、`8aa5f77d35ac1d00d1f444193543307a7e9b391c`（`#16`）、`07d183e350ce4a1ed4f91bdfa1875c996e710d2b`（`#17`）、`feb8761aeda31749f3d54c6e1f8ef460540567a1`（`#19`）、`485884913308cdf7564bc60da2e416be637083b5`（`#21`）、`04e109af4b4786a0d49fbbeefdd77af15a9f495e`（`#22`）、`69ed3bfbdb314f901d4cf4120f1caaaf0b6aa529`（`#30`）、`0d89a31be016457c180501417dd2c0f34ce844a6`（`#18`）。
+- **公开规模**：r8 前置规模为 10 文件、`+394/-31`；r9 至 r11 的增量按上节整体登记。
 - **核心文件**：`crates/tui/src/lib.rs`、`core/{engine,events,ops}.rs`、`core/engine/{handle,turn_loop}.rs`、`runtime_handoff.rs`、`route_runtime.rs`、`runtime_threads.rs`、`automation_manager.rs`、`session_manager.rs`。
 - **内容**：
   - 在 v0.9.5 原生 library target 上只公开 Pinvou 实际使用的模块和宿主类型，不恢复旧的全量 bin facade。
   - 以根级窄重导出公开 `FleetRoster` 与工作区角色目录常量，供嵌入宿主在写入角色文件后装配和热刷新名册；不公开整个 `fleet` 模块。
   - 提供只读持久化 worker 投影，供 live 宿主结合自身进程纪元判断状态；恢复入口仍按 v0.9.5 原语把孤儿 worker 收敛为 interrupted。
   - 提供 opaque resolved route、显式 route limits 和 embedding host route override。
+  - 显式 route 输出上限参与请求预算；严格直连 provider 只在唯一自有模型行匹配时允许 wire model 大小写归一，避免把网关或歧义模型静默改写。
   - 保留宿主需要的 runtime thread / Automation 接口和 `EngineConfig` 注入边界。
   - 将无副作用的运行时 session snapshot 与已知进程重启后的显式 tool history recovery 分开，避免嵌入宿主把仍在执行的工具调用误判为崩溃。
   - 提供通用的宿主批量取消操作和失败终态标记，供会话停止与 Engine 回收安全收敛后台子智能体。
   - 为 steer 提供可关联 id、提交/丢弃事件和跨中断 keep-inbox 所有权，停止路径显式丢弃未提交输入，避免消息在 UI 与 Engine 之间静默消失或跨会话泄漏。
+  - `withdraw_steer` 返回可区分撤回、已提交和不存在的 `SteerWithdrawal`，宿主无需从竞态错误文本推断结果。
   - `Op::EditLastTurn` 与宿主落盘兜底共用 `edit_last_turn_target`：工具结果与内部运行时信封同样以 `role = "user"` 持久化，裸 role 扫描会把截断落在 tool result 上；真实但不支持的最新用户内容必须拒绝，不能跳到更早文本。拒绝路径发送类型化错误与失败终态，不调用 provider，也不改变历史。
   - 固定采样路由剥离显式非 1 的 `temperature`（否则 400 "only 1 is allowed"）：Kimi Code 会员路由按会员模型名单精确匹配（`k3` / `k3-256k` / `kimi-for-coding` / `kimi-for-coding-highspeed`，Chat 方言 seam）；DeepSeek 侧仅在 Responses 方言对精确 `deepseek-v4-flash` 保留兼容 shim，Chat 方言按官方文档的 0..=2 契约透传（v4-pro 走 Chat 线，实测不受限）。网关与其他模型契约不动。修复 code 页手动压缩在 Kimi Code 路由必现 400。
   - `CompactionCompleted` 事件新增 `post_input_tokens`：压缩完成后完整请求的输入 token 保守估算（复用引擎 canonical 估算，含 system prompt 与压缩摘要），供宿主在压缩完成后立即刷新用量展示；TUI 与 runtime thread 持久化路径不消费。
@@ -96,7 +105,7 @@
 
 ### T2：工具兼容与命令执行安全
 
-- **commits**：`595adce47e2d1bcf895d7bfd6426c074eb969324`、`3bbf8421ebdb16bff71f83dac4d42c8fb65f0f02`（`Pinvou/CodeWhale#12`）、`a36e6cd533024cfe5724bae21875aea42b2ed87a`（`Pinvou/CodeWhale#13`）、`d127aed113529dc93754d044b9f352e9746f6b83`（`Pinvou/CodeWhale#15`）、`8aa5f77d35ac1d00d1f444193543307a7e9b391c`（`Pinvou/CodeWhale#16` 的 Shell 取消边界）。
+- **commits**：`595adce47e2d1bcf895d7bfd6426c074eb969324`、`3bbf8421ebdb16bff71f83dac4d42c8fb65f0f02`（`#12`）、`a36e6cd533024cfe5724bae21875aea42b2ed87a`（`#13`）、`d127aed113529dc93754d044b9f352e9746f6b83`（`#15`）、`8aa5f77d35ac1d00d1f444193543307a7e9b391c`（`#16` 的 Shell 取消边界）、`44730dfe596b70f86ae2f928959877a3e3f494e4`（`#27`）、`665b46cd9e67326459223aa662931bd36d726004`（`#29`）、`04e109af4b4786a0d49fbbeefdd77af15a9f495e`（`#22`）、`4831c3797b76485a912b056c76a4cff22f0a2863`（`#25`）、`e68a185c2ba07f327bd8b63bbfea6a70a96f33ea`（`#26`）。
 - **核心文件**：`core/engine.rs`、`core/engine/tool_setup.rs`、`core/ops.rs`、`tools/file.rs`、`command_safety.rs`、`tools/shell.rs`、`docs/TOOL_SURFACE.md`。
 - **内容**：
   - `EngineConfig.extra_tools` 让宿主工具在 Plan、Agent、Yolo 等 turn registry 中一致注册。
@@ -106,6 +115,8 @@
   - 多行 Shell 按 segment 检查；破坏性命令在自动批准模式下仍被阻断。
   - Engine 取消路径按 turn id 终止当前轮未被宿主接管的前台 Shell，不依赖工具 future drop；后台/宿主管理的任务保持原有所有权边界。
   - schema 约束的 JSON 容器兼容、工具续轮 provider 角色顺序和已知内部 runtime suffix 展示清理继续沿用 r6 行为。
+  - Moonshot 工具 schema 按单个不兼容工具降级并发出一次用户可见诊断；具名选择不得指向已省略工具。宿主 MCP 密钥 resolver 不写进程环境，禁用 server 在 pool、catalog、直接调用、reload 与子智能体继承入口统一不可见。
+  - Windows Shell 跨 poll 保留增量解码状态，避免拆分 UTF-8 序列被替换；h2/lru 安全更新不改变公开接口。
   - registry-first 提示只引用 canonical action；Custom SubAgent 的显式旧 action allowlist 通过 alias 映射解析到 canonical family，不扩大实际工具权限。
   - 当前工具面不恢复已退役的独立追加文件工具，也没有改动 `request_user_input`。
   - r8 在 catalog 与最终 dispatch 共用 exact allowlist；显式受限轮次可清空 trusted roots，并禁止 MCP 初始化、控制面 shell、动态工具和子 Agent。控制面限制保持到下一条消息出队，受限排队续轮（goal self-continuation）、编辑重放与 MCP reload 同样拒绝；轮后子智能体完成和后台 Shell 唤醒延迟到显式新消息安装替代权限。Hook 默认关闭；受限审计保留 event 与 tool_name 等非私有身份字段，输入/输出/路径固定脱敏；`None` 保持现有 GUI 行为。
@@ -178,7 +189,7 @@ CodeWhale 当前已通过：
 cargo fmt --all -- --check
 cargo check / Pinvou fork CI
 cargo test -p codewhale-tui --lib --locked forkguard_ -- --test-threads=1
-41 passed / 0 failed
+56 passed / 0 failed
 ```
 
 父仓当前已通过：
@@ -186,17 +197,17 @@ cargo test -p codewhale-tui --lib --locked forkguard_ -- --test-threads=1
 ```text
 cargo fmt --all -- --check
 ./scripts/fork-guard.sh
-CodeWhale 41 passed；pinvou3-app 21 passed
+CodeWhale 56 passed；pinvou3-app 22 passed
 cargo test --lib --locked forkguard_admitted_display_fallback -- --test-threads=1
 2 passed / 0 failed
 node --test pinvou3-app/tests/scheduled_tasks_unit.test.js
 PASS
 python3 scripts/architecture-guard.py
 ./scripts/verify-public-submodule.sh
-pinvou-v0.9.5-r10 -> feb8761aeda31749f3d54c6e1f8ef460540567a1
+pinvou-v0.9.5-r11 -> 0d89a31be016457c180501417dd2c0f34ce844a6
 ```
 
-完整结果见 `docs/codewhale-upgrade-0.9.0-to-0.9.5.md`。环境相关忽略/基线失败按实际验证披露；`scripts/verify-public-submodule.sh` 已锁定不可变标签 `pinvou-v0.9.5-r10` 与父仓 gitlink 一致。
+完整结果见 `docs/codewhale-upgrade-0.9.0-to-0.9.5.md`。环境相关忽略/基线失败按实际验证披露；`scripts/verify-public-submodule.sh` 已锁定不可变标签 `pinvou-v0.9.5-r11` 与父仓 gitlink 一致。
 
 ## 5. 后续修改规则
 

--- a/docs/fork-policy.en.md
+++ b/docs/fork-policy.en.md
@@ -1,14 +1,14 @@
 # Pinvou CodeWhale Fork Policy
 
-> Updated: 2026-08-25. Public maintenance baseline: upstream `v0.9.5` r10; PRs #16, #17, and #19 are published within the existing four long-lived topics.
+> Updated: 2026-08-27. Public maintenance baseline: upstream `v0.9.5` r11; PRs #18, #21, #22, #25, #26, #27, #29, and #30 are published within the existing four long-lived topics.
 > Canonical Chinese policy: [`docs/fork-policy.md`](fork-policy.md). This English page is a condensed summary; the Chinese version is the complete, authoritative process.
 
 ## Baseline
 
 - Upstream: `Hmbown/CodeWhale` `v0.9.5` at `853cb707bbcf4f7dc4268fba6d811e0d04083f9c`.
-- Public maintenance branch: `Pinvou/CodeWhale:pinvou3-clean` at `feb8761ae` (`pinvou-v0.9.5-r10`).
+- Public maintenance branch: `Pinvou/CodeWhale:pinvou3-clean` at `0d89a31be` (`pinvou-v0.9.5-r11`).
 - The pre-upgrade head `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` remains available as tag `pinvou-v0.9.0-r4` and branch `backup/pinvou3-clean-v0.9.0-r4`.
-- `Pinvou/CodeWhale#16`, `#17`, and `#19` were squash-merged as `8aa5f77d35ac1d00d1f444193543307a7e9b391c`, `07d183e350ce4a1ed4f91bdfa1875c996e710d2b`, and `feb8761aeda31749f3d54c6e1f8ef460540567a1`; `pinvou3-clean` and immutable tag `pinvou-v0.9.5-r10` are publicly reachable at the latter commit. Tags `r1` through `r10` remain immutable.
+- `Pinvou/CodeWhale#18`, `#21`, `#22`, `#25`, `#26`, `#27`, `#29`, and `#30` are published in r11. `pinvou3-clean` and immutable tag `pinvou-v0.9.5-r11` are publicly reachable at `0d89a31be016457c180501417dd2c0f34ce844a6`; tags `r1` through `r11` remain immutable.
 - Keep exactly four long-lived topics:
 
   1. Host embedding and routing boundary
@@ -22,7 +22,7 @@ The exact commits and fingerprints are recorded in [`docs/fork-modifications.md`
 
 - Prefer the app bridge, bundle instructions/Skills, MCP/connectors/plugins, then an upstream contribution. Keep a fork patch only when the behavior must be atomic inside CodeWhale's Engine, SubAgent, Task, or Automation lifecycle.
 - Product tool policy, UI, workspace selection, and business routing stay in `pinvou3-app`.
-- The soft drift limits are 1,500 net added lines and 200 fork-distinct lines per file (net = added minus removed, same accounting as the register). The published r10 baseline is 64 files and `+5612/-702` (net 4,910 added lines); exceeding a limit is not an automatic rejection but requires an explicit retention and reduction assessment. r10 adds exact Kimi Code fixed-sampling compatibility, K3/K3-256K metadata, a DeepSeek V4 Flash Responses shim, and complete post-compaction input estimation. Future reduction prioritizes generic per-turn policy, host insertion/edit APIs, session snapshot/recovery APIs, provider compatibility, and Automation lifecycle fixes for upstreaming.
+- The soft drift limits are 1,500 net added lines and 200 fork-distinct lines per file (net = added minus removed, same accounting as the register). The published r11 baseline is 96 files and `+7840/-980` (net 6,860 added lines), with `+2242/-292` across 48 files over r10. r11 adds strict-direct model casing compatibility, explicit route output ceilings, per-tool Moonshot degradation with a visible diagnostic, host MCP secret resolution and deny-surface sealing, observable steer withdrawal, Windows Shell decoding, and dependency security fixes. Future reduction prioritizes generic per-turn policy, host insertion/edit APIs, session snapshot/recovery APIs, provider compatibility, host MCP policy, and Automation lifecycle fixes for upstreaming.
 - Fixups are squashed into their owning topic; no long-lived catch-up commit chains are maintained, and generic host configuration, routing, tools, Automation, and OAuth must remain within their owning boundary.
 - A fork-distinct change must update the modification register and guard fingerprints, include a result-oriented `forkguard_*` test where applicable, and pass `./scripts/fork-guard.sh --fast`.
 - For a large upstream refactor, clean re-fork from the release tag and re-express each surviving topic. Do not preserve merge-conflict batches as long-lived history.

--- a/docs/fork-policy.md
+++ b/docs/fork-policy.md
@@ -1,15 +1,15 @@
 # Pinvou 对 CodeWhale 底座的 fork 维护策略
 
-> 最后更新：2026-08-25（公开维护基线：上游 `v0.9.5` r10；PR #16、#17 与 #19 已发布到现有 4 个 Pinvou 主题）
+> 最后更新：2026-08-27（公开维护基线：上游 `v0.9.5` r11；PR #18、#21、#22、#25、#26、#27、#29 与 #30 已发布到现有 4 个 Pinvou 主题）
 > 配套：`docs/fork-modifications.md`、`scripts/fork-guard.sh`、`docs/底座升级验收清单.md`
 > English: [`docs/fork-policy.en.md`](fork-policy.en.md)
 
 ## 0. 当前基线
 
 - 上游：`Hmbown/CodeWhale` tag `v0.9.5`，commit `853cb707bbcf4f7dc4268fba6d811e0d04083f9c`。
-- 公开维护分支：`Pinvou/CodeWhale:pinvou3-clean`，head `feb8761ae`（`pinvou-v0.9.5-r10`）。
+- 公开维护分支：`Pinvou/CodeWhale:pinvou3-clean`，head `0d89a31be`（`pinvou-v0.9.5-r11`）。
 - 升级前基线 `03e9e1027c03ce1e4b35ab9e3ccce751b65b9624` 同时保留在 tag `pinvou-v0.9.0-r4` 和 branch `backup/pinvou3-clean-v0.9.0-r4`。
-- `Pinvou/CodeWhale#16`、`#17` 与 `#19` 已分别 squash 合并为 `8aa5f77d35ac1d00d1f444193543307a7e9b391c`、`07d183e350ce4a1ed4f91bdfa1875c996e710d2b` 和 `feb8761aeda31749f3d54c6e1f8ef460540567a1`；`pinvou3-clean` 与固定标签 `pinvou-v0.9.5-r10` 均公开可达并指向后者，`r1` 至 `r10` 保持不可变。
+- `Pinvou/CodeWhale#18`、`#21`、`#22`、`#25`、`#26`、`#27`、`#29` 与 `#30` 已发布进 r11；`pinvou3-clean` 与固定标签 `pinvou-v0.9.5-r11` 均公开可达并指向 `0d89a31be016457c180501417dd2c0f34ce844a6`，`r1` 至 `r11` 保持不可变。
 - `.gitmodules` 不配置浮动 `branch`；发布后父仓 gitlink、维护分支和不可变标签必须指向同一 commit。
 - 当前只维护 4 个长期主题：
 
@@ -39,7 +39,7 @@ Pinvou 的产品工具白名单、UI、工作区选择和业务策略留在 app�
 - 总 drift 软上限：净增 1500 行（净增 = 新增 − 删除行数，与下方基线表述同口径）。
 - 单文件 fork-distinct 改动软上限：200 行。
 - 超过不是自动拒绝，但必须记录保留原因和减量顺序。
-- r10 公开基线相对 `v0.9.5` 为 `+5612/-702，64 文件`，净增 4910 行。r10 在 r9 上增加精确的 Kimi Code 固定采样兼容、K3/K3-256K 模型元数据、DeepSeek V4 Flash Responses 兼容和压缩后完整输入估算；既有保留量来自逐轮工具权限、Automation 持久化、会话恢复生命周期、工具兼容和嵌入上下文密封。后续优先上游化通用逐轮权限、宿主插入/编辑接口、会话快照/恢复 API、provider 兼容和 Automation 生命周期修复。
+- r11 公开基线相对 `v0.9.5` 为 `+7840/-980，96 文件`，净增 6860 行；相对 r10 为 `+2242/-292，48 文件`。本轮增加严格直连模型大小写兼容、route 输出上限、Moonshot 按工具降级与可见诊断、MCP 密钥解析/禁用面封闭、可观测 steer 撤回、Windows Shell 解码和依赖安全修复；均归入现有主题。后续优先上游化通用逐轮权限、宿主插入/编辑接口、会话快照/恢复 API、provider 兼容、MCP 宿主策略和 Automation 生命周期修复。
 
 ### 1.3 主题提交
 

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
  "ignore",
  "image",
  "libc",
- "lru",
+ "lru 0.18.2",
  "mimalloc",
  "oauth2",
  "objc2",
@@ -4742,6 +4742,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6046,7 +6055,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinvou-knowledge"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6072,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "pinvou3-tauri"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "age",
  "agent-backend-api",
@@ -6663,7 +6672,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum 0.27.2",
  "thiserror 2.0.20",
  "unicode-segmentation",
@@ -8738,7 +8747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -4095,8 +4095,8 @@ mod tests {
             })
         );
         assert_eq!(
-            config.compaction.token_threshold, 56_570,
-            "未知远端 OpenAI-compatible alias 应沿用底座 8K 保守输出预留"
+            config.compaction.token_threshold, 45_648,
+            "the explicit 24K route output limit for an unknown remote OpenAI-compatible alias must participate in the compaction budget"
         );
     }
 
@@ -5205,6 +5205,45 @@ mod tests {
                 .and_then(|providers| providers.zai.reasoning_stream_style.as_deref()),
             Some(SEPARATE_REASONING_FIELD)
         );
+    }
+
+    #[test]
+    fn forkguard_zai_direct_route_survives_model_casing_mismatch() {
+        // The foundation zai catalog uses GLM-5.2, while Settings and existing
+        // configurations may store glm-5.2. Both spellings must resolve on the
+        // direct z.ai endpoint and converge to the catalog's canonical form
+        // (Pinvou/CodeWhale#18).
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        for model in ["glm-5.2", "GLM-5.2"] {
+            let mut bridge = fixture_bridge();
+            set_active_model(
+                &mut bridge,
+                ModelPreset::OpenaiCompatible,
+                model,
+                "https://api.z.ai/api/coding/paas/v4",
+                "sk-zai",
+            );
+            bridge.prefs.normalize_saved_model_metadata();
+            assert_eq!(
+                bridge.provider(),
+                "zai",
+                "vendor=glm must route to the zai provider"
+            );
+
+            let route = bridge
+                .resolve_runtime_route_for_model(model)
+                .unwrap_or_else(|error| panic!("failed to resolve route for {model}: {error}"));
+            assert_eq!(
+                route.model(),
+                "GLM-5.2",
+                "{model} must use the catalog's canonical spelling"
+            );
+        }
     }
 
     #[test]

--- a/scripts/fork-guard.sh
+++ b/scripts/fork-guard.sh
@@ -6,8 +6,8 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TUI="$REPO/CodeWhale"
 APP="$REPO/pinvou3-app/src-tauri"
 EXPECTED_UPSTREAM="853cb707bbcf4f7dc4268fba6d811e0d04083f9c"
-PUBLISHED_HEAD="feb8761aeda31749f3d54c6e1f8ef460540567a1"
-PUBLISHED_COMMITS=14
+PUBLISHED_HEAD="0d89a31be016457c180501417dd2c0f34ce844a6"
+PUBLISHED_COMMITS=29
 FAST_ONLY=0
 [[ "${1:-}" == "--fast" ]] && FAST_ONLY=1
 
@@ -17,21 +17,21 @@ bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 
 fail=0
 
-bold "── 第 0 层：v0.9.5 r10 公开四主题基线拓扑 ──"
+bold "── 第 0 层：v0.9.5 r11 公开四主题基线拓扑 ──"
 actual_head="$(git -C "$TUI" rev-parse HEAD 2>/dev/null || true)"
 if [[ "$actual_head" == "$PUBLISHED_HEAD" ]]; then
   expected_commits="$PUBLISHED_COMMITS"
-  green "  ✓ CodeWhale gitlink 指向 r10 四主题公开基线 $PUBLISHED_HEAD"
+  green "  ✓ CodeWhale gitlink 指向 r11 四主题公开基线 $PUBLISHED_HEAD"
 else
   expected_commits=""
-  red "  ✗ CodeWhale HEAD 为 ${actual_head:-<unreadable>}，应为 r10 公开 head $PUBLISHED_HEAD"
+  red "  ✗ CodeWhale HEAD 为 ${actual_head:-<unreadable>}，应为 r11 公开 head $PUBLISHED_HEAD"
   fail=1
 fi
 
 if git -C "$TUI" merge-base --is-ancestor "$EXPECTED_UPSTREAM" HEAD 2>/dev/null; then
-  green "  ✓ r10 公开基线继承官方 v0.9.5"
+  green "  ✓ r11 公开基线继承官方 v0.9.5"
 else
-  red "  ✗ r10 公开基线未继承官方 v0.9.5 $EXPECTED_UPSTREAM"
+  red "  ✗ r11 公开基线未继承官方 v0.9.5 $EXPECTED_UPSTREAM"
   fail=1
 fi
 
@@ -39,7 +39,7 @@ commit_count="$(git -C "$TUI" rev-list --count "$EXPECTED_UPSTREAM..HEAD" 2>/dev
 if [[ -n "$expected_commits" && "$commit_count" == "$expected_commits" ]]; then
   green "  ✓ v0.9.5 之上 $expected_commits 个登记提交"
 else
-  red "  ✗ v0.9.5 之上有 ${commit_count:-<unreadable>} 个 commit，r10 合法拓扑应为 ${expected_commits:-14}"
+  red "  ✗ v0.9.5 之上有 ${commit_count:-<unreadable>} 个 commit，r11 合法拓扑应为 ${expected_commits:-29}"
   fail=1
 fi
 
@@ -74,6 +74,11 @@ fingerprints=(
   "T1|deepseek-v4-flash Responses 采样回归 |CodeWhale/crates/tui/src/client/responses/tests.rs|fn forkguard_deepseek_v4_flash_responses_drops_non_one_temperature"
   "T1|压缩完成事件携带新上下文估算        |CodeWhale/crates/tui/src/core/events.rs|post_input_tokens: Option<u64>"
   "T1|压缩后估算覆盖完整请求输入          |CodeWhale/crates/tui/src/core/engine/tests.rs|fn forkguard_compaction_completed_reports_complete_post_input_tokens"
+  "T1|显式 route 输出上限参与请求预算      |CodeWhale/crates/tui/src/route_budget.rs|pub(crate) fn effective_max_output_tokens_for_route("
+  "T1|steer 撤回结果具有明确状态          |CodeWhale/crates/tui/src/core/engine.rs|pub enum SteerWithdrawal"
+  "T1|steer 撤回竞态边界回归              |CodeWhale/crates/tui/src/core/engine/tests.rs|async fn forkguard_steer_lifecycle_withdrawal_is_bounded_and_prevents_commit"
+  "T1|严格直连模型大小写仅限明确自有行    |CodeWhale/crates/config/src/route/resolver.rs|let allow_casefold_wire_match = class == ProviderClass::StrictDirect"
+  "T1|严格直连大小写回退行为回归          |CodeWhale/crates/config/src/route/tests.rs|fn resolver_direct_owned_row_match_survives_casing_mismatch"
 
   "T2|宿主额外工具入口                    |CodeWhale/crates/tui/src/core/engine.rs|pub struct ExtraTools("
   "T2|动态禁用工具操作                    |CodeWhale/crates/tui/src/core/ops.rs|SetDisallowedTools { tools: Vec<String> }"
@@ -89,6 +94,13 @@ fingerprints=(
   "T2|错误降级提示保持 provider 角色合法  |CodeWhale/crates/tui/src/core/engine/tests.rs|async fn forkguard_tool_error_degradation_preserves_provider_role_sequence"
   "T2|Registry 提示使用 canonical 工具面 |CodeWhale/crates/tui/src/core/engine/tests.rs|fn registry_first_policy_is_in_the_initial_prompt_only_when_mcp_is_enabled"
   "T2|旧 action alias 解析为 canonical   |CodeWhale/crates/tui/src/tools/subagent/tests.rs|fn custom_child_allowlist_omitting_load_skill_fails_closed"
+  "T2|Moonshot 工具降级产生用户可见诊断   |CodeWhale/crates/tui/src/core/events.rs|pub fn tool_projection_warning_message("
+  "T2|具名 tool_choice 不得指向省略工具  |CodeWhale/crates/tui/src/client.rs|async fn forkguard_moonshot_rejects_named_choice_for_omitted_tool"
+  "T2|Moonshot 每轮只发一次投影诊断       |CodeWhale/crates/tui/src/client.rs|async fn forkguard_moonshot_stream_emits_one_projection_warning"
+  "T2|宿主 MCP 密钥解析不写进程环境       |CodeWhale/crates/tui/src/mcp.rs|pub fn install_mcp_secret_resolver("
+  "T2|禁用 MCP server 从全部 pool 面消失 |CodeWhale/crates/tui/src/mcp/tests.rs|fn forkguard_mcp_pool_denied_server_disappears_from_every_surface"
+  "T2|子智能体不得绕过 MCP 禁用继承       |CodeWhale/crates/tui/src/tools/subagent/tests.rs|fn forkguard_spawn_request_inherit_disallowed_tools_opt_out_not_honored"
+  "T2|Shell 跨 poll 保持 UTF-8 解码状态  |CodeWhale/crates/tui/src/tools/shell/output.rs|fn forkguard_shell_output_decoder_preserves_utf8_across_poll_boundaries"
 
   "T3|ambient project authority 密封       |CodeWhale/crates/tui/src/project_context.rs|fn forkguard_runtime_loader_ignores_ambient_project_authority"
   "T3|Permissions 100 KiB 窄例外回归      |CodeWhale/crates/tui/src/prompts.rs|fn forkguard_instruction_fragment_preserves_content_beyond_default_cap"
@@ -121,6 +133,7 @@ fingerprints=(
   "APP|v0.9.5 subagent state root 透传     |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|cfg.subagent_state_root = Some(roots.ledger);"
   "APP|停止与回收级联取消子智能体          |pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs|Op::CancelSubAgents"
   "APP|resolved route 由宿主统一解析        |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|pub fn resolve_runtime_route_for_model("
+  "APP|GLM 小写存量配置解析到规范直连模型  |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|fn forkguard_zai_direct_route_survives_model_casing_mismatch"
   "APP|128K/256K compaction 合约            |pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs|fn forkguard_compaction_128k_scenarios"
   "APP|定时任务复用 shared run API          |pinvou3-app/src-tauri/src/features/scheduled/tasks.rs|run_now_shared(&self.automations"
   "APP|多智能体面板只读 live worker         |pinvou3-app/src-tauri/src/features/multiagent/transcripts.rs|read_persisted_agent_worker_records(workspace)"

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -96,7 +96,7 @@ class CiGatePolicyTests(unittest.TestCase):
         self.assertNotIn("--allow-registered-candidate", verifier_gate)
         self.assertNotIn("LOCAL_SECURITY_HEAD", verifier)
         self.assertIn('[[ "$tag_target" != "$gitlink" ]]', verifier)
-        self.assertIn('PINVOU_CODEWHALE_TAG="pinvou-v0.9.5-r10"', verifier)
+        self.assertIn('PINVOU_CODEWHALE_TAG="pinvou-v0.9.5-r11"', verifier)
         self.assertIn("unknown argument", verifier)
 
     def test_pr_modes_and_stacked_pr_triggers_are_explicit(self):

--- a/scripts/verify-public-submodule.sh
+++ b/scripts/verify-public-submodule.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PINVOU_CODEWHALE_PATH="CodeWhale"
 PINVOU_CODEWHALE_URL="https://github.com/Pinvou/CodeWhale.git"
-PINVOU_CODEWHALE_TAG="pinvou-v0.9.5-r10"
+PINVOU_CODEWHALE_TAG="pinvou-v0.9.5-r11"
 
 if [[ $# -ne 0 ]]; then
   echo "unknown argument: $1" >&2


### PR DESCRIPTION
## Background

CodeWhale `pinvou-v0.9.5-r11` has been published, while the parent repository still pins r10. This PR syncs the public gitlink from the current `main` and replaces the conflicted earlier candidate #295.

## Changes

- Sync the CodeWhale gitlink and parent `Cargo.lock` to `pinvou-v0.9.5-r11` (`0d89a31be016457c180501417dd2c0f34ce844a6`).
- Update the Chinese and English fork policies, modification registry, r11 topology and behavior fingerprints, public tag validation, and CI policy regression coverage.
- Retain the valuable GLM strict-direct model casing regression from #295, and update the existing compaction assertion for the explicit r11 route output budget.
- Exclude the obsolete compatibility work already covered by `main`, and stop carrying the r8 gitlink from #295.

## Verification

- `./scripts/fork-guard.sh`: CodeWhale 56/56 and parent 22/22 passed.
- Full parent Rust library suite: 1451 passed, 0 failed, 11 ignored.
- Locked CodeWhale compile checks passed for `--lib --bins` and `--lib --tests`; parent `--lib --locked` passed.
- `python3 scripts/architecture-guard.py`, `node scripts/sync-version.mjs --check`, all 17 CI policy tests, public submodule validation, scheduled-task unit tests, and the system prompt dump passed.
- `git diff --check` and Rust formatting passed.
- After the language review fix, both affected parent Rust regressions passed individually and `./scripts/fork-guard.sh --fast` passed again.

## Known baseline issue

The full CodeWhale library run produced 10127 passed, 6 failed, and 11 ignored. Five of the six failures passed when rerun precisely with an isolated `CODEWHALE_HOME`. The remaining `skill_lifecycle_uninstall_removes_installed_skill` test still failed in isolation, but its test and implementation paths are unchanged from r10 to r11, so it is treated as an existing baseline failure. The fork guard, affected tests, and locked compile checks for this PR all pass.

## Risks

The functional behavior comes from the published and immutable r11 baseline. Parent-side changes are limited to the gitlink, lockfile, documentation and fingerprints, and bridge regressions. The disclosed pre-existing CodeWhale full-suite failure can be addressed separately and does not block this r11 baseline alignment.