### PR TITLE
fix(app): align 5 model-facing prompts with audit

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/bundle/mcp-servers/present_artifact_server.py
+++ b/pinvou3-app/src-tauri/resources/common/bundle/mcp-servers/present_artifact_server.py
@@ -48,7 +48,7 @@ TOOL_DEF = {
             },
             "title": {
                 "type": "string",
-                "description": "客户一眼看懂的中文标题,不要用文件名,要有叙述感。",
+                "description": "客户一眼看懂的标题，与你的回复同语种，不要用文件名，要有叙述感。",
             },
             "description": {
                 "type": "string",

--- a/pinvou3-app/src-tauri/src/app/commands/multiagent.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/multiagent.rs
@@ -11,20 +11,24 @@ use super::prelude::*;
 use crate::features::assistant::expert_roster::ExpertRosterSnapshot;
 use crate::features::multiagent;
 
-/// 多智能体资源上限的每轮提醒数字（与 bridge.rs 的 MULTI_AGENT_* 常量一致）。
+/// Per-turn reminder numbers for the multi-agent resource caps (must match the
+/// MULTI_AGENT_* constants in bridge.rs).
 ///
-/// 会话分两档：Work 会话直属并行 4 / 全树准入 8；原生 Code 会话直属并行 6 /
-/// 全树准入 12（`build_engine_config_for_multi_agent` 按 `is_code_session` 取值，
-/// 提醒对两类会话都注入——数字必须跟档位走，否则模型按错误上限自我节流）。
+/// Sessions split into two tiers: Work sessions run 4 direct-child concurrent /
+/// 8 tree-wide admitted; native Code sessions run 6 / 12
+/// (`build_engine_config_for_multi_agent` picks the tier via `is_code_session`,
+/// and the reminder is injected into both — the numbers must follow the tier or
+/// the model self-throttles against the wrong cap).
 pub(crate) struct DelegationLimits {
-    /// 直属子智能体同时执行上限（launch_concurrency）。
+    /// Max direct children running at the same time (launch_concurrency).
     pub max_concurrent: usize,
-    /// 整棵树排队与执行合计上限（max_subagents）。
+    /// Max queued + running across the whole tree (max_subagents).
     pub max_admitted: usize,
 }
 
-/// 会话类型推导提醒数字：Code 会话 6/12，Work 会话 4/8。
-/// 数字取自调用点而非本模块再定义一份常量，避免与 engine 配置漂移。
+/// Derive reminder numbers from the session tier: Code sessions 6/12, Work 4/8.
+/// The numbers come from the bridge constants instead of a second copy here, so
+/// the reminder cannot drift from the engine config.
 pub(crate) fn delegation_limits_for(pool: &EnginePool, session_id: &str) -> DelegationLimits {
     if pool.is_code_session(session_id) {
         DelegationLimits {
@@ -53,7 +57,7 @@ pub(crate) fn delegation_limits_for(pool: &EnginePool, session_id: &str) -> Dele
 ///   开启模式后积极寻找有实际收益的委派，不按任务“简单/复杂”一刀切，也不机械凑数；
 ///   **不提 `workflow`**：底座把 read_only 子任务钳成四个
 ///   本地文件工具、结构化阶段默认不传递上游结果（`depends_on_results` 留空）
-///   两处基线行为未修，正是真机”调研断网、汇总烧穿预算”事故的根因——在
+///   两处基线行为未修，正是真机"调研断网、汇总烧穿预算"事故的根因——在
 ///   底座修复前不向模型开放或推荐该路径；
 /// - 专家池内置卡与用户自创卡都可作为 `profile`，用户卡优先；本地算法按当前任务筛到
 ///   最多 20 位，只把 profile id、名称和短能力说明列给主 agent，完整人设仅在派中后进入
@@ -63,10 +67,11 @@ pub(crate) fn delegation_limits_for(pool: &EnginePool, session_id: &str) -> Dele
 /// - 资源护栏：主会话是总协调者，普通委派使用 `max_depth=0` 成为叶子；只有
 ///   任务本身足够复杂时，第一层调用省略深度参数以继承会话上限并允许再拆
 ///   一层。第二层不得继续派生；每个子智能体显式使用底座允许的最高执行预算，
-///   避免角色默认步数截断有效工作；并发/准入数字按会话档位传入
-///   （`DelegationLimits`，Work 4/8、Code 6/12）。
+///   avoid role-default step caps cutting real work short; the concurrency /
+///   admission numbers follow the session tier (`DelegationLimits`, Work 4/8,
+///   Code 6/12).
 /// - Git 与子智能体工作区策略沿用普通对话语义，由父模型按任务自主决定；App
-///   不把每个会话强制 git 化，也不禁用底座已有的 worktree 能力；
+///   不把每个会话强制 git 化，也不封禁底座已有的 worktree 能力。
 fn delegation_reminder_with_roles(roles: Vec<String>, limits: &DelegationLimits) -> String {
     let roster_block = if roles.is_empty() {
         "（本轮未匹配到合适专家，可不带 `profile` 裸派）".to_string()
@@ -161,8 +166,8 @@ pub(crate) fn prepare_delegation_turn(
         };
     }
     let snapshot = ExpertRosterSnapshot::capture();
-    // 并发/准入数字按会话档位取值（Code 6/12、Work 4/8），与
-    // build_engine_config_for_multi_agent 装进 engine 的实际上限同源。
+    // Concurrency/admission numbers follow the session tier (Code 6/12, Work
+    // 4/8) — the same caps build_engine_config_for_multi_agent installs.
     let limits = delegation_limits_for(pool, session_id);
     let reminder = delegation_reminder_with_roles(snapshot.available_role_lines(task), &limits);
     PreparedDelegationTurn {
@@ -183,7 +188,8 @@ pub(crate) fn prepend_delegation_replay_reminder(
     if !enabled || !pool.multi_agent_mode_available(session_id) {
         return content;
     }
-    // EditLastTurn 不带新 route,同样按会话档位取数字（与 engine 实际上限同源）。
+    // EditLastTurn carries no new route; pull tier numbers the same way (same
+    // source as the engine's actual caps).
     let limits = delegation_limits_for(pool, session_id);
     let reminder = delegation_reminder_with_roles(Vec::new(), &limits);
     format!("{reminder}\n\n---\n\n{content}")
@@ -250,7 +256,8 @@ mod tests {
         MULTI_AGENT_WORK_MAX_ADMITTED, MULTI_AGENT_WORK_MAX_CONCURRENT,
     };
 
-    /// Work 档位（4/8）与 Code 档位（6/12）的提醒数字,单测两档都钉。
+    /// Reminder numbers for the Work tier (4/8) and Code tier (6/12); tests pin
+    /// both tiers.
     fn work_limits() -> DelegationLimits {
         DelegationLimits {
             max_concurrent: MULTI_AGENT_WORK_MAX_CONCURRENT,
@@ -303,7 +310,7 @@ mod tests {
                 && msg.contains("不要传任何正数深度覆盖值")
                 && msg.contains("同时执行最多 4 个")
                 && msg.contains("合计最多 8 个"),
-            "多智能体必须明确两层委派和并发/准入资源边界(Work 档): {msg}"
+            "multi-agent reminder must state the two-level delegation and the concurrency/admission caps (Work tier): {msg}"
         );
         assert!(
             msg.contains("Git 与工作区策略由你按任务自主完成")
@@ -438,9 +445,10 @@ mod tests {
         assert!(msg.contains("第二层子智能体不得继续派生"));
     }
 
-    /// 并发/准入数字必须跟会话档位走（回归：曾写死 Work 档 4/8，Code 会话
-    /// 实际上限 6/12，模型会按错误上限自我节流）。数字与 bridge.rs 的
-    /// MULTI_AGENT_* 常量同源，两边不得漂移。
+    /// The concurrency/admission numbers must follow the session tier (regression:
+    /// they used to be hardcoded to the Work tier 4/8, so Code sessions — whose
+    /// real caps are 6/12 — made the model self-throttle against the wrong limit).
+    /// The numbers share the MULTI_AGENT_* constants in bridge.rs and must not drift.
     #[test]
     fn delegation_reminder_resource_limits_follow_session_tier() {
         let work = delegation_reminder("审查 React 前端代码", &work_limits());
@@ -448,31 +456,31 @@ mod tests {
 
         assert!(
             work.contains("同时执行最多 4 个") && work.contains("合计最多 8 个"),
-            "Work 档提醒必须是 4/8: {work}"
+            "Work-tier reminder must state 4/8: {work}"
         );
         assert!(
             code.contains("同时执行最多 6 个") && code.contains("合计最多 12 个"),
-            "Code 档提醒必须是 6/12: {code}"
+            "Code-tier reminder must state 6/12: {code}"
         );
         assert!(
             !code.contains("同时执行最多 4 个") && !code.contains("合计最多 8 个"),
-            "Code 档提醒不得残留 Work 档数字: {code}"
+            "Code-tier reminder must not leak Work-tier numbers: {code}"
         );
         assert_eq!(
             MULTI_AGENT_WORK_MAX_CONCURRENT, 4,
-            "Work 并发常量漂移会同时改坏 engine 配置与提醒,需人工复核档位语义"
+            "Work concurrency constant drifted; this breaks both the engine config and the reminder — re-check the tier semantics"
         );
         assert_eq!(
             MULTI_AGENT_WORK_MAX_ADMITTED, 8,
-            "Work 准入常量漂移需人工复核档位语义"
+            "Work admission constant drifted; re-check the tier semantics"
         );
         assert_eq!(
             MULTI_AGENT_CODE_MAX_CONCURRENT, 6,
-            "Code 并发常量漂移需人工复核档位语义"
+            "Code concurrency constant drifted; re-check the tier semantics"
         );
         assert_eq!(
             MULTI_AGENT_CODE_MAX_ADMITTED, 12,
-            "Code 准入常量漂移需人工复核档位语义"
+            "Code admission constant drifted; re-check the tier semantics"
         );
     }
 

--- a/pinvou3-app/src-tauri/src/app/commands/multiagent.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/multiagent.rs
@@ -11,6 +11,38 @@ use super::prelude::*;
 use crate::features::assistant::expert_roster::ExpertRosterSnapshot;
 use crate::features::multiagent;
 
+/// 多智能体资源上限的每轮提醒数字（与 bridge.rs 的 MULTI_AGENT_* 常量一致）。
+///
+/// 会话分两档：Work 会话直属并行 4 / 全树准入 8；原生 Code 会话直属并行 6 /
+/// 全树准入 12（`build_engine_config_for_multi_agent` 按 `is_code_session` 取值，
+/// 提醒对两类会话都注入——数字必须跟档位走，否则模型按错误上限自我节流）。
+pub(crate) struct DelegationLimits {
+    /// 直属子智能体同时执行上限（launch_concurrency）。
+    pub max_concurrent: usize,
+    /// 整棵树排队与执行合计上限（max_subagents）。
+    pub max_admitted: usize,
+}
+
+/// 会话类型推导提醒数字：Code 会话 6/12，Work 会话 4/8。
+/// 数字取自调用点而非本模块再定义一份常量，避免与 engine 配置漂移。
+pub(crate) fn delegation_limits_for(pool: &EnginePool, session_id: &str) -> DelegationLimits {
+    if pool.is_code_session(session_id) {
+        DelegationLimits {
+            max_concurrent:
+                crate::features::assistant::platform::bridge::MULTI_AGENT_CODE_MAX_CONCURRENT,
+            max_admitted:
+                crate::features::assistant::platform::bridge::MULTI_AGENT_CODE_MAX_ADMITTED,
+        }
+    } else {
+        DelegationLimits {
+            max_concurrent:
+                crate::features::assistant::platform::bridge::MULTI_AGENT_WORK_MAX_CONCURRENT,
+            max_admitted:
+                crate::features::assistant::platform::bridge::MULTI_AGENT_WORK_MAX_ADMITTED,
+        }
+    }
+}
+
 /// 多智能体模式的每轮委派提醒（拼在用户消息之前，chat 发送链注入）。
 ///
 /// **每轮都要重申**：实测长上下文里模型对开头一次性教学的遵循率衰减（skill
@@ -21,7 +53,7 @@ use crate::features::multiagent;
 ///   开启模式后积极寻找有实际收益的委派，不按任务“简单/复杂”一刀切，也不机械凑数；
 ///   **不提 `workflow`**：底座把 read_only 子任务钳成四个
 ///   本地文件工具、结构化阶段默认不传递上游结果（`depends_on_results` 留空）
-///   两处基线行为未修，正是真机"调研断网、汇总烧穿预算"事故的根因——在
+///   两处基线行为未修，正是真机”调研断网、汇总烧穿预算”事故的根因——在
 ///   底座修复前不向模型开放或推荐该路径；
 /// - 专家池内置卡与用户自创卡都可作为 `profile`，用户卡优先；本地算法按当前任务筛到
 ///   最多 20 位，只把 profile id、名称和短能力说明列给主 agent，完整人设仅在派中后进入
@@ -31,10 +63,11 @@ use crate::features::multiagent;
 /// - 资源护栏：主会话是总协调者，普通委派使用 `max_depth=0` 成为叶子；只有
 ///   任务本身足够复杂时，第一层调用省略深度参数以继承会话上限并允许再拆
 ///   一层。第二层不得继续派生；每个子智能体显式使用底座允许的最高执行预算，
-///   避免角色默认步数截断有效工作；工作模式使用直属并行 4 / 全树准入 8。
+///   避免角色默认步数截断有效工作；并发/准入数字按会话档位传入
+///   （`DelegationLimits`，Work 4/8、Code 6/12）。
 /// - Git 与子智能体工作区策略沿用普通对话语义，由父模型按任务自主决定；App
-///   不把每个会话强制 git 化，也不封禁底座已有的 worktree 能力。
-fn delegation_reminder_with_roles(roles: Vec<String>) -> String {
+///   不把每个会话强制 git 化，也不禁用底座已有的 worktree 能力；
+fn delegation_reminder_with_roles(roles: Vec<String>, limits: &DelegationLimits) -> String {
     let roster_block = if roles.is_empty() {
         "（本轮未匹配到合适专家，可不带 `profile` 裸派）".to_string()
     } else {
@@ -43,6 +76,8 @@ fn delegation_reminder_with_roles(roles: Vec<String>) -> String {
             roles.join("\n")
         )
     };
+    let max_concurrent = limits.max_concurrent;
+    let max_admitted = limits.max_admitted;
     format!(
         "本会话已开启多智能体模式：请按任务形态**主动委派**，工具面与普通\
          对话完全一致（联网检索、读取网页等照常）：\n\
@@ -67,8 +102,8 @@ fn delegation_reminder_with_roles(roles: Vec<String>) -> String {
          `agent` 必须显式传 `max_steps=2000` 与 `wall_time_secs=86400`，不得回落到\
          角色默认的 60/120 步；若允许直属子智能体继续拆分，任务说明中也必须\
          把同一预算规则传给它。预算只是避免提前截断的上限，任务完成后立即\
-         收束，不得为耗尽预算而空转。直属子智能体同时执行最多 4 个，\
-         整棵树排队与执行合计最多 8 个；不要递归裂变；\n\
+         收束，不得为耗尽预算而空转。直属子智能体同时执行最多 {max_concurrent} 个，\
+         整棵树排队与执行合计最多 {max_admitted} 个；不要递归裂变；\n\
          4. Git 与工作区策略由你按任务自主完成：只读任务、没有写入的并行\
          任务，以及串行的“修改→测试→审查”接力可使用默认共享工作区；共享\
          工作区不得安排两个及以上并行写入者。同一 Git 仓库确需并行写入时\
@@ -100,9 +135,9 @@ fn delegation_reminder_with_roles(roles: Vec<String>) -> String {
 }
 
 #[cfg(test)]
-fn delegation_reminder(task: &str) -> String {
+fn delegation_reminder(task: &str, limits: &DelegationLimits) -> String {
     let snapshot = ExpertRosterSnapshot::capture();
-    delegation_reminder_with_roles(snapshot.available_role_lines(task))
+    delegation_reminder_with_roles(snapshot.available_role_lines(task), limits)
 }
 
 /// 一次普通多智能体 turn 的模型内容与专家配置必须共用同一个快照。
@@ -126,7 +161,10 @@ pub(crate) fn prepare_delegation_turn(
         };
     }
     let snapshot = ExpertRosterSnapshot::capture();
-    let reminder = delegation_reminder_with_roles(snapshot.available_role_lines(task));
+    // 并发/准入数字按会话档位取值（Code 6/12、Work 4/8），与
+    // build_engine_config_for_multi_agent 装进 engine 的实际上限同源。
+    let limits = delegation_limits_for(pool, session_id);
+    let reminder = delegation_reminder_with_roles(snapshot.available_role_lines(task), &limits);
     PreparedDelegationTurn {
         content: format!("{reminder}\n\n---\n\n{content}"),
         expert_snapshot: Some(snapshot),
@@ -145,7 +183,9 @@ pub(crate) fn prepend_delegation_replay_reminder(
     if !enabled || !pool.multi_agent_mode_available(session_id) {
         return content;
     }
-    let reminder = delegation_reminder_with_roles(Vec::new());
+    // EditLastTurn 不带新 route,同样按会话档位取数字（与 engine 实际上限同源）。
+    let limits = delegation_limits_for(pool, session_id);
+    let reminder = delegation_reminder_with_roles(Vec::new(), &limits);
     format!("{reminder}\n\n---\n\n{content}")
 }
 
@@ -204,13 +244,32 @@ pub async fn read_subagent_transcript(
 
 #[cfg(test)]
 mod tests {
-    use super::delegation_reminder;
+    use super::{delegation_reminder, DelegationLimits};
+    use crate::features::assistant::platform::bridge::{
+        MULTI_AGENT_CODE_MAX_ADMITTED, MULTI_AGENT_CODE_MAX_CONCURRENT,
+        MULTI_AGENT_WORK_MAX_ADMITTED, MULTI_AGENT_WORK_MAX_CONCURRENT,
+    };
+
+    /// Work 档位（4/8）与 Code 档位（6/12）的提醒数字,单测两档都钉。
+    fn work_limits() -> DelegationLimits {
+        DelegationLimits {
+            max_concurrent: MULTI_AGENT_WORK_MAX_CONCURRENT,
+            max_admitted: MULTI_AGENT_WORK_MAX_ADMITTED,
+        }
+    }
+
+    fn code_limits() -> DelegationLimits {
+        DelegationLimits {
+            max_concurrent: MULTI_AGENT_CODE_MAX_CONCURRENT,
+            max_admitted: MULTI_AGENT_CODE_MAX_ADMITTED,
+        }
+    }
 
     /// 每轮提醒教的是**强制委派任务、父模型只统筹**（ADR-0006）：只教裸
     /// `agent` 集群，单任务至少一个、可拆任务尽量拆、父模型亲自协调汇总。
     #[test]
     fn delegation_reminder_teaches_delegation() {
-        let msg = delegation_reminder("审查 React 前端代码");
+        let msg = delegation_reminder("审查 React 前端代码", &work_limits());
         assert!(msg.contains("主动委派"), "必须点名主动委派的行事方式");
         assert!(
             msg.contains("`agent` 工具"),
@@ -243,8 +302,8 @@ mod tests {
                 && msg.contains("第二层子智能体不得继续派生")
                 && msg.contains("不要传任何正数深度覆盖值")
                 && msg.contains("同时执行最多 4 个")
-                && msg.contains("最多 8 个"),
-            "多智能体必须明确两层委派和并发/准入资源边界"
+                && msg.contains("合计最多 8 个"),
+            "多智能体必须明确两层委派和并发/准入资源边界(Work 档): {msg}"
         );
         assert!(
             msg.contains("Git 与工作区策略由你按任务自主完成")
@@ -293,7 +352,7 @@ mod tests {
     /// name 字段只收 ASCII token，中文名只能走文本约定，界面据此显示身份。
     #[test]
     fn delegation_reminder_relies_on_expert_pool_only() {
-        let msg = delegation_reminder("审查 React 前端代码");
+        let msg = delegation_reminder("审查 React 前端代码", &work_limits());
         assert!(
             msg.contains("写好提示词"),
             "必须教模型自拟任务说明（无合适专家时裸派）"
@@ -325,7 +384,7 @@ mod tests {
     /// 也不得再教手写 script / plan 协议的任何碎片（真机事故的根因）。
     #[test]
     fn delegation_reminder_never_mentions_the_workflow_path() {
-        let msg = delegation_reminder("审查 React 前端代码");
+        let msg = delegation_reminder("审查 React 前端代码", &work_limits());
         assert!(
             !msg.contains("workflow"),
             "底座 read_only 工具钳制与阶段结果不传递未修，不得推荐 workflow：{msg}"
@@ -357,13 +416,13 @@ mod tests {
     /// （回归：此前正是因为字符串断行丢了 `\`，提示语里混进大段缩进。）
     #[test]
     fn delegation_reminder_contains_no_stray_indentation() {
-        let msg = delegation_reminder("审查 React 前端代码");
+        let msg = delegation_reminder("审查 React 前端代码", &work_limits());
         assert!(!msg.contains("  "), "提示语混入了源码缩进空格:\n{msg}");
     }
 
     #[test]
     fn delegation_reminder_uses_work_resource_limits() {
-        let msg = delegation_reminder("审查 React 前端代码");
+        let msg = delegation_reminder("审查 React 前端代码", &work_limits());
 
         assert!(!msg.contains("工作会话"));
         assert!(!msg.contains("保持克制"));
@@ -379,9 +438,47 @@ mod tests {
         assert!(msg.contains("第二层子智能体不得继续派生"));
     }
 
+    /// 并发/准入数字必须跟会话档位走（回归：曾写死 Work 档 4/8，Code 会话
+    /// 实际上限 6/12，模型会按错误上限自我节流）。数字与 bridge.rs 的
+    /// MULTI_AGENT_* 常量同源，两边不得漂移。
+    #[test]
+    fn delegation_reminder_resource_limits_follow_session_tier() {
+        let work = delegation_reminder("审查 React 前端代码", &work_limits());
+        let code = delegation_reminder("审查 React 前端代码", &code_limits());
+
+        assert!(
+            work.contains("同时执行最多 4 个") && work.contains("合计最多 8 个"),
+            "Work 档提醒必须是 4/8: {work}"
+        );
+        assert!(
+            code.contains("同时执行最多 6 个") && code.contains("合计最多 12 个"),
+            "Code 档提醒必须是 6/12: {code}"
+        );
+        assert!(
+            !code.contains("同时执行最多 4 个") && !code.contains("合计最多 8 个"),
+            "Code 档提醒不得残留 Work 档数字: {code}"
+        );
+        assert_eq!(
+            MULTI_AGENT_WORK_MAX_CONCURRENT, 4,
+            "Work 并发常量漂移会同时改坏 engine 配置与提醒,需人工复核档位语义"
+        );
+        assert_eq!(
+            MULTI_AGENT_WORK_MAX_ADMITTED, 8,
+            "Work 准入常量漂移需人工复核档位语义"
+        );
+        assert_eq!(
+            MULTI_AGENT_CODE_MAX_CONCURRENT, 6,
+            "Code 并发常量漂移需人工复核档位语义"
+        );
+        assert_eq!(
+            MULTI_AGENT_CODE_MAX_ADMITTED, 12,
+            "Code 准入常量漂移需人工复核档位语义"
+        );
+    }
+
     #[test]
     fn delegation_reminder_uses_maximum_child_execution_budget() {
-        let msg = delegation_reminder("审查大型代码变更");
+        let msg = delegation_reminder("审查大型代码变更", &work_limits());
 
         assert!(
             msg.contains("`max_steps=2000`")

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -57,12 +57,13 @@ const SEPARATE_REASONING_FIELD: &str = "separate_field";
 
 // 多智能体是“主会话总协调、复杂任务最多再拆一层”的 agent 集群，不是
 // 无界递归树。普通对话继续沿用 CodeWhale 原始上限；仅开启多智能体的
-// 会话收紧资源预算。
+// 会话收紧资源预算。pub(crate)：每轮委派提醒（app/commands/multiagent.rs）
+// 的数字与之共用，避免提醒文案与 engine 实际上限漂移。
 const MULTI_AGENT_MAX_SPAWN_DEPTH: u32 = 2;
-const MULTI_AGENT_WORK_MAX_CONCURRENT: usize = 4;
-const MULTI_AGENT_WORK_MAX_ADMITTED: usize = 8;
-const MULTI_AGENT_CODE_MAX_CONCURRENT: usize = 6;
-const MULTI_AGENT_CODE_MAX_ADMITTED: usize = 12;
+pub(crate) const MULTI_AGENT_WORK_MAX_CONCURRENT: usize = 4;
+pub(crate) const MULTI_AGENT_WORK_MAX_ADMITTED: usize = 8;
+pub(crate) const MULTI_AGENT_CODE_MAX_CONCURRENT: usize = 6;
+pub(crate) const MULTI_AGENT_CODE_MAX_ADMITTED: usize = 12;
 
 fn configure_provider(
     config: &mut ProviderConfig,
@@ -205,6 +206,10 @@ impl crate::features::memory::MemoryReviewModel for Pinvou3Bridge {
         self.effective_model_owned()
             .map(|model| model.preset)
             .unwrap_or_else(|| self.prefs.advanced.model_preset.unwrap_or_default())
+    }
+
+    fn memory_locale_tag(&self) -> String {
+        self.locale_tag().to_string()
     }
 }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -55,10 +55,13 @@ fn shared_credential_store() -> &'static SystemCredentialStore {
 const LOCAL_VLLM_API_KEY: &str = "local-no-auth";
 const SEPARATE_REASONING_FIELD: &str = "separate_field";
 
-// 多智能体是“主会话总协调、复杂任务最多再拆一层”的 agent 集群，不是
-// 无界递归树。普通对话继续沿用 CodeWhale 原始上限；仅开启多智能体的
-// 会话收紧资源预算。pub(crate)：每轮委派提醒（app/commands/multiagent.rs）
-// 的数字与之共用，避免提醒文案与 engine 实际上限漂移。
+// Multi-agent is an agent cluster where the main session stays the overall
+// coordinator and complex tasks nest at most one extra level — not an unbounded
+// recursive tree. Plain conversations keep the original CodeWhale caps; only
+// sessions with multi-agent enabled get a tighter resource budget. The tier
+// constants are pub(crate) so the per-turn delegation reminder
+// (app/commands/multiagent.rs) reads the same numbers and cannot drift from the
+// engine's actual caps.
 const MULTI_AGENT_MAX_SPAWN_DEPTH: u32 = 2;
 pub(crate) const MULTI_AGENT_WORK_MAX_CONCURRENT: usize = 4;
 pub(crate) const MULTI_AGENT_WORK_MAX_ADMITTED: usize = 8;

--- a/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
@@ -798,7 +798,7 @@ mod tests {
                 && block.contains("`Bash(action=\"run\")` 全量展开"),
             "统一检索结果头必须带二进制来源禁令: {block}"
         );
-        // 带告警时禁令仍在(头部追加在告警之前不成立——两者都在头段)。
+        // 带告警时禁令仍在:禁令位于固定头段文本内,告警只追加在其后,不会挤掉禁令。
         let with_warnings = build_unified_context_block(&unified, &["远程服务离线".to_string()]);
         assert!(with_warnings.contains("部分来源暂时不可用"));
         assert!(with_warnings.contains("禁止调用 `File(action=\"read\")`"));

--- a/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
@@ -103,7 +103,7 @@ fn source_rank_score(rank: usize) -> f64 {
 }
 
 fn build_unified_context_block(hits: &[UnifiedHit], warnings: &[String]) -> String {
-    let mut out = "在本会话启用的本地与远程知识集中检索到以下相关片段(已统一排序)。请严格基于这些片段作答并注明来源文件；上下文不足时可再次调用 `kb_search`，或用 `source_ref` 调用 `kb_open_source`。\n\n".to_string();
+    let mut out = "在本会话启用的本地与远程知识集中检索到以下相关片段(已统一排序)。请严格基于这些片段作答并注明来源文件；上下文不足时可再次调用 `kb_search`，或用 `source_ref` 调用 `kb_open_source`。对于 XLSX/DOCX/PPTX 等二进制来源，禁止调用 `File(action=\"read\")` 或用 `Bash(action=\"run\")` 全量展开。\n\n".to_string();
     if !warnings.is_empty() {
         out.push_str("部分来源暂时不可用：");
         out.push_str(&warnings.join("；"));
@@ -774,6 +774,34 @@ mod tests {
             Some(("cube/server:1".to_string(), 7, 42, 3))
         );
         assert!(parse_remote_source_ref("kbremote:bad:7:42:chunk:-1").is_none());
+    }
+
+    /// kb_search(生产统一检索)结果头也必须带二进制来源禁令:模型看到片段不足时
+    /// 会试图用 File/Bash 全量展开 XLSX/DOCX/PPTX,该禁令此前只在 kb_open_source
+    /// 描述与 system reminder 里(回归:生产结果头漏了)。
+    #[test]
+    fn unified_context_block_forbids_binary_source_expansion() {
+        let unified = vec![UnifiedHit {
+            collection_name: "硬件资料".to_string(),
+            document_name: "散热报告.xlsx".to_string(),
+            source_path: "/docs/散热报告.xlsx".to_string(),
+            source_ref: "kbdoc:42:chunk:3".to_string(),
+            text: "CPU 峰值温度 78℃".to_string(),
+            score: 1.0,
+        }];
+        let block = build_unified_context_block(&unified, &[]);
+        assert!(block.contains("严格基于这些片段作答"));
+        assert!(block.contains("kb_open_source"));
+        assert!(
+            block.contains("XLSX/DOCX/PPTX 等二进制来源")
+                && block.contains("禁止调用 `File(action=\"read\")`")
+                && block.contains("`Bash(action=\"run\")` 全量展开"),
+            "统一检索结果头必须带二进制来源禁令: {block}"
+        );
+        // 带告警时禁令仍在(头部追加在告警之前不成立——两者都在头段)。
+        let with_warnings = build_unified_context_block(&unified, &["远程服务离线".to_string()]);
+        assert!(with_warnings.contains("部分来源暂时不可用"));
+        assert!(with_warnings.contains("禁止调用 `File(action=\"read\")`"));
     }
 
     /// 超总字符预算:保证第一条一定注入,余下截断并提示剩余条数。

--- a/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
+++ b/pinvou3-app/src-tauri/src/features/knowledge/kb_tool.rs
@@ -776,9 +776,11 @@ mod tests {
         assert!(parse_remote_source_ref("kbremote:bad:7:42:chunk:-1").is_none());
     }
 
-    /// kb_search(生产统一检索)结果头也必须带二进制来源禁令:模型看到片段不足时
-    /// 会试图用 File/Bash 全量展开 XLSX/DOCX/PPTX,该禁令此前只在 kb_open_source
-    /// 描述与 system reminder 里(回归:生产结果头漏了)。
+    /// The kb_search (production unified search) result header must also carry
+    /// the binary-source prohibition: when the snippets look insufficient the
+    /// model tries to fully expand XLSX/DOCX/PPTX via File/Bash. The rule used to
+    /// exist only in the kb_open_source description and the system reminder
+    /// (regression: the production result header missed it).
     #[test]
     fn unified_context_block_forbids_binary_source_expansion() {
         let unified = vec![UnifiedHit {
@@ -796,9 +798,10 @@ mod tests {
             block.contains("XLSX/DOCX/PPTX 等二进制来源")
                 && block.contains("禁止调用 `File(action=\"read\")`")
                 && block.contains("`Bash(action=\"run\")` 全量展开"),
-            "统一检索结果头必须带二进制来源禁令: {block}"
+            "unified search result header must carry the binary-source prohibition: {block}"
         );
-        // 带告警时禁令仍在:禁令位于固定头段文本内,告警只追加在其后,不会挤掉禁令。
+        // The prohibition survives warnings: it lives inside the fixed header
+        // text and warnings are appended after it, so they cannot displace it.
         let with_warnings = build_unified_context_block(&unified, &["远程服务离线".to_string()]);
         assert!(with_warnings.contains("部分来源暂时不可用"));
         assert!(with_warnings.contains("禁止调用 `File(action=\"read\")`"));

--- a/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
@@ -115,6 +115,40 @@ ttl_days 规则：
 如果没有值得记的内容，输出 {"items":[]}。
 "#;
 
+/// 记忆复盘提示词的输出语言指令，按 UI locale 追加到 system prompt 末尾。
+///
+/// 同 review 侧 output_language_directive（features/review/mod.rs）的等价物：
+/// 提示词本体留中文（按收敛性精调过，逐句翻译会引入行为漂移），只让模型把
+/// **自然语言字段值**（content / reason）切到目标语言——JSON key、kind / topic /
+/// action 枚举值保持 ASCII。zh-Hans 及未知 locale → None（no-op，提示词原样）。
+/// 没有这条指令时，英文/日文 UI 用户的记忆 content 会被写成中文，注入会话后
+/// 拽偏回复语言。
+pub(super) fn memory_output_language_directive(locale_tag: &str) -> Option<String> {
+    // zh-Hans：即使本轮对话是英文，content 也强制简体中文——中文 prompt 本体
+    // 不够硬，英文上下文下会漂成英文 content（review 侧实测同款问题）。
+    if locale_tag == "zh-Hans" {
+        return Some(
+            "\n\n## 输出语言(强制)\n\
+             JSON 里所有自然语言字段值(content / reason)必须用简体中文,即使本轮\
+             对话是英文/日文也别跟着写。JSON 的 key、action / kind / topic 枚举值\
+             保持原样 ASCII。"
+                .to_string(),
+        );
+    }
+    let lang = match locale_tag {
+        "en" => "English",
+        "ja" => "Japanese (日本語)",
+        _ => return None, // 未知 locale → 提示词原样中文
+    };
+    Some(format!(
+        "\n\n## Output Language (HARD override)\n\
+         Write EVERY natural-language value in your JSON output in {lang}: `content` \
+         and `reason`. This OVERRIDES any wording above that asks for Chinese. Keep \
+         all JSON keys and enum values (`action`, `kind`, `topic`) exactly as \
+         specified — those stay ASCII/English."
+    ))
+}
+
 fn memory_review_log_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
@@ -443,6 +477,12 @@ async fn request_llm_memory_review(
         "never_memory": never,
     })
     .to_string();
+    // 非中文 locale 追加输出语言指令(否则记忆 content 被写成中文,注入英文 UI
+    // 会话后拽偏回复语言;同 review 侧 output_language_directive 先例)。
+    let prompt = match memory_output_language_directive(&bridge.memory_locale_tag()) {
+        Some(suffix) => format!("{LLM_REVIEW_PROMPT}{suffix}"),
+        None => LLM_REVIEW_PROMPT.to_string(),
+    };
     // Anthropic 官方端点是 Messages 协议（x-api-key 鉴权，system 独立字段，
     // 无 response_format），走原生直连；其余 preset 仍走 OpenAI chat/completions。
     if preset == ModelPreset::Anthropic {
@@ -451,7 +491,7 @@ async fn request_llm_memory_review(
             &base_url,
             &bridge.memory_api_key(),
             &model_name,
-            LLM_REVIEW_PROMPT,
+            &prompt,
             &user_content,
             900,
         )
@@ -461,7 +501,7 @@ async fn request_llm_memory_review(
     let mut body = json!({
         "model": model_name,
         "messages": [
-            { "role": "system", "content": LLM_REVIEW_PROMPT },
+            { "role": "system", "content": prompt },
             { "role": "user", "content": user_content }
         ],
         "temperature": 0,

--- a/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
@@ -115,22 +115,32 @@ ttl_days 规则：
 如果没有值得记的内容，输出 {"items":[]}。
 "#;
 
-/// 记忆复盘提示词的输出语言指令，按 UI locale 追加到 system prompt 末尾。
+/// Output-language directive for the memory review prompt, appended to the
+/// system prompt according to the UI locale.
 ///
-/// 同 review 侧 output_language_directive（features/review/mod.rs）的等价物：
-/// 提示词本体留中文（按收敛性精调过，逐句翻译会引入行为漂移），只让模型把
-/// **自然语言字段值**（content / reason）切到目标语言——JSON key、kind / topic /
-/// action 枚举值保持 ASCII。zh-Hans 及未知 locale → None（no-op，提示词原样）。
+/// Equivalent of the review-side `output_language_directive`
+/// (features/review/mod.rs): the prompt body stays Chinese (tuned for
+/// convergence; translating it line by line would introduce behavioral drift)
+/// and only the **natural-language field values** (`content` / `reason`) switch
+/// to the target language — JSON keys and `kind` / `topic` / `action` enum
+/// values stay ASCII. zh-Hans and unknown locales → None (no-op, prompt
+/// unchanged).
 ///
-/// 可达性说明：enforce_memory_locale_policy（platform/prefs/mod.rs）在每次
-/// load/save 都把非 zh-Hans UI 的 memory_enabled 压回 false，正常流程下 en/ja
-/// 用户不跑记忆复盘，本指令是防御纵深而非修复可达故障——zh-Hans 分支是每轮
-/// 复盘的实际路径（英文对话也强制中文 content，防漂移同 review 侧实测）；
-/// en/ja 分支只兜住「切到中文选稍后重启 → 重开记忆 → 旧引擎快照仍带旧
-/// locale」的窄窗口。
+/// Reachability: `enforce_memory_locale_policy` (platform/prefs/mod.rs) forces
+/// `memory_enabled` back to false for non-zh-Hans UI on every load/save, so in
+/// the normal flow en/ja users never run memory review. This directive is
+/// defense-in-depth mirroring the review-side precedent, not a fix for a
+/// reachable failure — the zh-Hans branch is the live per-review path (it
+/// hard-forces Chinese `content` even in English conversations, the same
+/// measured drift the review side hit); the en/ja branches only cover the
+/// narrow window where the locale was switched to Chinese with "restart later",
+/// memory was re-enabled, and a pre-switch engine snapshot still carries the
+/// old locale.
 pub(super) fn memory_output_language_directive(locale_tag: &str) -> Option<String> {
-    // zh-Hans：即使本轮对话是英文，content 也强制简体中文——中文 prompt 本体
-    // 不够硬，英文上下文下会漂成英文 content（review 侧实测同款问题）。
+    // zh-Hans: force `content` to Simplified Chinese even when the conversation
+    // is in English — the Chinese prompt body alone is not hard enough, and the
+    // values drift to English in English contexts (same issue measured on the
+    // review side).
     if locale_tag == "zh-Hans" {
         return Some(
             "\n\n## 输出语言(强制)\n\
@@ -143,7 +153,7 @@ pub(super) fn memory_output_language_directive(locale_tag: &str) -> Option<Strin
     let lang = match locale_tag {
         "en" => "English",
         "ja" => "Japanese (日本語)",
-        _ => return None, // 未知 locale → 提示词原样中文
+        _ => return None, // unknown locale → keep the prompt as-is (Chinese)
     };
     Some(format!(
         "\n\n## Output Language (HARD override)\n\
@@ -482,9 +492,10 @@ async fn request_llm_memory_review(
         "never_memory": never,
     })
     .to_string();
-    // 按 locale 追加输出语言指令,与 review 侧 output_language_directive 先例
-    // 对齐(防御纵深:非中文 UI 的记忆已被 enforce_memory_locale_policy 关闭,
-    // 可达性详见 memory_output_language_directive 文档)。
+    // Append the output-language directive per locale, mirroring the review-side
+    // output_language_directive precedent (defense-in-depth: memory is disabled
+    // for non-Chinese UIs by enforce_memory_locale_policy; see the
+    // memory_output_language_directive docs for reachability).
     let prompt = match memory_output_language_directive(&bridge.memory_locale_tag()) {
         Some(suffix) => format!("{LLM_REVIEW_PROMPT}{suffix}"),
         None => LLM_REVIEW_PROMPT.to_string(),

--- a/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/llm_review.rs
@@ -121,8 +121,13 @@ ttl_days 规则：
 /// 提示词本体留中文（按收敛性精调过，逐句翻译会引入行为漂移），只让模型把
 /// **自然语言字段值**（content / reason）切到目标语言——JSON key、kind / topic /
 /// action 枚举值保持 ASCII。zh-Hans 及未知 locale → None（no-op，提示词原样）。
-/// 没有这条指令时，英文/日文 UI 用户的记忆 content 会被写成中文，注入会话后
-/// 拽偏回复语言。
+///
+/// 可达性说明：enforce_memory_locale_policy（platform/prefs/mod.rs）在每次
+/// load/save 都把非 zh-Hans UI 的 memory_enabled 压回 false，正常流程下 en/ja
+/// 用户不跑记忆复盘，本指令是防御纵深而非修复可达故障——zh-Hans 分支是每轮
+/// 复盘的实际路径（英文对话也强制中文 content，防漂移同 review 侧实测）；
+/// en/ja 分支只兜住「切到中文选稍后重启 → 重开记忆 → 旧引擎快照仍带旧
+/// locale」的窄窗口。
 pub(super) fn memory_output_language_directive(locale_tag: &str) -> Option<String> {
     // zh-Hans：即使本轮对话是英文，content 也强制简体中文——中文 prompt 本体
     // 不够硬，英文上下文下会漂成英文 content（review 侧实测同款问题）。
@@ -477,8 +482,9 @@ async fn request_llm_memory_review(
         "never_memory": never,
     })
     .to_string();
-    // 非中文 locale 追加输出语言指令(否则记忆 content 被写成中文,注入英文 UI
-    // 会话后拽偏回复语言;同 review 侧 output_language_directive 先例)。
+    // 按 locale 追加输出语言指令,与 review 侧 output_language_directive 先例
+    // 对齐(防御纵深:非中文 UI 的记忆已被 enforce_memory_locale_policy 关闭,
+    // 可达性详见 memory_output_language_directive 文档)。
     let prompt = match memory_output_language_directive(&bridge.memory_locale_tag()) {
         Some(suffix) => format!("{LLM_REVIEW_PROMPT}{suffix}"),
         None => LLM_REVIEW_PROMPT.to_string(),

--- a/pinvou3-app/src-tauri/src/features/memory/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/tests.rs
@@ -1080,9 +1080,10 @@ fn llm_review_prompt_matches_supported_actions() {
     assert!(!LLM_REVIEW_PROMPT.contains("must_create_recent_activity"));
 }
 
-/// 记忆复盘提示词本体无语言约束，非中文 locale 必须追加输出语言指令（content /
-/// reason 跟 UI 语言，枚举值保持 ASCII）；zh-Hans/未知 → no-op。缺失时英文 UI
-/// 用户的记忆会被写成中文，注入会话后拽偏回复语言（review 侧同款先例）。
+/// 记忆复盘提示词本体无语言约束，输出语言指令按 locale 追加（content /
+/// reason 跟 UI 语言，枚举值保持 ASCII）；zh-Hans/未知 → no-op。en/ja 分支是
+/// 防御纵深（非中文 UI 的记忆已被 enforce_memory_locale_policy 关闭），与
+/// review 侧先例对齐。
 #[test]
 fn memory_review_output_language_directive_follows_locale() {
     use super::llm_review::memory_output_language_directive;

--- a/pinvou3-app/src-tauri/src/features/memory/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/tests.rs
@@ -1080,38 +1080,43 @@ fn llm_review_prompt_matches_supported_actions() {
     assert!(!LLM_REVIEW_PROMPT.contains("must_create_recent_activity"));
 }
 
-/// 记忆复盘提示词本体无语言约束，输出语言指令按 locale 追加（content /
-/// reason 跟 UI 语言，枚举值保持 ASCII）；zh-Hans/未知 → no-op。en/ja 分支是
-/// 防御纵深（非中文 UI 的记忆已被 enforce_memory_locale_policy 关闭），与
-/// review 侧先例对齐。
+/// The memory review prompt body carries no language constraint of its own; the
+/// output-language directive is appended per locale (`content` / `reason` follow
+/// the UI language, enum values stay ASCII); zh-Hans/unknown → no-op. The en/ja
+/// branches are defense-in-depth (memory is disabled for non-Chinese UIs by
+/// enforce_memory_locale_policy), mirroring the review-side precedent.
 #[test]
 fn memory_review_output_language_directive_follows_locale() {
     use super::llm_review::memory_output_language_directive;
 
-    let en = memory_output_language_directive("en").expect("en 应有指令");
+    let en = memory_output_language_directive("en").expect("en must have a directive");
     assert!(
         en.contains("Write EVERY natural-language value")
             && en.contains("`content`")
             && en.contains("`reason`")
             && en.contains("English"),
-        "en 指令必须覆盖 content/reason 且点名 English: {en}"
+        "en directive must cover content/reason and name English: {en}"
     );
     assert!(
         en.contains("Keep") && en.contains("JSON keys") && en.contains("exactly as"),
-        "en 指令必须保住 JSON key/枚举值 ASCII: {en}"
+        "en directive must keep JSON keys/enum values ASCII: {en}"
     );
-    let ja = memory_output_language_directive("ja").expect("ja 应有指令");
-    assert!(ja.contains("Japanese"), "ja 指令点名 Japanese: {ja}");
-    let zh = memory_output_language_directive("zh-Hans").expect("zh-Hans 应有指令");
+    let ja = memory_output_language_directive("ja").expect("ja must have a directive");
+    assert!(
+        ja.contains("Japanese"),
+        "ja directive must name Japanese: {ja}"
+    );
+    let zh = memory_output_language_directive("zh-Hans").expect("zh-Hans must have a directive");
     assert!(
         zh.contains("必须用简体中文") && zh.contains("枚举值"),
-        "zh-Hans 强制中文且保枚举 ASCII: {zh}"
+        "zh-Hans directive must force Chinese and keep enums ASCII: {zh}"
     );
     assert!(
         memory_output_language_directive("fr").is_none(),
-        "未知 locale 回退 no-op"
+        "unknown locale must fall back to a no-op"
     );
-    // 提示词本体不得自带输出语言约束（语言由 locale 指令层负责）。
+    // The prompt body must not carry its own output-language constraint (the
+    // locale directive layer owns language).
     assert!(!LLM_REVIEW_PROMPT.contains("输出语言"));
     assert!(!LLM_REVIEW_PROMPT.contains("Output Language"));
 }

--- a/pinvou3-app/src-tauri/src/features/memory/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/tests.rs
@@ -1080,6 +1080,41 @@ fn llm_review_prompt_matches_supported_actions() {
     assert!(!LLM_REVIEW_PROMPT.contains("must_create_recent_activity"));
 }
 
+/// 记忆复盘提示词本体无语言约束，非中文 locale 必须追加输出语言指令（content /
+/// reason 跟 UI 语言，枚举值保持 ASCII）；zh-Hans/未知 → no-op。缺失时英文 UI
+/// 用户的记忆会被写成中文，注入会话后拽偏回复语言（review 侧同款先例）。
+#[test]
+fn memory_review_output_language_directive_follows_locale() {
+    use super::llm_review::memory_output_language_directive;
+
+    let en = memory_output_language_directive("en").expect("en 应有指令");
+    assert!(
+        en.contains("Write EVERY natural-language value")
+            && en.contains("`content`")
+            && en.contains("`reason`")
+            && en.contains("English"),
+        "en 指令必须覆盖 content/reason 且点名 English: {en}"
+    );
+    assert!(
+        en.contains("Keep") && en.contains("JSON keys") && en.contains("exactly as"),
+        "en 指令必须保住 JSON key/枚举值 ASCII: {en}"
+    );
+    let ja = memory_output_language_directive("ja").expect("ja 应有指令");
+    assert!(ja.contains("Japanese"), "ja 指令点名 Japanese: {ja}");
+    let zh = memory_output_language_directive("zh-Hans").expect("zh-Hans 应有指令");
+    assert!(
+        zh.contains("必须用简体中文") && zh.contains("枚举值"),
+        "zh-Hans 强制中文且保枚举 ASCII: {zh}"
+    );
+    assert!(
+        memory_output_language_directive("fr").is_none(),
+        "未知 locale 回退 no-op"
+    );
+    // 提示词本体不得自带输出语言约束（语言由 locale 指令层负责）。
+    assert!(!LLM_REVIEW_PROMPT.contains("输出语言"));
+    assert!(!LLM_REVIEW_PROMPT.contains("Output Language"));
+}
+
 #[test]
 fn scenario_review_writes_long_and_recent_memories() {
     let _home = IsolatedPinvouHome::new("long-recent");

--- a/pinvou3-app/src-tauri/src/features/memory/types.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/types.rs
@@ -19,10 +19,13 @@ pub trait MemoryReviewModel {
     fn memory_base_url(&self) -> String;
     fn memory_api_key(&self) -> String;
     fn memory_model_preset(&self) -> ModelPreset;
-    /// UI locale（BCP 47 tag，如 "zh-Hans"/"en"/"ja"）。记忆复盘提示词本体是中文，
-    /// 按 locale 追加输出语言指令，与 review 侧 output_language_directive 先例
-    /// 对齐；zh-Hans 分支是每轮复盘的实际路径，en/ja 是换语言「稍后重启」后旧
-    /// 引擎快照窄窗口的防御纵深（可达性详见 memory_output_language_directive）。
+    /// UI locale (BCP 47 tag, e.g. "zh-Hans"/"en"/"ja"). The memory review prompt
+    /// body is Chinese, so an output-language directive is appended per locale,
+    /// mirroring the review-side `output_language_directive` precedent; the
+    /// zh-Hans branch is the live per-review path, while en/ja are
+    /// defense-in-depth for the narrow pre-switch engine-snapshot window after a
+    /// "restart later" locale switch (see memory_output_language_directive for
+    /// reachability).
     fn memory_locale_tag(&self) -> String;
 }
 

--- a/pinvou3-app/src-tauri/src/features/memory/types.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/types.rs
@@ -20,8 +20,9 @@ pub trait MemoryReviewModel {
     fn memory_api_key(&self) -> String;
     fn memory_model_preset(&self) -> ModelPreset;
     /// UI locale（BCP 47 tag，如 "zh-Hans"/"en"/"ja"）。记忆复盘提示词本体是中文，
-    /// 非中文 locale 需要追加输出语言指令，否则记忆 content 会被写成中文、
-    /// 注入英文 UI 会话后拽偏回复语言（同 review 侧 output_language_directive 先例）。
+    /// 按 locale 追加输出语言指令，与 review 侧 output_language_directive 先例
+    /// 对齐；zh-Hans 分支是每轮复盘的实际路径，en/ja 是换语言「稍后重启」后旧
+    /// 引擎快照窄窗口的防御纵深（可达性详见 memory_output_language_directive）。
     fn memory_locale_tag(&self) -> String;
 }
 

--- a/pinvou3-app/src-tauri/src/features/memory/types.rs
+++ b/pinvou3-app/src-tauri/src/features/memory/types.rs
@@ -19,6 +19,10 @@ pub trait MemoryReviewModel {
     fn memory_base_url(&self) -> String;
     fn memory_api_key(&self) -> String;
     fn memory_model_preset(&self) -> ModelPreset;
+    /// UI locale（BCP 47 tag，如 "zh-Hans"/"en"/"ja"）。记忆复盘提示词本体是中文，
+    /// 非中文 locale 需要追加输出语言指令，否则记忆 content 会被写成中文、
+    /// 注入英文 UI 会话后拽偏回复语言（同 review 侧 output_language_directive 先例）。
+    fn memory_locale_tag(&self) -> String;
 }
 
 pub const PROFILE_VERSION: u32 = 1;

--- a/pinvou3-app/src-tauri/src/features/review/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/review/mod.rs
@@ -738,6 +738,26 @@ fn full_transcript(messages: &[Message]) -> String {
     lines.join("\n")
 }
 
+/// B1 转交消息(resolvePinvouReview,品悟检阅弹窗勾选「让 AI 改」等动作后由前端
+/// 双桥同文组装、以 Boss 身份发回主会话)的段头前缀。按勾选动作分五段拼一条消息,
+/// **任意段都可能打头**(只勾 verify 时消息以"以下几条涉及外部事实"开头),故须
+/// 全量前缀匹配而非单一 starts_with。与 `pinvou3-app/src/platform/tauri/bridge/chat.js`
+/// 及 `pinvou3-app/src/platform/web/bridge.js` 的 resolvePinvouReview 保持同步。
+/// 历史注释里的旧前缀「请参考下面 Pinvou 的检阅意见」在开源基线(e34024e6)起就
+/// 从未被任何前端发送过(双桥自始使用「请按下面的检阅意见」),无需保留兼容分支。
+const B1_TRANSFER_PREFIXES: &[&str] = &[
+    // fix 段头
+    "请按下面的检阅意见",
+    // verify 段头
+    "以下几条涉及外部事实",
+    // adopt 段头
+    "以下事项我已拍板",
+    // ask 段头
+    "以下待定项请用 request_user_input 正式问我",
+    // fill 段头
+    "以下维度产物还缺",
+];
+
 /// 确定性投影（§4.2，超长降级用）：Boss 原话全留 / request_user_input 决策 /
 /// Web(action=search) 事实截断；丢 checklist、thinking、tool 细节。**产物不在这里**——由
 /// build_context 读 workspace 文件真实内容（修 edit_file bug，§10.10）。
@@ -750,11 +770,15 @@ fn project(messages: &[Message]) -> String {
         let is_user = m.role == "user";
         for b in &m.content {
             match b {
-                // B1 转交消息(applyPinvouReview 固定前缀)是 pinvou 上轮审阅回传,不是 Boss
-                // 原始需求——投影排除,否则其中引用的旧数字会被当成"AI 当前状态"误导;采纳的
-                // 决策已落在产物文件里(产物才是真相)。
+                // B1 转交消息(resolvePinvouReview 组装的固定段头)是 pinvou 上轮审阅回传,不是
+                // Boss 原始需求——投影排除,否则其中引用的旧数字会被当成"AI 当前状态"误导;采纳的
+                // 决策已落在产物文件里(产物才是真相)。前端(tauri/web 双桥同文)按勾选动作拼段,
+                // 段头五种皆可能打头,须全量识别;详见 B1_TRANSFER_PREFIXES 注释。
                 ContentBlock::Text { text, .. }
-                    if is_user && !text.starts_with("请参考下面 Pinvou 的检阅意见") =>
+                    if is_user
+                        && !B1_TRANSFER_PREFIXES
+                            .iter()
+                            .any(|prefix| text.starts_with(prefix)) =>
                 {
                     boss_says.push(text.clone())
                 }
@@ -1227,13 +1251,41 @@ mod tests {
 
     #[test]
     fn project_excludes_b1_transfer_messages() {
-        let messages = vec![
-            user_text("帮我规划欧洲游，预算 2 万"),
-            user_text("请参考下面 Pinvou 的检阅意见，修改前面的内容：\n- 【预算】采纳 8.5w（国庆 5-7w 难实现）"),
+        // 前端双桥(tauri/chat.js、web/bridge.js)的 resolvePinvouReview 按勾选动作
+        // 拼段,五种段头皆可能打头——逐一构造真实前缀用例(源串取自桥端原文)。
+        let real_prefixes = [
+            (
+                "fix",
+                "请按下面的检阅意见，**只定向修改对应段落，不要全文重写**：",
+            ),
+            (
+                "verify",
+                "以下几条涉及外部事实，**先查证再改、标明依据，别凭记忆直接改**：",
+            ),
+            ("adopt", "以下事项我已拍板，按此更新产物："),
+            (
+                "ask",
+                "以下待定项请用 request_user_input 正式问我，别自己猜：",
+            ),
+            (
+                "fill",
+                "以下维度产物还缺，请补充进去（保留其余、只增不改）：",
+            ),
         ];
-        let p = project(&messages);
-        assert!(p.contains("帮我规划欧洲游"), "Boss 原话保留: {p}");
-        assert!(!p.contains("5-7w"), "转交消息(含上轮旧数字)要排除: {p}");
+        for (kind, prefix) in real_prefixes {
+            let messages = vec![
+                user_text("帮我规划欧洲游，预算 2 万"),
+                user_text(&format!(
+                    "{prefix}\n- 【预算】采纳 8.5w（国庆 5-7w 难实现）"
+                )),
+            ];
+            let p = project(&messages);
+            assert!(p.contains("帮我规划欧洲游"), "Boss 原话保留({kind}): {p}");
+            assert!(
+                !p.contains("5-7w"),
+                "{kind} 段头的转交消息(含上轮旧数字)要排除: {p}"
+            );
+        }
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/review/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/review/mod.rs
@@ -738,23 +738,28 @@ fn full_transcript(messages: &[Message]) -> String {
     lines.join("\n")
 }
 
-/// B1 转交消息(resolvePinvouReview,品悟检阅弹窗勾选「让 AI 改」等动作后由前端
-/// 双桥同文组装、以 Boss 身份发回主会话)的段头前缀。按勾选动作分五段拼一条消息,
-/// **任意段都可能打头**(只勾 verify 时消息以"以下几条涉及外部事实"开头),故须
-/// 全量前缀匹配而非单一 starts_with。与 `pinvou3-app/src/platform/tauri/bridge/chat.js`
-/// 及 `pinvou3-app/src/platform/web/bridge.js` 的 resolvePinvouReview 保持同步。
-/// 历史注释里的旧前缀「请参考下面 Pinvou 的检阅意见」在开源基线(e34024e6)起就
-/// 从未被任何前端发送过(双桥自始使用「请按下面的检阅意见」),无需保留兼容分支。
+/// Section-header prefixes of B1 transfer messages (resolvePinvouReview: after
+/// the Pinvou review dialog checks "let AI fix" and similar actions, both
+/// frontend bridges assemble the message identically and send it back to the
+/// main session as the Boss). The message is composed of up to five sections,
+/// one per checked action, and **any of them can lead** (checking only verify
+/// makes the message start with "以下几条涉及外部事实"), so matching must cover
+/// all prefixes instead of a single starts_with. Keep in sync with
+/// resolvePinvouReview in `pinvou3-app/src/platform/tauri/bridge/chat.js` and
+/// `pinvou3-app/src/platform/web/bridge.js`. The old prefix found in historical
+/// comments ("请参考下面 Pinvou 的检阅意见") has never been sent by any frontend
+/// since the open-source baseline (e34024e6) — both bridges always used
+/// "请按下面的检阅意见" — so no compatibility branch is needed.
 const B1_TRANSFER_PREFIXES: &[&str] = &[
-    // fix 段头
+    // fix section header
     "请按下面的检阅意见",
-    // verify 段头
+    // verify section header
     "以下几条涉及外部事实",
-    // adopt 段头
+    // adopt section header
     "以下事项我已拍板",
-    // ask 段头
+    // ask section header
     "以下待定项请用 request_user_input 正式问我",
-    // fill 段头
+    // fill section header
     "以下维度产物还缺",
 ];
 
@@ -770,10 +775,15 @@ fn project(messages: &[Message]) -> String {
         let is_user = m.role == "user";
         for b in &m.content {
             match b {
-                // B1 转交消息(resolvePinvouReview 组装的固定段头)是 pinvou 上轮审阅回传,不是
-                // Boss 原始需求——投影排除,否则其中引用的旧数字会被当成"AI 当前状态"误导;采纳的
-                // 决策已落在产物文件里(产物才是真相)。前端(tauri/web 双桥同文)按勾选动作拼段,
-                // 段头五种皆可能打头,须全量识别;详见 B1_TRANSFER_PREFIXES 注释。
+                // B1 transfer messages (fixed section headers assembled by
+                // resolvePinvouReview) are the Pinvou review feedback from the
+                // previous round, not the Boss's original request — project them
+                // out, otherwise stale numbers quoted there get read as "the AI's
+                // current state"; adopted decisions already live in the artifact
+                // files (the artifacts are the truth). The frontend (identical in
+                // the tauri/web bridges) composes one section per checked action
+                // and any of the five headers can lead, so all must be recognized;
+                // see the B1_TRANSFER_PREFIXES docs.
                 ContentBlock::Text { text, .. }
                     if is_user
                         && !B1_TRANSFER_PREFIXES
@@ -1251,8 +1261,10 @@ mod tests {
 
     #[test]
     fn project_excludes_b1_transfer_messages() {
-        // 前端双桥(tauri/chat.js、web/bridge.js)的 resolvePinvouReview 按勾选动作
-        // 拼段,五种段头皆可能打头——逐一构造真实前缀用例(源串取自桥端原文)。
+        // Both frontend bridges (tauri/chat.js, web/bridge.js) compose
+        // resolvePinvouReview sections per checked action and any of the five
+        // headers can lead — build one case per real prefix (strings taken
+        // verbatim from the bridge sources).
         let real_prefixes = [
             (
                 "fix",
@@ -1280,10 +1292,13 @@ mod tests {
                 )),
             ];
             let p = project(&messages);
-            assert!(p.contains("帮我规划欧洲游"), "Boss 原话保留({kind}): {p}");
+            assert!(
+                p.contains("帮我规划欧洲游"),
+                "Boss's own words kept ({kind}): {p}"
+            );
             assert!(
                 !p.contains("5-7w"),
-                "{kind} 段头的转交消息(含上轮旧数字)要排除: {p}"
+                "transfer message led by the {kind} header (with last round's stale numbers) must be excluded: {p}"
             );
         }
     }

--- a/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
+++ b/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
@@ -299,7 +299,20 @@ test('停止按钮与引擎回收都级联取消子智能体', () => {
 // ── 会话级开关 + 每轮委派提醒（Rust 源结构契约） ─────────────────────────────
 
 test('旧独立入口退役：多智能体经会话级开关 + 每轮注入委派提醒', () => {
-  assert.match(commandSource, /fn delegation_reminder_with_roles\(roles: Vec<String>\)/, 'Work 与原生 Code 多智能体按同轮候选生成委派提醒');
+  assert.match(commandSource, /fn delegation_reminder_with_roles\(roles: Vec<String>, limits: &DelegationLimits\)/, 'Work 与原生 Code 多智能体按同轮候选生成委派提醒');
+  // Per-turn reminder numbers must come from the session tier (DelegationLimits),
+  // not from hardcoded literals: Work sessions run 4 concurrent / 8 admitted,
+  // native Code sessions 6 / 12 (same constants the engine config installs).
+  assert.match(
+    commandSource,
+    /pub\(crate\) struct DelegationLimits \{[\s\S]{0,160}pub max_concurrent: usize,[\s\S]{0,160}pub max_admitted: usize,[\s\S]{0,160}\}/,
+    'reminder numbers are carried by DelegationLimits so both tiers can be asserted',
+  );
+  assert.match(
+    commandSource,
+    /pub\(crate\) fn delegation_limits_for\(pool: &EnginePool, session_id: &str\) -> DelegationLimits \{[\s\S]{0,400}pool\.is_code_session\(session_id\)/,
+    'tier selection must reuse the same is_code_session predicate as the engine config',
+  );
   assert.match(commandSource, /pub\(crate\) fn prepare_delegation_turn\(/, '普通发送与方案接受必须复用同一轮提醒/名册快照组装');
   assert.match(commandSource, /snapshot\.available_role_lines\(task\)/, '候选提醒必须从本轮名册快照筛选，避免提示与实际派工错位');
   assert.match(rosterSource, /EXPERT_CANDIDATE_LIMIT:\s*usize\s*=\s*20/, '父模型每轮最多看到 20 位专家短候选');
@@ -395,10 +408,13 @@ test('旧独立入口退役：多智能体经会话级开关 + 每轮注入委�
   const assistantBridgeSource = read('src-tauri', 'src', 'features', 'assistant', 'platform', 'bridge.rs');
   const engineSource = read('src-tauri', 'src', 'features', 'assistant', 'engine.rs');
   assert.match(assistantBridgeSource, /MULTI_AGENT_MAX_SPAWN_DEPTH:\s*u32\s*=\s*2/);
-  assert.match(assistantBridgeSource, /MULTI_AGENT_WORK_MAX_CONCURRENT:\s*usize\s*=\s*4/);
-  assert.match(assistantBridgeSource, /MULTI_AGENT_WORK_MAX_ADMITTED:\s*usize\s*=\s*8/);
-  assert.match(assistantBridgeSource, /MULTI_AGENT_CODE_MAX_CONCURRENT:\s*usize\s*=\s*6/);
-  assert.match(assistantBridgeSource, /MULTI_AGENT_CODE_MAX_ADMITTED:\s*usize\s*=\s*12/);
+  // Tier constants are pub(crate): the per-turn delegation reminder reads the
+  // same single source of truth as build_engine_config_for_multi_agent.
+  // Work tier runs 4 concurrent / 8 admitted; native Code tier 6 / 12.
+  assert.match(assistantBridgeSource, /pub\(crate\) const MULTI_AGENT_WORK_MAX_CONCURRENT: usize = 4;/, 'Work tier direct-child concurrency is 4');
+  assert.match(assistantBridgeSource, /pub\(crate\) const MULTI_AGENT_WORK_MAX_ADMITTED: usize = 8;/, 'Work tier tree-wide admission is 8');
+  assert.match(assistantBridgeSource, /pub\(crate\) const MULTI_AGENT_CODE_MAX_CONCURRENT: usize = 6;/, 'Code tier direct-child concurrency is 6');
+  assert.match(assistantBridgeSource, /pub\(crate\) const MULTI_AGENT_CODE_MAX_ADMITTED: usize = 12;/, 'Code tier tree-wide admission is 12');
   assert.match(
     assistantBridgeSource,
     /build_multi_agent_send_message_op[\s\S]{0,700}build_multi_agent_hook_executor/,

--- a/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
+++ b/pinvou3-app/tests/multiagent_plan_normalize.test.mjs
@@ -299,7 +299,7 @@ test('停止按钮与引擎回收都级联取消子智能体', () => {
 // ── 会话级开关 + 每轮委派提醒（Rust 源结构契约） ─────────────────────────────
 
 test('旧独立入口退役：多智能体经会话级开关 + 每轮注入委派提醒', () => {
-  assert.match(commandSource, /fn delegation_reminder_with_roles\(roles: Vec<String>, limits: &DelegationLimits\)/, 'Work 与原生 Code 多智能体按同轮候选生成委派提醒');
+  assert.match(commandSource, /fn delegation_reminder_with_roles\(roles: Vec<String>, limits: &DelegationLimits\)/, 'Work and native Code multi-agent sessions generate the delegation reminder from the same per-turn candidate roster');
   // Per-turn reminder numbers must come from the session tier (DelegationLimits),
   // not from hardcoded literals: Work sessions run 4 concurrent / 8 admitted,
   // native Code sessions 6 / 12 (same constants the engine config installs).


### PR DESCRIPTION
## Summary

Fixes five audit-verified divergences where Rust-side model-facing prompts disagreed with documented/duplicated behavior elsewhere in the codebase. All five were re-verified against source before fixing.

### 1. Review projection B1 transfer filter was dead (MAJOR)
`features/review/mod.rs` filtered B1 transfer messages by prefix `请参考下面 Pinvou 的检阅意见` — a prefix **no frontend ever sent** (verified back to the community baseline `e34024e6`: both bridges have always used `请按下面的检阅意见`). The filter therefore never excluded anything. Additionally, the frontend assembles the message from up to five section headers (fix/verify/adopt/ask/fill) and **any of them can lead** the message, so a single-prefix match would still miss 4 of 5 shapes. Fix: `B1_TRANSFER_PREFIXES` matches all five real bridge strings; test `project_excludes_b1_transfer_messages` now iterates the exact bridge strings per header. No old-prefix compatibility branch is needed (documented in the constant's comment: the old prefix was never client-emitted).

### 2. Multiagent reminder concurrency numbers hardcoded 4/8 (MINOR)
`build_engine_config_for_multi_agent` configures Work sessions 4/8 and native Code sessions 6/12 (`MULTI_AGENT_*` constants in bridge.rs), but the per-turn reminder hardcoded 4/8 for both tiers — Code-tier models would self-throttle to wrong limits. Fix: new `DelegationLimits` + `delegation_limits_for(pool, session_id)` selects the tier via `pool.is_code_session`; `delegation_reminder_with_roles` formats the numbers. All three reminder entry points (`prepare_delegation_turn` in chat.rs/interaction.rs path and `prepend_delegation_replay_reminder` in memory.rs edit_last_turn) updated. The `MULTI_AGENT_*` constants are now `pub(crate)` so the reminder shares the single source of truth with engine config. New regression test pins both tiers and the constant values.

### 3. Memory LLM review had no output-language instruction (MINOR)
`LLM_REVIEW_PROMPT` and `user_content` carried no locale signal, so memory `content` language was left entirely to the model. Fix: added `memory_output_language_directive` mirroring the review-side `output_language_directive` precedent (zh-Hans hard-forces Chinese; en/ja switch natural-language values; JSON keys/enums stay ASCII; unknown → no-op). Locale flows through a new `MemoryReviewModel::memory_locale_tag` implemented by `Pinvou3Bridge::locale_tag` — same source the review path uses, no new global state.

**Reachability note (corrected after review):** `enforce_memory_locale_policy` (prefs) force-disables `memory_enabled` for non-zh-Hans UI on every load/save, so en/ja users never run memory review through the normal flow — this fix is **defense-in-depth mirroring the review-side precedent, not a fix for a reachable failure**. The zh-Hans branch is the live per-review path (hard-forces Chinese `content` even in English conversations, same measured drift the review side hit); the en/ja branches only cover the narrow window where the locale was switched to Chinese with "restart later", memory was re-enabled, and a pre-switch engine snapshot still carries the old locale.

### 4. kb_search result header missing binary-source prohibition (MINOR)
The production unified search header (`build_unified_context_block`) lacked the "no File/Bash full expansion for XLSX/DOCX/PPTX" rule that exists in the `kb_open_source` tool description, the session system reminder, and the non-production `build_kb_context_block`. Added one line with matching wording; new test asserts its presence (also with warnings present).

### 5. present_artifact title description hardcoded "Chinese title" (MINOR)
The MCP `tools/list` description is sent verbatim to the model, contradicting the locale-based title language policy (`instructions-work.md` `{{PINVOU3_TITLE_LANG}}`, bridge.rs comment documents the same class of bug). Changed to locale-neutral wording ("same language as your reply"). Verified: the file is embedded via `PRESENT_ARTIFACT_SERVER_PY` and re-extracted on every startup via `write_if_changed` (byte comparison), and it is **not** part of the `BUNDLE_INSTRUCTIONS_HASH` (build.rs hashes only instructions*.md + deny_sensitive_paths.sh) — no hash/version bump or test unlock needed.

## Verification

- [x] `cargo test --lib` targeted: review (22 passed), multiagent (7 passed, incl. new tier test), memory (46 passed, incl. new language-directive test), knowledge (64 passed), bridge (85), runtime_bundle (27), app::commands (167)
- [x] `cargo fmt --check` clean
- [x] `python3 scripts/architecture-guard.py` — passed, no debt increased
- [x] `node scripts/sync-version.mjs --check` — all consistent
- [x] grep: old prefix filter gone (only a history-explaining comment remains); 4/8 hardcoded reminder text parameterized; no "中文标题" in server.py
- [x] No frontend changes; both bridges were already consistent with each other

documented-behavior fixes only; locale/limit values sourced from existing constants
