### PR TITLE
ci(gate): shorten pull request latency

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -5,7 +5,8 @@ name: mac-build
 # runner:macos-15(GitHub-hosted Apple Silicon,M Series;钉死大版本号以保证可复现)。
 #
 # 与 pr-check.yml 的 rust-test 关系:
-# - rust-test 在 ubuntu 上跑完整 lib tests,是主线 gate。
+# - rust-test runs full lib tests for high-risk ready PRs, matching merge groups,
+#   and every main push. Explicitly low-risk Rust changes use the fast gate.
 # - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟,
 #   验证 macOS 平台目标零回归。真发版的 thin-LTO --release 产物由 scripts/release-macos.sh 产出。
 # - mac-build 不跑 relay e2e(那需要 remote-control-relay 的 node_modules,mac-build 不装

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,32 +5,32 @@ name: PR Check
 # - version-consistency:强制校验 VERSION 单一事实来源与 SemVer 规则。
 # - fast-gate(秒级,每 PR 都跑):fork-guard 指纹 + fork 合规联动 + Python 确定性测试。
 # - changes:检测本 PR 有没有 Rust 代码、发布契约、L1 harness 或前端改动,给后续 job 做 paths filter。
-# - frontend-test:Draft 跑 lint/build/逻辑测试；Ready PR 跑定向浏览器 smoke；
-#   Merge Queue 对最新组合提交跑完整受影响前端门禁。
+# - frontend-test: Draft runs lint/build/logic tests. Ready PRs and Merge Queue
+#   select browser smokes from their actual base/head diff and fail closed for
+#   unknown or shared paths.
 # - release-contract-test:发布链路改动只跑配置/脚本契约,不在 PR 构建安装包。
 # - knowledge-rust:独立 pinvou-knowledge crate/部署入口改动跑 fmt/clippy/test 与 shell
 #   语法检查；依赖或策略改动时追加 cargo-deny，不依赖 Tauri workspace 间接覆盖。
-# - rust-test(编译类):Draft/普通 PR 默认不跑;Ready 高风险 PR 可加 ci:full-rust
-#   标签提前跑；Merge Queue 对最新组合提交运行；main push 无条件累计验证并写暖
-#   cache(防 concurrency pending 替换盲区)。
+# - rust-test: Draft and explicitly low-risk Rust changes skip the large test
+#   binary. Ready high-risk PRs and their combined Merge Queue tree run Linux
+#   regressions; Windows runs once on the ready PR. Main always runs both.
 # - rust-lint:Draft 只跑 fmt；Ready/Queue/main 跑 clippy；cargo-deny 仅在依赖
 #   或策略路径变化时追加，三项均无 continue-on-error。
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
 #   只启用实测零欠账的 lint(deny),有欠账的 lint/group 显式 allow,
 #   欠账由清理 PR(#35 及后续)消化后逐个升 deny。
-# - windows-rust-test:Windows 专属原语在原生 runner 执行;Ready PR/Merge Queue
-#   按 Rust 路径触发;main 每次保留下来的 push 无条件累计验证(防 pending 替换盲区)。
+# - windows-rust-test: Native Windows coverage runs for ready high-risk paths or
+#   ci:full-rust. Merge Queue does not repeat it; main retains cumulative coverage.
 # - windows-codex-runtime-test:Relevant PRs exercise the browser-wrapper lifecycle,
 #   prepare Node + ACP Bridge, and verify packaged resources on native Windows.
-# - benchmark-contract / benchmark-test:评测代码保持 CI 隔离，仓库工作流中硬关闭；
-#   不得通过 PR 标签、路径或 Merge Queue 事件启用，避免影响主工程门禁与运行资源。
+# - Benchmarks stay outside product PR/MQ gates and run manually in an isolated environment.
 # - required-gate:PR 阶段汇总所有适用检查，作为唯一 required check。
 # - merge_group:按 base/head 的真实组合 diff 运行适用门禁，保证验证对象就是
 #   最新 main + 入队 PR；因此无冲突 PR 不需要为主线日常前进反复人工 rebase。
 #
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
-# - Rust 相关 push main 跑 rust-test:cache 存 main 作用域,供 Merge Queue/显式 PR 复用。
+# - Main runs full rust-test and stores a main-scoped cache for high-risk/explicit PRs.
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
@@ -126,12 +126,9 @@ jobs:
     outputs:
       rust_code: ${{ steps.filter.outputs.rust_code }}
       rust_dependencies: ${{ steps.filter.outputs.rust_dependencies }}
+      rust_full: ${{ steps.filter.outputs.rust_full }}
       knowledge_rust: ${{ steps.filter.outputs.knowledge_rust }}
       knowledge_dependencies: ${{ steps.filter.outputs.knowledge_dependencies }}
-      benchmark: ${{ steps.filter.outputs.benchmark }}
-      benchmark_cli: ${{ steps.filter.outputs.benchmark_cli }}
-      benchmark_headless: ${{ steps.filter.outputs.benchmark_headless }}
-      benchmark_codewhale: ${{ steps.filter.outputs.benchmark_codewhale }}
       release_contract: ${{ steps.filter.outputs.release_contract }}
       pet: ${{ steps.filter.outputs.pet }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -145,6 +142,7 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          predicate-quantifier: some-with-excludes
           filters: |
             rust_code:
               - '**/*.rs'
@@ -163,6 +161,22 @@ jobs:
               - '.gitmodules'
               - '.github/workflows/pr-check.yml'
               - '.github/workflows/mac-build.yml'
+            # All unclassified Rust paths fail closed to full regression. Only
+            # isolated leaf-feature boundaries are explicitly low risk; changes
+            # to their registration or app command surface still run full tests.
+            rust_full:
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+              - '**/deny.toml'
+              - '**/build.rs'
+              - '.cargo/**'
+              - '.gitmodules'
+              - 'CodeWhale'
+              - 'pinvou3-app/src-tauri/rust-toolchain.toml'
+              - 'pinvou3-app/src-tauri/**/*.rs'
+              - '!pinvou3-app/src-tauri/src/features/feedback/**'
+              - '!pinvou3-app/src-tauri/src/features/personas/**'
+              - '!pinvou3-app/src-tauri/src/features/pet/**'
             knowledge_rust:
               - 'pinvou-knowledge/**/*.rs'
               - 'pinvou-knowledge/Cargo.toml'
@@ -174,26 +188,6 @@ jobs:
               - 'pinvou-knowledge/Cargo.lock'
               - 'pinvou3-app/src-tauri/deny.toml'
               - '.github/workflows/pr-check.yml'
-            benchmark:
-              - 'pinvou-cli/**'
-              - 'pinvou3-app/src-tauri/src/features/assistant/product_runtime/headless_bridge.rs'
-              - 'pinvou3-app/src-tauri/tests/headless_bridge_contract.rs'
-              - 'pinvou3-app/src-tauri/src/features/assistant/product_runtime/**'
-              - 'pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs'
-              - 'pinvou3-app/src-tauri/Cargo.toml'
-              - 'pinvou3-app/src-tauri/Cargo.lock'
-              - 'CodeWhale'
-            benchmark_cli:
-              - 'pinvou-cli/**'
-            benchmark_headless:
-              - 'pinvou3-app/src-tauri/src/features/assistant/product_runtime/headless_bridge.rs'
-              - 'pinvou3-app/src-tauri/tests/headless_bridge_contract.rs'
-              - 'pinvou3-app/src-tauri/src/features/assistant/product_runtime/**'
-              - 'pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs'
-              - 'pinvou3-app/src-tauri/Cargo.toml'
-              - 'pinvou3-app/src-tauri/Cargo.lock'
-            benchmark_codewhale:
-              - 'CodeWhale'
             release_contract:
               - 'VERSION'
               - 'scripts/sync-version.mjs'
@@ -373,8 +367,9 @@ jobs:
     # 合并原 diff-viewer-test + pet-frontend-test:两者各自 npm ci + build:ui 纯重复,
     # pet 跑 npm test(链尾含 test:diff-parser)与 diff-viewer 的 test:diff-parser 也重复,
     # 且 pet 缺 lint:ui。统一为一个 job 后:依赖/build 各装一次、lint 全覆盖。
-    # Draft 仅跑 lint/build/逻辑测试；Ready PR 按 diff 选定 browser smoke；
-    # merge_group 对最新组合提交跑完整 browser smoke。
+    # Draft runs lint/build/logic tests. Ready PRs and merge groups select browser
+    # smokes from their actual base/head diff. Shared, unknown, test-infrastructure,
+    # and empty diffs fail closed to the complete smoke set.
     if: ${{ !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.pet == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -456,9 +451,22 @@ jobs:
             esac
           done < "$RUNNER_TEMP/frontend-smokes.tsv"
 
-      - name: Merge Queue 完整浏览器 smoke
+      - name: Merge Queue diff-selected browser smoke
         if: ${{ github.event_name == 'merge_group' }}
-        run: npm run test:browser-smoke
+        env:
+          BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | node ../scripts/select-frontend-smokes.mjs \
+            > "$RUNNER_TEMP/frontend-smokes.tsv"
+          while IFS="$(printf '\t')" read -r kind target; do
+            case "$kind" in
+              npm) npm run "$target" ;;
+              node) node "$target" ;;
+              *) echo "Unknown smoke kind: $kind" >&2; exit 1 ;;
+            esac
+          done < "$RUNNER_TEMP/frontend-smokes.tsv"
 
   relay-test:
     name: relay-test
@@ -658,9 +666,9 @@ jobs:
   rust-test:
     name: rust-test
     needs: changes
-    # Draft/普通 PR 默认跳过；可信高风险场景按路径/标签触发；Ready 高风险 PR
-    # 可用标签提前跑。main push 无条件执行累计状态验证,避免 concurrency 用后续
-    # 非 Rust pending 替换含 Rust 变更的 pending 后,只看相邻 diff 而漏检。
+    # Ready high-risk PRs and matching merge groups run the full Linux regression.
+    # Explicitly low-risk leaf changes stay on compile/lint feedback; unknown Rust
+    # paths fail closed through rust_full. Main always runs the cumulative regression.
     if: >-
       ${{
         !cancelled() &&
@@ -668,12 +676,16 @@ jobs:
         (
           github.event_name == 'push' ||
           (
-            needs.changes.outputs.rust_code == 'true' &&
+            github.event_name == 'merge_group' &&
+            needs.changes.outputs.rust_full == 'true'
+          ) ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.draft == false &&
             (
-              github.event_name == 'merge_group' ||
+              needs.changes.outputs.rust_full == 'true' ||
               (
-                github.event_name == 'pull_request' &&
-                github.event.pull_request.draft == false &&
+                needs.changes.outputs.rust_code == 'true' &&
                 contains(github.event.pull_request.labels.*.name, 'ci:full-rust')
               )
             )
@@ -682,8 +694,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     # Tauri + fastembed + aws-lc-sys 全冷编译耗时长;设上限避免卡死 runner 占用。
-    # 知识库依赖进入主测试二进制后,Merge Queue 两次在 ThinLTO 链接期令 16GB
-    # hosted runner 失联。限制 backend 并行会延长链接,故同步放宽到 120min。
+    # High-risk PR, combined-tree, and main runs retain a 120-minute safety limit.
     timeout-minutes: 120
     env:
       # 经 rustc-stack-wrapper 直接注入 RUST_MIN_STACK=16MiB 到编译期 rustc 进程
@@ -753,10 +764,9 @@ jobs:
         run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
 
       # remote_control 的真实 relay 下载 e2e 需要 node + relay 依赖,缺 node_modules/ws 时
-      # 该 e2e 会自动 skip —— 装上依赖让 CI 真正执行它,而不是绿灯假过。
-      # push(main) 只编译不执行测试(见下方 --no-run),不需要 relay/Chrome 运行时依赖。
+      # Install relay dependencies so high-risk PR, combined-tree, and main runs
+      # execute the real e2e instead of silently skipping it.
       - name: Node.js (relay e2e)
-        if: ${{ github.event_name != 'push' }}
         uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -764,11 +774,9 @@ jobs:
           cache-dependency-path: remote-control-relay/package-lock.json
 
       - name: relay 依赖 (真实 relay e2e)
-        if: ${{ github.event_name != 'push' }}
         run: npm --prefix remote-control-relay ci --prefer-offline --no-audit
 
       - name: 浏览器驱动依赖 (真实 Chrome 下载 e2e)
-        if: ${{ github.event_name != 'push' }}
         # real-browser driver 从 pinvou3-app/node_modules 加载 puppeteer-core。
         # npm --prefix pinvou3-app install 即使指定单包也会解析并安装项目完整依赖树，
         # 因此直接用 package-lock 驱动的 npm ci，避免额外维护一份硬编码版本并保证可复现。
@@ -783,7 +791,7 @@ jobs:
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      # MQ/PR(ci:full-rust) 跑完整 lib 测试(含真实 relay/Chrome e2e)。
+      # High-risk/explicit PRs, matching merge groups, and main run all lib tests.
       # 保留 --test-threads=1:虽已把 env 写测试收敛到 crate 级唯一锁
       # (bridge::paths::tests::ENV_LOCK),但进程级 env 对未持锁的读取者仍全局可见，
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
@@ -792,41 +800,30 @@ jobs:
       # strict_mode 的三个确定性回归已并入 pinvou3_lib 单测，和全量 lib tests
       # 共用一次编译与链接，避免第二个 integration test 目标重复链接全依赖树。
       - name: cargo test --lib（含 strict_mode 回归；真 bge-m3/vLLM 测试已 #[ignore]）
-        if: ${{ github.event_name != 'push' }}
         run: |
           chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
           export CHROME="$chrome"
           export PINVOU_REQUIRE_REMOTE_E2E=1
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1
 
-      # push(main) 唯一目的是暖 cache(Swatinem/rust-cache save-if main)。
-      # MQ 已对同一代码跑过完整 lib 测试,squash 合并后的 push 不再重复执行测试;
-      # --no-run 编译含 test harness 的全部 target 产物(与完整 test 的编译腿一致),
-      # 供热 MQ restore 后增量复用,省去测试执行时间。
-      # 不需要 relay/Chrome 运行时依赖(上方 setup-node/relay/浏览器 step 已按 !=push 跳过)。
-      - name: cargo test --lib --no-run (push main 仅编译暖 cache)
-        if: ${{ github.event_name == 'push' }}
-        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
-
   windows-rust-test:
     name: windows-rust-test
     needs: changes
-    # Windows 专属原语必须在原生 runner 执行；Draft 保持快速反馈，Ready PR 与
-    # Merge Queue 按 Rust 路径触发。main 每次保留下来的 push 都执行 Windows 原生
-    # 累计验证，避免 concurrency 用后续非 Rust pending 替换含 Rust 变更的 pending
-    # 后，按相邻 diff 路由导致中间提交永远未经过 Windows 编译。
+    # Native Windows coverage runs once on ready high-risk/explicit PRs and on main.
+    # Merge Queue does not repeat this 20+ minute leg; Linux validates the combined tree.
     if: >-
       ${{
         !cancelled() &&
         (
           github.event_name == 'push' ||
           (
-            needs.changes.outputs.rust_code == 'true' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.draft == false &&
             (
-              github.event_name == 'merge_group' ||
+              needs.changes.outputs.rust_full == 'true' ||
               (
-                github.event_name == 'pull_request' &&
-                github.event.pull_request.draft == false
+                needs.changes.outputs.rust_code == 'true' &&
+                contains(github.event.pull_request.labels.*.name, 'ci:full-rust')
               )
             )
           )
@@ -1069,149 +1066,6 @@ jobs:
       - name: macOS Codex 与 Claude Runtime 原生打包冒烟
         run: npm --prefix pinvou3-app run test:codex-acp-macos-runtime
 
-  benchmark-contract:
-    name: benchmark-contract
-    needs: changes
-    # Benchmark CI 在本 PR 中必须保持硬关闭：不接受 label/path/event 开启。
-    # 如需验证，由维护者在隔离环境本地执行，不得占用主工程 PR/MQ 门禁。
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper
-    steps:
-      - name: Checkout (含 submodule)
-        uses: actions/checkout@v7
-        with:
-          submodules: false
-
-      - name: 初始化公共底座 submodule
-        run: git submodule update --init --recursive -- CodeWhale
-
-      - name: 装 Tauri + pinvou3 Linux 系统依赖
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev \
-            librsvg2-dev libssl-dev \
-            libx11-dev libxi-dev libxtst-dev \
-            libayatana-appindicator3-dev \
-            build-essential pkg-config cmake
-
-      - name: bge-m3 占位 (骗过 tauri-build 资源校验)
-        run: |
-          d=pinvou3-app/src-tauri/resources/bge-m3
-          mkdir -p "$d"
-          for f in config.json model.onnx tokenizer.json tokenizer_config.json special_tokens_map.json; do
-            : > "$d/$f"
-          done
-
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: 对齐 rust-toolchain.toml 锁定的工具链
-        working-directory: pinvou3-app/src-tauri
-        run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            pinvou-cli
-            pinvou3-app/src-tauri
-            CodeWhale
-          shared-key: benchmark-contract
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      - name: benchmark 核心与适配器契约测试
-        run: >-
-          cargo test --manifest-path pinvou-cli/Cargo.toml --all-features
-          -p agent-backend-api -p benchmark-core -p adapter-smoke -p adapter-gaia
-
-      - name: benchmark CLI 无 product-backend 契约测试
-        run: >-
-          cargo test --manifest-path pinvou-cli/Cargo.toml
-          -p pinvou-cli --no-default-features
-
-      # cargo check --test 会编译集成测试本身，能捕获 cfg(not(windows)) 下的 trait
-      # 签名漂移；行为回归由同 job 的 core tests 与 Merge Queue 的 Rust lib tests 覆盖。
-      - name: Linux headless benchmark 契约编译
-        run: |
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml \
-            --features benchmark-hooks --lib \
-            features::assistant::product_runtime::headless_bridge:: \
-            -- --test-threads=1
-          cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml \
-            --features benchmark-hooks --test headless_bridge_contract
-
-      - name: CodeWhale 受限工具安全回归
-        if: ${{ needs.changes.outputs.benchmark_codewhale == 'true' }}
-        run: >-
-          cargo test --manifest-path CodeWhale/Cargo.toml
-          -p codewhale-tui --lib --locked forkguard_ -- --test-threads=1
-
-  benchmark-test:
-    name: benchmark-test
-    needs: changes
-    # 完整 Benchmark 矩阵同样硬关闭；PR 标签不得绕过隔离边界。
-    if: ${{ false }}
-    runs-on: windows-latest
-    timeout-minutes: 90
-    env:
-      # 同 windows-rust-test:经 RUSTC_WRAPPER 注入 rustc-stack-wrapper.exe,
-      # 只在编译期 rustc 注入 RUST_MIN_STACK=16MiB。app 工作区 dev profile 对
-      # 依赖开 O2 后,codewhale-tui 的 codegen 线程在默认栈下溢出
-      # (STATUS_STACK_OVERFLOW,CI 实证)。.exe 经 CreateProcess 直启,规避
-      # cmd 8191 字符命令行上限;必须用 ${{ github.workspace }} 绝对路径。
-      RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.exe
-    steps:
-      - name: Checkout (含 submodule)
-        uses: actions/checkout@v7
-        with:
-          submodules: false
-
-      - name: 初始化公共底座 submodule
-        shell: bash
-        run: git submodule update --init --recursive -- CodeWhale
-
-      - name: Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      # 编译 Windows 专用 .exe 栈 wrapper(源码 scripts/rustc-stack-wrapper.rs)。
-      # 直接调 rustc 编译、不经 cargo,故不受本 job 的 RUSTC_WRAPPER 影响。
-      - name: 编译 Windows 栈 wrapper(.exe)
-        shell: bash
-        run: rustc -O pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.rs -o pinvou3-app/src-tauri/scripts/rustc-stack-wrapper.exe
-
-      - name: Cargo cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            pinvou-cli
-            pinvou3-app/src-tauri
-            CodeWhale
-          shared-key: benchmark-test
-
-      - name: benchmark workspace 全特性测试
-        shell: bash
-        run: cargo test --manifest-path pinvou-cli/Cargo.toml --all-features
-
-      - name: benchmark workspace 无 product-backend 测试
-        shell: bash
-        run: cargo test --manifest-path pinvou-cli/Cargo.toml --no-default-features
-
-      - name: headless benchmark 契约测试
-        shell: bash
-        run: >-
-          cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml
-          --features benchmark-hooks --test headless_bridge_contract
-
-      - name: CodeWhale 受限工具安全回归
-        shell: bash
-        run: >-
-          cargo test --manifest-path CodeWhale/Cargo.toml
-          -p codewhale-tui --lib --locked forkguard_ -- --test-threads=1
-
   required-gate:
     name: required-gate
     needs:
@@ -1228,7 +1082,6 @@ jobs:
       - windows-rust-test
       - macos-codex-runtime-test
       - windows-codex-runtime-test
-      - benchmark-contract
     if: ${{ always() && ((github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1248,7 +1101,6 @@ jobs:
           WINDOWS_RUST_RESULT: ${{ needs.windows-rust-test.result }}
           MACOS_CODEX_RESULT: ${{ needs.macos-codex-runtime-test.result }}
           WINDOWS_CODEX_RESULT: ${{ needs.windows-codex-runtime-test.result }}
-          BENCHMARK_CONTRACT_RESULT: ${{ needs.benchmark-contract.result }}
         run: |
           if [[ "$GITHUB_EVENT_NAME" == "merge_group" ]]; then
             # 队列提交由 GitHub 生成，不重复校验人工 commit message；
@@ -1272,8 +1124,7 @@ jobs:
             "rust-test:$RUST_RESULT" \
             "windows-rust-test:$WINDOWS_RUST_RESULT" \
             "macos-codex-runtime-test:$MACOS_CODEX_RESULT" \
-            "windows-codex-runtime-test:$WINDOWS_CODEX_RESULT" \
-            "benchmark-contract:$BENCHMARK_CONTRACT_RESULT"; do
+            "windows-codex-runtime-test:$WINDOWS_CODEX_RESULT"; do
             name="${item%%:*}"
             result="${item#*:}"
             case "$result" in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,26 +90,41 @@ Tests requiring a live model, network service, credential, or large model asset 
 Pull requests use a staged, path-aware gate. Draft pull requests run fast feedback
 (lint, build, deterministic logic tests, and Rust formatting where applicable).
 Ready pull requests add browser smokes selected from the actual diff, platform
-runtime contracts, and other affected checks. Release-chain changes run lightweight
-contract tests only; full deb, dmg, and nsis packages are built only after a
+runtime contracts, and other affected checks. Ready Rust pull requests run fast
+formatting, lint, dependency-policy, and compile feedback by default. All unknown
+Rust paths fail closed to full regression; only documented isolated leaf-feature
+boundaries use the lightweight route. Dependency, CodeWhale gitlink, app-command,
+platform, permission, credential, session, remote-control, and other high-blast-
+radius paths automatically add full Linux and Windows Rust regression before
+queueing. Maintainers can apply `ci:full-rust` to force the same full regression
+for another ready Rust pull request; the label has no effect on a draft.
+The current lightweight Rust boundaries are internal-only changes under `feedback`,
+`personas`, and `pet`. Changing their registration, app commands, shared platform
+surface, Cargo metadata, or any unclassified Rust path still runs full regression.
+Release-chain changes run lightweight contract tests only; full deb, dmg, and nsis
+packages are built only after a
 `VERSION` change reaches `main`, or through an explicit `workflow_dispatch`.
 
 The merge queue runs the applicable product gates against the actual combined tree
-of the queued pull request and the latest `main`. Rust changes run full Rust tests
-there; frontend changes run the complete browser-smoke set there. Add the
-`ci:full-rust` label to a **ready**, high-risk Rust pull request only when early full
-feedback is worth the extra run; the label does not start full Rust tests on a
-draft. During review, maintainers should inspect only required checks:
+of the queued pull request and the latest `main`. Rust changes run formatting,
+Clippy, compile, and dependency-policy checks there. High-blast-radius Rust changes
+also run the full Linux behavior regression on the combined tree; Windows coverage
+already ran on the ready PR and is not repeated. Frontend changes run browser smokes
+selected from the merge group's actual base/head diff; shared, unknown, or test-
+infrastructure paths fall back to the complete smoke set. Full Linux and Windows
+Rust regressions run on every retained `main` push and continue to warm the shared
+caches. A red main regression is a stop signal for further queueing until it is
+fixed or reverted. During review, maintainers should inspect only required checks:
 
 ```bash
 gh pr checks <number> --required
 ```
 
-Do not wait for non-required post-merge platform or release builds. Queue independent
-ready pull requests without routine rebases; resolve actual conflicts, and let the
-queue validate freshness. Maintainers may queue at most two low-risk, independent
-pull requests in one merge group. Dependency-lock, CI, release, permission, session,
-CodeWhale gitlink, and other high-risk changes enter alone.
+Do not wait for non-required post-merge platform or release builds when `main` is
+green. Queue independent ready pull requests without routine rebases; resolve actual
+conflicts, and let the queue validate freshness. Maintainers may queue at most two
+low-risk, independent pull requests in one merge group. Dependency-lock, CI, release,
+permission, session, CodeWhale gitlink, and other high-risk changes enter alone.
 
 ## Pull requests
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -87,20 +87,30 @@ cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-thre
 
 PR 使用分层、按路径选择的门禁。Draft 跑 lint、build、确定性逻辑测试和
 适用的 Rust fmt 快检；Ready PR 追加由实际 diff 选定的浏览器 smoke、平台
-Runtime 契约和其他受影响检查。发布链路改动只跑轻量契约测试；完整
+Runtime 契约和其他受影响检查。Ready Rust PR 默认运行快速的格式、lint、
+依赖策略和编译反馈；未知 Rust 路径默认进入完整回归，只有明确登记的孤立叶子
+功能边界走轻量路径。依赖、CodeWhale gitlink、应用命令、平台、权限、凭据、
+Session、远控及其他高爆炸半径路径会在入队前自动追加完整 Linux/Windows Rust 回归。
+其他 Ready Rust PR 可用 `ci:full-rust` 强制追加同款全量回归；Draft 不响应该
+标签。目前轻量 Rust 边界仅限 `feedback`、`personas`、`pet` 模块内部改动；它们的
+注册、应用命令、共享平台接口、Cargo 元数据或任何未分类 Rust 路径仍进入完整回归。
+发布链路改动只跑轻量契约测试；完整
 deb、dmg、nsis 安装包仅在 `VERSION` 改动进入 `main` 后，或人工明确触发
 `workflow_dispatch` 时构建。
 
 Merge Queue 在入队 PR 与最新 `main` 的实际组合树上运行适用门禁：Rust 改动
-执行完整 Rust 测试，前端改动执行完整浏览器 smoke。仅 Ready 且高风险的
-Rust PR 需要提前完整反馈时添加 `ci:full-rust`；该标签不会在 Draft 上启动
-完整 Rust 测试。评审阶段只查看 required checks：
+运行格式、Clippy、编译和依赖策略检查；高爆炸半径 Rust 改动还会在组合树上执行
+完整 Linux 行为回归，Windows 已在 Ready PR 验证，不在队列重复。前端改动按
+merge group 的真实 base/head diff 选择浏览器 smoke，共享、未知或测试设施路径
+fail-closed 回退全套。每个保留下来的 `main` push 都执行完整 Linux / Windows
+Rust 回归并持续写暖缓存；main 回归变红后应停止继续入队，直至修复或回滚。
+评审阶段只查看 required checks：
 
 ```bash
 gh pr checks <编号> --required
 ```
 
-不要等待非 required 的合入后平台构建或发布构建。无真实冲突的独立 Ready PR
+main 绿色时不要等待非 required 的合入后平台构建或发布构建。无真实冲突的独立 Ready PR
 可直接入队，由队列验证新鲜度。每个 merge group 最多放两个低风险、相互独立的
 PR；依赖锁、CI、发布、权限、Session、CodeWhale gitlink 及其他高风险改动单独入队。
 

--- a/docs/code-native-agent.md
+++ b/docs/code-native-agent.md
@@ -360,8 +360,9 @@ bridge 的 chat 状态机绑定单一 activeSession，代码页与主聊天并�
 
 1. 渐进重构：`codex_acp` / `CodexAcpView` 同时承载 ACP 与 Native 两种运行时，
    建议逐步上提为 `code_sessions` / `CodeView`，两条链路分别做 adapter/hook。
-2. CI 增强：正式 `rust-test` 目前 skipped（Windows 只 `--no-run`），建议加
-   `ci:full-rust` 让完整测试成为该 head 的正式 check。
+2. CI hardening: high-blast-radius paths automatically run full Linux/Windows
+   `rust-test`; maintainers can add `ci:full-rust` to another ready Rust PR, and
+   high-risk merge groups retain the full Linux regression on the combined tree.
 3. 代码会话工具/技能分化（审阅建议②，已定论）：代码会话当前继承全集
    工具，已落地的隔离有——连接器工具按 scope 整形（§8.3）、隐藏
    `present_artifact`、skill 双 scope 治理（§8.6：组合目录过滤 catalogue +

--- a/docs/marketplace-unification.md
+++ b/docs/marketplace-unification.md
@@ -216,16 +216,18 @@ install_bundle(id):
 5. **审计成对**：授权/拦截/迁移决策落事件日志。
 6. **fork 边界**：底座只进三条通用缝；每次 gitlink 更新跑 `fork-guard.sh --fast`
    + 契约测试；fork-distinct 行为同步登记 `docs/fork-modifications.md`。
-7. **验证基线**：`cargo test --lib -- --test-threads=1` 串行全量（CI Merge Queue
-   同款），bundle 测试共享 `platform::paths::tests::ENV_LOCK` 消除环境竞争；
-   `cargo fmt --check`、`architecture-guard.py` 通过。
+7. **Validation baseline**: high-risk ready PRs and main run
+   `cargo test --lib -- --test-threads=1`; high-risk merge groups repeat the Linux
+   behavior regression on the combined tree. Bundle tests share
+   `platform::paths::tests::ENV_LOCK`; `cargo fmt --check` and
+   `architecture-guard.py` must pass.
 
 ## 11. 风险与对策
 
 | 风险 | 对策 |
 |---|---|
 | 上游不接受 ToolingSource | fork 短期沉淀可接受（用户少 = 同步冲突面小）；缝按可上游化标准设计，不掺 Pinvou 语义 |
-| Phase 3 切换爆炸半径 | 切换前新旧数据源逐字段对照测试；串行全量 + Merge Queue 为准 |
+| Phase 3 cutover blast radius | Compare old/new data sources field by field; require full serial PR regression plus the combined-tree Merge Queue gate |
 | 存量用户迁移失败 | 迁移幂等 + 失败回滚 FileSource + 重装自愈逃生门 |
 | 技能不落盘损失可调试性 | dump_session_tooling + 审计日志补上，列入 Phase 1 验收 |
 | 过渡形态沉淀为永久复杂度 | V5 条件认领等过渡设计登记退出条件（本文 §8 Phase 4），capability-governance.md 跟踪 |

--- a/pinvou3-app/tests/tauri_platform_layout.test.js
+++ b/pinvou3-app/tests/tauri_platform_layout.test.js
@@ -157,7 +157,10 @@ assert.ok(
   submoduleUpdates.every((command) => command.endsWith("-- CodeWhale")),
   "CI may only initialize the public engine submodule",
 );
-assert.match(workflow, /npm run test:browser-smoke/);
+assert.match(workflow, /Merge Queue diff-selected browser smoke/);
+assert.match(workflow, /github\.event\.merge_group\.base_sha/);
+assert.match(workflow, /github\.event\.merge_group\.head_sha/);
+assert.doesNotMatch(workflow, /npm run test:browser-smoke/);
 assert.doesNotMatch(workflow, /frontend-test:[\s\S]{0,300}\n\s*if:\s*\$\{\{\s*false\s*\}\}/);
 for (const stalePath of [
   "pinvou3-app/src-tauri/src/app/bridge",

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -1,5 +1,6 @@
 import re
 import unittest
+from fnmatch import fnmatchcase
 from pathlib import Path
 
 
@@ -40,6 +41,21 @@ def _is_covered_by_trigger(entry, trigger_paths):
         if trigger.endswith("/**") and entry.startswith(trigger[:-2]):
             return True
     return False
+
+
+def _matches_paths_filter(path, patterns):
+    """Model paths-filter v4 some-with-excludes routing for policy examples."""
+    included = any(
+        fnmatchcase(path, pattern)
+        for pattern in patterns
+        if not pattern.startswith("!")
+    )
+    excluded = any(
+        fnmatchcase(path, pattern[1:])
+        for pattern in patterns
+        if pattern.startswith("!")
+    )
+    return included and not excluded
 
 
 class CiGatePolicyTests(unittest.TestCase):
@@ -120,9 +136,11 @@ class CiGatePolicyTests(unittest.TestCase):
         )[1].split("\n  relay-test:", maxsplit=1)[0]
         self.assertIn("github.event.pull_request.draft == false", frontend)
         self.assertIn("Ready PR 定向浏览器 smoke", frontend)
-        self.assertIn("Merge Queue 完整浏览器 smoke", frontend)
-        self.assertIn("select-frontend-smokes.mjs", frontend)
-        self.assertIn("npm run test:browser-smoke", frontend)
+        self.assertIn("Merge Queue diff-selected browser smoke", frontend)
+        self.assertIn("github.event.merge_group.base_sha", frontend)
+        self.assertIn("github.event.merge_group.head_sha", frontend)
+        self.assertEqual(frontend.count("select-frontend-smokes.mjs"), 2)
+        self.assertNotIn("npm run test:browser-smoke", frontend)
         self.assertEqual(frontend.count("npm run test:markdown"), 0)
 
     def test_static_analysis_gate_configs_route_to_frontend_test(self):
@@ -164,6 +182,7 @@ class CiGatePolicyTests(unittest.TestCase):
         for output in (
             "rust_code",
             "rust_dependencies",
+            "rust_full",
             "knowledge_rust",
             "knowledge_dependencies",
             "release_contract",
@@ -234,91 +253,94 @@ class CiGatePolicyTests(unittest.TestCase):
         self.assertIn("- knowledge-rust", required_gate)
         self.assertIn('"knowledge-rust:$KNOWLEDGE_RUST_RESULT"', required_gate)
 
-    def test_benchmark_jobs_are_hard_disabled_and_cannot_be_enabled_by_label(self):
+    def test_benchmark_jobs_stay_out_of_product_pr_workflow(self):
+        self.assertNotIn("\n  benchmark-contract:", self.pr_workflow)
+        self.assertNotIn("\n  benchmark-test:", self.pr_workflow)
         changes = self.pr_workflow.split("\n  changes:", maxsplit=1)[1].split(
             "\n  fast-gate:", maxsplit=1
         )[0]
-        self.assertIn("benchmark:", changes)
-        self.assertIn("benchmark_cli:", changes)
-        self.assertIn("benchmark_headless:", changes)
-        self.assertIn("benchmark_codewhale:", changes)
-        self.assertIn("- 'pinvou-cli/**'", changes)
+        self.assertNotIn("benchmark:", changes)
+        self.assertNotIn("benchmark_cli:", changes)
+        self.assertNotIn("benchmark_headless:", changes)
+        self.assertNotIn("benchmark_codewhale:", changes)
+
+    def test_full_rust_filter_fails_closed_with_stable_module_boundaries(self):
+        changes = _without_yaml_comments(
+            self.pr_workflow.split("\n  changes:", maxsplit=1)[1].split(
+                "\n  fast-gate:", maxsplit=1
+            )[0]
+        )
+        rust_full = changes.split("            rust_full:", maxsplit=1)[1].split(
+            "            knowledge_rust:", maxsplit=1
+        )[0]
+        rust_full_paths = _extract_quoted_paths(rust_full)
         self.assertIn(
-            "- 'pinvou3-app/src-tauri/src/features/assistant/product_runtime/headless_bridge.rs'",
+            "predicate-quantifier: some-with-excludes",
             changes,
         )
+        self.assertIn("pinvou3-app/src-tauri/**/*.rs", rust_full_paths)
 
-        contract = self.pr_workflow.split("\n  benchmark-contract:", maxsplit=1)[1].split(
-            "\n  benchmark-test:", maxsplit=1
-        )[0]
-        contract_header = contract.split("\n    runs-on:", maxsplit=1)[0]
-        self.assertIn("if: ${{ false }}", contract_header)
-        self.assertNotIn("ci:full-benchmark", contract_header)
-        self.assertNotIn("github.event_name", contract_header)
-        self.assertNotIn("needs.changes.outputs.benchmark == 'true'", contract_header)
-        self.assertIn("runs-on: ubuntu-latest", contract)
-        self.assertIn(
-            "RUSTC_WRAPPER: ${{ github.workspace }}/pinvou3-app/src-tauri/scripts/rustc-stack-wrapper",
-            contract,
+        low_risk_boundaries = (
+            "!pinvou3-app/src-tauri/src/features/feedback/**",
+            "!pinvou3-app/src-tauri/src/features/personas/**",
+            "!pinvou3-app/src-tauri/src/features/pet/**",
         )
-        self.assertIn(
-            "cargo test --manifest-path pinvou-cli/Cargo.toml --all-features", contract
+        for boundary in low_risk_boundaries:
+            self.assertIn(boundary, rust_full_paths)
+
+        high_risk_examples = (
+            "pinvou3-app/src-tauri/src/app/commands/chat.rs",
+            "pinvou3-app/src-tauri/src/app/commands/interaction.rs",
+            "pinvou3-app/src-tauri/src/app/commands/settings.rs",
+            "pinvou3-app/src-tauri/src/features/knowledge/mod.rs",
+            "pinvou3-app/src-tauri/src/features/review/mod.rs",
+            "pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs",
+            "pinvou3-app/src-tauri/src/features/voice/voice_asr.rs",
+            "pinvou3-app/src-tauri/src/features/updater/mod.rs",
+            "pinvou3-app/src-tauri/src/features/future_feature/mod.rs",
+            "pinvou3-app/src-tauri/tests/headless_bridge_contract.rs",
         )
-        for package in (
-            "agent-backend-api",
-            "benchmark-core",
-            "adapter-smoke",
-            "adapter-gaia",
+        for path in high_risk_examples:
+            self.assertTrue(
+                _matches_paths_filter(path, rust_full_paths),
+                f"unclassified/high-risk Rust path must run full tests: {path}",
+            )
+
+        low_risk_examples = (
+            "pinvou3-app/src-tauri/src/features/feedback/mod.rs",
+            "pinvou3-app/src-tauri/src/features/personas/mod.rs",
+            "pinvou3-app/src-tauri/src/features/pet/platform/detach.rs",
+        )
+        for path in low_risk_examples:
+            self.assertFalse(
+                _matches_paths_filter(path, rust_full_paths),
+                f"documented low-risk leaf should use the fast route: {path}",
+            )
+
+        for workflow_path in (
+            ".github/workflows/pr-check.yml",
+            ".github/workflows/mac-build.yml",
         ):
-            self.assertIn(f"-p {package}", contract)
-        self.assertIn(
-            "-p pinvou-cli --no-default-features", contract
-        )
-        self.assertIn(
-            "cargo check --manifest-path pinvou3-app/src-tauri/Cargo.toml", contract
-        )
-        self.assertIn("--features benchmark-hooks --test headless_bridge_contract", contract)
-        self.assertIn("--features benchmark-hooks --lib", contract)
-        self.assertIn(
-            "features::assistant::product_runtime::headless_bridge::", contract
-        )
-        self.assertIn("-- --test-threads=1", contract)
-        self.assertIn("needs.changes.outputs.benchmark_codewhale == 'true'", contract)
+            self.assertNotIn(
+                workflow_path,
+                rust_full_paths,
+                "workflow policy changes must not link the full application tests",
+            )
 
-        benchmark = self.pr_workflow.split("\n  benchmark-test:", maxsplit=1)[1].split(
-            "\n  required-gate:", maxsplit=1
-        )[0]
-        benchmark_header = benchmark.split("\n    runs-on:", maxsplit=1)[0]
-        self.assertIn("cargo test --manifest-path pinvou-cli/Cargo.toml --all-features", benchmark)
-        self.assertIn(
-            "cargo test --manifest-path pinvou-cli/Cargo.toml --no-default-features", benchmark
+        literal_feature_files = [
+            path
+            for path in rust_full_paths
+            if "/src/features/" in path
+            and path.endswith(".rs")
+            and "*" not in path
+        ]
+        self.assertEqual(
+            literal_feature_files,
+            [],
+            "rust_full must not enumerate internal feature files",
         )
-        self.assertIn("--features benchmark-hooks", benchmark)
-        self.assertIn("cargo test --manifest-path CodeWhale/Cargo.toml", benchmark)
-        self.assertIn("-p codewhale-tui --lib --locked forkguard_", benchmark)
-        self.assertIn("            CodeWhale", benchmark)
-        self.assertIn("if: ${{ false }}", benchmark_header)
-        self.assertNotIn("ci:full-benchmark", benchmark_header)
-        self.assertNotIn("github.event_name", benchmark_header)
-        self.assertNotIn("github.event_name == 'merge_group'", benchmark)
-        self.assertNotIn("github.event_name == 'push'", benchmark)
-        self.assertNotIn("needs.changes.outputs.benchmark", benchmark_header)
-        self.assertNotIn("\n        if:", benchmark)
 
-        benchmark_filter = changes.split("benchmark:", 1)[1].split(
-            "release_contract:", 1
-        )[0]
-        self.assertNotIn(".github/workflows/pr-check.yml", benchmark_filter)
-
-        required_gate = self.pr_workflow.split("\n  required-gate:", maxsplit=1)[1]
-        self.assertIn("- benchmark-contract", required_gate)
-        self.assertIn("BENCHMARK_CONTRACT_RESULT", required_gate)
-        self.assertIn('"benchmark-contract:$BENCHMARK_CONTRACT_RESULT"', required_gate)
-        self.assertNotIn("- benchmark-test", required_gate)
-        self.assertNotIn("BENCHMARK_TEST_RESULT", required_gate)
-        self.assertNotIn('"benchmark-test:$BENCHMARK_TEST_RESULT"', required_gate)
-
-    def test_rust_modes_preserve_fast_drafts_and_final_queue_validation(self):
+    def test_rust_modes_run_combined_full_regression_only_for_high_risk(self):
         self.assertIn("merge_group:", self.pr_workflow)
         self.assertIn("ci:full-rust", self.pr_workflow)
         rust_lint = self.pr_workflow.split(
@@ -331,7 +353,15 @@ class CiGatePolicyTests(unittest.TestCase):
         rust_test = self.pr_workflow.split("\n  rust-test:", maxsplit=1)[1].split(
             "\n  windows-rust-test:", maxsplit=1
         )[0]
-        self.assertIn("github.event_name == 'merge_group'", rust_test)
+        self.assertRegex(
+            rust_test,
+            r"github\.event_name == 'merge_group'\s*&&\s*"
+            r"needs\.changes\.outputs\.rust_full == 'true'",
+        )
+        self.assertIn(
+            "needs.changes.outputs.rust_full == 'true'",
+            rust_test,
+        )
         self.assertIn(
             "needs.changes.outputs.rust_code == 'true'",
             rust_test,
@@ -341,12 +371,16 @@ class CiGatePolicyTests(unittest.TestCase):
             "contains(github.event.pull_request.labels.*.name, 'ci:full-rust')",
             rust_test,
         )
-        # main push 无条件累计验证(防 concurrency pending 替换盲区),
-        # 不与 rust_code 路径条件短路。
+        # Main is a cumulative regression and must not depend on adjacent diff paths.
         self.assertIn(
             "github.event_name == 'push' ||",
             rust_test,
         )
+        self.assertIn(
+            "cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1",
+            rust_test,
+        )
+        self.assertNotIn("cargo test --lib --no-run", rust_test)
         self.assertIn("timeout-minutes: 120", rust_test)
         self.assertIn(
             'RUSTFLAGS: "-C link-arg=-fuse-ld=lld '
@@ -356,8 +390,7 @@ class CiGatePolicyTests(unittest.TestCase):
         )
 
     def test_windows_rust_test_cumulative_main_push_is_path_independent(self):
-        # concurrency 可能用后续非 Rust pending 替换含 Rust 变更的 pending;main 的
-        # Windows 累计验证不得依赖单次 push 的相邻路径 diff,push 无条件执行。
+        # Main's Windows regression must remain independent of adjacent diff paths.
         windows_rust_test = self.pr_workflow.split(
             "\n  windows-rust-test:", maxsplit=1
         )[1].split("\n  windows-codex-runtime-test:", maxsplit=1)[0]
@@ -365,9 +398,12 @@ class CiGatePolicyTests(unittest.TestCase):
             "github.event_name == 'push' ||", windows_rust_test
         )
         self.assertIn(
-            "needs.changes.outputs.rust_code == 'true' &&\n"
-            "            (\n"
-            "              github.event_name == 'merge_group' ||",
+            "needs.changes.outputs.rust_full == 'true'",
+            windows_rust_test,
+        )
+        self.assertNotIn("github.event_name == 'merge_group'", windows_rust_test)
+        self.assertIn(
+            "contains(github.event.pull_request.labels.*.name, 'ci:full-rust')",
             windows_rust_test,
         )
         self.assertIn(


### PR DESCRIPTION
## Background

Recent merge-group runs showed that the large Tauri Rust test binary was dominated by compile/link cost and frequently lost its hosted runner, while the test body itself completed in seconds. The duplicated Linux/Windows regressions made ordinary pull requests wait on unstable work that was not always proportional to the changed surface.

## Changes

- Route application Rust paths fail closed: every unclassified `src-tauri` Rust path triggers full regression.
- Keep only internal changes under `feedback`, `personas`, and `pet` on the lightweight route. Registration, app-command, shared-platform, Cargo, and unknown paths still trigger full tests.
- Run full Linux/Windows regression on ready high-risk PRs, repeat Linux behavior tests on the Merge Queue combined tree, and avoid repeating the 20+ minute Windows leg in the queue.
- Keep full Linux/Windows regressions on every retained `main` push.
- Select frontend browser smokes from the actual ready-PR or merge-group diff, with fail-closed fallback for shared, unknown, test-infrastructure, or empty diffs.
- Remove two permanently disabled benchmark jobs from the product PR workflow.
- Update contribution guidance and CI policy regressions.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (84 passed)
- `node --test scripts/tests/select-frontend-smokes.test.mjs` (10 passed)
- `node pinvou3-app/tests/tauri_platform_layout.test.js`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`
- `./scripts/verify-public-submodule.sh`
- `./scripts/ci-fork-link-check.sh origin/main`
- `python3 scripts/mcp-server-contract-smoke.py` and all built-in MCP server tests
- `actionlint 1.7.12`, YAML parsing, language scan, and `git diff --check`

## Risk

The three explicitly low-risk leaf modules receive full behavior regression after merge on `main`; their ready PR and merge-group paths still run Rust formatting, Clippy, compile checks, and dependency policy. Any change outside those exact module boundaries fails closed to full pre-merge coverage.