### PR TITLE
fix(gaia): 保留电子表格附件结构信息

### DIFF
--- a/docs/gaia-benchmark.md
+++ b/docs/gaia-benchmark.md
@@ -85,6 +85,8 @@ pinvou benchmark run gaia --split validation --level 1
 
 - 每道题有 600 秒超时限制。
 - 代理使用 `pinvou-gaia-public-web/v1` 工具策略，可访问公开 web 资源。
+- Office/PDF 附件在 host 侧预解析；XLSX 会同时提供工作表值以及有界的填充色、公式和合并
+  区域注释。评测附件提示只声明 profile 实际允许的只读能力。
 - 输出契约为 `gaia-final/v1`：题目 prompt 会注入最终答案格式指令
   （`FINAL ANSWER: <answer>`）。解析按行、大小写不敏感，并容忍常见 Markdown 强调；只提取最后一个已识别标记所在行的内容。最后一个标记为空时任务以 `missing_final_answer` 终态计为失败，不回退到更早标记或正文。
   预测以 `utf8-text/v1` 持久化在该 run 的私有目录中。当前 CLI 尚未提供 purge 子命令；需要清理时必须在确认 run 已停止后删除对应的 `~/.pinvou3/eval/runs/<run-id>/`，不要删除整个运行时根目录。

--- a/docs/gaia-native-turn-tool-policy.md
+++ b/docs/gaia-native-turn-tool-policy.md
@@ -138,8 +138,10 @@ ExecutionRequest::NativeTurn.tool_policy
 
 - Product backend 将已解析附件复制到 per-session 临时 workspace，不持久化原路径。
 - 拒绝目录、symlink/reparse point、危险文件名和超限文件。
-- Office/PDF 使用 host `file_ingest` 在 `spawn_blocking` 中预处理；这不等于开放 Office/MCP
-  或 shell 工具。
+- Office/PDF 使用 host `file_ingest` 在 `spawn_blocking` 中预处理；XLSX 除单元格值外还保留
+  非默认填充色、公式和合并区域的有界结构注释。这不等于开放 Office/MCP 或 shell 工具。
+- 附件提示必须与 profile 的实际权限一致；只读评测不得提示模型调用 File 写入、shell 或
+  代码执行动作，大附件只能提示分页只读。
 - Ingest 共享 task 单一 deadline，并受输入/输出大小和解析深度限制。
 - 绝对外部路径、`..`、symlink/junction 逃逸和用户 trusted roots 均拒绝。
 - cancel、timeout、prepare/run/close 错误均清理 session、staging 和中间产物。

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -6116,6 +6116,7 @@ dependencies = [
  "parking_lot",
  "pinvou-knowledge",
  "qrcode",
+ "quick-xml",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rusqlite",

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -159,6 +159,9 @@ walkdir = "2"
 # 0.36 拉入 quick-xml 0.41+,修 RUSTSEC-2026-0194/0195 ReDoS。
 # 剩余 quick-xml 0.39.4 由 plist/tauri 传递,等上游。
 calamine = "0.36"
+# XLSX structure preservation: inspect OOXML cell styles, formulas, and merged
+# ranges that calamine's value-only Range intentionally does not expose.
+quick-xml = "0.41"
 # 文本附件编码兜底：把国内常见 GBK / GB18030 文件真正转成 UTF-8，
 # 避免 `from_utf8_lossy` 把中文正文替换成一串 U+FFFD。
 encoding_rs = "0.8"

--- a/pinvou3-app/src-tauri/src/features/assistant/attachments.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/attachments.rs
@@ -313,6 +313,7 @@ fn push_large_attachment_section(
     attachment_dir: &str,
     stage_original_text: bool,
     reference_absolute: bool,
+    read_only_tools: bool,
 ) {
     let read_path = if a.kind == "text" && !stage_original_text {
         a.path.clone()
@@ -340,11 +341,21 @@ fn push_large_attachment_section(
          **绝不能**只凭预览回答涉及全文/全表的问题。\n\
          完整内容已是纯文本,共 {} 行,路径: `{}`\n\
          预览(仅开头几行):\n```\n{}```\n\
-         需要完整内容时:\n\
-         - 统计/筛选/聚合(尤其表格数据):优先用 `Bash(action=\"run\")` 写 awk 或 python 一次算出结果,不要逐页通读\n\
-         - 通读/定位:用 `File(action=\"read\")` 分页(start_line/max_lines;返回 truncated=\"true\" 时按 next_start_line 续读)\n",
+         需要完整内容时:\n",
         a.token_estimate, total_lines, read_path, preview
     ));
+    if read_only_tools {
+        out.push_str(
+            "- 通读/定位:用 `File(action=\"read\")` 分页(start_line/max_lines;返回 \
+             truncated=\"true\" 时按 next_start_line 续读)\n\
+             - 当前会话只有只读工具;不要请求 Bash、代码执行或 File 写入动作\n",
+        );
+    } else {
+        out.push_str(
+            "- 统计/筛选/聚合(尤其表格数据):优先用 `Bash(action=\"run\")` 写 awk 或 python一次算出结果,不要逐页通读\n\
+             - 通读/定位:用 `File(action=\"read\")` 分页(start_line/max_lines;返回 truncated=\"true\" 时按 next_start_line 续读)\n",
+        );
+    }
 }
 
 /// 落盘附件在消息里的引用形式：默认 workspace 相对路径（引擎 cwd 即落盘根）；
@@ -365,12 +376,13 @@ fn staged_reference(
 /// 图片拷进 workspace 后引导 LLM 调 image_analyze 读图(Qwen3.6 有视觉能力);
 /// 文本类附件按 token 预算分流:小→全量内联,大→落盘+路径+预览(见常量注释)。
 /// `reference_absolute` 见 `staged_reference`；普通对话与 scheduled 传 false。
-pub(crate) fn build_message_with_attachments_in_dir(
+fn build_message_with_attachments_in_dir_with_access(
     text: String,
     attachments: Vec<crate::features::files::file_ingest::IngestResult>,
     workspace: &std::path::Path,
     attachment_dir: &str,
     reference_absolute: bool,
+    read_only_tools: bool,
 ) -> String {
     if attachments.is_empty() {
         return text;
@@ -428,11 +440,19 @@ pub(crate) fn build_message_with_attachments_in_dir(
                 && inline_spent.saturating_add(a.token_estimate) <= ATTACH_TOTAL_BUDGET_TOKENS;
             if fits {
                 inline_spent = inline_spent.saturating_add(a.token_estimate);
-                out.push_str(
-                    "**以下代码块是文件完整内容,可直接使用,不需要再调 `File(action=\"read\")` / \
-                     `File(action=\"search_name\")` 重新读取。**如需保存修改版本,用 `File(action=\"write\")` 写到 \
-                     PINVOU3_WORKSPACE 下;单个文件过大时拆分为多个有明确用途的文件。\n",
-                );
+                if read_only_tools {
+                    out.push_str(
+                        "**以下代码块是文件完整内容,可直接使用,不需要再调 `File(action=\"read\")` / \
+                         `File(action=\"search_name\")` 重新读取。**当前会话只有只读工具;不要请求 File 写入、\
+                         Bash 或代码执行动作。\n",
+                    );
+                } else {
+                    out.push_str(
+                        "**以下代码块是文件完整内容,可直接使用,不需要再调 `File(action=\"read\")` / \
+                         `File(action=\"search_name\")` 重新读取。**如需保存修改版本,用 `File(action=\"write\")` 写到 \
+                         PINVOU3_WORKSPACE 下;单个文件过大时拆分为多个有明确用途的文件。\n",
+                    );
+                }
                 out.push_str("```\n");
                 out.push_str(md);
                 if !md.ends_with('\n') {
@@ -448,6 +468,7 @@ pub(crate) fn build_message_with_attachments_in_dir(
                     attachment_dir,
                     attachment_dir != "attachments",
                     reference_absolute,
+                    read_only_tools,
                 );
             }
         } else if let Some(warning) = &a.warning {
@@ -459,6 +480,23 @@ pub(crate) fn build_message_with_attachments_in_dir(
     out
 }
 
+pub(crate) fn build_message_with_attachments_in_dir(
+    text: String,
+    attachments: Vec<crate::features::files::file_ingest::IngestResult>,
+    workspace: &std::path::Path,
+    attachment_dir: &str,
+    reference_absolute: bool,
+) -> String {
+    build_message_with_attachments_in_dir_with_access(
+        text,
+        attachments,
+        workspace,
+        attachment_dir,
+        reference_absolute,
+        false,
+    )
+}
+
 /// 普通对话附件入口。pub 仅为 L1 dialog harness 复用(lib.rs re-export)，
 /// 不是对外 API；scheduled chat 走上面的 run 专属目录入口。
 pub fn build_message_with_attachments(
@@ -467,6 +505,24 @@ pub fn build_message_with_attachments(
     workspace: &std::path::Path,
 ) -> String {
     build_message_with_attachments_in_dir(text, attachments, workspace, "attachments", false)
+}
+
+/// Restricted evaluation entry point. Attachment evidence is identical to the
+/// product path, but tool guidance never advertises write, shell, or code
+/// execution capabilities that the evaluation policy forbids.
+pub(crate) fn build_read_only_message_with_attachments(
+    text: String,
+    attachments: Vec<crate::features::files::file_ingest::IngestResult>,
+    workspace: &std::path::Path,
+) -> String {
+    build_message_with_attachments_in_dir_with_access(
+        text,
+        attachments,
+        workspace,
+        "attachments",
+        false,
+        true,
+    )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -556,6 +612,7 @@ pub(crate) fn prepare_native_user_message_in_dir(
                     attachment_dir != "attachments",
                     // Native 分支图片/文件都暂存到执行根,落盘根与引擎 cwd 一致,相对引用。
                     false,
+                    false,
                 );
             }
         } else if let Some(warning) = &a.warning {
@@ -567,4 +624,51 @@ pub(crate) fn prepare_native_user_message_in_dir(
         segment.push_str("---\n");
     }
     Ok(segment)
+}
+
+#[cfg(test)]
+mod read_only_prompt_tests {
+    use super::build_read_only_message_with_attachments;
+    use crate::features::files::file_ingest::IngestResult;
+
+    fn attachment(markdown: String, token_estimate: u32) -> IngestResult {
+        IngestResult {
+            kind: "xlsx".into(),
+            basename: "report.xlsx".into(),
+            path: "attachments/report.xlsx".into(),
+            markdown: Some(markdown),
+            token_estimate,
+            byte_size: 128,
+            warning: None,
+        }
+    }
+
+    #[test]
+    fn inline_evaluation_attachment_never_advertises_mutating_tools() {
+        let workspace = tempfile::tempdir().unwrap();
+        let prompt = build_read_only_message_with_attachments(
+            "inspect".into(),
+            vec![attachment("A | B\n1 | 2".into(), 10)],
+            workspace.path(),
+        );
+
+        assert!(prompt.contains("当前会话只有只读工具"));
+        assert!(!prompt.contains("File(action=\"write\")"));
+        assert!(!prompt.contains("Bash(action=\"run\")"));
+    }
+
+    #[test]
+    fn large_evaluation_attachment_only_advertises_paged_reads() {
+        let workspace = tempfile::tempdir().unwrap();
+        let prompt = build_read_only_message_with_attachments(
+            "inspect".into(),
+            vec![attachment("row\n".repeat(20_000), 50_000)],
+            workspace.path(),
+        );
+
+        assert!(prompt.contains("File(action=\"read\")"));
+        assert!(prompt.contains("不要请求 Bash、代码执行或 File 写入动作"));
+        assert!(!prompt.contains("Bash(action=\"run\")"));
+        assert!(!prompt.contains("File(action=\"write\")"));
+    }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/attachments.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/attachments.rs
@@ -352,7 +352,7 @@ fn push_large_attachment_section(
         );
     } else {
         out.push_str(
-            "- 统计/筛选/聚合(尤其表格数据):优先用 `Bash(action=\"run\")` 写 awk 或 python一次算出结果,不要逐页通读\n\
+            "- 统计/筛选/聚合(尤其表格数据):优先用 `Bash(action=\"run\")` 写 awk 或 python 一次算出结果,不要逐页通读\n\
              - 通读/定位:用 `File(action=\"read\")` 分页(start_line/max_lines;返回 truncated=\"true\" 时按 next_start_line 续读)\n",
         );
     }

--- a/pinvou3-app/src-tauri/src/features/assistant/product_runtime/headless_bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/product_runtime/headless_bridge.rs
@@ -22,7 +22,7 @@ use tauri::Manager;
 use tokio::sync::Mutex as AsyncMutex;
 
 use crate::features::assistant::attachments::{
-    build_message_with_attachments, stage_file_in_workspace,
+    build_read_only_message_with_attachments, stage_file_in_workspace,
 };
 use crate::features::assistant::engine_pool::{EnginePool, EngineToolFactory, ToolPolicy};
 use crate::features::assistant::platform::headless_attachments::ensure_staged_attachments_supported;
@@ -163,7 +163,7 @@ fn prepare_product_attachment_content(
             &execution_root.join(staged_path),
         ));
     }
-    Ok(build_message_with_attachments(
+    Ok(build_read_only_message_with_attachments(
         prompt,
         attachments,
         &execution_root,

--- a/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_ingest.rs
@@ -34,6 +34,8 @@ mod ingest_email;
 mod ingest_office;
 #[path = "ingest_pdf.rs"]
 mod ingest_pdf;
+#[path = "spreadsheet_structure.rs"]
+mod spreadsheet_structure;
 #[path = "text_decode.rs"]
 mod text_decode;
 #[path = "visual_preview.rs"]

--- a/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
+++ b/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
@@ -17,6 +17,8 @@ use super::ingest_deps::{
     pdf_tool_command, system_tools,
 };
 
+const MAX_FORMULAS_PER_SHEET: usize = 2_048;
+
 /// pandoc 原生支持的文字文档（docx/odt）摄入：`pandoc -t markdown`。
 pub(super) fn ingest_pandoc(
     path: &Path,
@@ -171,11 +173,18 @@ pub(super) fn ingest_spreadsheet(
 /// 单元格内换行折成空格，避免破坏「一行 = 一条记录」的语义（利于切块/检索）。
 fn spreadsheet_all_sheets_text(path: &Path) -> Result<String, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("读取文件失败: {e}"))?;
-    spreadsheet_text_from_bytes(&bytes)
+    let preserve_xlsx_structure = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("xlsx"));
+    spreadsheet_text_from_bytes(&bytes, preserve_xlsx_structure)
 }
 
 /// 抽取核心（接收字节，便于单测喂 fixture）。见 [`spreadsheet_all_sheets_text`]。
-fn spreadsheet_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
+fn spreadsheet_text_from_bytes(
+    bytes: &[u8],
+    preserve_xlsx_structure: bool,
+) -> Result<String, String> {
     // DataType trait 提供 Data::is_empty()（calamine 0.26 是 trait 方法，非固有）。
     use calamine::{Data, DataType, Reader, open_workbook_auto_from_rs};
 
@@ -216,11 +225,73 @@ fn spreadsheet_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
             out.push('\n');
         }
         out.push('\n');
+        match wb.worksheet_formula(&name) {
+            Ok(formulas) => append_formula_annotations(&mut out, &name, &formulas),
+            Err(error) => log::warn!("spreadsheet formula extraction failed: {error}"),
+        }
     }
-    if let Ok(Some(structure)) = super::spreadsheet_structure::xlsx_structure_annotations(bytes) {
-        out.push_str(&structure);
+    if preserve_xlsx_structure {
+        match super::spreadsheet_structure::xlsx_structure_annotations(bytes) {
+            Ok(Some(structure)) => out.push_str(&structure),
+            Ok(None) => {}
+            Err(error) => log::warn!("XLSX structure extraction failed: {error}"),
+        }
     }
     Ok(out)
+}
+
+fn append_formula_annotations(
+    out: &mut String,
+    sheet_name: &str,
+    formulas: &calamine::Range<String>,
+) {
+    let Some((start_row, start_column)) = formulas.start() else {
+        return;
+    };
+    let mut written = 0usize;
+    let mut truncated = false;
+    for (relative_row, relative_column, formula) in formulas.used_cells() {
+        if formula.is_empty() {
+            continue;
+        }
+        if written == MAX_FORMULAS_PER_SHEET {
+            truncated = true;
+            break;
+        }
+        if written == 0 {
+            out.push_str("### 工作表公式：");
+            out.push_str(sheet_name);
+            out.push('\n');
+        }
+        out.push_str("- ");
+        out.push_str(&a1_cell(
+            start_row.saturating_add(relative_row as u32),
+            start_column.saturating_add(relative_column as u32),
+        ));
+        out.push_str(": =");
+        out.push_str(formula.strip_prefix('=').unwrap_or(formula));
+        out.push('\n');
+        written += 1;
+    }
+    if truncated {
+        out.push_str("- 公式过多，以上列表已截断\n");
+    }
+    if written > 0 {
+        out.push('\n');
+    }
+}
+
+fn a1_cell(row: u32, column: u32) -> String {
+    let mut remaining = u64::from(column) + 1;
+    let mut letters = Vec::new();
+    while remaining > 0 {
+        let digit = ((remaining - 1) % 26) as u8;
+        letters.push(char::from(b'A' + digit));
+        remaining = (remaining - 1) / 26;
+    }
+    letters.reverse();
+    let column_name: String = letters.into_iter().collect();
+    format!("{column_name}{}", u64::from(row) + 1)
 }
 
 /// 演示类（.pptx/.ppt/.odp + WPS .dps）：LibreOffice **没有 Impress→txt 导出**
@@ -314,7 +385,7 @@ mod tests {
         // （实测 4-sheet 散热报告只抽到首页、CPU/温升数据全失）。calamine 必须把
         // 全部工作表逐行抽出。fixture 是 3-sheet 合成表（Cover/配置表/温升表）。
         let bytes = include_bytes!("../../../test-fixtures/multi_sheet.xlsx");
-        let txt = spreadsheet_text_from_bytes(bytes).expect("calamine 应能解析 fixture");
+        let txt = spreadsheet_text_from_bytes(bytes, true).expect("calamine 应能解析 fixture");
         // 三个工作表标题都要在
         assert!(txt.contains("## 工作表：Cover"), "缺 Cover sheet");
         assert!(
@@ -333,5 +404,26 @@ mod tests {
             txt.contains("CPU | key part | model | Ultra 7 258V SRPMN"),
             "同一行单元格应保留在一行"
         );
+    }
+
+    #[test]
+    fn spreadsheet_appends_structure_and_expanded_shared_formulas() {
+        let bytes = super::super::spreadsheet_structure::synthetic_xlsx_fixture();
+        let txt = spreadsheet_text_from_bytes(&bytes, true).expect("应能解析合成 XLSX");
+
+        assert!(txt.contains("### 工作表公式：Map"));
+        assert!(txt.contains("D3: =SUM(A1:B1)"));
+        assert!(txt.contains("D4: =SUM(A2:B2)"));
+        assert!(txt.contains("### 工作表结构：Map"));
+        assert!(txt.contains("fill #00FF00: A1, C2"));
+        assert!(txt.contains("合并区域: A1:B1"));
+    }
+
+    #[test]
+    fn converts_zero_based_coordinates_to_a1_notation() {
+        assert_eq!(a1_cell(0, 0), "A1");
+        assert_eq!(a1_cell(9, 25), "Z10");
+        assert_eq!(a1_cell(0, 26), "AA1");
+        assert_eq!(a1_cell(41, 701), "ZZ42");
     }
 }

--- a/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
+++ b/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
@@ -171,11 +171,11 @@ pub(super) fn ingest_spreadsheet(
 /// 单元格内换行折成空格，避免破坏「一行 = 一条记录」的语义（利于切块/检索）。
 fn spreadsheet_all_sheets_text(path: &Path) -> Result<String, String> {
     let bytes = std::fs::read(path).map_err(|e| format!("读取文件失败: {e}"))?;
-    spreadsheet_text_from_bytes(bytes)
+    spreadsheet_text_from_bytes(&bytes)
 }
 
 /// 抽取核心（接收字节，便于单测喂 fixture）。见 [`spreadsheet_all_sheets_text`]。
-fn spreadsheet_text_from_bytes(bytes: Vec<u8>) -> Result<String, String> {
+fn spreadsheet_text_from_bytes(bytes: &[u8]) -> Result<String, String> {
     // DataType trait 提供 Data::is_empty()（calamine 0.26 是 trait 方法，非固有）。
     use calamine::{Data, DataType, Reader, open_workbook_auto_from_rs};
 
@@ -216,6 +216,9 @@ fn spreadsheet_text_from_bytes(bytes: Vec<u8>) -> Result<String, String> {
             out.push('\n');
         }
         out.push('\n');
+    }
+    if let Ok(Some(structure)) = super::spreadsheet_structure::xlsx_structure_annotations(bytes) {
+        out.push_str(&structure);
     }
     Ok(out)
 }
@@ -310,7 +313,7 @@ mod tests {
         // 防回归：旧实现走 LibreOffice CSV 只导「活动工作表」，多 sheet 文件丢 90% 内容
         // （实测 4-sheet 散热报告只抽到首页、CPU/温升数据全失）。calamine 必须把
         // 全部工作表逐行抽出。fixture 是 3-sheet 合成表（Cover/配置表/温升表）。
-        let bytes = include_bytes!("../../../test-fixtures/multi_sheet.xlsx").to_vec();
+        let bytes = include_bytes!("../../../test-fixtures/multi_sheet.xlsx");
         let txt = spreadsheet_text_from_bytes(bytes).expect("calamine 应能解析 fixture");
         // 三个工作表标题都要在
         assert!(txt.contains("## 工作表：Cover"), "缺 Cover sheet");

--- a/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
+++ b/pinvou3-app/src-tauri/src/features/files/ingest_office.rs
@@ -191,6 +191,11 @@ fn spreadsheet_text_from_bytes(
     let mut wb = open_workbook_auto_from_rs(std::io::Cursor::new(bytes))
         .map_err(|e| format!("calamine 解析失败: {e}"))?;
 
+    // calamine 对 XLSX 公式 Range 按公式格极值做稠密物化（见
+    // spreadsheet_structure::MAX_FORMULA_SPAN_CELLS），必须先按内容预扫跨度；
+    // XLS/ODS 是打开时预构建、网格有界，返回 None 即无需守卫。
+    let formula_span_limits = super::spreadsheet_structure::xlsx_formula_span_limits(bytes);
+
     let cell = |c: &Data| -> String {
         if c.is_empty() {
             String::new()
@@ -225,9 +230,20 @@ fn spreadsheet_text_from_bytes(
             out.push('\n');
         }
         out.push('\n');
-        match wb.worksheet_formula(&name) {
-            Ok(formulas) => append_formula_annotations(&mut out, &name, &formulas),
-            Err(error) => log::warn!("spreadsheet formula extraction failed: {error}"),
+        let formula_span = formula_span_limits
+            .as_ref()
+            .and_then(|limits| limits.get(&name));
+        if formula_span.is_none_or(|&(rows, cols)| {
+            rows.saturating_mul(cols) <= super::spreadsheet_structure::MAX_FORMULA_SPAN_CELLS
+        }) {
+            match wb.worksheet_formula(&name) {
+                Ok(formulas) => append_formula_annotations(&mut out, &name, &formulas),
+                Err(error) => log::warn!("spreadsheet formula extraction failed: {error}"),
+            }
+        } else {
+            log::warn!(
+                "spreadsheet formula extraction skipped for sheet {name}: formula cell span exceeds limit"
+            );
         }
     }
     if preserve_xlsx_structure {
@@ -260,7 +276,7 @@ fn append_formula_annotations(
         }
         if written == 0 {
             out.push_str("### 工作表公式：");
-            out.push_str(sheet_name);
+            out.push_str(&super::spreadsheet_structure::flatten_text(sheet_name));
             out.push('\n');
         }
         out.push_str("- ");
@@ -269,7 +285,9 @@ fn append_formula_annotations(
             start_column.saturating_add(relative_column as u32),
         ));
         out.push_str(": =");
-        out.push_str(formula.strip_prefix('=').unwrap_or(formula));
+        out.push_str(&super::spreadsheet_structure::flatten_text(
+            formula.strip_prefix('=').unwrap_or(formula),
+        ));
         out.push('\n');
         written += 1;
     }
@@ -425,5 +443,27 @@ mod tests {
         assert_eq!(a1_cell(9, 25), "Z10");
         assert_eq!(a1_cell(0, 26), "AA1");
         assert_eq!(a1_cell(41, 701), "ZZ42");
+    }
+
+    #[test]
+    fn distant_formula_span_sheet_keeps_values_without_formulas() {
+        // 若跨度守卫被移除，calamine 会对该 fixture 触发 PB 级稠密分配并
+        // abort 整个测试进程（红=进程崩溃），而非普通断言失败。
+        let bytes = super::super::spreadsheet_structure::distant_formula_fixture();
+        let txt = spreadsheet_text_from_bytes(&bytes, true).expect("ingest 应安全完成");
+        assert!(txt.contains("## 工作表：Map"), "值路径不受守卫影响");
+        assert!(
+            !txt.contains("### 工作表公式"),
+            "超限公式的注记应整段跳过: {txt}"
+        );
+    }
+
+    #[test]
+    fn formula_annotations_fold_control_whitespace() {
+        let bytes = super::super::spreadsheet_structure::folded_formula_fixture();
+        let txt = spreadsheet_text_from_bytes(&bytes, true).expect("应能解析 fixture");
+        assert!(txt.contains("### 工作表公式：Fold X"), "{txt}");
+        assert!(txt.contains("A1: =SUM(1) + 2"), "{txt}");
+        assert!(!txt.contains("=SUM(1)\n"), "公式文本不得携带原始换行");
     }
 }

--- a/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
+++ b/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
@@ -1,8 +1,9 @@
 //! XLSX-only structural metadata extraction.
 //!
 //! Calamine intentionally exposes cell values rather than presentation styles.
-//! Some spreadsheets encode essential meaning in fill colors, formulas, or
-//! merged regions, so retain those OOXML facts as compact text annotations.
+//! Some spreadsheets encode essential meaning in fill colors or merged
+//! regions, so retain those OOXML facts as compact text annotations. Formula
+//! extraction stays on calamine so shared formulas are expanded correctly.
 
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::{Reader, XmlVersion};
@@ -10,7 +11,6 @@ use std::collections::{BTreeMap, HashMap};
 use std::io::{Cursor, Read, Seek};
 
 const MAX_STYLE_CELLS: usize = 4_096;
-const MAX_FORMULAS: usize = 2_048;
 const MAX_MERGED_RANGES: usize = 1_024;
 const MAX_XML_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
 
@@ -24,7 +24,7 @@ struct Fill {
 impl Fill {
     fn label(&self) -> Option<String> {
         let pattern = self.pattern.as_deref().unwrap_or("none");
-        if pattern == "none" && self.foreground.is_none() && self.background.is_none() {
+        if pattern == "none" {
             return None;
         }
         let mut parts = Vec::new();
@@ -45,10 +45,8 @@ impl Fill {
 #[derive(Debug, Default)]
 struct SheetAnnotations {
     fills: BTreeMap<String, Vec<String>>,
-    formulas: Vec<(String, String)>,
     merged_ranges: Vec<String>,
     style_cells_truncated: bool,
-    formulas_truncated: bool,
     merges_truncated: bool,
 }
 
@@ -79,10 +77,7 @@ pub(super) fn xlsx_structure_annotations(bytes: &[u8]) -> Result<Option<String>,
             continue;
         };
         let annotations = parse_sheet_annotations(&xml, &style_fills)?;
-        if annotations.fills.is_empty()
-            && annotations.formulas.is_empty()
-            && annotations.merged_ranges.is_empty()
-        {
+        if annotations.fills.is_empty() && annotations.merged_ranges.is_empty() {
             continue;
         }
         rendered.push_str("### 工作表结构：");
@@ -97,19 +92,6 @@ pub(super) fn xlsx_structure_annotations(bytes: &[u8]) -> Result<Option<String>,
         }
         if annotations.style_cells_truncated {
             rendered.push_str("- 填充单元格过多，以上列表已截断\n");
-        }
-        if !annotations.formulas.is_empty() {
-            rendered.push_str("- 公式:\n");
-            for (cell, formula) in annotations.formulas {
-                rendered.push_str("  - ");
-                rendered.push_str(&cell);
-                rendered.push_str(": =");
-                rendered.push_str(&formula);
-                rendered.push('\n');
-            }
-        }
-        if annotations.formulas_truncated {
-            rendered.push_str("  - 公式过多，以上列表已截断\n");
         }
         if !annotations.merged_ranges.is_empty() {
             rendered.push_str("- 合并区域: ");
@@ -163,13 +145,7 @@ fn attr(element: &BytesStart<'_>, key: &[u8]) -> Option<String> {
 
 fn color(element: &BytesStart<'_>) -> Option<String> {
     if let Some(rgb) = attr(element, b"rgb") {
-        let normalized = rgb.trim_start_matches('#');
-        let rgb = if normalized.len() == 8 {
-            &normalized[2..]
-        } else {
-            normalized
-        };
-        return Some(format!("#{}", rgb.to_ascii_uppercase()));
+        return normalized_rgb(&rgb);
     }
     for (key, label) in [
         (b"indexed".as_slice(), "indexed"),
@@ -181,6 +157,21 @@ fn color(element: &BytesStart<'_>) -> Option<String> {
         }
     }
     None
+}
+
+fn normalized_rgb(value: &str) -> Option<String> {
+    let normalized = value.trim_start_matches('#');
+    if !matches!(normalized.len(), 6 | 8)
+        || !normalized.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    let visible = if normalized.len() == 8 {
+        normalized.get(2..)?
+    } else {
+        normalized
+    };
+    Some(format!("#{}", visible.to_ascii_uppercase()))
 }
 
 fn parse_style_fills(xml: &str) -> Result<Vec<Option<String>>, String> {
@@ -314,17 +305,13 @@ fn parse_sheet_annotations(
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
     let mut annotations = SheetAnnotations::default();
-    let mut current_cell: Option<String> = None;
-    let mut current_formula = String::new();
-    let mut in_formula = false;
     let mut style_cell_count = 0usize;
 
     loop {
         match reader.read_event() {
             Ok(Event::Start(element)) if element.local_name().as_ref() == b"c" => {
-                current_cell = attr(&element, b"r");
                 if let (Some(cell), Some(style_id)) = (
-                    current_cell.as_ref(),
+                    attr(&element, b"r"),
                     attr(&element, b"s").and_then(|value| value.parse::<usize>().ok()),
                 ) {
                     if let Some(Some(fill)) = style_fills.get(style_id) {
@@ -333,7 +320,7 @@ fn parse_sheet_annotations(
                                 .fills
                                 .entry(fill.clone())
                                 .or_default()
-                                .push(cell.clone());
+                                .push(cell);
                             style_cell_count += 1;
                         } else {
                             annotations.style_cells_truncated = true;
@@ -360,59 +347,6 @@ fn parse_sheet_annotations(
                     }
                 }
             }
-            Ok(Event::Start(element)) if element.local_name().as_ref() == b"f" => {
-                in_formula = true;
-                current_formula.clear();
-            }
-            Ok(Event::Text(text)) if in_formula => {
-                let decoded = text
-                    .xml_content(XmlVersion::Implicit1_0)
-                    .map_err(|error| format!("解析 XLSX 公式失败: {error}"))?;
-                current_formula.push_str(&decoded);
-            }
-            Ok(Event::GeneralRef(reference)) if in_formula => {
-                if let Some(character) = reference
-                    .resolve_char_ref()
-                    .map_err(|error| format!("解析 XLSX 公式字符引用失败: {error}"))?
-                {
-                    current_formula.push(character);
-                } else {
-                    let name = reference
-                        .decode()
-                        .map_err(|error| format!("解析 XLSX 公式实体失败: {error}"))?;
-                    if let Some(value) = quick_xml::escape::resolve_predefined_entity(&name) {
-                        current_formula.push_str(value);
-                    } else {
-                        current_formula.push('&');
-                        current_formula.push_str(&name);
-                        current_formula.push(';');
-                    }
-                }
-            }
-            Ok(Event::CData(text)) if in_formula => {
-                let decoded = text
-                    .xml_content(XmlVersion::Implicit1_0)
-                    .map_err(|error| format!("解析 XLSX 公式 CDATA 失败: {error}"))?;
-                current_formula.push_str(&decoded);
-            }
-            Ok(Event::End(element)) if element.local_name().as_ref() == b"f" => {
-                in_formula = false;
-                if !current_formula.is_empty() {
-                    if annotations.formulas.len() < MAX_FORMULAS {
-                        annotations.formulas.push((
-                            current_cell.clone().unwrap_or_else(|| "?".into()),
-                            current_formula.clone(),
-                        ));
-                    } else {
-                        annotations.formulas_truncated = true;
-                    }
-                }
-            }
-            Ok(Event::End(element)) if element.local_name().as_ref() == b"c" => {
-                current_cell = None;
-                current_formula.clear();
-                in_formula = false;
-            }
             Ok(Event::Start(element) | Event::Empty(element))
                 if element.local_name().as_ref() == b"mergeCell" =>
             {
@@ -433,60 +367,62 @@ fn parse_sheet_annotations(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(super) fn synthetic_xlsx_fixture() -> Vec<u8> {
     use std::io::Write;
     use zip::write::SimpleFileOptions;
 
-    fn synthetic_xlsx() -> Vec<u8> {
-        let mut bytes = Cursor::new(Vec::new());
-        {
-            let mut zip = zip::ZipWriter::new(&mut bytes);
-            let options = SimpleFileOptions::default();
-            let files = [
-                (
-                    "[Content_Types].xml",
-                    r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/></Types>"#,
-                ),
-                (
-                    "_rels/.rels",
-                    r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
-                ),
-                (
-                    "xl/workbook.xml",
-                    r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Map" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
-                ),
-                (
-                    "xl/_rels/workbook.xml.rels",
-                    r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#,
-                ),
-                (
-                    "xl/styles.xml",
-                    r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fills count="3"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill><fill><patternFill patternType="solid"><fgColor rgb="FF00FF00"/><bgColor indexed="64"/></patternFill></fill></fills><cellXfs count="2"><xf numFmtId="0" fillId="0"/><xf numFmtId="0" fillId="2" applyFill="1"/></cellXfs></styleSheet>"#,
-                ),
-                (
-                    "xl/worksheets/sheet1.xml",
-                    r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" s="1" t="inlineStr"><is><t>START</t></is></c></row><row r="2"><c r="C2" s="1"/></row><row r="3"><c r="D3"><f>SUM(A1:B1)</f><v>3</v></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:B1"/></mergeCells></worksheet>"#,
-                ),
-            ];
-            for (path, content) in files {
-                zip.start_file(path, options).unwrap();
-                zip.write_all(content.as_bytes()).unwrap();
-            }
-            zip.finish().unwrap();
+    let mut bytes = Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut bytes);
+        let options = SimpleFileOptions::default();
+        let files = [
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/></Types>"#,
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Map" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fills count="3"><fill><patternFill patternType="none"><fgColor rgb="FFFF0000"/></patternFill></fill><fill><patternFill patternType="gray125"/></fill><fill><patternFill patternType="solid"><fgColor rgb="FF00FF00"/><bgColor indexed="64"/></patternFill></fill></fills><cellXfs count="2"><xf numFmtId="0" fillId="0"/><xf numFmtId="0" fillId="2" applyFill="1"/></cellXfs></styleSheet>"#,
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1:D4"/><sheetData><row r="1"><c r="A1" s="1" t="inlineStr"><is><t>START</t></is></c></row><row r="2"><c r="C2" s="1"/></row><row r="3"><c r="D3"><f t="shared" ref="D3:D4" si="0">SUM(A1:B1)</f><v>3</v></c></row><row r="4"><c r="D4"><f t="shared" si="0"/><v>5</v></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:B1"/></mergeCells></worksheet>"#,
+            ),
+        ];
+        for (path, content) in files {
+            zip.start_file(path, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
         }
-        bytes.into_inner()
+        zip.finish().unwrap();
     }
+    bytes.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
 
     #[test]
-    fn preserves_fills_formulas_and_merged_ranges() {
-        let rendered = xlsx_structure_annotations(&synthetic_xlsx())
+    fn preserves_fills_and_merged_ranges() {
+        let rendered = xlsx_structure_annotations(&synthetic_xlsx_fixture())
             .unwrap()
             .unwrap();
         assert!(rendered.contains("### 工作表结构：Map"));
         assert!(rendered.contains("fill #00FF00: A1, C2"));
-        assert!(rendered.contains("D3: =SUM(A1:B1)"));
         assert!(rendered.contains("合并区域: A1:B1"));
+        assert!(!rendered.contains("#FF0000"));
     }
 
     #[test]
@@ -499,14 +435,33 @@ mod tests {
     }
 
     #[test]
-    fn preserves_formulas_and_merges_when_styles_are_absent() {
+    fn preserves_merges_when_styles_are_absent() {
         let annotations = parse_sheet_annotations(
             r#"<worksheet><sheetData><row><c r="B2"><f>A1&amp;"x"</f></c></row></sheetData><mergeCells><mergeCell ref="C3:D4"/></mergeCells></worksheet>"#,
             &[],
         )
         .unwrap();
 
-        assert_eq!(annotations.formulas, vec![("B2".into(), "A1&\"x\"".into())]);
         assert_eq!(annotations.merged_ranges, vec!["C3:D4"]);
+    }
+
+    #[test]
+    fn rejects_non_ascii_or_malformed_rgb_without_panicking() {
+        assert_eq!(normalized_rgb("FéFF00F"), None);
+        assert_eq!(normalized_rgb("GG00FF00"), None);
+        assert_eq!(normalized_rgb("FF00ff00").as_deref(), Some("#00FF00"));
+    }
+
+    #[test]
+    fn none_pattern_ignores_decorative_color_attributes() {
+        assert_eq!(
+            Fill {
+                pattern: Some("none".into()),
+                foreground: Some("#FF0000".into()),
+                background: None,
+            }
+            .label(),
+            None
+        );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
+++ b/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
@@ -1,0 +1,512 @@
+//! XLSX-only structural metadata extraction.
+//!
+//! Calamine intentionally exposes cell values rather than presentation styles.
+//! Some spreadsheets encode essential meaning in fill colors, formulas, or
+//! merged regions, so retain those OOXML facts as compact text annotations.
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::{Reader, XmlVersion};
+use std::collections::{BTreeMap, HashMap};
+use std::io::{Cursor, Read, Seek};
+
+const MAX_STYLE_CELLS: usize = 4_096;
+const MAX_FORMULAS: usize = 2_048;
+const MAX_MERGED_RANGES: usize = 1_024;
+const MAX_XML_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(Debug, Default)]
+struct Fill {
+    pattern: Option<String>,
+    foreground: Option<String>,
+    background: Option<String>,
+}
+
+impl Fill {
+    fn label(&self) -> Option<String> {
+        let pattern = self.pattern.as_deref().unwrap_or("none");
+        if pattern == "none" && self.foreground.is_none() && self.background.is_none() {
+            return None;
+        }
+        let mut parts = Vec::new();
+        if let Some(color) = &self.foreground {
+            parts.push(format!("fill {color}"));
+        } else if let Some(color) = &self.background {
+            parts.push(format!("background {color}"));
+        } else {
+            parts.push(format!("fill pattern {pattern}"));
+        }
+        if pattern != "none" && pattern != "solid" {
+            parts.push(format!("pattern {pattern}"));
+        }
+        Some(parts.join(", "))
+    }
+}
+
+#[derive(Debug, Default)]
+struct SheetAnnotations {
+    fills: BTreeMap<String, Vec<String>>,
+    formulas: Vec<(String, String)>,
+    merged_ranges: Vec<String>,
+    style_cells_truncated: bool,
+    formulas_truncated: bool,
+    merges_truncated: bool,
+}
+
+pub(super) fn xlsx_structure_annotations(bytes: &[u8]) -> Result<Option<String>, String> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes))
+        .map_err(|error| format!("打开 XLSX 结构失败: {error}"))?;
+    let style_fills = read_zip_text(&mut archive, "xl/styles.xml")?
+        .map(|styles| parse_style_fills(&styles))
+        .transpose()?
+        .unwrap_or_default();
+
+    let workbook = read_zip_text(&mut archive, "xl/workbook.xml")?
+        .ok_or_else(|| "XLSX 缺少 workbook.xml".to_string())?;
+    let relationships = read_zip_text(&mut archive, "xl/_rels/workbook.xml.rels")?
+        .ok_or_else(|| "XLSX 缺少 workbook relationships".to_string())?;
+    let relationship_targets = parse_relationship_targets(&relationships)?;
+    let sheets = parse_sheets(&workbook)?;
+
+    let mut rendered = String::new();
+    for (sheet_name, relationship_id) in sheets {
+        let Some(target) = relationship_targets.get(&relationship_id) else {
+            continue;
+        };
+        let Some(path) = normalized_sheet_path(target) else {
+            continue;
+        };
+        let Some(xml) = read_zip_text(&mut archive, &path)? else {
+            continue;
+        };
+        let annotations = parse_sheet_annotations(&xml, &style_fills)?;
+        if annotations.fills.is_empty()
+            && annotations.formulas.is_empty()
+            && annotations.merged_ranges.is_empty()
+        {
+            continue;
+        }
+        rendered.push_str("### 工作表结构：");
+        rendered.push_str(&sheet_name);
+        rendered.push('\n');
+        for (fill, cells) in annotations.fills {
+            rendered.push_str("- ");
+            rendered.push_str(&fill);
+            rendered.push_str(": ");
+            rendered.push_str(&cells.join(", "));
+            rendered.push('\n');
+        }
+        if annotations.style_cells_truncated {
+            rendered.push_str("- 填充单元格过多，以上列表已截断\n");
+        }
+        if !annotations.formulas.is_empty() {
+            rendered.push_str("- 公式:\n");
+            for (cell, formula) in annotations.formulas {
+                rendered.push_str("  - ");
+                rendered.push_str(&cell);
+                rendered.push_str(": =");
+                rendered.push_str(&formula);
+                rendered.push('\n');
+            }
+        }
+        if annotations.formulas_truncated {
+            rendered.push_str("  - 公式过多，以上列表已截断\n");
+        }
+        if !annotations.merged_ranges.is_empty() {
+            rendered.push_str("- 合并区域: ");
+            rendered.push_str(&annotations.merged_ranges.join(", "));
+            rendered.push('\n');
+        }
+        if annotations.merges_truncated {
+            rendered.push_str("- 合并区域过多，以上列表已截断\n");
+        }
+        rendered.push('\n');
+    }
+
+    Ok((!rendered.is_empty()).then_some(rendered))
+}
+
+fn read_zip_text<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    path: &str,
+) -> Result<Option<String>, String> {
+    let file = match archive.by_name(path) {
+        Ok(file) => file,
+        Err(zip::result::ZipError::FileNotFound) => return Ok(None),
+        Err(error) => return Err(format!("读取 XLSX 条目失败: {error}")),
+    };
+    let mut text = String::new();
+    file.take(MAX_XML_ENTRY_BYTES + 1)
+        .read_to_string(&mut text)
+        .map_err(|error| format!("读取 XLSX XML 失败: {error}"))?;
+    if text.len() as u64 > MAX_XML_ENTRY_BYTES {
+        return Err(format!(
+            "XLSX XML 条目超过 {} MiB 限制",
+            MAX_XML_ENTRY_BYTES / 1024 / 1024
+        ));
+    }
+    Ok(Some(text))
+}
+
+fn attr(element: &BytesStart<'_>, key: &[u8]) -> Option<String> {
+    element
+        .attributes()
+        .with_checks(false)
+        .flatten()
+        .find(|attribute| attribute.key.local_name().as_ref() == key)
+        .and_then(|attribute| {
+            attribute
+                .normalized_value(XmlVersion::Implicit1_0)
+                .ok()
+                .map(|value| value.into_owned())
+        })
+}
+
+fn color(element: &BytesStart<'_>) -> Option<String> {
+    if let Some(rgb) = attr(element, b"rgb") {
+        let normalized = rgb.trim_start_matches('#');
+        let rgb = if normalized.len() == 8 {
+            &normalized[2..]
+        } else {
+            normalized
+        };
+        return Some(format!("#{}", rgb.to_ascii_uppercase()));
+    }
+    for (key, label) in [
+        (b"indexed".as_slice(), "indexed"),
+        (b"theme".as_slice(), "theme"),
+        (b"auto".as_slice(), "auto"),
+    ] {
+        if let Some(value) = attr(element, key) {
+            return Some(format!("{label}:{value}"));
+        }
+    }
+    None
+}
+
+fn parse_style_fills(xml: &str) -> Result<Vec<Option<String>>, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut fills = Vec::new();
+    let mut cell_fill_ids = Vec::new();
+    let mut current_fill: Option<Fill> = None;
+    let mut in_fills = false;
+    let mut in_cell_xfs = false;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) => match element.local_name().as_ref() {
+                b"fills" => in_fills = true,
+                b"fill" if in_fills => current_fill = Some(Fill::default()),
+                b"patternFill" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().pattern = attr(&element, b"patternType");
+                }
+                b"fgColor" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().foreground = color(&element);
+                }
+                b"bgColor" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().background = color(&element);
+                }
+                b"cellXfs" => in_cell_xfs = true,
+                b"xf" if in_cell_xfs => {
+                    cell_fill_ids.push(
+                        attr(&element, b"fillId")
+                            .and_then(|value| value.parse::<usize>().ok())
+                            .unwrap_or(0),
+                    );
+                }
+                _ => {}
+            },
+            Ok(Event::Empty(element)) => match element.local_name().as_ref() {
+                b"patternFill" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().pattern = attr(&element, b"patternType");
+                }
+                b"fgColor" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().foreground = color(&element);
+                }
+                b"bgColor" if current_fill.is_some() => {
+                    current_fill.as_mut().unwrap().background = color(&element);
+                }
+                b"xf" if in_cell_xfs => {
+                    cell_fill_ids.push(
+                        attr(&element, b"fillId")
+                            .and_then(|value| value.parse::<usize>().ok())
+                            .unwrap_or(0),
+                    );
+                }
+                _ => {}
+            },
+            Ok(Event::End(element)) => match element.local_name().as_ref() {
+                b"fill" if in_fills => fills.push(current_fill.take().unwrap_or_default()),
+                b"fills" => in_fills = false,
+                b"cellXfs" => in_cell_xfs = false,
+                _ => {}
+            },
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("解析 XLSX 样式失败: {error}")),
+            _ => {}
+        }
+    }
+
+    Ok(cell_fill_ids
+        .into_iter()
+        .map(|fill_id| fills.get(fill_id).and_then(Fill::label))
+        .collect())
+}
+
+fn parse_relationship_targets(xml: &str) -> Result<HashMap<String, String>, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut targets = HashMap::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element) | Event::Empty(element))
+                if element.local_name().as_ref() == b"Relationship" =>
+            {
+                if let (Some(id), Some(target)) = (attr(&element, b"Id"), attr(&element, b"Target"))
+                {
+                    targets.insert(id, target);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("解析 XLSX relationships 失败: {error}")),
+            _ => {}
+        }
+    }
+    Ok(targets)
+}
+
+fn parse_sheets(xml: &str) -> Result<Vec<(String, String)>, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut sheets = Vec::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element) | Event::Empty(element))
+                if element.local_name().as_ref() == b"sheet" =>
+            {
+                if let (Some(name), Some(id)) = (attr(&element, b"name"), attr(&element, b"id")) {
+                    sheets.push((name, id));
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("解析 XLSX 工作表失败: {error}")),
+            _ => {}
+        }
+    }
+    Ok(sheets)
+}
+
+fn normalized_sheet_path(target: &str) -> Option<String> {
+    let target = target.trim_start_matches('/');
+    let candidate = if target.starts_with("xl/") {
+        target.to_string()
+    } else {
+        format!("xl/{target}")
+    };
+    (!candidate.split('/').any(|part| part == "..") && candidate.starts_with("xl/"))
+        .then_some(candidate)
+}
+
+fn parse_sheet_annotations(
+    xml: &str,
+    style_fills: &[Option<String>],
+) -> Result<SheetAnnotations, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut annotations = SheetAnnotations::default();
+    let mut current_cell: Option<String> = None;
+    let mut current_formula = String::new();
+    let mut in_formula = false;
+    let mut style_cell_count = 0usize;
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) if element.local_name().as_ref() == b"c" => {
+                current_cell = attr(&element, b"r");
+                if let (Some(cell), Some(style_id)) = (
+                    current_cell.as_ref(),
+                    attr(&element, b"s").and_then(|value| value.parse::<usize>().ok()),
+                ) {
+                    if let Some(Some(fill)) = style_fills.get(style_id) {
+                        if style_cell_count < MAX_STYLE_CELLS {
+                            annotations
+                                .fills
+                                .entry(fill.clone())
+                                .or_default()
+                                .push(cell.clone());
+                            style_cell_count += 1;
+                        } else {
+                            annotations.style_cells_truncated = true;
+                        }
+                    }
+                }
+            }
+            Ok(Event::Empty(element)) if element.local_name().as_ref() == b"c" => {
+                if let (Some(cell), Some(style_id)) = (
+                    attr(&element, b"r"),
+                    attr(&element, b"s").and_then(|value| value.parse::<usize>().ok()),
+                ) {
+                    if let Some(Some(fill)) = style_fills.get(style_id) {
+                        if style_cell_count < MAX_STYLE_CELLS {
+                            annotations
+                                .fills
+                                .entry(fill.clone())
+                                .or_default()
+                                .push(cell);
+                            style_cell_count += 1;
+                        } else {
+                            annotations.style_cells_truncated = true;
+                        }
+                    }
+                }
+            }
+            Ok(Event::Start(element)) if element.local_name().as_ref() == b"f" => {
+                in_formula = true;
+                current_formula.clear();
+            }
+            Ok(Event::Text(text)) if in_formula => {
+                let decoded = text
+                    .xml_content(XmlVersion::Implicit1_0)
+                    .map_err(|error| format!("解析 XLSX 公式失败: {error}"))?;
+                current_formula.push_str(&decoded);
+            }
+            Ok(Event::GeneralRef(reference)) if in_formula => {
+                if let Some(character) = reference
+                    .resolve_char_ref()
+                    .map_err(|error| format!("解析 XLSX 公式字符引用失败: {error}"))?
+                {
+                    current_formula.push(character);
+                } else {
+                    let name = reference
+                        .decode()
+                        .map_err(|error| format!("解析 XLSX 公式实体失败: {error}"))?;
+                    if let Some(value) = quick_xml::escape::resolve_predefined_entity(&name) {
+                        current_formula.push_str(value);
+                    } else {
+                        current_formula.push('&');
+                        current_formula.push_str(&name);
+                        current_formula.push(';');
+                    }
+                }
+            }
+            Ok(Event::CData(text)) if in_formula => {
+                let decoded = text
+                    .xml_content(XmlVersion::Implicit1_0)
+                    .map_err(|error| format!("解析 XLSX 公式 CDATA 失败: {error}"))?;
+                current_formula.push_str(&decoded);
+            }
+            Ok(Event::End(element)) if element.local_name().as_ref() == b"f" => {
+                in_formula = false;
+                if !current_formula.is_empty() {
+                    if annotations.formulas.len() < MAX_FORMULAS {
+                        annotations.formulas.push((
+                            current_cell.clone().unwrap_or_else(|| "?".into()),
+                            current_formula.clone(),
+                        ));
+                    } else {
+                        annotations.formulas_truncated = true;
+                    }
+                }
+            }
+            Ok(Event::End(element)) if element.local_name().as_ref() == b"c" => {
+                current_cell = None;
+                current_formula.clear();
+                in_formula = false;
+            }
+            Ok(Event::Start(element) | Event::Empty(element))
+                if element.local_name().as_ref() == b"mergeCell" =>
+            {
+                if let Some(range) = attr(&element, b"ref") {
+                    if annotations.merged_ranges.len() < MAX_MERGED_RANGES {
+                        annotations.merged_ranges.push(range);
+                    } else {
+                        annotations.merges_truncated = true;
+                    }
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("解析 XLSX 工作表结构失败: {error}")),
+            _ => {}
+        }
+    }
+    Ok(annotations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    fn synthetic_xlsx() -> Vec<u8> {
+        let mut bytes = Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut bytes);
+            let options = SimpleFileOptions::default();
+            let files = [
+                (
+                    "[Content_Types].xml",
+                    r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/></Types>"#,
+                ),
+                (
+                    "_rels/.rels",
+                    r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+                ),
+                (
+                    "xl/workbook.xml",
+                    r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Map" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+                ),
+                (
+                    "xl/_rels/workbook.xml.rels",
+                    r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#,
+                ),
+                (
+                    "xl/styles.xml",
+                    r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fills count="3"><fill><patternFill patternType="none"/></fill><fill><patternFill patternType="gray125"/></fill><fill><patternFill patternType="solid"><fgColor rgb="FF00FF00"/><bgColor indexed="64"/></patternFill></fill></fills><cellXfs count="2"><xf numFmtId="0" fillId="0"/><xf numFmtId="0" fillId="2" applyFill="1"/></cellXfs></styleSheet>"#,
+                ),
+                (
+                    "xl/worksheets/sheet1.xml",
+                    r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" s="1" t="inlineStr"><is><t>START</t></is></c></row><row r="2"><c r="C2" s="1"/></row><row r="3"><c r="D3"><f>SUM(A1:B1)</f><v>3</v></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:B1"/></mergeCells></worksheet>"#,
+                ),
+            ];
+            for (path, content) in files {
+                zip.start_file(path, options).unwrap();
+                zip.write_all(content.as_bytes()).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        bytes.into_inner()
+    }
+
+    #[test]
+    fn preserves_fills_formulas_and_merged_ranges() {
+        let rendered = xlsx_structure_annotations(&synthetic_xlsx())
+            .unwrap()
+            .unwrap();
+        assert!(rendered.contains("### 工作表结构：Map"));
+        assert!(rendered.contains("fill #00FF00: A1, C2"));
+        assert!(rendered.contains("D3: =SUM(A1:B1)"));
+        assert!(rendered.contains("合并区域: A1:B1"));
+    }
+
+    #[test]
+    fn rejects_relationship_path_traversal() {
+        assert_eq!(normalized_sheet_path("../secrets.xml"), None);
+        assert_eq!(
+            normalized_sheet_path("worksheets/sheet1.xml").as_deref(),
+            Some("xl/worksheets/sheet1.xml")
+        );
+    }
+
+    #[test]
+    fn preserves_formulas_and_merges_when_styles_are_absent() {
+        let annotations = parse_sheet_annotations(
+            r#"<worksheet><sheetData><row><c r="B2"><f>A1&amp;"x"</f></c></row></sheetData><mergeCells><mergeCell ref="C3:D4"/></mergeCells></worksheet>"#,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(annotations.formulas, vec![("B2".into(), "A1&\"x\"".into())]);
+        assert_eq!(annotations.merged_ranges, vec!["C3:D4"]);
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
+++ b/pinvou3-app/src-tauri/src/features/files/spreadsheet_structure.rs
@@ -14,6 +14,12 @@ const MAX_STYLE_CELLS: usize = 4_096;
 const MAX_MERGED_RANGES: usize = 1_024;
 const MAX_XML_ENTRY_BYTES: u64 = 32 * 1024 * 1024;
 
+/// 上限单个工作表公式格张成面积。calamine 的 `worksheet_formula` 会按公式格
+/// `r` 属性极值把 `Range<String>` 物化成稠密网格（`Range::from_sparse`），
+/// 恶意文件两个对角公式格即可触发 PB 级单次分配并 abort 宿主进程，必须在
+/// 调用前按内容预扫跨度。
+pub(super) const MAX_FORMULA_SPAN_CELLS: u64 = 4 * 1024 * 1024;
+
 #[derive(Debug, Default)]
 struct Fill {
     pattern: Option<String>,
@@ -38,7 +44,7 @@ impl Fill {
         if pattern != "none" && pattern != "solid" {
             parts.push(format!("pattern {pattern}"));
         }
-        Some(parts.join(", "))
+        Some(flatten_text(&parts.join(", ")))
     }
 }
 
@@ -81,7 +87,7 @@ pub(super) fn xlsx_structure_annotations(bytes: &[u8]) -> Result<Option<String>,
             continue;
         }
         rendered.push_str("### 工作表结构：");
-        rendered.push_str(&sheet_name);
+        rendered.push_str(&flatten_text(&sheet_name));
         rendered.push('\n');
         for (fill, cells) in annotations.fills {
             rendered.push_str("- ");
@@ -105,6 +111,130 @@ pub(super) fn xlsx_structure_annotations(bytes: &[u8]) -> Result<Option<String>,
     }
 
     Ok((!rendered.is_empty()).then_some(rendered))
+}
+
+/// 每表公式格跨度 `(rows, cols)`（按表名索引）。`None` 表示 bytes 不是
+/// OOXML 工作簿：calamine 对 XLS/ODS 的公式 Range 是打开时预构建、网格有界，
+/// 无需守卫。工作表路径解析完全镜像 calamine 自身逻辑（基目录取自根
+/// `_rels/.rels` 的 officeDocument Target），非 `xl/` 布局无法绕过守卫。
+pub(super) fn xlsx_formula_span_limits(bytes: &[u8]) -> Option<HashMap<String, (u64, u64)>> {
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).ok()?;
+    let base = workbook_base_folder(&mut archive).ok()?;
+    let workbook = read_zip_text(&mut archive, &format!("{base}workbook.xml")).ok()??;
+    let relationships =
+        read_zip_text(&mut archive, &format!("{base}_rels/workbook.xml.rels")).ok()??;
+    let relationship_targets = parse_relationship_targets(&relationships).ok()?;
+    let mut limits = HashMap::new();
+    for (sheet_name, relationship_id) in parse_sheets(&workbook).ok()? {
+        let Some(target) = relationship_targets.get(&relationship_id) else {
+            continue;
+        };
+        let path = if let Some(absolute) = target.strip_prefix('/') {
+            absolute.to_string()
+        } else {
+            format!("{base}{target}")
+        };
+        let Ok(Some(xml)) = read_zip_text(&mut archive, &path) else {
+            continue;
+        };
+        let (rows, cols) = formula_cell_span(&xml);
+        limits.insert(flatten_text(&sheet_name), (rows, cols));
+    }
+    Some(limits)
+}
+
+/// calamine `Xlsx::read_package_relationships` 的镜像：workbook 基目录取自根
+/// `_rels/.rels` 中 officeDocument 关系 Target 的目录前缀（剥离开头 `/`）。
+fn workbook_base_folder<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<R>,
+) -> Result<String, String> {
+    let root_rels = read_zip_text(archive, "_rels/.rels")?.ok_or("_rels/.rels 缺失")?;
+    let mut reader = Reader::from_str(&root_rels);
+    reader.config_mut().trim_text(true);
+    let mut target = None;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element) | Event::Empty(element))
+                if element.local_name().as_ref() == b"Relationship" =>
+            {
+                let is_office_document = attr(&element, b"Type")
+                    .is_some_and(|relationship_type| relationship_type.ends_with("officeDocument"));
+                if is_office_document {
+                    target = attr(&element, b"Target");
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => return Err(format!("解析 XLSX 根 relationships 失败: {error}")),
+            _ => {}
+        }
+    }
+    let directory = target
+        .as_deref()
+        .and_then(|target| target.rfind('/').map(|end| &target[..=end]))
+        .map(|directory| directory.strip_prefix('/').unwrap_or(directory));
+    Ok(directory.unwrap_or("").to_string())
+}
+
+/// 工作表内公式格的跨度 `(rows, cols)`，取自带 `r` 属性且含 `<f>` 子元素的
+/// 单元格极值。无 `r` 属性的单元格在 calamine 中按顺序递推定位，跨度受 XML
+/// 条目体积约束，无需纳入守卫。
+fn formula_cell_span(xml: &str) -> (u64, u64) {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut max_row = 0u64;
+    let mut max_col = 0u64;
+    let mut current_cell: Option<(u64, u64)> = None;
+    let mut formula_cell: Option<(u64, u64)> = None;
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) => match element.local_name().as_ref() {
+                b"c" => {
+                    current_cell =
+                        attr(&element, b"r").and_then(|reference| parse_cell_reference(&reference));
+                }
+                b"f" => formula_cell = current_cell,
+                _ => {}
+            },
+            Ok(Event::Empty(element)) if element.local_name().as_ref() == b"f" => {
+                formula_cell = current_cell;
+            }
+            Ok(Event::End(element)) if element.local_name().as_ref() == b"c" => {
+                if let Some((row, col)) = formula_cell.take() {
+                    max_row = max_row.max(row);
+                    max_col = max_col.max(col);
+                }
+                current_cell = None;
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    (max_row.saturating_add(1), max_col.saturating_add(1))
+}
+
+/// A1 风格引用 → 零基 `(row, col)`；畸形输入返回 `None`。
+fn parse_cell_reference(reference: &str) -> Option<(u64, u64)> {
+    let bytes = reference.as_bytes();
+    let mut columns = 0u64;
+    let mut digits = 0usize;
+    while digits < bytes.len() && bytes[digits].is_ascii_alphabetic() {
+        columns = columns
+            .checked_mul(26)?
+            .checked_add(u64::from(bytes[digits].to_ascii_uppercase() - b'A') + 1)?;
+        digits += 1;
+    }
+    if digits == 0 || digits == bytes.len() {
+        return None;
+    }
+    let row: u64 = reference[digits..].parse().ok()?;
+    Some((row.checked_sub(1)?, columns.checked_sub(1)?))
+}
+
+/// 注记文本会拼进 ingest 正文「一行 = 一条记录」的行网格，控制空白必须与值
+/// 路径同样折叠，防止用字符引用（如 `&#10;`）伪造 `###` 节结构。
+pub(super) fn flatten_text(value: &str) -> String {
+    value.replace(['\n', '\r', '\t'], " ")
 }
 
 fn read_zip_text<R: Read + Seek>(
@@ -174,6 +304,20 @@ fn normalized_rgb(value: &str) -> Option<String> {
     Some(format!("#{}", visible.to_ascii_uppercase()))
 }
 
+/// fill 子元素（patternFill/fgColor/bgColor）应用到当前 fill；不在 `<fill>`
+/// 内部时静默忽略（如 dxfs 里的同名词素），无 panic 路径。
+fn apply_fill_element(current_fill: &mut Option<Fill>, element: &BytesStart<'_>) {
+    let Some(fill) = current_fill.as_mut() else {
+        return;
+    };
+    match element.local_name().as_ref() {
+        b"patternFill" => fill.pattern = attr(element, b"patternType"),
+        b"fgColor" => fill.foreground = color(element),
+        b"bgColor" => fill.background = color(element),
+        _ => {}
+    }
+}
+
 fn parse_style_fills(xml: &str) -> Result<Vec<Option<String>>, String> {
     let mut reader = Reader::from_str(xml);
     reader.config_mut().trim_text(true);
@@ -188,14 +332,8 @@ fn parse_style_fills(xml: &str) -> Result<Vec<Option<String>>, String> {
             Ok(Event::Start(element)) => match element.local_name().as_ref() {
                 b"fills" => in_fills = true,
                 b"fill" if in_fills => current_fill = Some(Fill::default()),
-                b"patternFill" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().pattern = attr(&element, b"patternType");
-                }
-                b"fgColor" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().foreground = color(&element);
-                }
-                b"bgColor" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().background = color(&element);
+                b"patternFill" | b"fgColor" | b"bgColor" => {
+                    apply_fill_element(&mut current_fill, &element);
                 }
                 b"cellXfs" => in_cell_xfs = true,
                 b"xf" if in_cell_xfs => {
@@ -208,14 +346,11 @@ fn parse_style_fills(xml: &str) -> Result<Vec<Option<String>>, String> {
                 _ => {}
             },
             Ok(Event::Empty(element)) => match element.local_name().as_ref() {
-                b"patternFill" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().pattern = attr(&element, b"patternType");
-                }
-                b"fgColor" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().foreground = color(&element);
-                }
-                b"bgColor" if current_fill.is_some() => {
-                    current_fill.as_mut().unwrap().background = color(&element);
+                // `<fill/>`（空填充）是合法 OOXML：跳过入列会让后续 fillId
+                // 整体错位，静默产出错误的填充标注。
+                b"fill" if in_fills => fills.push(current_fill.take().unwrap_or_default()),
+                b"patternFill" | b"fgColor" | b"bgColor" => {
+                    apply_fill_element(&mut current_fill, &element);
                 }
                 b"xf" if in_cell_xfs => {
                     cell_fill_ids.push(
@@ -320,7 +455,7 @@ fn parse_sheet_annotations(
                                 .fills
                                 .entry(fill.clone())
                                 .or_default()
-                                .push(cell);
+                                .push(flatten_text(&cell));
                             style_cell_count += 1;
                         } else {
                             annotations.style_cells_truncated = true;
@@ -339,7 +474,7 @@ fn parse_sheet_annotations(
                                 .fills
                                 .entry(fill.clone())
                                 .or_default()
-                                .push(cell);
+                                .push(flatten_text(&cell));
                             style_cell_count += 1;
                         } else {
                             annotations.style_cells_truncated = true;
@@ -352,7 +487,7 @@ fn parse_sheet_annotations(
             {
                 if let Some(range) = attr(&element, b"ref") {
                     if annotations.merged_ranges.len() < MAX_MERGED_RANGES {
-                        annotations.merged_ranges.push(range);
+                        annotations.merged_ranges.push(flatten_text(&range));
                     } else {
                         annotations.merges_truncated = true;
                     }
@@ -411,6 +546,74 @@ pub(super) fn synthetic_xlsx_fixture() -> Vec<u8> {
 }
 
 #[cfg(test)]
+fn xlsx_fixture(files: &[(&str, &str)]) -> Vec<u8> {
+    use std::io::Write;
+    use zip::write::SimpleFileOptions;
+
+    let mut bytes = Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut bytes);
+        let options = SimpleFileOptions::default();
+        for (path, content) in files {
+            zip.start_file(path, options).unwrap();
+            zip.write_all(content.as_bytes()).unwrap();
+        }
+        zip.finish().unwrap();
+    }
+    bytes.into_inner()
+}
+
+const TEST_CONTENT_TYPES: &str = r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/></Types>"#;
+
+#[cfg(test)]
+pub(super) fn distant_formula_fixture() -> Vec<u8> {
+    xlsx_fixture(&[
+        ("[Content_Types].xml", TEST_CONTENT_TYPES),
+        (
+            "_rels/.rels",
+            r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/workbook.xml",
+            r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Map" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+        ),
+        // 值全部聚在 A1，两个对角公式格把公式格张成撑到整表极限：
+        // calamine 的稠密物化会请求 2^32 × 16384 × 24 字节，必须被守卫拦截。
+        (
+            "xl/worksheets/sheet1.xml",
+            r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1"><f>SUM(1)</f><v>1</v></c></row><row r="4294967295"><c r="XFD4294967295"><f>SUM(1)</f></c></row></sheetData></worksheet>"#,
+        ),
+    ])
+}
+
+#[cfg(test)]
+pub(super) fn folded_formula_fixture() -> Vec<u8> {
+    xlsx_fixture(&[
+        ("[Content_Types].xml", TEST_CONTENT_TYPES),
+        (
+            "_rels/.rels",
+            r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/workbook.xml",
+            r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Fold&#10;X" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/worksheets/sheet1.xml",
+            r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1"><f>SUM(1)&#10;+ 2</f><v>3</v></c></row></sheetData></worksheet>"#,
+        ),
+    ])
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -463,5 +666,134 @@ mod tests {
             .label(),
             None
         );
+    }
+
+    #[test]
+    fn formula_span_limits_track_formula_cells_only() {
+        let limits = xlsx_formula_span_limits(&synthetic_xlsx_fixture()).unwrap();
+        // 只有 D3/D4 带公式；值格 A1/C2 不参与张成。
+        assert_eq!(limits.get("Map"), Some(&(4, 4)));
+    }
+
+    #[test]
+    fn non_ooxml_bytes_have_no_formula_span_limits() {
+        assert!(xlsx_formula_span_limits(b"not a zip").is_none());
+    }
+
+    #[test]
+    fn distant_formula_cells_exceed_span_limit() {
+        let limits = xlsx_formula_span_limits(&distant_formula_fixture()).unwrap();
+        let &(rows, cols) = limits.get("Map").expect("恶意 fixture 应解析出 Map");
+        assert_eq!((rows, cols), (4_294_967_295, 16_384));
+        assert!(rows.saturating_mul(cols) > MAX_FORMULA_SPAN_CELLS);
+    }
+
+    #[test]
+    fn guard_resolves_nonstandard_base_folder() {
+        let bytes = xlsx_fixture(&[
+            ("[Content_Types].xml", TEST_CONTENT_TYPES),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="deep/workbook.xml"/></Relationships>"#,
+            ),
+            (
+                "deep/workbook.xml",
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Base" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "deep/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+            ),
+            (
+                "deep/worksheets/sheet1.xml",
+                r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="2"><c r="B2"><f>A1</f></c></row></sheetData></worksheet>"#,
+            ),
+        ]);
+        let limits = xlsx_formula_span_limits(&bytes).unwrap();
+        assert_eq!(limits.get("Base"), Some(&(2, 2)));
+    }
+
+    #[test]
+    fn self_closing_fill_keeps_style_indices() {
+        let bytes = xlsx_fixture(&[
+            ("[Content_Types].xml", TEST_CONTENT_TYPES),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Map" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fills count="2"><fill/><fill><patternFill patternType="solid"><fgColor rgb="FF00FF00"/></patternFill></fill></fills><cellXfs count="1"><xf numFmtId="0" fillId="1" applyFill="1"/></cellXfs></styleSheet>"#,
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="2"><c r="B2" s="0"/></row></sheetData></worksheet>"#,
+            ),
+        ]);
+        let rendered = xlsx_structure_annotations(&bytes).unwrap().unwrap();
+        // `<fill/>` 占据 fillId 0：跳过它会让 fillId=1 越界、注记整个丢失。
+        assert!(rendered.contains("fill #00FF00: B2"), "{rendered}");
+    }
+
+    #[test]
+    fn annotation_output_folds_control_whitespace() {
+        let bytes = xlsx_fixture(&[
+            ("[Content_Types].xml", TEST_CONTENT_TYPES),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Bad&#10;### 工作表结构：X" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/styles.xml",
+                r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fills count="1"><fill><patternFill patternType="solid"><fgColor rgb="FF00FF00"/></patternFill></fill></fills><cellXfs count="1"><xf numFmtId="0" fillId="0" applyFill="1"/></cellXfs></styleSheet>"#,
+            ),
+            (
+                "xl/worksheets/sheet1.xml",
+                r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A&#10;1" s="0"/></row></sheetData><mergeCells count="1"><mergeCell ref="C&#10;3:D4"/></mergeCells></worksheet>"#,
+            ),
+        ]);
+        let rendered = xlsx_structure_annotations(&bytes).unwrap().unwrap();
+        assert!(
+            rendered.contains("### 工作表结构：Bad ### 工作表结构：X"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("fill #00FF00: A 1"), "{rendered}");
+        assert!(rendered.contains("合并区域: C 3:D4"), "{rendered}");
+        // 折叠后只允许出现一个节头，伪造的 `###` 标题必须消失。
+        assert_eq!(
+            rendered
+                .lines()
+                .filter(|line| line.starts_with("### 工作表结构"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn fill_label_folds_control_whitespace() {
+        let label = Fill {
+            pattern: Some("solid".into()),
+            foreground: None,
+            background: Some("indexed:6\n4".into()),
+        }
+        .label()
+        .unwrap();
+        assert_eq!(label, "background indexed:6 4");
     }
 }


### PR DESCRIPTION
## 概要

保留 GAIA 只读附件任务所需的电子表格结构信息，并确保附件提示与评测 profile 实际开放的工具权限一致。

## 背景

现有电子表格导入路径使用 calamine 抽取单元格值，但 calamine 有意不提供展示层结构。因此，当任务答案依赖单元格填充色、公式或合并区域时，相关证据会在模型读取附件前丢失。

此外，共用附件提示会引导模型调用 File 写入和 Bash 执行，而 GAIA profile 只允许只读 File 访问，提示内容与实际权限不一致。

## 变更

- 新增有界的 XLSX OOXML 结构抽取，保留非默认填充色、公式和合并区域。
- 保持现有全部工作表单元格值抽取逻辑不变；可选结构注释读取失败时安全降级，不影响原有正文。
- 拒绝工作表 relationship 路径穿越，并限制单个 XML 条目大小及结构注释数量。
- 为 headless 评测新增只读附件提示路径，不改变普通聊天和定时任务的既有提示。
- 增加回归测试，并更新 GAIA benchmark 与工具权限文档。

## 验证

- cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check
- cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml spreadsheet_structure --lib -- --nocapture：3 项通过
- cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml spreadsheet_extracts_all_sheets --lib -- --nocapture：通过
- cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml read_only_prompt_tests --lib -- --nocapture：2 项通过
- python3 scripts/architecture-guard.py：通过
- ./scripts/fork-guard.sh --fast：通过
- git diff --check origin/main...HEAD：通过

## 影响与说明

- 普通 GUI 与定时任务附件提示继续保留原有的写入和计算引导。
- XLSX 结构抽取完全在 host 侧只读执行，不会向 GAIA 开放 Office、shell 或代码执行工具。
- 音频转写以及模型自身的推理、算术错误不在本次变更范围内。
- 测试构建仍会输出现有的 CodeWhale private-interface 警告，本次没有新增此类警告。

## 提交检查

- [x] PR 已基于最新 main。
- [x] PR 标题遵循提交主题约定；标题和正文按维护者要求使用中文。
- [x] 每个提交都包含匹配的 Signed-off-by trailer。
- [x] 未包含凭据、私有数据、内部地址或敏感日志。
- [x] 行为变更已同步更新测试和文档。
- [x] CodeWhale gitlink 与 fork 行为未发生变化。