### PR TITLE
fix(build): pin Windows tar to System32 bsdtar

### DIFF
--- a/pinvou3-app/scripts/tauri/chrome-devtools-mcp.js
+++ b/pinvou3-app/scripts/tauri/chrome-devtools-mcp.js
@@ -140,6 +140,16 @@ function applyTargetIdAdapter(
   return assertTargetIdAdapterIntegrity(root, { expectedSha256 });
 }
 
+// Windows PATH order may resolve `tar` to Git for Windows' GNU tar, which reads the
+// drive letter of `D:\...` as an rsh remote host and fails with "Cannot connect to D:
+// resolve failed". Windows 10 1803+ ships a bsdtar at System32 that handles local
+// drive paths natively, so resolve it explicitly instead of relying on PATH.
+function systemTarCommand({ platform = process.platform, systemRoot = process.env.SystemRoot } = {}) {
+  if (platform !== "win32") return "tar";
+  const bsdtar = path.join(systemRoot || "C:\\Windows", "System32", "tar.exe");
+  return fs.existsSync(bsdtar) ? bsdtar : "tar";
+}
+
 function isPreparedRoot(root, marker = expectedMarker()) {
   try {
     const actual = JSON.parse(fs.readFileSync(path.join(root, MARKER_NAME), "utf8"));
@@ -253,8 +263,9 @@ function prepareChromeDevtoolsMcp({ platform = process.platform } = {}) {
         `chrome-devtools-mcp@${VERSION} SHA-512 mismatch (expected ${INTEGRITY_SHA512.slice(0, 16)}…, actual ${hash.slice(0, 16)}…)`,
       );
     }
-    // 3) Extract with tar (bsdtar on macOS/Linux and tar.exe on Windows 10+).
-    run("tar", ["-xzf", tarball, "-C", stagingRoot], { cwd: stagingRoot });
+    // 3) Extract with tar (bsdtar on macOS/Linux and the System32 bsdtar on Windows;
+    //    see systemTarCommand for why PATH order must not decide on Windows).
+    run(systemTarCommand(), ["-xzf", tarball, "-C", stagingRoot], { cwd: stagingRoot });
     const unpacked = path.join(stagingRoot, "package");
     if (!fs.existsSync(unpacked)) {
       throw new Error("Extracted tarball is missing package/; the upstream layout changed");
@@ -295,6 +306,7 @@ module.exports = {
   isPrepared,
   isPreparedRoot,
   outputRoot,
+  systemTarCommand,
 };
 
 if (require.main === module) {

--- a/pinvou3-app/tests/tauri_chrome_devtools_mcp_tar.test.js
+++ b/pinvou3-app/tests/tauri_chrome_devtools_mcp_tar.test.js
@@ -1,0 +1,69 @@
+// Regression contract for the Windows NSIS release build: PATH order on Windows CI
+// resolves `tar` to Git for Windows' GNU tar, which reads the drive letter of
+// `D:\...` as an rsh remote host and fails with "Cannot connect to D: resolve
+// failed". The chrome-devtools-mcp vendor step must therefore extract through the
+// System32 bsdtar instead of a bare PATH-resolved `tar`.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { systemTarCommand } = require("../scripts/tauri/chrome-devtools-mcp.js");
+
+assert.equal(systemTarCommand({ platform: "darwin" }), "tar");
+assert.equal(systemTarCommand({ platform: "linux" }), "tar");
+
+const previousSystemRoot = process.env.SystemRoot;
+const windowsRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pinvou-tar-probe-"));
+try {
+  const system32 = path.join(windowsRoot, "System32");
+  fs.mkdirSync(system32);
+  const bsdtar = path.join(system32, "tar.exe");
+  fs.writeFileSync(bsdtar, "");
+  assert.equal(
+    systemTarCommand({ platform: "win32", systemRoot: windowsRoot }),
+    bsdtar,
+    "Windows must extract with the System32 bsdtar, not a PATH-resolved GNU tar",
+  );
+
+  process.env.SystemRoot = windowsRoot;
+  assert.equal(
+    systemTarCommand({ platform: "win32" }),
+    bsdtar,
+    "without an explicit systemRoot the command must come from the SystemRoot environment",
+  );
+
+  fs.rmSync(bsdtar);
+  assert.equal(
+    systemTarCommand({ platform: "win32" }),
+    "tar",
+    "without System32 tar.exe the command falls back to PATH resolution",
+  );
+
+  assert.equal(
+    systemTarCommand({ platform: "win32", systemRoot: path.join(windowsRoot, "Missing") }),
+    "tar",
+    "a non-existent SystemRoot must fall back to PATH resolution",
+  );
+} finally {
+  if (previousSystemRoot === undefined) delete process.env.SystemRoot;
+  else process.env.SystemRoot = previousSystemRoot;
+  fs.rmSync(windowsRoot, { recursive: true, force: true });
+}
+
+// The extraction call site must go through systemTarCommand(); a bare "tar" would
+// reintroduce the drive-letter failure whenever PATH resolves to GNU tar first.
+const source = fs.readFileSync(
+  path.join(__dirname, "..", "scripts", "tauri", "chrome-devtools-mcp.js"),
+  "utf8",
+);
+assert.match(
+  source,
+  /run\(systemTarCommand\(\), \["-xzf", tarball, "-C", stagingRoot\]/,
+  "the tarball extraction must resolve tar through systemTarCommand()",
+);
+assert.doesNotMatch(
+  source,
+  /run\("tar",\s*\[/,
+  "tar must not be spawned as a bare PATH-resolved command on any platform",
+);


### PR DESCRIPTION
## Summary

The 0.8.8 `release-packages` run failed only on the Windows NSIS job ([run 33165641581](https://github.com/Pinvou/pinvou-agent/actions/runs/33165641581/job/98891038284)); macOS dmg and both Linux deb jobs succeeded.

Root cause: `scripts/tauri/chrome-devtools-mcp.js` extracts the vendored npm tarball by spawning a bare `tar` from PATH. The failing step runs under `shell: bash`, so PATH resolves `tar` to Git for Windows' GNU tar first. GNU tar reads the drive letter of `D:\...` as an rsh remote host and aborts:

```
tar -xzf D:\...\chrome-devtools-mcp-1.7.0.tgz ... failed with status=2:
tar (child): Cannot connect to D: resolve failed
```

Fix: on `win32`, resolve the bsdtar shipped with Windows 10 1803+ at `%SystemRoot%\System32\tar.exe` explicitly (which the existing comment already assumed) instead of relying on PATH order. macOS/Linux keep the PATH-resolved `tar`. If System32 `tar.exe` is missing, the command falls back to the previous PATH behavior, so there is no regression below the repo's Windows 10 1809 baseline.

## Test plan

- [x] New `pinvou3-app/tests/tauri_chrome_devtools_mcp_tar.test.js` covers the resolution matrix (non-win32, System32 present/missing, missing `SystemRoot`, environment default) and a source contract that the extraction goes through `systemTarCommand()` and never spawns a bare `"tar"`.
- [x] `node --test tests/tauri_chrome_devtools_mcp_tar.test.js tests/tauri_effective_config.test.js`: 2/2 pass.
- [x] End-to-end regression on macOS: `node scripts/tauri/chrome-devtools-mcp.js` re-vendored 1.7.0 through the modified extraction call (download → SHA-512 → extract → adapter → 29-tool catalog) and exited 0.
- [x] `npm run lint:node` (0 errors), `npm run lint:knip` (clean), `python3 scripts/architecture-guard.py` (passed).

The real Windows validation is the `release-packages` workflow after merge; the failing step will resolve `tar` through System32 and no longer depend on Git-bash PATH order.
