### PR TITLE
ci: fix rust-test hosted-runner loss (main push + merge queue)

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -5,8 +5,9 @@ name: mac-build
 # runner:macos-15(GitHub-hosted Apple Silicon,M Series;钉死大版本号以保证可复现)。
 #
 # 与 pr-check.yml 的 rust-test 关系:
-# - rust-test runs full lib tests for high-risk ready PRs, matching merge groups,
-#   and every main push. Explicitly low-risk Rust changes use the fast gate.
+# - rust-test runs full lib tests for high-risk ready PRs and matching merge
+#   groups; main push runs cumulative compile-only verification (--no-run) to
+#   warm the shared cache. Explicitly low-risk Rust changes use the fast gate.
 # - mac-build 在 macos-15 上只跑 cargo check + cargo test --lib + release-fast 冒烟,
 #   验证 macOS 平台目标零回归。真发版的 thin-LTO --release 产物由 scripts/release-macos.sh 产出。
 # - mac-build 不跑 relay e2e(那需要 remote-control-relay 的 node_modules,mac-build 不装

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -720,8 +720,11 @@ jobs:
       # 不设 codegen-units:dev 默认 256,对 test 改动最小(不影响 release 的 codegen=1)。
       CARGO_PROFILE_DEV_LTO: "thin"
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld -C link-arg=-Wl,--thinlto-jobs=1 -C link-arg=-Wl,--threads=1"
-    # dev profile 的 line-tables-only 已固化进 Cargo.toml [profile.dev],不再需要
-    # CARGO_PROFILE_DEV_DEBUG 环境变量。
+      # Cargo.toml [profile.dev] 固化 line-tables-only(本地调试体验);CI 改为完全
+      # 关闭 DWARF:panic 的 file:line 由 Location(rodata)提供,不依赖 debuginfo。
+      # 关掉后缩小目标文件与测试二进制体积,降低 ThinLTO link 内存峰值和 target
+      # 目录磁盘占用(16GB runner 上 rust-test 链接期多次把 runner 打到失联)。
+      CARGO_PROFILE_DEV_DEBUG: "0"
     steps:
       - name: Checkout (含 submodule)
         uses: actions/checkout@v7
@@ -743,7 +746,8 @@ jobs:
             librsvg2-dev libssl-dev \
             libx11-dev libxi-dev libxtst-dev \
             libayatana-appindicator3-dev \
-            build-essential pkg-config cmake lld
+            build-essential pkg-config cmake lld \
+            time
 
       # bge-m3 是 gitignored 大资源(559M),CI 干净 checkout 没有它,而 tauri_build::build()
       # 会校验 tauri.conf resources 路径存在。单测用 mem()=embedder None、不加载真模型,真
@@ -799,6 +803,11 @@ jobs:
 
       # High-risk/explicit PRs and matching merge groups run all lib tests
       # (含真实 relay/Chrome e2e)。
+      # 编译链接与测试执行拆成两个 step:该 job 在 16GB hosted runner 上多次在
+      # 本环节被打到 runner 失联(日志全丢,只剩 step 状态可查),拆开后失联时
+      # 能定位是编译/链接期还是测试执行期。ci-memguard.sh 每 5s 输出内存/磁盘
+      # 时间序列,并在可用内存跌破阈值时抢先杀掉 cargo/rustc/lld,把 runner
+      # 失联转化为带完整日志的 step 失败。
       # 保留 --test-threads=1:虽已把 env 写测试收敛到 crate 级唯一锁
       # (bridge::paths::tests::ENV_LOCK),但进程级 env 对未持锁的读取者仍全局可见，
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
@@ -806,13 +815,32 @@ jobs:
       # 或让所有读写都通过同一隔离层，超出本 PR 范围。
       # strict_mode 的三个确定性回归已并入 pinvou3_lib 单测，和全量 lib tests
       # 共用一次编译与链接，避免第二个 integration test 目标重复链接全依赖树。
+      - name: cargo test --lib --no-run（编译链接测试二进制）
+        if: ${{ github.event_name != 'push' }}
+        run: |
+          bash scripts/ci-memguard.sh &
+          guard_pid=$!
+          set +e
+          /usr/bin/time -v cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
+          status=$?
+          set -e
+          kill "$guard_pid" 2>/dev/null || true
+          exit "$status"
+
       - name: cargo test --lib（含 strict_mode 回归；真 bge-m3/vLLM 测试已 #[ignore]）
         if: ${{ github.event_name != 'push' }}
         run: |
           chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
           export CHROME="$chrome"
           export PINVOU_REQUIRE_REMOTE_E2E=1
+          bash scripts/ci-memguard.sh &
+          guard_pid=$!
+          set +e
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1
+          status=$?
+          set -e
+          kill "$guard_pid" 2>/dev/null || true
+          exit "$status"
 
       # push(main) 唯一目的是暖 cache(Swatinem/rust-cache save-if main)。
       # MQ 已对同一代码跑过完整 lib 测试,squash 合并后的 push 不再重复执行测试;
@@ -820,11 +848,19 @@ jobs:
       # 供热 MQ restore 后增量复用,省去测试执行时间。
       # 不需要 relay/Chrome 运行时依赖(上方 setup-node/relay/浏览器 step 已按 !=push 跳过)。
       # 2026-08-28 #372 曾让 push 改跑全量测试:main push 恢复暖 cache 后连续 5 次
-      # "hosted runner lost communication"(16GB runner 资源耗尽,MQ 同代码冷编译反而
-      # 全绿),故恢复只编译设计;不要在 push 上重新打开测试执行。
+      # "hosted runner lost communication"(MQ 自身也间歇性失联,push 100% 触发),
+      # 故恢复只编译设计;不要在 push 上重新打开测试执行。
       - name: cargo test --lib --no-run (push main 仅编译暖 cache)
         if: ${{ github.event_name == 'push' }}
-        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
+        run: |
+          bash scripts/ci-memguard.sh &
+          guard_pid=$!
+          set +e
+          /usr/bin/time -v cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
+          status=$?
+          set -e
+          kill "$guard_pid" 2>/dev/null || true
+          exit "$status"
 
   windows-rust-test:
     name: windows-rust-test

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,8 @@ name: PR Check
 #   语法检查；依赖或策略改动时追加 cargo-deny，不依赖 Tauri workspace 间接覆盖。
 # - rust-test: Draft and explicitly low-risk Rust changes skip the large test
 #   binary. Ready high-risk PRs and their combined Merge Queue tree run Linux
-#   regressions; Windows runs once on the ready PR. Main always runs both.
+#   regressions; Windows runs once on the ready PR. main push 无条件累计编译
+#   验证并写暖 cache(--no-run,不执行测试;MQ 已对同一组合树跑过全量测试)。
 # - rust-lint:Draft 只跑 fmt；Ready/Queue/main 跑 clippy；cargo-deny 仅在依赖
 #   或策略路径变化时追加，三项均无 continue-on-error。
 #   与 rust-test 并行,各自独立 cache。clippy 规则见 Cargo.toml [lints] 表:
@@ -30,7 +31,8 @@ name: PR Check
 #
 # Cache 策略(2026-07 诊断:PR cache 挂 refs/pull/N/merge 作用域互不可见 + 1.3GB/份
 # 顶死 10GB 限额被 LRU 秒驱逐 → 每轮全冷编译 ~9min):
-# - Main runs full rust-test and stores a main-scoped cache for high-risk/explicit PRs.
+# - Main compiles rust-test targets (--no-run) and stores a main-scoped cache for
+#   high-risk/explicit PRs; full test execution stays on the Merge Queue/PR leg.
 # - save-if 仅 main:PR 侧只读不写,不再刷爆限额挤掉暖 cache。
 # - rust-cache 的 restore 有前缀回退(restoreKey 不含 lockfile hash),PR 改 Cargo.lock
 #   也能从 main cache 增量编译,不再全冷。
@@ -668,7 +670,8 @@ jobs:
     needs: changes
     # Ready high-risk PRs and matching merge groups run the full Linux regression.
     # Explicitly low-risk leaf changes stay on compile/lint feedback; unknown Rust
-    # paths fail closed through rust_full. Main always runs the cumulative regression.
+    # paths fail closed through rust_full. main push 无条件执行累计编译验证并写暖
+    # cache(防 concurrency pending 替换盲区),但只编译不执行测试(见下方 --no-run)。
     if: >-
       ${{
         !cancelled() &&
@@ -764,9 +767,10 @@ jobs:
         run: rustup default "$(rustup show active-toolchain | awk '{print $1}')"
 
       # remote_control 的真实 relay 下载 e2e 需要 node + relay 依赖,缺 node_modules/ws 时
-      # Install relay dependencies so high-risk PR, combined-tree, and main runs
-      # execute the real e2e instead of silently skipping it.
+      # 该 e2e 会自动 skip —— 装上依赖让 CI 真正执行它,而不是绿灯假过。
+      # push(main) 只编译不执行测试(见下方 --no-run),不需要 relay/Chrome 运行时依赖。
       - name: Node.js (relay e2e)
+        if: ${{ github.event_name != 'push' }}
         uses: actions/setup-node@v7
         with:
           node-version: "22"
@@ -774,9 +778,11 @@ jobs:
           cache-dependency-path: remote-control-relay/package-lock.json
 
       - name: relay 依赖 (真实 relay e2e)
+        if: ${{ github.event_name != 'push' }}
         run: npm --prefix remote-control-relay ci --prefer-offline --no-audit
 
       - name: 浏览器驱动依赖 (真实 Chrome 下载 e2e)
+        if: ${{ github.event_name != 'push' }}
         # real-browser driver 从 pinvou3-app/node_modules 加载 puppeteer-core。
         # npm --prefix pinvou3-app install 即使指定单包也会解析并安装项目完整依赖树，
         # 因此直接用 package-lock 驱动的 npm ci，避免额外维护一份硬编码版本并保证可复现。
@@ -791,7 +797,8 @@ jobs:
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      # High-risk/explicit PRs, matching merge groups, and main run all lib tests.
+      # High-risk/explicit PRs and matching merge groups run all lib tests
+      # (含真实 relay/Chrome e2e)。
       # 保留 --test-threads=1:虽已把 env 写测试收敛到 crate 级唯一锁
       # (bridge::paths::tests::ENV_LOCK),但进程级 env 对未持锁的读取者仍全局可见，
       # 多线程测试仍可能观察到其他测试的临时值。Mutex poison 后通过 into_inner()
@@ -800,11 +807,24 @@ jobs:
       # strict_mode 的三个确定性回归已并入 pinvou3_lib 单测，和全量 lib tests
       # 共用一次编译与链接，避免第二个 integration test 目标重复链接全依赖树。
       - name: cargo test --lib（含 strict_mode 回归；真 bge-m3/vLLM 测试已 #[ignore]）
+        if: ${{ github.event_name != 'push' }}
         run: |
           chrome="$(command -v google-chrome || command -v chromium || command -v chromium-browser)"
           export CHROME="$chrome"
           export PINVOU_REQUIRE_REMOTE_E2E=1
           cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1
+
+      # push(main) 唯一目的是暖 cache(Swatinem/rust-cache save-if main)。
+      # MQ 已对同一代码跑过完整 lib 测试,squash 合并后的 push 不再重复执行测试;
+      # --no-run 编译含 test harness 的全部 target 产物(与完整 test 的编译腿一致),
+      # 供热 MQ restore 后增量复用,省去测试执行时间。
+      # 不需要 relay/Chrome 运行时依赖(上方 setup-node/relay/浏览器 step 已按 !=push 跳过)。
+      # 2026-08-28 #372 曾让 push 改跑全量测试:main push 恢复暖 cache 后连续 5 次
+      # "hosted runner lost communication"(16GB runner 资源耗尽,MQ 同代码冷编译反而
+      # 全绿),故恢复只编译设计;不要在 push 上重新打开测试执行。
+      - name: cargo test --lib --no-run (push main 仅编译暖 cache)
+        if: ${{ github.event_name == 'push' }}
+        run: cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-run
 
   windows-rust-test:
     name: windows-rust-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,10 +111,11 @@ Clippy, compile, and dependency-policy checks there. High-blast-radius Rust chan
 also run the full Linux behavior regression on the combined tree; Windows coverage
 already ran on the ready PR and is not repeated. Frontend changes run browser smokes
 selected from the merge group's actual base/head diff; shared, unknown, or test-
-infrastructure paths fall back to the complete smoke set. Full Linux and Windows
-Rust regressions run on every retained `main` push and continue to warm the shared
-caches. A red main regression is a stop signal for further queueing until it is
-fixed or reverted. During review, maintainers should inspect only required checks:
+infrastructure paths fall back to the complete smoke set. Every retained `main` push
+runs cumulative Linux compile verification (full test execution stays on the
+merge-queue leg, which already validates the same combined tree) and native Windows
+checks, and continues to warm the shared caches. A red main regression is a stop
+signal for further queueing until it is fixed or reverted. During review, maintainers should inspect only required checks:
 
 ```bash
 gh pr checks <number> --required

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -102,8 +102,9 @@ Merge Queue 在入队 PR 与最新 `main` 的实际组合树上运行适用门�
 运行格式、Clippy、编译和依赖策略检查；高爆炸半径 Rust 改动还会在组合树上执行
 完整 Linux 行为回归，Windows 已在 Ready PR 验证，不在队列重复。前端改动按
 merge group 的真实 base/head diff 选择浏览器 smoke，共享、未知或测试设施路径
-fail-closed 回退全套。每个保留下来的 `main` push 都执行完整 Linux / Windows
-Rust 回归并持续写暖缓存；main 回归变红后应停止继续入队，直至修复或回滚。
+fail-closed 回退全套。每个保留下来的 `main` push 都执行 Linux 累计编译验证
+（全量测试由 Merge Queue 在同一组合树上完成，push 不重复执行）与 Windows
+原生检查，并持续写暖缓存；main 回归变红后应停止继续入队，直至修复或回滚。
 评审阶段只查看 required checks：
 
 ```bash

--- a/docs/marketplace-unification.md
+++ b/docs/marketplace-unification.md
@@ -216,9 +216,9 @@ install_bundle(id):
 5. **审计成对**：授权/拦截/迁移决策落事件日志。
 6. **fork 边界**：底座只进三条通用缝；每次 gitlink 更新跑 `fork-guard.sh --fast`
    + 契约测试；fork-distinct 行为同步登记 `docs/fork-modifications.md`。
-7. **Validation baseline**: high-risk ready PRs and main run
-   `cargo test --lib -- --test-threads=1`; high-risk merge groups repeat the Linux
-   behavior regression on the combined tree. Bundle tests share
+7. **Validation baseline**: high-risk ready PRs and high-risk merge groups run
+   `cargo test --lib -- --test-threads=1` on the combined tree; main push keeps
+   cumulative compile verification (`--no-run`) and cache warming. Bundle tests share
    `platform::paths::tests::ENV_LOCK`; `cargo fmt --check` and
    `architecture-guard.py` must pass.
 

--- a/scripts/ci-memguard.sh
+++ b/scripts/ci-memguard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# rust-test CI 内存看门狗。
+#
+# 背景:ubuntu-latest hosted runner 只有 16GB 内存。rust-test 的测试二进制
+# 链接(700+ crate 的 ThinLTO,lld 单线程)是数分钟的内存高峰,历史上多次把
+# runner 打到与 GitHub 失联("The hosted runner lost communication with the
+# server");一旦失联,该 job 的日志全部丢失,无法取证是编译、链接还是测试
+# 执行耗尽了内存。
+#
+# 本脚本在后台以 5s 间隔输出 MemAvailable / 磁盘剩余 / RSS 前三进程的时间
+# 序列;当可用内存跌破阈值时抢先 KILL cargo/rustc/lld/测试二进制,把
+# 「runner 失联零日志」转化为「step 失败但日志完整」,保住诊断现场。
+#
+# 用法:在 cargo step 内后台启动,step 结束时 kill 掉:
+#   bash scripts/ci-memguard.sh &
+#   guard_pid=$!
+#   cargo test ...
+#   kill "$guard_pid" 2>/dev/null || true
+set -u
+
+THRESHOLD_KB=${MEMGUARD_THRESHOLD_KB:-1572864} # 默认 1.5 GiB
+
+while :; do
+  avail_kb=$(awk '/MemAvailable/ {print $2}' /proc/meminfo)
+  disk_free=$(df -h / | awk 'NR==2 {print $4}')
+  top=$(ps -eo rss=,comm= --sort=-rss | head -3 | awk '{printf "%s=%dMB ", $2, $1/1024}')
+  echo "$(date -u +%H:%M:%S) MemAvailable=$((avail_kb / 1024))MB disk_free=${disk_free} top: ${top}"
+  if [ "${avail_kb}" -lt "${THRESHOLD_KB}" ]; then
+    echo "MEMGUARD: MemAvailable 跌破 $((THRESHOLD_KB / 1024))MB,抢先杀掉 cargo/rustc/lld/测试进程以保住 runner"
+    pkill -KILL -f 'ld\.lld' || true
+    pkill -KILL -x rustc || true
+    pkill -KILL -x cargo || true
+    pkill -KILL -f 'pinvou3_lib-' || true
+    exit 42
+  fi
+  sleep 5
+done

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -393,6 +393,17 @@ class CiGatePolicyTests(unittest.TestCase):
             "        if: ${{ github.event_name == 'push' }}",
             rust_test,
         )
+        # 16GB runner 失联防护:编译与执行拆成独立 step(失联后日志全丢,按 step
+        # 状态定位阶段),内存看门狗把 runner 失联转化为带日志的 step 失败,CI 关
+        # DWARF 缩小测试二进制降低链接内存峰值。三条腿(push/MQ 编译/MQ 执行)
+        # 都必须挂看门狗。
+        self.assertIn(
+            "- name: cargo test --lib --no-run（编译链接测试二进制）\n"
+            "        if: ${{ github.event_name != 'push' }}",
+            rust_test,
+        )
+        self.assertEqual(rust_test.count("bash scripts/ci-memguard.sh &"), 3)
+        self.assertIn('CARGO_PROFILE_DEV_DEBUG: "0"', rust_test)
         self.assertIn("timeout-minutes: 120", rust_test)
         self.assertIn(
             'RUSTFLAGS: "-C link-arg=-fuse-ld=lld '

--- a/scripts/tests/test_ci_gate_policy.py
+++ b/scripts/tests/test_ci_gate_policy.py
@@ -371,7 +371,8 @@ class CiGatePolicyTests(unittest.TestCase):
             "contains(github.event.pull_request.labels.*.name, 'ci:full-rust')",
             rust_test,
         )
-        # Main is a cumulative regression and must not depend on adjacent diff paths.
+        # Main is a cumulative compile verification and must not depend on
+        # adjacent diff paths.
         self.assertIn(
             "github.event_name == 'push' ||",
             rust_test,
@@ -380,7 +381,18 @@ class CiGatePolicyTests(unittest.TestCase):
             "cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1",
             rust_test,
         )
-        self.assertNotIn("cargo test --lib --no-run", rust_test)
+        # push(main) 只编译暖 cache,不执行测试:MQ 已对同一组合树跑过全量测试;
+        # push 恢复暖 cache 后跑全量测试曾连续触发 hosted runner 失联(见 workflow 注释)。
+        self.assertIn(
+            "- name: cargo test --lib（含 strict_mode 回归；真 bge-m3/vLLM 测试已 #[ignore]）\n"
+            "        if: ${{ github.event_name != 'push' }}",
+            rust_test,
+        )
+        self.assertIn(
+            "- name: cargo test --lib --no-run (push main 仅编译暖 cache)\n"
+            "        if: ${{ github.event_name == 'push' }}",
+            rust_test,
+        )
         self.assertIn("timeout-minutes: 120", rust_test)
         self.assertIn(
             'RUSTFLAGS: "-C link-arg=-fuse-ld=lld '


### PR DESCRIPTION
## Why

Two overlapping failures, same root cause family — the 16 GB hosted runner dying inside the `cargo test --lib` step:

**1. main push: 100% runner loss since #372.** #372 switched the main-push `rust-test` leg from compile-only cache warming (`--no-run`) to executing the full `cargo test --lib` suite. Since then 5 of 6 main-push `rust-test` jobs died mid-step with "The hosted runner lost communication with the server". The merge queue already runs the full Linux regression on the exact combined tree, so main-push test execution is redundant.

**2. merge queue: intermittent runner loss for weeks.** 10 MQ runs lost the runner the same way since 2026-08-17 (always inside the `cargo test --lib` step). The step compiles and links one test binary from 767 crates; on a green run the ThinLTO single-threaded link alone runs 5+ minutes. Its memory peak rides the 16 GB limit, so some runs tip over. When the runner is lost, GitHub discards all job logs — the failure has never been diagnosable beyond the step-level status.

## What changes

**Push leg (revert to proven-green design):**
- push(main) goes back to compile-only: Node/relay/Chrome e2e dependency steps and the full test step are gated to `event != 'push'`; a `cargo test --lib --no-run` step keeps warming the main-scoped cache. A comment records the incident so this does not get re-opened accidentally.

**MQ/PR leg (keep full regression, stop losing runners):**
- Split compile+link (`--no-run`) and test execution into separate steps — a lost run then localizes the failing phase via step status.
- New `scripts/ci-memguard.sh` wraps every cargo leg: samples MemAvailable/disk/top-RSS every 5 s into the step log, and kills cargo/rustc/lld before the box dies — turning a silent runner loss into a step failure with complete logs (memory time series included).
- `CARGO_PROFILE_DEV_DEBUG=0` for this job: panic `file:line` comes from `Location` rodata, not DWARF, so CI keeps actionable failure output while objects, the test binary, and the link memory peak shrink.
- `/usr/bin/time -v` on the compile legs records peak RSS on green runs, giving baseline headroom data.

**Tests/docs:** `test_ci_gate_policy.py` updated to lock the new structure (step guards, memguard on all three legs, debug env); `CONTRIBUTING*.md`, `docs/marketplace-unification.md`, `mac-build.yml` comments synced.

## Verification

- `pytest scripts/tests/test_ci_gate_policy.py` 19/19, `test_benchmark_isolation_policy.py` 5/5, `test_architecture_guard.py` 10/10; YAML validated; `bash -n` on the new script.
- Real validation lands after merge: the next MQ runs and the next retained main push should stay green; if memory still tips over, the memguard converts it into a logged, localized step failure instead of a lost runner.