### PR TITLE
chore: align Cargo.lock member versions to 0.8.8

### DIFF
--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -6055,7 +6055,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pinvou-knowledge"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "pinvou3-tauri"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "age",
  "agent-backend-api",


### PR DESCRIPTION
## Background

`chore(release): bump version to 0.8.8` (#374) updated the workspace members' `Cargo.toml` versions via `node scripts/sync-version.mjs`, but `pinvou3-app/src-tauri/Cargo.lock` still recorded the two workspace member entries at 0.8.7. Every subsequent cargo invocation therefore wants to rewrite the lock, and any `cargo test --locked` / `--locked` gate fails at the resolution step — before compiling:

```
error: cannot update the lock file .../Cargo.lock because --locked was passed to prevent this
```

Found while re-running the combined-tree gates on PR #216.

## Changes

Regenerate `pinvou3-app/src-tauri/Cargo.lock` on current `main` so the member entries match the manifests:

- `pinvou-knowledge` 0.8.7 → 0.8.8
- `pinvou3-tauri` (root) 0.8.7 → 0.8.8

Third-party `0.8.7` pins in the lock (e.g. `rand`, `crossbeam-deque`, `core-foundation-sys`) are untouched; the diff is exactly these two lines.

## Verification

- `cargo metadata --locked --offline`: pass (was the failing check)
- `cargo test --locked --offline --lib` end-to-end on this tree: resolution passes, full compile succeeds, `forkguard_search_provider_translates_from_prefs` 1/1 pass
- `cargo fmt --check`: clean; `scripts/validate-commit-msg.py`: pass; `git diff --check`: clean

## Follow-up note

`scripts/sync-version.mjs` does not update `Cargo.lock`; every future `VERSION` bump will reintroduce this drift. Consider teaching the script to refresh the lock's member entries (or documenting a `cargo metadata` re-run in the release checklist) in a separate change.
