### PR TITLE
ci: purge poisoned rust-test cache lineage

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -797,7 +797,15 @@ jobs:
         with:
           workspaces: pinvou3-app/src-tauri
           # 稳定 key 前缀(跨 PR/push 一致);restore 按前缀回退,lock 变了也增量。
-          shared-key: rust-test
+          # 2026-08-29 事故:当日 11:28(UTC)保存的 rust-test cache 谱系产物被污染
+          # (#379 切换 CARGO_PROFILE_DEV_DEBUG=0 期间,旧 codegen 产物与新产物混存于
+          # 同一 target 被整体打包),凡 restore 该谱系链接出的测试二进制,执行数秒内
+          # 把 runner VM 打到失联(1s 遥测实证:MemAvailable ~14.6GB、磁盘/负载全程
+          # 健康,死亡点在套件内随机;全新 cache 冷编译对照组同 runner 池全绿,
+          # Windows 谱系不受影响)。已 purge 污染谱系并 bump key 切断前缀回退。
+          # 今后修改 RUSTFLAGS / CARGO_PROFILE_* / rust-toolchain 等影响 codegen
+          # 的输入时必须同步 bump 此 key,避免新旧产物混链再次污染。
+          shared-key: rust-test-v2
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## 根因(2026-08-29 多轮遥测取证)

rust-test 100% runner 失联的致死因子是 **rust-test cargo cache 谱系被污染**,不是测试内容、不是 runner 池、也不是编译期内存峰值:

- 8-29 11:28(UTC)由 main push 保存的 `v0-rust-rust-test-Linux-x64-5ebc4fcf-*`(1.07GB)在 #379 切换 `CARGO_PROFILE_DEV_DEBUG=0` 期间把新旧 codegen 产物混存进同一 target 打包;
- 凡 restore 该谱系链接出的测试二进制,执行数秒内 VM 失联。1s 分辨率遥测实证死亡前全程健康(MemAvailable ~14.6GB / 磁盘 80G / load ~3.5),死亡点在套件内随机(turn_lifecycle / updater / bridge / sessions / session_browser_cleanup / marketplace 都出现过);
- A/B 对照(同一 runner 池相隔 7 分钟):restore 污染谱系 → 死;全新 cache key 冷编译 → 全绿。Windows 谱系不受影响(独立 cache);
- 历史绿灯 run 33246493841 的 rerun(旧代码 + 今天的 cache)同样失败 → 与 PR 代码无关。

## 修复

1. 已 `gh cache delete` purge 两条 rust-test Linux 污染谱系(5ebc4fcf / 5316ac1e);
2. `shared-key: rust-test → rust-test-v2` 切断前缀回退;注释固化规则:今后修改 RUSTFLAGS / CARGO_PROFILE_* / rust-toolchain 等影响 codegen 的输入必须同步 bump key。

## 验证

- 含本修复的 run 33265156959:rust-test 编译腿(全冷 15m02s)+ 执行腿全绿,1718 passed / 11 ignored。
- (第一轮修复里还带了 env 对齐,实测对下述残留无效,已回退,保持最小 diff。)

## 已知残留(不阻断,另案跟进)

执行腿内 cargo 会重编一次根 crate(`Compiling pinvou3-tauri` → Finished in 1m42s,然后测试仅 6.9s)。已实证与 CHROME/PINVOU_REQUIRE_REMOTE_E2E env 无关;可能源于 tauri-build/缓存指纹细节,可用 `CARGO_LOG=cargo::core::compiler::fingerprint=trace` 另案定位。纯耗时浪费,无失联风险(本 run 实测内存健康)。

诊断遥测分支见 #381(不合并)。