### PR TITLE
ci: stop caching rust-test target dir (runner loss)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -796,15 +796,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: pinvou3-app/src-tauri
+          # 2026-08-29/30 事故:凡 restore 本 job 的 target/ 缓存并据其链接出的
+          # 测试二进制,执行数秒内把 runner VM 打到失联(1s 遥测实证:内存/磁盘/
+          # 负载全程健康,死亡点在套件内随机)。与 cache 内容的新旧无关——#379
+          # (debug=0)之后每次 main push 保存的 target/ 都在 restore 后复现致死,
+          # 而全冷编译(不吃 target/ 缓存)的对照组同 runner 池 100% 全绿;
+          # 纯文档 PR 也死,与 PR 代码无关。根因定位期间先关掉 target/ 缓存:
+          # 只缓存 ~/.cargo(registry/git 索引,省下载),target/ 每次全冷编译
+          # (~15 分钟,与绿色对照组同构)。根因查明并验证前不要重新打开。
+          cache-targets: false
           # 稳定 key 前缀(跨 PR/push 一致);restore 按前缀回退,lock 变了也增量。
-          # 2026-08-29 事故:当日 11:28(UTC)保存的 rust-test cache 谱系产物被污染
-          # (#379 切换 CARGO_PROFILE_DEV_DEBUG=0 期间,旧 codegen 产物与新产物混存于
-          # 同一 target 被整体打包),凡 restore 该谱系链接出的测试二进制,执行数秒内
-          # 把 runner VM 打到失联(1s 遥测实证:MemAvailable ~14.6GB、磁盘/负载全程
-          # 健康,死亡点在套件内随机;全新 cache 冷编译对照组同 runner 池全绿,
-          # Windows 谱系不受影响)。已 purge 污染谱系并 bump key 切断前缀回退。
-          # 今后修改 RUSTFLAGS / CARGO_PROFILE_* / rust-toolchain 等影响 codegen
-          # 的输入时必须同步 bump 此 key,避免新旧产物混链再次污染。
           shared-key: rust-test-v2
           # 只在 main 保存(暖 cache 唯一来源);PR 侧只读,不占 10GB 限额。
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -413,6 +413,23 @@ async function expand(page) {
       .filter(call => call.cmd === 'browser_show_native_surface').length >= 2);
     const generationRecovered = window.__TAURI_INVOKES__
       .filter(call => call.cmd === 'browser_show_native_surface').length >= 2;
+    // Opening the browser collapses the app sidebar with a transition. Let both
+    // the narrow layout and the legacy-width ratio migration settle before
+    // measuring drag geometry; otherwise a ResizeObserver render can race the
+    // synthetic pointer sequence and discard the transient panel width.
+    await window.__uiWait__(() =>
+      (document.querySelector('[data-testid="app-sidebar"]')?.getBoundingClientRect().width || 0) < 100
+      && (document.querySelector('[data-testid="chat-composer-wrap"]')?.getBoundingClientRect().width || 0) > 300);
+    await window.__uiStable__(() => {
+      const host = document.querySelector('[data-testid="right-dock-host"]');
+      return host ? [
+        host.getBoundingClientRect().width,
+        host.parentElement?.getBoundingClientRect().width || 0,
+        host.dataset.preferredRatio,
+        localStorage.getItem('pinvou_right_dock_ratio'),
+        host.querySelector('[role="separator"]')?.getBoundingClientRect().left,
+      ] : null;
+    });
     const separator = dockHost?.querySelector('[role="separator"]');
     const widthBeforeResize = dockHost?.getBoundingClientRect().width || 0;
     const migratedRatio = Number.parseFloat(localStorage.getItem('pinvou_right_dock_ratio') || '0');


### PR DESCRIPTION
## 背景

#382 的 purge+换 key 只清了存量。v2 cache(05:31 UTC 由 main push 冷编译保存)之后,**12 个 PR 的 rust-test 全部 runner 失联**,含两个纯文档 PR(Rust 代码与 main 完全相同)——与 PR 代码无关。

## 修正后的判别结论

- 全冷编译(不吃 target/ 缓存)的 run 100% 全绿(#382 两次验证、probe 对照、tech-debt-cleanup);
- 凡 restore 本 job target/ 缓存并据其链接测试二进制的 run,执行腿开始数秒内 VM 失联,日志被 GitHub 全删;
- 致死因子随每次 main push 的 cache 保存**再生**,purge 无法根治。

## 本 PR(止血)

rust-test job 的 rust-cache 改 `cache-targets: false`:只缓存 ~/.cargo(registry/git 索引),target/ 每次全冷编译(~15 分钟,与绿色对照组同构)。rust-lint / knowledge-rust / windows-rust-test 的缓存不受影响(它们 restore 后正常)。

代价:rust-test 每次全冷编译,MQ 每个合并周期多 ~15 分钟。根因查明并验证前不恢复 target/ 缓存。

## 进行中

遥测取证在 #381 继续(无缓冲输出 + 1s 采样 + dmesg),定位为什么 restore 的 target/ 会致死;同时计划做 restore vs 冷编译产物逐字节 hash 对比。根因查明后再评估恢复 target/ 缓存。