### PR TITLE
fix(engine): preserve unsubmitted reservation across reclaim

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/engine.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine.rs
@@ -226,6 +226,11 @@ struct TranscriptFallback {
 /// any transcript sanitization rule prepared for the operation. Once
 /// `mark_submitted` is called, the authoritative engine terminal event owns
 /// lifecycle completion.
+///
+/// The reservation is bound to the session-scoped lifecycle, not to any one
+/// engine: engine reclaim (idle reap, model-change rebuild) leaves an
+/// unsubmitted reservation valid so its pending send can respawn a fresh
+/// engine and submit to it.
 pub(crate) struct TurnReservation {
     lifecycle: Arc<TurnLifecycle>,
     reservation_id: u64,
@@ -799,39 +804,33 @@ impl TurnLifecycle {
         Some(transition)
     }
 
-    /// Reclaim a lifecycle after an engine disappears. A reservation which
-    /// never reached the engine mailbox is invalidated silently; only an
-    /// accepted/started operation owns a user-visible terminal event.
+    /// Reclaim a lifecycle after an engine disappears. Only a submitted
+    /// operation is claimed as a user-visible interrupted terminal. A
+    /// reservation which never reached the engine mailbox stays valid: the
+    /// lifecycle is session-scoped and survives engine replacement, so the
+    /// pending send respawns a fresh engine (lazy spawn) and submits to it
+    /// instead of failing with an invalidated reservation (#352).
     fn claim_reclaimed_transition(&self) -> Option<TerminalTransition> {
         let transition = {
             let mut state = self.state.lock();
-            if !state.active || state.terminal_emitted {
+            if !state.active || state.terminal_emitted || !state.submitted {
                 return None;
             }
+            let admission = Self::take_admission_locked(&mut state);
+            let fallback = Self::active_transcript_fallback_locked(&state);
             state.reclaimed = true;
-            if !state.submitted {
-                if let Some(reservation_id) = state.active_reservation_id.take() {
-                    Self::remove_unsubmitted_rule_locked(&mut state, reservation_id);
-                }
-                state.active = false;
-                state.turn_id = None;
-                None
-            } else {
-                let admission = Self::take_admission_locked(&mut state);
-                let fallback = Self::active_transcript_fallback_locked(&state);
-                state.terminal_emitted = true;
-                state.terminal_closing = true;
-                state.active = false;
-                state.submitted = false;
-                state.active_reservation_id = None;
-                Some(TerminalTransition {
-                    terminal: EmittedTerminal {
-                        turn_id: state.turn_id.take(),
-                    },
-                    admission,
-                    fallback,
-                })
-            }
+            state.terminal_emitted = true;
+            state.terminal_closing = true;
+            state.active = false;
+            state.submitted = false;
+            state.active_reservation_id = None;
+            Some(TerminalTransition {
+                terminal: EmittedTerminal {
+                    turn_id: state.turn_id.take(),
+                },
+                admission,
+                fallback,
+            })
         };
         transition
     }
@@ -1614,16 +1613,7 @@ impl AppEngine {
         session_id: &str,
         shell_cleanup_failed: bool,
     ) -> bool {
-        // 回收/中断不经过 TurnComplete：清掉 self_metrics 打点与 memory turn capture，
-        // 避免中断轮在进程级 map 里永久驻留。
-        if let Some(m) = app
-            .try_state::<crate::features::monitor::MonitorState>()
-            .map(|s| s.self_metrics())
-        {
-            m.on_turn_aborted(session_id);
-        }
-        crate::features::memory::discard_turn_capture(session_id);
-        match finish_reclaimed_lifecycle_turn(
+        let terminal = finish_reclaimed_lifecycle_turn(
             &self.turn_lifecycle,
             app,
             store,
@@ -1633,11 +1623,24 @@ impl AppEngine {
             shell_cleanup_failed,
             false,
         )
-        .await
+        .await;
+        let Some(terminal) = terminal else {
+            return false;
+        };
+        // 回收/中断不经过 TurnComplete：清掉 self_metrics 打点与 memory turn capture，
+        // 避免中断轮在进程级 map 里永久驻留。仅在确实认领到轮次时清理——未提交
+        // reservation 保持有效，它的轮次会在重建后的引擎上正常完成，不能提前清理。
+        if let Some(m) = app
+            .try_state::<crate::features::monitor::MonitorState>()
+            .map(|s| s.self_metrics())
         {
-            Some(EmittedTerminal {
+            m.on_turn_aborted(session_id);
+        }
+        crate::features::memory::discard_turn_capture(session_id);
+        match terminal {
+            EmittedTerminal {
                 turn_id: Some(turn_id),
-            }) => {
+            } => {
                 let _ = self.turn_events.send(EngineTurnSignal::Terminal {
                     turn_id,
                     status: TurnOutcomeStatus::Interrupted,
@@ -1645,8 +1648,7 @@ impl AppEngine {
                 });
                 true
             }
-            Some(EmittedTerminal { turn_id: None }) => true,
-            None => false,
+            EmittedTerminal { turn_id: None } => true,
         }
     }
 
@@ -2445,7 +2447,7 @@ mod turn_lifecycle_tests {
     }
 
     #[test]
-    fn reclaim_invalidates_reserved_turn_without_claiming_a_terminal() {
+    fn reclaim_preserves_unsubmitted_reservation_across_engine_removal() {
         let lifecycle = Arc::new(TurnLifecycle::default());
         let mut reservation = lifecycle.reserve().expect("reserve");
         reservation
@@ -2458,19 +2460,27 @@ mod turn_lifecycle_tests {
             .prepare_actual_user_content("private unsent prompt".to_string())
             .expect("actual prompt");
 
+        // 引擎回收（idle reap / 模型变更重建）不得认领终态，也不得作废未提交
+        // reservation：lifecycle 是 session 级，发送方会在重建后的引擎上提交。
         assert!(lifecycle.claim_reclaimed_transition().is_none());
         assert_eq!(lifecycle.claim_terminal(), None);
-        let invalidated = reservation
+        reservation
             .prepare_actual_user_content("private unsent prompt".to_string())
-            .expect_err("reclaimed reservation must reject a later send");
-        assert!(invalidated.to_string().contains("reservation invalidated"));
-        drop(reservation);
-        let next = lifecycle.reserve().expect("reclaim released reservation");
-        let (messages, matched) =
+            .expect("reclaimed reservation stays valid for the respawned engine");
+        reservation
+            .ensure_active()
+            .expect("unsubmitted reservation survives engine reclaim");
+        // sanitization rule 同样存活：快照中的 raw prompt 仍会被替换为展示消息。
+        let (sanitized, matched) =
             lifecycle.sanitize_messages(vec![engine_user("private unsent prompt")]);
-        assert!(!matched);
-        assert_eq!(messages, vec![engine_user("private unsent prompt")]);
-        drop(next);
+        assert!(matched);
+        assert_eq!(sanitized, vec![message("user", "never submitted")]);
+        // reservation 仍持有唯一轮次槽位，直至 RAII Drop 归还。
+        assert!(lifecycle.reserve().is_err());
+        drop(reservation);
+        lifecycle
+            .reserve()
+            .expect("reservation drop releases the turn slot");
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -1199,11 +1199,15 @@ impl EnginePool {
     /// 复核会话仍然空闲（TOCTOU 防护）——`reap_idle_engines` 的候选快照到拿到
     /// 锁之间可能已有新 turn：`reserve_turn` 不取 gate 可先行 reserve
     /// （lifecycle 转 active），`send_reserved_user_message` 先抢 gate 提交并
-    /// 刷新活动时钟。此处若不复核，在跑 turn 会被 reclaim 收口成 Interrupted，
-    /// 已 reserve 未提交的 reservation 会被失效化、排队发送直接失败。复核要求
+    /// 刷新活动时钟。此处若不复核，在跑 turn 会被 reclaim 收口成 Interrupted
+    /// （未提交 reservation 则按下方语义保留，不会被失效）。复核要求
     /// 快照后活动时钟未前进且按现值仍满足回收条件（谓词见
     /// [`should_still_reap_after_snapshot`]）；不满足则跳过，留待下一轮巡检。
-    /// 返回是否真正回收。删除 / 切模型路径仍走 `evict`，语义不变。
+    /// 返回是否真正回收。删除 / 切模型路径仍走 `evict`，不做空闲复核；它们的
+    /// reclaim 对未提交 reservation 同样保留——删除路径发送方随后的
+    /// `store.load` 守卫仍会报错，切模型路径的待发消息会提交到重建后的新模型
+    /// 引擎。唯一仍会作废未提交 reservation 的是 [`Self::evict_locked`] 的
+    /// 无引擎分支（reserve 先于 lazy spawn 的窗口）。
     ///
     /// 残余窗口（复核之后、reclaim 收口之前的极短区间内新 reserve 的未提交
     /// reservation）不再失效：`claim_reclaimed_transition` 只认领已提交轮次，
@@ -1573,8 +1577,8 @@ impl EnginePool {
 
     /// 原子切换多智能体资源策略：先占用与发送相同的 lifecycle 槽位，再在
     /// session turn gate 内持久化状态并回收旧引擎。这样发送与切换不可能交错成
-    /// “新开关 + 旧引擎”或“旧开关 + 新引擎”。未提交 reservation 会在回收时
-    /// 静默失效，不产生伪造的 chat:done。
+    /// “新开关 + 旧引擎”或“旧开关 + 新引擎”。回收只认领已提交轮次，不产生
+    /// 伪造的 chat:done；本函数持有的占位 reservation 由 Drop 归还槽位。
     pub(crate) async fn reconfigure_multi_agent_mode(
         &self,
         session_id: &str,
@@ -1816,6 +1820,13 @@ impl EnginePool {
             // A user may have opened this conversation since the previous run.
             // Scheduled execution must rebuild from the latest task profile and
             // global model/provider settings instead of reusing that old client.
+            // Known limitation: a user reservation pending between reserve_turn
+            // and the turn gate on this fresh run session survives the reclaim
+            // (claim_reclaimed_transition preserves unsubmitted turns), so the
+            // send below bails "session_turn_in_progress" and this tick fails
+            // while the user's message goes through on the respawned engine.
+            // The window is ms-scale after create_session; every run owns a
+            // fresh session, so nothing propagates to the next run.
             self.evict_locked(session_id).await;
             let engine = match self
                 .get_or_spawn_with_policy(session_id, true, None)
@@ -2455,7 +2466,8 @@ mod scheduled_model_tests {
         // 空闲；快照后、回收拿到锁之前用户新发 turn（reserve_turn 不取 gate
         // 可先行 reserve，send_reserved_user_message 抢 gate 提交并刷新活动
         // 时钟）。复核必须发现活动并跳过回收，否则在跑 turn 会被 reclaim 收口
-        // 成 Interrupted，未提交 reservation 会被失效化导致发送直接失败。
+        // 成 Interrupted；未提交 reservation 虽已保留，仍会被无谓地换到重建
+        // 引擎上重提交。
         let turn_locks = SessionTurnLocks::default();
         let runtime_locks = SessionTurnLocks::default();
         let lifecycles = SessionTurnLifecycles::default();

--- a/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/engine_pool.rs
@@ -1205,9 +1205,10 @@ impl EnginePool {
     /// [`should_still_reap_after_snapshot`]）；不满足则跳过，留待下一轮巡检。
     /// 返回是否真正回收。删除 / 切模型路径仍走 `evict`，语义不变。
     ///
-    /// 已知残余窗口：复核之后、reclaim 收口之前的极短区间内新 reserve 的
-    /// 未提交 reservation 仍会被 `claim_reclaimed_transition` 静默失效（与
-    /// 删除路径同语义，不发伪造终态，发送侧收到明确错误），不阻断 turn。
+    /// 残余窗口（复核之后、reclaim 收口之前的极短区间内新 reserve 的未提交
+    /// reservation）不再失效：`claim_reclaimed_transition` 只认领已提交轮次，
+    /// 未提交 reservation 绑定的是 session 级 lifecycle 而非引擎，发送方会在
+    /// `get_or_spawn` 重建引擎后正常提交（#352）。
     async fn evict_if_idle(&self, session_id: &str, snapshot_last_active_ms: u64) -> bool {
         let active_id = self.store.active_id();
         evict_if_idle_with_gates(


### PR DESCRIPTION
## What

`claim_reclaimed_transition` now claims only submitted turns. A turn reservation that was reserved but not yet submitted stays valid when its engine is reclaimed: the lifecycle is session-scoped and survives engine replacement, so the pending send respawns a fresh engine (lazy spawn) and submits to it instead of failing.

Also gates the reclaim side effects (`self_metrics` abort, memory turn capture discard) on an actually claimed turn, so a surviving reservation is not cleaned up prematurely, and updates the `evict_if_idle` "known residual window" doc plus the rewritten lifecycle regression test.

Partially addresses #352 (the `send_user_message failed: turn reservation invalidated or no longer active` failure). The issue's other sub-problems — the stale 32.8K UI context denominator, the cumulative per-turn `input_tokens` billing semantics, and the missing per-model context-window override — are display/config-layer work and stay out of scope here.

## Why (root cause)

The reaper/rebuild invalidation killed reservations that never reached an engine mailbox, producing a local, millisecond-level send failure that never touched the model server. Two trigger paths:

1. **Idle-reaper residual window** (the reporter's 62 ms case): a reservation created between the reaper's in-gate recheck and its reclaim finalization was silently invalidated; the sender then failed at `ensure_active` after acquiring the turn gate.
2. **Model-save lazy rebuild** (deterministic): `save_model` only bumps the runtime-model revision, so the next turn's `get_or_spawn` reclaims the stale engine while the sender itself holds the turn gate, invalidating its own reservation before the respawned engine can submit.

Safety of preservation: an unsubmitted reservation has no tie to the removed engine — its op never reached the old engine mailbox (no zombie `TurnStarted` possible), the transcript rule is only installed at submission time, and `belongs_to` passes because every engine of a session shares the same session-scoped lifecycle.

## Impact & risk

- Unchanged semantics: submitted-turn interrupted terminal on reclaim, cancel (`claim_unsubmitted_terminal_impl`), session delete, and multi-agent reconfigure invalidation paths.
- Behavior change is confined to the reclaim path for unsubmitted reservations; worst case after the change is a slower first message (engine respawn) instead of a lost one.
- Risk is concentrated in the turn lifecycle state machine; covered by the rewritten regression test `reclaim_preserves_unsubmitted_reservation_across_engine_removal` plus the existing lifecycle suite.

## Tests run

- `cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib -- --test-threads=1` — 1721 passed, 0 failed (on the rebased branch)
- `cargo clippy --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib --no-deps` — no findings under `features/assistant` (pre-existing CodeWhale path-dep warnings only)
- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `python3 scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast` (no submodule change)

## Unverified

- The `save_model` lazy-rebuild end-to-end flow needs a real `AppEngine` (not constructible in tests); its semantic change is entirely inside `claim_reclaimed_transition` and covered at the lifecycle level.
- No manual app-level repro was performed (reproducing the reaper race requires shrinking `IDLE_EVICT_AFTER_SECS`/`REAP_INTERVAL_SECS` in a debug build).
- Local network to GitHub was intermittent during development; the branch was rebased onto the latest `origin/main` (`e198735d`) before this PR.
