### PR TITLE
fix(connectors): one-scan WeCom QR and browser-open allowlist

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -713,6 +713,8 @@ const EXTERNAL_URL_ALLOWLIST: &[&str] = &[
     "https://meeting.tencent.com/",
     // 企业微信扫码授权页(wecom-cli auth init 的 gen 落地页);连接企业微信走这里开浏览器
     "https://work.weixin.qq.com/",
+    // 钉钉 device 授权登录页(dws auth login --device 打印的 user_code 登录页);连接钉钉走这里开浏览器
+    "https://login.dingtalk.com/",
     // Obsidian 官网:知识库连接器探测到未安装时,引导用户下载
     "https://obsidian.md/",
     // Canva 可画 MCP 返回的设计编辑链接/预览图资源

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -711,9 +711,9 @@ const EXTERNAL_URL_ALLOWLIST: &[&str] = &[
     "https://accounts.larksuite.com/",
     // 腾讯会议 OAuth 授权页；连接腾讯会议时可从流程卡打开浏览器
     "https://meeting.tencent.com/",
-    // 企业微信扫码授权页(wecom-cli auth init 的 gen 落地页);连接企业微信走这里开浏览器
+    // WeCom scan-to-authorize page (the gen landing page printed by `wecom-cli auth init`); connecting WeCom opens the browser here
     "https://work.weixin.qq.com/",
-    // 钉钉 device 授权登录页(dws auth login --device 打印的 user_code 登录页);连接钉钉走这里开浏览器
+    // DingTalk device authorization login page (the user_code login page printed by `dws auth login --device`); connecting DingTalk opens the browser here
     "https://login.dingtalk.com/",
     // Obsidian 官网:知识库连接器探测到未安装时,引导用户下载
     "https://obsidian.md/",

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -711,6 +711,8 @@ const EXTERNAL_URL_ALLOWLIST: &[&str] = &[
     "https://accounts.larksuite.com/",
     // 腾讯会议 OAuth 授权页；连接腾讯会议时可从流程卡打开浏览器
     "https://meeting.tencent.com/",
+    // 企业微信扫码授权页(wecom-cli auth init 的 gen 落地页);连接企业微信走这里开浏览器
+    "https://work.weixin.qq.com/",
     // Obsidian 官网:知识库连接器探测到未安装时,引导用户下载
     "https://obsidian.md/",
     // Canva 可画 MCP 返回的设计编辑链接/预览图资源

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1537,6 +1537,7 @@ async fn open_external_url_rejects_off_allowlist_targets() {
         "https://www.canva.cn.evil.com/api/action",               // Canva 子域钓鱼
         "https://export-download.canva.cn.evil.com/x.png",        // Canva 资源域钓鱼
         "https://meeting.tencent.com.evil.com/qrcode-login.html", // 腾讯会议授权域钓鱼
+        "http://work.weixin.qq.com/ai/qc/gen",                    // 企业微信授权页非 https
         "https://bce.baidu.com/",                                 // 非 console 子域,不放行
         "javascript:alert(1)",                                    // js scheme
         "file:///etc/passwd",                                     // file scheme
@@ -1619,6 +1620,13 @@ fn external_allowlist_allows_known_targets_rejects_lookalikes() {
     assert!(url_in_external_allowlist(
         "https://docs.qq.com/scenario/open-claw.html?nlc=1"
     ));
+    // 企业微信扫码授权页(wecom-cli auth init 落地页)
+    assert!(url_in_external_allowlist(
+        "https://work.weixin.qq.com/ai/qc/gen?source=wecom_cli_external&scode=abc"
+    ));
+    assert!(url_in_external_allowlist(
+        "https://work.weixin.qq.com/ai/qc/c?s=abc&for_native=true"
+    ));
     assert!(url_in_external_allowlist("http://localhost:8080/"));
     assert!(url_in_external_allowlist("https://127.0.0.1:8443/preview"));
     assert!(url_in_external_allowlist("http://[::1]:3000/"));
@@ -1638,6 +1646,9 @@ fn external_allowlist_allows_known_targets_rejects_lookalikes() {
     ));
     assert!(!url_in_external_allowlist(
         "https://meeting.tencent.com.evil.com/qrcode-login.html"
+    ));
+    assert!(!url_in_external_allowlist(
+        "https://work.weixin.qq.com.evil.com/ai/qc/gen"
     ));
     assert!(!url_in_external_allowlist(
         "https://docs.qq.com.evil.com/scenario/open-claw.html?nlc=1"

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1538,6 +1538,7 @@ async fn open_external_url_rejects_off_allowlist_targets() {
         "https://export-download.canva.cn.evil.com/x.png",        // Canva 资源域钓鱼
         "https://meeting.tencent.com.evil.com/qrcode-login.html", // 腾讯会议授权域钓鱼
         "http://work.weixin.qq.com/ai/qc/gen",                    // 企业微信授权页非 https
+        "http://login.dingtalk.com/device",                       // 钉钉授权页非 https
         "https://bce.baidu.com/",                                 // 非 console 子域,不放行
         "javascript:alert(1)",                                    // js scheme
         "file:///etc/passwd",                                     // file scheme
@@ -1627,6 +1628,10 @@ fn external_allowlist_allows_known_targets_rejects_lookalikes() {
     assert!(url_in_external_allowlist(
         "https://work.weixin.qq.com/ai/qc/c?s=abc&for_native=true"
     ));
+    // 钉钉 device 授权登录页(dws auth login --device 打印,带 user_code)
+    assert!(url_in_external_allowlist(
+        "https://login.dingtalk.com/device?user_code=ABCDEF"
+    ));
     assert!(url_in_external_allowlist("http://localhost:8080/"));
     assert!(url_in_external_allowlist("https://127.0.0.1:8443/preview"));
     assert!(url_in_external_allowlist("http://[::1]:3000/"));
@@ -1649,6 +1654,12 @@ fn external_allowlist_allows_known_targets_rejects_lookalikes() {
     ));
     assert!(!url_in_external_allowlist(
         "https://work.weixin.qq.com.evil.com/ai/qc/gen"
+    ));
+    assert!(!url_in_external_allowlist(
+        "https://login.dingtalk.com.evil.com/device"
+    ));
+    assert!(!url_in_external_allowlist(
+        "https://dingtalk.com.evil.com/device"
     ));
     assert!(!url_in_external_allowlist(
         "https://docs.qq.com.evil.com/scenario/open-claw.html?nlc=1"

--- a/pinvou3-app/src-tauri/src/app/commands/tests.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/tests.rs
@@ -1537,17 +1537,17 @@ async fn open_external_url_rejects_off_allowlist_targets() {
         "https://www.canva.cn.evil.com/api/action",               // Canva 子域钓鱼
         "https://export-download.canva.cn.evil.com/x.png",        // Canva 资源域钓鱼
         "https://meeting.tencent.com.evil.com/qrcode-login.html", // 腾讯会议授权域钓鱼
-        "http://work.weixin.qq.com/ai/qc/gen",                    // 企业微信授权页非 https
-        "http://login.dingtalk.com/device",                       // 钉钉授权页非 https
-        "https://bce.baidu.com/",                                 // 非 console 子域,不放行
-        "javascript:alert(1)",                                    // js scheme
-        "file:///etc/passwd",                                     // file scheme
-        "https://google.com/",                                    // 任何第三方域
-        "http://localhost.evil.com:8080/",                        // localhost 前缀钓鱼
-        "http://user@localhost:8080/",                            // 不允许 URL 凭据
-        "http://192.168.1.10:8080/",                              // 局域网地址不是 loopback
-        "",                                                       // 空串
-        "metaso.cn/",                                             // 缺 scheme
+        "http://work.weixin.qq.com/ai/qc/gen",                    // WeCom auth page over non-https
+        "http://login.dingtalk.com/device", // DingTalk auth page over non-https
+        "https://bce.baidu.com/",           // 非 console 子域,不放行
+        "javascript:alert(1)",              // js scheme
+        "file:///etc/passwd",               // file scheme
+        "https://google.com/",              // 任何第三方域
+        "http://localhost.evil.com:8080/",  // localhost 前缀钓鱼
+        "http://user@localhost:8080/",      // 不允许 URL 凭据
+        "http://192.168.1.10:8080/",        // 局域网地址不是 loopback
+        "",                                 // 空串
+        "metaso.cn/",                       // 缺 scheme
     ];
     for url in rejected {
         let err = open_external_url(url.to_string()).await.err();
@@ -1621,14 +1621,14 @@ fn external_allowlist_allows_known_targets_rejects_lookalikes() {
     assert!(url_in_external_allowlist(
         "https://docs.qq.com/scenario/open-claw.html?nlc=1"
     ));
-    // 企业微信扫码授权页(wecom-cli auth init 落地页)
+    // WeCom scan-to-authorize page (wecom-cli auth init landing page)
     assert!(url_in_external_allowlist(
         "https://work.weixin.qq.com/ai/qc/gen?source=wecom_cli_external&scode=abc"
     ));
     assert!(url_in_external_allowlist(
         "https://work.weixin.qq.com/ai/qc/c?s=abc&for_native=true"
     ));
-    // 钉钉 device 授权登录页(dws auth login --device 打印,带 user_code)
+    // DingTalk device authorization login page (printed by `dws auth login --device`, carries user_code)
     assert!(url_in_external_allowlist(
         "https://login.dingtalk.com/device?user_code=ABCDEF"
     ));

--- a/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
@@ -204,11 +204,17 @@ pub fn make_qr(url: &str) -> Option<String> {
 }
 
 /// 把 CLI 落盘的二维码 PNG(wecom-cli `--output-qrcode`)包装成 data URL,
-/// 供前端 `<img src>` 直接显示。校验 PNG 签名,读到非 PNG / 截断文件返回 `None`
-/// (调用方回退 [`make_qr`] 自绘)。
+/// 供前端 `<img src>` 直接显示。校验 PNG 签名 + IEND 尾双锚点,非 PNG / 截断文件
+/// 返回 `None`(调用方回退 [`make_qr`] 自绘)。
 pub fn png_data_url(bytes: &[u8]) -> Option<String> {
     const PNG_SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
-    if bytes.len() < 8 || !bytes.starts_with(PNG_SIGNATURE) {
+    // IEND chunk 恒为 length(0)+type+CRC:对 IEND 内容 CRC 固定,可直接整段比对。
+    // 只验签名会把「只写了头部」的半截文件当完整,浏览器里渲染成坏图。
+    const IEND_TAIL: &[u8] = b"\x00\x00\x00\x00IEND\xae\x42\x60\x82";
+    if bytes.len() < PNG_SIGNATURE.len() + IEND_TAIL.len()
+        || !bytes.starts_with(PNG_SIGNATURE)
+        || !bytes.ends_with(IEND_TAIL)
+    {
         return None;
     }
     Some(format!("data:image/png;base64,{}", b64(bytes)))
@@ -488,11 +494,11 @@ mod tests {
         assert!(svg.contains("<svg"), "应含 <svg> 根节点");
     }
 
-    /// CLI 落盘 PNG → data URL;非 PNG / 截断字节拒绝(调用方回退 make_qr)。
+    /// CLI 落盘 PNG → data URL;签名 + IEND 尾校验,非 PNG / 截断字节拒绝(调用方回退 make_qr)。
     #[test]
     fn png_data_url_validates_signature() {
-        let png = b"\x89PNG\r\n\x1a\nrest-of-file-bytes";
-        let data_url = png_data_url(png).expect("带签名的字节应通过");
+        let png = b"\x89PNG\r\n\x1a\nrest-of-file\x00\x00\x00\x00IEND\xae\x42\x60\x82";
+        let data_url = png_data_url(png).expect("带签名和 IEND 尾的字节应通过");
         assert!(data_url.starts_with("data:image/png;base64,"));
         // 解码回原字节,确认无损。
         let b64 = data_url.trim_start_matches("data:image/png;base64,");
@@ -500,6 +506,14 @@ mod tests {
 
         assert!(png_data_url(b"").is_none(), "空字节应拒绝");
         assert!(png_data_url(b"\x89PNG").is_none(), "不足签名长度应拒绝");
+        assert!(
+            png_data_url(b"\x89PNG\r\n\x1a\n").is_none(),
+            "仅签名无 IEND 尾(半截文件)应拒绝"
+        );
+        assert!(
+            png_data_url(b"\x89PNG\r\n\x1a\nbody\x00\x00\x00\x00IEND\x00\x00\x00\x00").is_none(),
+            "IEND CRC 不对应拒绝"
+        );
         assert!(
             png_data_url(b"\x89JPEG\r\n\x1a\nrest").is_none(),
             "错误签名应拒绝"

--- a/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
@@ -203,6 +203,17 @@ pub fn make_qr(url: &str) -> Option<String> {
     ))
 }
 
+/// 把 CLI 落盘的二维码 PNG(wecom-cli `--output-qrcode`)包装成 data URL,
+/// 供前端 `<img src>` 直接显示。校验 PNG 签名,读到非 PNG / 截断文件返回 `None`
+/// (调用方回退 [`make_qr`] 自绘)。
+pub fn png_data_url(bytes: &[u8]) -> Option<String> {
+    const PNG_SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 8 || !bytes.starts_with(PNG_SIGNATURE) {
+        return None;
+    }
+    Some(format!("data:image/png;base64,{}", b64(bytes)))
+}
+
 /// 后台线程:逐行排空一个管道(防写满阻塞),抓到首个本连接器 URL 经 channel 送回。
 pub fn drain_for_url<R: std::io::Read + Send + 'static>(
     ctx: CliCtx,
@@ -475,6 +486,24 @@ mod tests {
         let b64 = qr.trim_start_matches("data:image/svg+xml;base64,");
         let svg = String::from_utf8(b64_decode(b64)).unwrap();
         assert!(svg.contains("<svg"), "应含 <svg> 根节点");
+    }
+
+    /// CLI 落盘 PNG → data URL;非 PNG / 截断字节拒绝(调用方回退 make_qr)。
+    #[test]
+    fn png_data_url_validates_signature() {
+        let png = b"\x89PNG\r\n\x1a\nrest-of-file-bytes";
+        let data_url = png_data_url(png).expect("带签名的字节应通过");
+        assert!(data_url.starts_with("data:image/png;base64,"));
+        // 解码回原字节,确认无损。
+        let b64 = data_url.trim_start_matches("data:image/png;base64,");
+        assert_eq!(b64_decode(b64), png.to_vec());
+
+        assert!(png_data_url(b"").is_none(), "空字节应拒绝");
+        assert!(png_data_url(b"\x89PNG").is_none(), "不足签名长度应拒绝");
+        assert!(
+            png_data_url(b"\x89JPEG\r\n\x1a\nrest").is_none(),
+            "错误签名应拒绝"
+        );
     }
 
     // 测试辅助:标准 base64 解码(生产 b64 的逆运算,仅测试用)。

--- a/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/connector_cli.rs
@@ -203,13 +203,16 @@ pub fn make_qr(url: &str) -> Option<String> {
     ))
 }
 
-/// 把 CLI 落盘的二维码 PNG(wecom-cli `--output-qrcode`)包装成 data URL,
-/// 供前端 `<img src>` 直接显示。校验 PNG 签名 + IEND 尾双锚点,非 PNG / 截断文件
-/// 返回 `None`(调用方回退 [`make_qr`] 自绘)。
+/// Wraps the QR PNG written to disk by the CLI (wecom-cli `--output-qrcode`) as a
+/// data URL so the frontend can show it directly via `<img src>`. Validates the PNG
+/// signature plus the IEND tail; non-PNG / truncated files return `None` (the
+/// caller falls back to [`make_qr`]).
 pub fn png_data_url(bytes: &[u8]) -> Option<String> {
     const PNG_SIGNATURE: &[u8] = b"\x89PNG\r\n\x1a\n";
-    // IEND chunk 恒为 length(0)+type+CRC:对 IEND 内容 CRC 固定,可直接整段比对。
-    // 只验签名会把「只写了头部」的半截文件当完整,浏览器里渲染成坏图。
+    // The IEND chunk is always length(0) + type + CRC: the CRC over the IEND
+    // content is fixed, so the whole tail can be compared verbatim. Checking only
+    // the signature would accept a half-written file (header only) and the browser
+    // would render a broken image.
     const IEND_TAIL: &[u8] = b"\x00\x00\x00\x00IEND\xae\x42\x60\x82";
     if bytes.len() < PNG_SIGNATURE.len() + IEND_TAIL.len()
         || !bytes.starts_with(PNG_SIGNATURE)
@@ -494,29 +497,35 @@ mod tests {
         assert!(svg.contains("<svg"), "应含 <svg> 根节点");
     }
 
-    /// CLI 落盘 PNG → data URL;签名 + IEND 尾校验,非 PNG / 截断字节拒绝(调用方回退 make_qr)。
+    /// CLI-written PNG → data URL; signature + IEND tail validated, non-PNG / truncated bytes rejected (caller falls back to make_qr).
     #[test]
     fn png_data_url_validates_signature() {
         let png = b"\x89PNG\r\n\x1a\nrest-of-file\x00\x00\x00\x00IEND\xae\x42\x60\x82";
-        let data_url = png_data_url(png).expect("带签名和 IEND 尾的字节应通过");
+        let data_url = png_data_url(png).expect("bytes with signature and IEND tail should pass");
         assert!(data_url.starts_with("data:image/png;base64,"));
-        // 解码回原字节,确认无损。
+        // Decode back to the original bytes to confirm losslessness.
         let b64 = data_url.trim_start_matches("data:image/png;base64,");
         assert_eq!(b64_decode(b64), png.to_vec());
 
-        assert!(png_data_url(b"").is_none(), "空字节应拒绝");
-        assert!(png_data_url(b"\x89PNG").is_none(), "不足签名长度应拒绝");
+        assert!(
+            png_data_url(b"").is_none(),
+            "empty bytes should be rejected"
+        );
+        assert!(
+            png_data_url(b"\x89PNG").is_none(),
+            "shorter than the signature should be rejected"
+        );
         assert!(
             png_data_url(b"\x89PNG\r\n\x1a\n").is_none(),
-            "仅签名无 IEND 尾(半截文件)应拒绝"
+            "signature without IEND tail (half-written file) should be rejected"
         );
         assert!(
             png_data_url(b"\x89PNG\r\n\x1a\nbody\x00\x00\x00\x00IEND\x00\x00\x00\x00").is_none(),
-            "IEND CRC 不对应拒绝"
+            "mismatched IEND CRC should be rejected"
         );
         assert!(
             png_data_url(b"\x89JPEG\r\n\x1a\nrest").is_none(),
-            "错误签名应拒绝"
+            "wrong signature should be rejected"
         );
     }
 

--- a/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
@@ -146,18 +146,66 @@ fn run_connect_flow(app: &AppHandle) {
     }
 }
 
+/// 等待 CLI 落盘的二维码 PNG(出现且长度稳定后读取,避免拿到半截文件)。
+/// 超时返回 `None`(调用方回退把 URL 自绘成二维码)。
+fn poll_qr_png(dir: &std::path::Path, timeout: Duration) -> Option<Vec<u8>> {
+    let path = dir.join("qr.png");
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Ok(bytes) = std::fs::read(&path) {
+            if !bytes.is_empty() {
+                std::thread::sleep(Duration::from_millis(200));
+                if let Ok(settled) = std::fs::read(&path) {
+                    if settled.len() == bytes.len() {
+                        return Some(settled);
+                    }
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
 /// 单段:`auth init --noninteractive --no-browser` 长驻 → 抓 URL 出二维码 → 等进程退出 → 查 ready。
 fn phase_scan(app: &AppHandle) -> Result<(), String> {
-    let mut cmd = wecom(&["auth", "init", "--noninteractive", "--no-browser"]);
+    // CLI 1.1.0 的 --output-qrcode 只接受当前目录下的相对路径:让它把真授权二维码 PNG
+    // 落在临时目录里。抓到的 stdout URL 是 /ai/qc/gen 落地页(打开后还要再扫一次),
+    // 不能直接编码成二维码;PNG 里的码才能一次扫码直达授权。旧 CLI 无此旗标时回退自绘。
+    let qr_dir = std::env::temp_dir().join(format!(
+        "pinvou3-wecom-qr-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    let _ = std::fs::create_dir_all(&qr_dir);
+    let mut cmd = wecom(&[
+        "auth",
+        "init",
+        "--noninteractive",
+        "--no-browser",
+        "--output-qrcode",
+        "qr.png",
+    ]);
+    cmd.current_dir(&qr_dir);
     // 独立进程组:npm shim(shell→node)派生的孙进程与 shim 同组,退出收割的
     // kill_pid_tree 按负 pid 组杀整棵树,单杀 shim pid 会把 node 孤儿化。
     crate::platform::process::std_process_group_leader(&mut cmd);
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("wecom-cli auth init 启动失败: {e}(需要先完成企微 CLI 在线安装)"))?;
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&qr_dir);
+            return Err(format!(
+                "wecom-cli auth init 启动失败: {e}(需要先完成企微 CLI 在线安装)"
+            ));
+        }
+    };
     let conn = app.state::<ConnectorConn>();
     conn.set_pid(ID, Some(child.id()));
 
@@ -177,13 +225,30 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
         Err(_) => {
             let _ = child.kill();
             conn.set_pid(ID, None);
+            let _ = std::fs::remove_dir_all(&qr_dir);
+            // 取消会 tree-kill 子进程 → 管道 EOF 走到这:用户主动停,静默收尾,不误报链接超时。
+            if conn.is_cancelled(ID) {
+                return Ok(());
+            }
             return Err("40s 内未拿到二维码链接(检查网络 / 代理)".into());
         }
     };
+    // 优先 CLI 落盘的真授权二维码;拿不到(旧 CLI / 写盘失败)回退自绘落地页二维码。
+    let qr = poll_qr_png(&qr_dir, Duration::from_secs(6))
+        .and_then(|bytes| cc::png_data_url(&bytes))
+        .or_else(|| cc::make_qr(&url));
+    let _ = std::fs::remove_dir_all(&qr_dir);
+    // 取消发生在等 PNG 的窗口内:静默退出。再发 wecom:qr 会把用户已关掉的扫码弹窗重新弹出。
+    // (wecom_cancel 已按 pid tree-kill,这里补 kill + pid 槽复位兜底竞态。)
+    if conn.is_cancelled(ID) {
+        let _ = child.kill();
+        conn.set_pid(ID, None);
+        return Ok(());
+    }
     cc::emit(
         app,
         "wecom:qr",
-        json!({ "phase": "authorize", "url": url, "qr_data_url": cc::make_qr(&url) }),
+        json!({ "phase": "authorize", "url": url, "qr_data_url": qr }),
     );
 
     // 等进程退出(用户扫码完成);期间轮询取消标志。退出后查 ready 收尾。
@@ -364,6 +429,29 @@ mod tests {
         assert!(!status_is_authorized("unauthorized")); // 前缀相同不能误判
         assert!(!status_is_authorized("Status: unauthorized"));
         assert!(!status_is_authorized(""));
+    }
+
+    /// 轮询 CLI 落盘的二维码 PNG:出现即读,缺文件/空目录等到超时回 None。
+    #[test]
+    fn poll_qr_png_reads_written_file_and_times_out() {
+        let dir = std::env::temp_dir().join(format!(
+            "pinvou3-wecom-poll-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        // 无文件 → 超时 None(用极短超时保持测试快)
+        assert!(poll_qr_png(&dir, Duration::from_millis(300)).is_none());
+        // 落盘后 → 读到稳定字节
+        let png = b"\x89PNG\r\n\x1a\npayload";
+        std::fs::write(dir.join("qr.png"), png).unwrap();
+        assert_eq!(
+            poll_qr_png(&dir, Duration::from_secs(3)).as_deref(),
+            Some(&png[..])
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// 手动停用标志:文件存在=停用,与连接状态正交。写/删一轮。

--- a/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
@@ -173,7 +173,8 @@ fn poll_qr_png(dir: &std::path::Path, timeout: Duration) -> Option<Vec<u8>> {
 fn phase_scan(app: &AppHandle) -> Result<(), String> {
     // CLI 1.1.0 的 --output-qrcode 只接受当前目录下的相对路径:让它把真授权二维码 PNG
     // 落在临时目录里。抓到的 stdout URL 是 /ai/qc/gen 落地页(打开后还要再扫一次),
-    // 不能直接编码成二维码;PNG 里的码才能一次扫码直达授权。旧 CLI 无此旗标时回退自绘。
+    // 不能直接编码成二维码;PNG 里的码才能一次扫码直达授权。能走到这的 CLI 必 ≥1.1.0
+    // (wecom_ensure_cli 的版本门已把旧版换装),回退自绘只覆盖写盘失败/轮询超时。
     let qr_dir = std::env::temp_dir().join(format!(
         "pinvou3-wecom-qr-{}",
         std::time::SystemTime::now()
@@ -181,7 +182,10 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     ));
-    let _ = std::fs::create_dir_all(&qr_dir);
+    if let Err(e) = std::fs::create_dir_all(&qr_dir) {
+        // 不吞:失败时 spawn 也会因 cwd 不存在而挂,但报因会被误读成「CLI 未安装」。
+        return Err(format!("创建扫码二维码临时目录失败: {e}"));
+    }
     let mut cmd = wecom(&[
         "auth",
         "init",
@@ -233,7 +237,7 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
             return Err("40s 内未拿到二维码链接(检查网络 / 代理)".into());
         }
     };
-    // 优先 CLI 落盘的真授权二维码;拿不到(旧 CLI / 写盘失败)回退自绘落地页二维码。
+    // 优先 CLI 落盘的真授权二维码;拿不到(写盘失败 / 轮询超时)回退自绘落地页二维码。
     let qr = poll_qr_png(&qr_dir, Duration::from_secs(6))
         .and_then(|bytes| cc::png_data_url(&bytes))
         .or_else(|| cc::make_qr(&url));

--- a/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
+++ b/pinvou3-app/src-tauri/src/features/connectors/wecom.rs
@@ -146,8 +146,9 @@ fn run_connect_flow(app: &AppHandle) {
     }
 }
 
-/// 等待 CLI 落盘的二维码 PNG(出现且长度稳定后读取,避免拿到半截文件)。
-/// 超时返回 `None`(调用方回退把 URL 自绘成二维码)。
+/// Waits for the QR PNG written to disk by the CLI (read once it exists and its
+/// length is stable, to avoid grabbing a half-written file).
+/// Returns `None` on timeout (the caller falls back to drawing the URL as a QR).
 fn poll_qr_png(dir: &std::path::Path, timeout: Duration) -> Option<Vec<u8>> {
     let path = dir.join("qr.png");
     let deadline = std::time::Instant::now() + timeout;
@@ -171,10 +172,13 @@ fn poll_qr_png(dir: &std::path::Path, timeout: Duration) -> Option<Vec<u8>> {
 
 /// 单段:`auth init --noninteractive --no-browser` 长驻 → 抓 URL 出二维码 → 等进程退出 → 查 ready。
 fn phase_scan(app: &AppHandle) -> Result<(), String> {
-    // CLI 1.1.0 的 --output-qrcode 只接受当前目录下的相对路径:让它把真授权二维码 PNG
-    // 落在临时目录里。抓到的 stdout URL 是 /ai/qc/gen 落地页(打开后还要再扫一次),
-    // 不能直接编码成二维码;PNG 里的码才能一次扫码直达授权。能走到这的 CLI 必 ≥1.1.0
-    // (wecom_ensure_cli 的版本门已把旧版换装),回退自绘只覆盖写盘失败/轮询超时。
+    // CLI 1.1.0's --output-qrcode only accepts a path relative to the current
+    // directory, so the real auth QR PNG is written into a temp dir. The stdout
+    // URL is the /ai/qc/gen landing page (which would ask the user to scan
+    // again) and cannot be encoded as the QR directly; only the PNG QR reaches
+    // authorization in one scan. Any CLI that reaches this point is ≥1.1.0
+    // (wecom_ensure_cli's version gate force-replaces older ones), so the
+    // self-drawn fallback only covers PNG write failure / poll timeout.
     let qr_dir = std::env::temp_dir().join(format!(
         "pinvou3-wecom-qr-{}",
         std::time::SystemTime::now()
@@ -183,8 +187,9 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
             .unwrap_or(0)
     ));
     if let Err(e) = std::fs::create_dir_all(&qr_dir) {
-        // 不吞:失败时 spawn 也会因 cwd 不存在而挂,但报因会被误读成「CLI 未安装」。
-        return Err(format!("创建扫码二维码临时目录失败: {e}"));
+        // Not swallowed: spawn would also fail on the missing cwd, but its cause
+        // would be misread as "CLI not installed".
+        return Err(format!("failed to create the scan QR temp dir: {e}"));
     }
     let mut cmd = wecom(&[
         "auth",
@@ -206,7 +211,7 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
         Err(e) => {
             let _ = std::fs::remove_dir_all(&qr_dir);
             return Err(format!(
-                "wecom-cli auth init 启动失败: {e}(需要先完成企微 CLI 在线安装)"
+                "failed to start wecom-cli auth init: {e} (install the WeCom CLI online first)"
             ));
         }
     };
@@ -230,20 +235,24 @@ fn phase_scan(app: &AppHandle) -> Result<(), String> {
             let _ = child.kill();
             conn.set_pid(ID, None);
             let _ = std::fs::remove_dir_all(&qr_dir);
-            // 取消会 tree-kill 子进程 → 管道 EOF 走到这:用户主动停,静默收尾,不误报链接超时。
+            // Cancel tree-kills the child → pipe EOF lands here: the user stopped
+            // on purpose, so finish silently instead of misreporting a link timeout.
             if conn.is_cancelled(ID) {
                 return Ok(());
             }
-            return Err("40s 内未拿到二维码链接(检查网络 / 代理)".into());
+            return Err("no QR link within 40s (check network / proxy)".into());
         }
     };
-    // 优先 CLI 落盘的真授权二维码;拿不到(写盘失败 / 轮询超时)回退自绘落地页二维码。
+    // Prefer the real auth QR written by the CLI; on failure (write failure /
+    // poll timeout) fall back to the self-drawn landing-page QR.
     let qr = poll_qr_png(&qr_dir, Duration::from_secs(6))
         .and_then(|bytes| cc::png_data_url(&bytes))
         .or_else(|| cc::make_qr(&url));
     let _ = std::fs::remove_dir_all(&qr_dir);
-    // 取消发生在等 PNG 的窗口内:静默退出。再发 wecom:qr 会把用户已关掉的扫码弹窗重新弹出。
-    // (wecom_cancel 已按 pid tree-kill,这里补 kill + pid 槽复位兜底竞态。)
+    // Cancel during the PNG wait window: exit silently. Emitting wecom:qr now
+    // would re-open the scan modal the user already dismissed.
+    // (wecom_cancel already tree-killed by pid; the extra kill + pid slot reset
+    // here covers the race.)
     if conn.is_cancelled(ID) {
         let _ = child.kill();
         conn.set_pid(ID, None);
@@ -435,7 +444,8 @@ mod tests {
         assert!(!status_is_authorized(""));
     }
 
-    /// 轮询 CLI 落盘的二维码 PNG:出现即读,缺文件/空目录等到超时回 None。
+    /// Polls the QR PNG written by the CLI: read once it appears; a missing
+    /// file / empty dir waits until timeout and returns None.
     #[test]
     fn poll_qr_png_reads_written_file_and_times_out() {
         let dir = std::env::temp_dir().join(format!(
@@ -446,9 +456,9 @@ mod tests {
                 .unwrap_or(0)
         ));
         std::fs::create_dir_all(&dir).unwrap();
-        // 无文件 → 超时 None(用极短超时保持测试快)
+        // No file → timeout None (a very short timeout keeps the test fast)
         assert!(poll_qr_png(&dir, Duration::from_millis(300)).is_none());
-        // 落盘后 → 读到稳定字节
+        // After the file lands → stable bytes are read
         let png = b"\x89PNG\r\n\x1a\npayload";
         std::fs::write(dir.join("qr.png"), png).unwrap();
         assert_eq!(

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -126,7 +126,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     // Stable empty array/object defaults: inline [] and {} are new references on every render, which makes memoized children re-render repeatedly.
     const EMPTY_STEPS = [];
     const EMPTY_COPY = {};
-    const FeishuFlowCard = ({ flow, onRetry, onCancel, name = '', twoStep = true, browserAuth = false, steps = EMPTY_STEPS, copy = EMPTY_COPY }) => {
+    const FeishuFlowCard = ({ flow, onRetry, onCancel, name = '', twoStep = true, browserAuth = false, steps = EMPTY_STEPS, copy = EMPTY_COPY, onBrowserOpenError = () => {} }) => {
       if (!flow) return null;
       const isErr = flow.phase === 'error';
       return (
@@ -164,7 +164,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
                 </div>
                 {flow.qrUrl && (
                   <button type="button"
-                    onClick={() => invokeTauri('open_external_url', { url: flow.qrUrl })}
+                    onClick={() => invokeTauri('open_external_url', { url: flow.qrUrl }).catch(onBrowserOpenError)}
                     className="shrink-0 text-[13px] text-blue-600 dark:text-blue-400 hover:underline"
                   >
                     {copy.reopen}
@@ -186,7 +186,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
                       <span className="font-mono text-[18px] font-bold tracking-wider text-slate-900 dark:text-white">{flow.userCode}</span>
                     </div>
                   )}
-                  {flow.qrUrl && <button type="button" onClick={() => invokeTauri('open_external_url', { url: flow.qrUrl })} className="text-[13px] text-blue-600 dark:text-blue-400 hover:underline">{copy.openBrowser}</button>}
+                  {flow.qrUrl && <button type="button" onClick={() => invokeTauri('open_external_url', { url: flow.qrUrl }).catch(onBrowserOpenError)} className="text-[13px] text-blue-600 dark:text-blue-400 hover:underline">{copy.openBrowser}</button>}
                 </div>
               </div>
             </div>
@@ -1874,6 +1874,8 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         invokeTauri('wecom_cancel').catch(() => {});
         wecomConn.setFlow(null); setBusyId(null);
       };
+      // 「在浏览器打开」失败(如外链白名单拒绝)时的兜底提示,此前静默无任何反馈。
+      const browserOpenFailed = () => setAlert({ visible: true, loading: false, title: storeCopy.openBrowserFailed, isInstall: false, isError: true });
       const wecomRetry = () => { connectWecom(); };
       const disconnectWecom = async () => {
         setBusyId('wecom');
@@ -2188,15 +2190,17 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
               {/* biome-ignore lint/a11y/noStaticElementInteractions: click-propagation stop layer, non-interactive container */}
               <div className="bg-white dark:bg-[#1C1C1E] rounded-3xl p-7 w-full max-w-[440px] flex flex-col items-center text-center shadow-2xl" onClick={e => e.stopPropagation()}>
                 <h3 className="text-[19px] font-bold text-slate-900 dark:text-white mb-4">{storeCopy.connectTitle(storeCopy.toolNames.wecom)}</h3>
-                {/* 文案精简(方案A):扫码指引交给内嵌页自己说，这里不重复。直接内嵌企微登录页
-                    （其 JS 动态渲染真正的登录码）——避免把 gen 网页地址编码成二维码导致的二次扫码。 */}
-                {wecomQr.url
-                  ? <iframe src={wecomQr.url} title={storeCopy.loginFrameTitle(storeCopy.toolNames.wecom)} className="w-full h-[440px] rounded-2xl border border-slate-200 dark:border-white/10 bg-white" scrolling="no" />
-                  : <div className="w-52 h-52 rounded-2xl border border-dashed border-slate-300 dark:border-white/10 flex items-center justify-center text-[12px] text-slate-400 px-4">{storeCopy.loginPageLoadFailed}</div>}
-                <div className="flex items-center gap-1.5 mt-4 text-[13px] text-slate-500 dark:text-slate-400">
+                {/* 后端下发 wecom-cli --output-qrcode 落盘的真授权二维码(一次扫码直达)。
+                    此前 iframe 内嵌 /ai/qc/gen 落地页:WKWebView 里常渲染不出码,
+                    且落地页 URL 编成二维码会让用户扫码后再扫一次。 */}
+                {wecomQr.qr && (
+                  <img src={wecomQr.qr} alt={storeCopy.wecomQrAlt} decoding="async" className="w-52 h-52 rounded-2xl border border-slate-200 bg-white p-1 dark:border-white/10" />
+                )}
+                <div className="mt-4 text-[13px] text-slate-500 dark:text-slate-400">{storeCopy.wecomScanHint}</div>
+                <div className="flex items-center gap-1.5 mt-2 text-[13px] text-slate-500 dark:text-slate-400">
                   <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse"></span> {storeCopy.waitingAuth}
                 </div>
-                <button type="button" onClick={() => { if (wecomQr.url) invokeTauri('open_external_url', { url: wecomQr.url }); }} className="mt-4 text-[13px] text-blue-600 dark:text-blue-400 hover:underline">{storeCopy.openInBrowser}</button>
+                <button type="button" onClick={() => { if (wecomQr.url) invokeTauri('open_external_url', { url: wecomQr.url }).catch(browserOpenFailed); }} className="mt-4 text-[13px] text-blue-600 dark:text-blue-400 hover:underline">{storeCopy.openInBrowser}</button>
                 <button type="button" onClick={cancel} className="mt-3 px-6 py-2 rounded-full text-[14px] font-semibold bg-slate-100 dark:bg-[#2C2C2E] text-slate-600 dark:text-slate-300">{storeCopy.cancel}</button>
               </div>
             </div>
@@ -2541,16 +2545,16 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
                   </div>
 
                   {externalAuthAvailable && selectedTool.feishuCli && feishuFlow && (
-                    <FeishuFlowCard flow={feishuFlow} steps={storeCopy.feishuSteps} name={storeCopy.toolNames.feishu} copy={detailCopy.flow} onRetry={feishuRetry} onCancel={feishuResetFlow} />
+                    <FeishuFlowCard flow={feishuFlow} steps={storeCopy.feishuSteps} name={storeCopy.toolNames.feishu} copy={detailCopy.flow} onRetry={feishuRetry} onCancel={feishuResetFlow} onBrowserOpenError={browserOpenFailed} />
                   )}
                   {externalAuthAvailable && selectedTool.wecomCli && wecomFlow && (
-                    <FeishuFlowCard flow={wecomFlow} steps={storeCopy.wecomSteps} name={storeCopy.toolNames.wecom} copy={detailCopy.flow} twoStep={false} onRetry={wecomRetry} onCancel={wecomResetFlow} />
+                    <FeishuFlowCard flow={wecomFlow} steps={storeCopy.wecomSteps} name={storeCopy.toolNames.wecom} copy={detailCopy.flow} twoStep={false} onRetry={wecomRetry} onCancel={wecomResetFlow} onBrowserOpenError={browserOpenFailed} />
                   )}
                   {externalAuthAvailable && selectedTool.dingtalkCli && dingtalkFlow && (
-                    <FeishuFlowCard flow={dingtalkFlow} steps={storeCopy.dingtalkSteps} name={storeCopy.toolNames.dingtalk} copy={detailCopy.flow} twoStep={false} onRetry={dingtalkRetry} onCancel={dingtalkResetFlow} />
+                    <FeishuFlowCard flow={dingtalkFlow} steps={storeCopy.dingtalkSteps} name={storeCopy.toolNames.dingtalk} copy={detailCopy.flow} twoStep={false} onRetry={dingtalkRetry} onCancel={dingtalkResetFlow} onBrowserOpenError={browserOpenFailed} />
                   )}
                   {externalAuthAvailable && selectedTool.tmeetCli && tmeetFlow && (
-                    <FeishuFlowCard flow={tmeetFlow.phase === 'error' && !detailCopy.showRawErrors ? { ...tmeetFlow, err: detailCopy.actions.operationFailed } : tmeetFlow} steps={detailCopy.tmeetSteps} name={detailCopy.tools.tmeet.title} copy={detailCopy.flow} twoStep={false} browserAuth={!!tmeetFlow.browserAuth} onRetry={tmeetRetry} onCancel={tmeetResetFlow} />
+                    <FeishuFlowCard flow={tmeetFlow.phase === 'error' && !detailCopy.showRawErrors ? { ...tmeetFlow, err: detailCopy.actions.operationFailed } : tmeetFlow} steps={detailCopy.tmeetSteps} name={detailCopy.tools.tmeet.title} copy={detailCopy.flow} twoStep={false} browserAuth={!!tmeetFlow.browserAuth} onRetry={tmeetRetry} onCancel={tmeetResetFlow} onBrowserOpenError={browserOpenFailed} />
                   )}
                   {selectedTool.feishuCli && feishuConnected && !feishuFlow && (
                     <div className="mb-8 flex items-center gap-3 p-4 rounded-2xl bg-emerald-50 dark:bg-emerald-500/10 border border-emerald-200 dark:border-emerald-500/30">

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -126,7 +126,8 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     // Stable empty array/object defaults: inline [] and {} are new references on every render, which makes memoized children re-render repeatedly.
     const EMPTY_STEPS = [];
     const EMPTY_COPY = {};
-    const FeishuFlowCard = ({ flow, onRetry, onCancel, name = '', twoStep = true, browserAuth = false, steps = EMPTY_STEPS, copy = EMPTY_COPY, onBrowserOpenError = () => {} }) => {
+    const NOOP = () => {};
+    const FeishuFlowCard = ({ flow, onRetry, onCancel, name = '', twoStep = true, browserAuth = false, steps = EMPTY_STEPS, copy = EMPTY_COPY, onBrowserOpenError = NOOP }) => {
       if (!flow) return null;
       const isErr = flow.phase === 'error';
       return (

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -2181,7 +2181,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           />, document.body)}
           {/* 飞书扫码二维码已内联进 FeishuFlowCard（详情弹窗内），不再单独浮层 */}
           {wecomQr && (() => {
-            const cancel = () => { invokeTauri('wecom_cancel').catch(() => {}); setWecomQr(null); setBusyId(null); };
+            // 对齐 wecomResetFlow:后端对取消已静默(不再发 wecom:error 清场),
+            // 这里必须自己清 flow,否则详情流程卡/mini 卡陈旧停在「待扫码」。
+            const cancel = () => { wecomConn.stopTick(); invokeTauri('wecom_cancel').catch(() => {}); wecomConn.setFlow(null); setWecomQr(null); setBusyId(null); };
             return createPortal((
             // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close layer; the keyboard path is covered by the dialog's cancel control
             // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close layer, non-interactive container

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -453,8 +453,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     }
 
     // iOS 风格弹窗（安装/卸载后提示需新建会话生效）
-    // z-[210]:与扫码弹窗等其余 z-[200] body portal 同层会退化为挂载顺序定叠放
-    // （alert 后挂载才在上层），显式高一级让报错弹窗永远可见，不依赖挂载时机。
+    // z-[210]: sharing z-[200] with the QR modal and other body portals would
+    // degrade stacking to mount order (the alert only paints on top because it
+    // mounts later); one explicit level up keeps the error alert always visible.
     const TsAlert = ({ alert, _theme, onDismiss, onNewChat, onCancelLoading, copy }) => { // eslint-disable-line no-unused-vars -- theme is kept for the existing props contract
       if (!alert.visible && !alert.loading) return null;
       return (
@@ -1876,7 +1877,7 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         invokeTauri('wecom_cancel').catch(() => {});
         wecomConn.setFlow(null); setBusyId(null);
       };
-      // 「在浏览器打开」失败(如外链白名单拒绝)时的兜底提示,此前静默无任何反馈。
+      // Fallback notice when "Open in browser" fails (e.g. external-url allowlist rejection); previously silent.
       const browserOpenFailed = () => setAlert({ visible: true, loading: false, title: storeCopy.openBrowserFailed, isInstall: false, isError: true });
       const wecomRetry = () => { connectWecom(); };
       const disconnectWecom = async () => {
@@ -2183,8 +2184,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
           />, document.body)}
           {/* 飞书扫码二维码已内联进 FeishuFlowCard（详情弹窗内），不再单独浮层 */}
           {wecomQr && (() => {
-            // 对齐 wecomResetFlow:后端对取消已静默(不再发 wecom:error 清场),
-            // 这里必须自己清 flow,否则详情流程卡/mini 卡陈旧停在「待扫码」。
+            // Mirrors wecomResetFlow: backend cancel is now silent (no wecom:error
+            // cleanup), so we must clear the flow here, otherwise the detail/mini
+            // flow cards stay stale on "waiting for scan".
             const cancel = () => { wecomConn.stopTick(); invokeTauri('wecom_cancel').catch(() => {}); wecomConn.setFlow(null); setWecomQr(null); setBusyId(null); };
             return createPortal((
             // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close layer; the keyboard path is covered by the dialog's cancel control
@@ -2194,9 +2196,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
               {/* biome-ignore lint/a11y/noStaticElementInteractions: click-propagation stop layer, non-interactive container */}
               <div className="bg-white dark:bg-[#1C1C1E] rounded-3xl p-7 w-full max-w-[440px] flex flex-col items-center text-center shadow-2xl" onClick={e => e.stopPropagation()}>
                 <h3 className="text-[19px] font-bold text-slate-900 dark:text-white mb-4">{storeCopy.connectTitle(storeCopy.toolNames.wecom)}</h3>
-                {/* 后端下发 wecom-cli --output-qrcode 落盘的真授权二维码(一次扫码直达)。
-                    此前 iframe 内嵌 /ai/qc/gen 落地页:WKWebView 里常渲染不出码,
-                    且落地页 URL 编成二维码会让用户扫码后再扫一次。 */}
+                {/* Real auth QR emitted by the backend (wecom-cli --output-qrcode PNG), one scan straight to authorization.
+                    Previously an iframe embedded the /ai/qc/gen landing page: WKWebView often failed to render the code,
+                    and encoding the landing-page URL as a QR made users scan a second time. */}
                 {wecomQr.qr && (
                   <img src={wecomQr.qr} alt={storeCopy.wecomQrAlt} decoding="async" className="w-52 h-52 rounded-2xl border border-slate-200 bg-white p-1 dark:border-white/10" />
                 )}

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -453,10 +453,12 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
     }
 
     // iOS 风格弹窗（安装/卸载后提示需新建会话生效）
+    // z-[210]:与扫码弹窗等其余 z-[200] body portal 同层会退化为挂载顺序定叠放
+    // （alert 后挂载才在上层），显式高一级让报错弹窗永远可见，不依赖挂载时机。
     const TsAlert = ({ alert, _theme, onDismiss, onNewChat, onCancelLoading, copy }) => { // eslint-disable-line no-unused-vars -- theme is kept for the existing props contract
       if (!alert.visible && !alert.loading) return null;
       return (
-        <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/40 backdrop-blur-sm">
+        <div className="fixed inset-0 z-[210] flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <div
             className="w-[280px] rounded-[20px] overflow-hidden shadow-2xl transition-transform duration-200 scale-100 bg-white/95 backdrop-blur-xl dark:bg-[#2C2C2E]"
             style={{ animation: 'tsAlertIn .2s ease-out' }}

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -800,7 +800,7 @@ desktopHint:'Install Obsidian on the desktop and create a vault first, then chec
   updatedQuoted:name=>`"${name}" updated`, updateSkillTitle:name=>`Update "${name}"`,
   updateSkillOverwriteHint:'This overwrites the skill with the latest store version. Your local changes to it will be lost.',
   notConnectedYet:name=>`"${name}" is not connected yet.`,
-  loginFrameTitle:name=>`${name} sign-in`, loginPageLoadFailed:'Failed to load the sign-in page—use browser authorization below', waitingAuth:'Waiting for authorization…', openInBrowser:'Open in browser',
+  wecomScanHint:'Scan with the WeCom app', wecomQrAlt:'WeCom sign-in QR code', openBrowserFailed:"Couldn't open the browser—retry or paste the link into your browser", waitingAuth:'Waiting for authorization…', openInBrowser:'Open in browser',
   mini:{ scan:'Scan pending', install:pct=>`Installing ${pct}%`, extract:pct=>`Extracting ${pct}%`, connecting:'Connecting', title:'Tap to view progress' },
   feishuSteps:[
 { key:'runtime', label:'Prepare runtime', sub:'Use the app-provided Node runtime' },

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -800,7 +800,7 @@ desktopHint:'Install Obsidian on the desktop and create a vault first, then chec
   updatedQuoted:name=>`"${name}" updated`, updateSkillTitle:name=>`Update "${name}"`,
   updateSkillOverwriteHint:'This overwrites the skill with the latest store version. Your local changes to it will be lost.',
   notConnectedYet:name=>`"${name}" is not connected yet.`,
-  wecomScanHint:'Scan with the WeCom app', wecomQrAlt:'WeCom sign-in QR code', openBrowserFailed:"Couldn't open the browser—retry or paste the link into your browser", waitingAuth:'Waiting for authorization…', openInBrowser:'Open in browser',
+  wecomScanHint:'Scan with the WeCom app', wecomQrAlt:'WeCom sign-in QR code', openBrowserFailed:"Couldn't open the browser—please retry", waitingAuth:'Waiting for authorization…', openInBrowser:'Open in browser',
   mini:{ scan:'Scan pending', install:pct=>`Installing ${pct}%`, extract:pct=>`Extracting ${pct}%`, connecting:'Connecting', title:'Tap to view progress' },
   feishuSteps:[
 { key:'runtime', label:'Prepare runtime', sub:'Use the app-provided Node runtime' },

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -802,7 +802,7 @@ desktopHint:'先にデスクトップで Obsidian をインストールして保
   updatedQuoted:name=>`「${name}」を更新しました`, updateSkillTitle:name=>`「${name}」を更新`,
   updateSkillOverwriteHint:'ストアの最新バージョンで上書きします。このスキルへのローカルの変更は失われます。',
   notConnectedYet:name=>`「${name}」はまだ接続されていません。`,
-  loginFrameTitle:name=>`${name} ログイン`, loginPageLoadFailed:'ログインページを読み込めませんでした。下のブラウザー認証をご利用ください', waitingAuth:'認証を待機中…', openInBrowser:'ブラウザーで開く',
+  wecomScanHint:'WeCom アプリでスキャンしてください', wecomQrAlt:'WeCom ログイン用QRコード', openBrowserFailed:'ブラウザーを開けませんでした。再試行するか、リンクをブラウザーに貼り付けて開いてください', waitingAuth:'認証を待機中…', openInBrowser:'ブラウザーで開く',
   mini:{ scan:'スキャン待ち', install:pct=>`インストール ${pct}%`, extract:pct=>`展開 ${pct}%`, connecting:'接続中', title:'タップして進捗を表示' },
   feishuSteps:[
 { key:'runtime', label:'ランタイムを準備', sub:'アプリ同梱の Node を使用' },

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -802,7 +802,7 @@ desktopHint:'先にデスクトップで Obsidian をインストールして保
   updatedQuoted:name=>`「${name}」を更新しました`, updateSkillTitle:name=>`「${name}」を更新`,
   updateSkillOverwriteHint:'ストアの最新バージョンで上書きします。このスキルへのローカルの変更は失われます。',
   notConnectedYet:name=>`「${name}」はまだ接続されていません。`,
-  wecomScanHint:'WeCom アプリでスキャンしてください', wecomQrAlt:'WeCom ログイン用QRコード', openBrowserFailed:'ブラウザーを開けませんでした。再試行するか、リンクをブラウザーに貼り付けて開いてください', waitingAuth:'認証を待機中…', openInBrowser:'ブラウザーで開く',
+  wecomScanHint:'WeCom アプリでスキャンしてください', wecomQrAlt:'WeCom ログイン用QRコード', openBrowserFailed:'ブラウザーを開けませんでした。もう一度お試しください', waitingAuth:'認証を待機中…', openInBrowser:'ブラウザーで開く',
   mini:{ scan:'スキャン待ち', install:pct=>`インストール ${pct}%`, extract:pct=>`展開 ${pct}%`, connecting:'接続中', title:'タップして進捗を表示' },
   feishuSteps:[
 { key:'runtime', label:'ランタイムを準備', sub:'アプリ同梱の Node を使用' },

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -830,7 +830,7 @@ desktopHint:'请先在桌面端安装 Obsidian 并创建笔记库，然后在这
   updatedQuoted:name=>`已更新「${name}」`, updateSkillTitle:name=>`更新「${name}」`,
   updateSkillOverwriteHint:'将覆盖为商店最新版本，你对该技能做的本地修改会丢失。',
   notConnectedYet:name=>`尚未连接「${name}」。`,
-  loginFrameTitle:name=>`${name}登录`, loginPageLoadFailed:'登录页加载失败，请用下方浏览器授权', waitingAuth:'等待授权中…', openInBrowser:'在浏览器打开',
+  wecomScanHint:'请使用企业微信 App 扫一扫', wecomQrAlt:'企业微信登录二维码', openBrowserFailed:'未能打开浏览器，请重试或把链接复制到浏览器打开', waitingAuth:'等待授权中…', openInBrowser:'在浏览器打开',
   mini:{ scan:'待扫码', install:pct=>`装 ${pct}%`, extract:pct=>`解压 ${pct}%`, connecting:'接入中', title:'点开查看进度' },
   feishuSteps:[
 { key:'runtime', label:'准备运行时', sub:'使用应用自带 Node' },

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -830,7 +830,7 @@ desktopHint:'请先在桌面端安装 Obsidian 并创建笔记库，然后在这
   updatedQuoted:name=>`已更新「${name}」`, updateSkillTitle:name=>`更新「${name}」`,
   updateSkillOverwriteHint:'将覆盖为商店最新版本，你对该技能做的本地修改会丢失。',
   notConnectedYet:name=>`尚未连接「${name}」。`,
-  wecomScanHint:'请使用企业微信 App 扫一扫', wecomQrAlt:'企业微信登录二维码', openBrowserFailed:'未能打开浏览器，请重试或把链接复制到浏览器打开', waitingAuth:'等待授权中…', openInBrowser:'在浏览器打开',
+  wecomScanHint:'请使用企业微信 App 扫一扫', wecomQrAlt:'企业微信登录二维码', openBrowserFailed:'未能打开浏览器，请重试', waitingAuth:'等待授权中…', openInBrowser:'在浏览器打开',
   mini:{ scan:'待扫码', install:pct=>`装 ${pct}%`, extract:pct=>`解压 ${pct}%`, connecting:'接入中', title:'点开查看进度' },
   feishuSteps:[
 { key:'runtime', label:'准备运行时', sub:'使用应用自带 Node' },

--- a/pinvou3-app/tests/tool_store_smoke.js
+++ b/pinvou3-app/tests/tool_store_smoke.js
@@ -174,7 +174,7 @@ function injectSource() {
         case 'get_bundle_visibility': return state.failVisibility ? Promise.reject(new Error('mock visibility read failure')) : Promise.resolve(state.hidden[args.scope]||[]);
         case 'set_bundle_visibility': state.hidden[args.scope]=(args.bundleIds||[]).map(toPackageId); return Promise.resolve(null);
         case 'feishu_apply_skills': case 'wecom_apply_skills': case 'dingtalk_apply_skills': case 'tmeet_apply_skills': return Promise.resolve(null);
-        // failOpenExternal 模拟外链白名单拒绝:企微扫码弹窗「在浏览器打开」须可见报错。
+        // failOpenExternal simulates an external-url allowlist rejection: the WeCom QR modal's "Open in browser" must surface a visible error.
         case 'open_external_url': return state.failOpenExternal ? Promise.reject('external-url-not-allowlisted') : Promise.resolve(null);
         default: return Promise.resolve(null);
       }
@@ -483,25 +483,26 @@ async function visibilityBox(page, cardText, modeLabel, click) {
       rec('飞书详情版本号以后端 lock 表为准',await page.evaluate(()=>document.body.innerText.includes('v9.9.9-lock')));
     }
     if(id==='wecom'){
-      // 企微真码弹窗:后端 emit 的 qr_data_url 直接进 <img>(iframe 已移除);
-      // 「在浏览器打开」被白名单拒绝时必须可见报错(此前静默);
-      // 取消须连流程卡一起清——后端对取消已静默,不再发 wecom:error 隐式清场。
+      // WeCom real-QR modal: the backend-emitted qr_data_url goes straight into <img> (iframe removed);
+      // an allowlist-rejected "Open in browser" must surface a visible error (previously silent);
+      // cancel must clear the flow card too — backend cancel is now silent, no wecom:error implicit cleanup.
       await page.evaluate(() => window.__emitTauri('wecom:qr', {
         phase: 'authorize',
         url: 'https://work.weixin.qq.com/ai/qc/gen?source=wecom_cli_external&test=1',
         qr_data_url: 'data:image/png;base64,AAAA',
       }));
       await sleep(150);
-      rec('企微扫码弹窗渲染后端下发的二维码', await page.evaluate(() => {
+      rec('WeCom QR modal renders the backend-issued QR', await page.evaluate(() => {
         const img = [...document.querySelectorAll('img')].find(i => (i.getAttribute('src') || '') === 'data:image/png;base64,AAAA');
         return !!img && document.body.innerText.includes('请使用企业微信 App 扫一扫');
       }));
       await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = true; });
       await clickExact(page, '在浏览器打开'); await sleep(150);
-      rec('企微浏览器打开被拒时可见报错且浮层置顶', await page.evaluate(() => {
+      rec('WeCom browser-open rejection shows a visible topmost alert', await page.evaluate(() => {
         if (!document.body.innerText.includes('未能打开浏览器')) return false;
-        // innerText 对遮挡免疫:再以 elementFromPoint 验证 alert 全屏层在自己的
-        // 中心点就是命中最上层,防止同层 body portal(如扫码弹窗)遮盖回归。
+        // innerText is blind to occlusion: also verify via elementFromPoint that the alert's
+        // fullscreen layer is the topmost hit at its own center, guarding against a
+        // same-level body portal (e.g. the QR modal) covering it again.
         const title = [...document.querySelectorAll('div')].find(d => (d.textContent || '').trim().startsWith('未能打开浏览器'));
         let layer = title;
         while (layer && !(layer.classList.contains('fixed') && layer.classList.contains('inset-0'))) layer = layer.parentElement;
@@ -514,7 +515,7 @@ async function visibilityBox(page, cardText, modeLabel, click) {
       await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = false; });
       await dismiss(page);
       await clickExact(page, '取消'); await sleep(150);
-      rec('企微弹窗取消后弹窗与流程卡一并清理', await page.evaluate(() => {
+      rec('WeCom modal cancel clears both modal and flow card', await page.evaluate(() => {
         const qrImg = [...document.querySelectorAll('img')].some(i => (i.getAttribute('src') || '') === 'data:image/png;base64,AAAA');
         return !qrImg && !document.body.innerText.includes('请使用企业微信 App 扫一扫');
       }));

--- a/pinvou3-app/tests/tool_store_smoke.js
+++ b/pinvou3-app/tests/tool_store_smoke.js
@@ -498,7 +498,19 @@ async function visibilityBox(page, cardText, modeLabel, click) {
       }));
       await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = true; });
       await clickExact(page, '在浏览器打开'); await sleep(150);
-      rec('企微浏览器打开被拒时可见报错', await page.evaluate(() => document.body.innerText.includes('未能打开浏览器')));
+      rec('企微浏览器打开被拒时可见报错且浮层置顶', await page.evaluate(() => {
+        if (!document.body.innerText.includes('未能打开浏览器')) return false;
+        // innerText 对遮挡免疫:再以 elementFromPoint 验证 alert 全屏层在自己的
+        // 中心点就是命中最上层,防止同层 body portal(如扫码弹窗)遮盖回归。
+        const title = [...document.querySelectorAll('div')].find(d => (d.textContent || '').trim().startsWith('未能打开浏览器'));
+        let layer = title;
+        while (layer && !(layer.classList.contains('fixed') && layer.classList.contains('inset-0'))) layer = layer.parentElement;
+        if (!layer) return false;
+        const r = layer.getBoundingClientRect();
+        let top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+        while (top && top !== layer) top = top.parentElement;
+        return top === layer;
+      }));
       await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = false; });
       await dismiss(page);
       await clickExact(page, '取消'); await sleep(150);

--- a/pinvou3-app/tests/tool_store_smoke.js
+++ b/pinvou3-app/tests/tool_store_smoke.js
@@ -49,7 +49,7 @@ function injectSource() {
       // government-writing 初始为独立已装（MCP gongwen 未装）:覆盖 G3 混合态——
       // companion 卡动作须来自技能级 readiness(卸载),首个用例卸载后回到未装态。
       installed:{},skills:{visualizer:false,'government-writing':true},connected:{feishu:false,wecom:false,dingtalk:false,tmeet:false,ima:false},
-      oauthAuth:{},oauthRequests:{},finishOAuthInstall:null,calls:[],obsidianChecks:0,composerChanged:0,failVisibility:false,
+      oauthAuth:{},oauthRequests:{},finishOAuthInstall:null,calls:[],obsidianChecks:0,composerChanged:0,failVisibility:false,failOpenExternal:false,
       hidden:{plain:[],code:[]}
     };
     window.addEventListener('pinvou:tools-changed',()=>{state.composerChanged++;});
@@ -173,7 +173,9 @@ function injectSource() {
         // mock 不再 no-op，勾选往返才可测）。
         case 'get_bundle_visibility': return state.failVisibility ? Promise.reject(new Error('mock visibility read failure')) : Promise.resolve(state.hidden[args.scope]||[]);
         case 'set_bundle_visibility': state.hidden[args.scope]=(args.bundleIds||[]).map(toPackageId); return Promise.resolve(null);
-        case 'feishu_apply_skills': case 'wecom_apply_skills': case 'dingtalk_apply_skills': case 'tmeet_apply_skills': case 'open_external_url': return Promise.resolve(null);
+        case 'feishu_apply_skills': case 'wecom_apply_skills': case 'dingtalk_apply_skills': case 'tmeet_apply_skills': return Promise.resolve(null);
+        // failOpenExternal 模拟外链白名单拒绝:企微扫码弹窗「在浏览器打开」须可见报错。
+        case 'open_external_url': return state.failOpenExternal ? Promise.reject('external-url-not-allowlisted') : Promise.resolve(null);
         default: return Promise.resolve(null);
       }
     }
@@ -479,6 +481,31 @@ async function visibilityBox(page, cardText, modeLabel, click) {
       // 刀9：版本号切后端源（mock 的 9.9.9-lock 与 tsToolsData 任何版本都不同,
       // 命中即证明渲染来自 bundle_readiness 的 bundle.version）
       rec('飞书详情版本号以后端 lock 表为准',await page.evaluate(()=>document.body.innerText.includes('v9.9.9-lock')));
+    }
+    if(id==='wecom'){
+      // 企微真码弹窗:后端 emit 的 qr_data_url 直接进 <img>(iframe 已移除);
+      // 「在浏览器打开」被白名单拒绝时必须可见报错(此前静默);
+      // 取消须连流程卡一起清——后端对取消已静默,不再发 wecom:error 隐式清场。
+      await page.evaluate(() => window.__emitTauri('wecom:qr', {
+        phase: 'authorize',
+        url: 'https://work.weixin.qq.com/ai/qc/gen?source=wecom_cli_external&test=1',
+        qr_data_url: 'data:image/png;base64,AAAA',
+      }));
+      await sleep(150);
+      rec('企微扫码弹窗渲染后端下发的二维码', await page.evaluate(() => {
+        const img = [...document.querySelectorAll('img')].find(i => (i.getAttribute('src') || '') === 'data:image/png;base64,AAAA');
+        return !!img && document.body.innerText.includes('请使用企业微信 App 扫一扫');
+      }));
+      await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = true; });
+      await clickExact(page, '在浏览器打开'); await sleep(150);
+      rec('企微浏览器打开被拒时可见报错', await page.evaluate(() => document.body.innerText.includes('未能打开浏览器')));
+      await page.evaluate(() => { window.__TOOL_STORE_TEST__.failOpenExternal = false; });
+      await dismiss(page);
+      await clickExact(page, '取消'); await sleep(150);
+      rec('企微弹窗取消后弹窗与流程卡一并清理', await page.evaluate(() => {
+        const qrImg = [...document.querySelectorAll('img')].some(i => (i.getAttribute('src') || '') === 'data:image/png;base64,AAAA');
+        return !qrImg && !document.body.innerText.includes('请使用企业微信 App 扫一扫');
+      }));
     }
     if(id==='tmeet'){
       await page.evaluate(() => window.__emitTauri('tmeet:qr', {


### PR DESCRIPTION
## Problem

User-reported WeCom connector issues in the tool store:

1. **Connect modal showed no QR code.** The modal embeds the URL printed by `wecom-cli auth init` in an iframe so the page renders its own login QR, but the page (a Vue SPA on `wwcdn.weixin.qq.com`) frequently fails to render inside the app WKWebView third-party iframe context, leaving the modal blank. The page itself sets no `X-Frame-Options`; the same iframe renders fine in Safari, so the blank is app-webview-specific.
2. **Detail-modal flow-card QR led to a second scan.** The backend captures the first URL the CLI prints — the `/ai/qc/gen` landing page — and encoded that URL into a QR. Scanning it opened the landing page, which asks the user to scan *again*.
3. **Both "Open in browser" buttons silently did nothing.** `open_external_url` enforces `EXTERNAL_URL_ALLOWLIST`, which had no WeCom (and no DingTalk) entry; the rejection surfaced only as an unhandled promise rejection.

## Fix

**WeCom (`fix(connectors): show real WeCom auth QR and allow browser open`)**

- `auth init` now runs with `--output-qrcode qr.png` (CLI ≥1.1.0 flag, only accepts a cwd-relative path, so the child runs in a per-attempt temp dir). The backend polls for the PNG (double-read length check against partial files), validates the PNG signature (`cc::png_data_url`), and emits it as `qr_data_url` — this is the real, directly scannable auth QR. Falls back to the locally drawn QR if the PNG never appears; event payload shape unchanged.
- Both the flow card and the connect modal now render the same one-scan QR; the iframe is gone.
- `https://work.weixin.qq.com/` added to `EXTERNAL_URL_ALLOWLIST` with the required allow/lookalike/non-https tests. The three `open_external_url` call sites now attach `.catch` and surface a visible alert (new `onBrowserOpenError` prop on the shared flow card); three-language copy added, two dead keys removed.
- Cancelling during the URL/PNG wait windows is now a silent stop: previously the kill-induced pipe EOF was reported as a "40s timeout" error, and a QR emitted after cancel could re-open the dismissed modal.
- Follow-up review fix (5004aa8ad): `TsAlert` is raised from `z-[200]` to `z-[210]` so the browser-open failure alert no longer relies on portal mount order to stack above the WeCom QR modal (both were `z-[200]` body portals; empirically the alert already painted on top because it mounts later, but that was implicit). The tool-store smoke assertion for the open-browser rejection now verifies via `elementFromPoint` that the alert is actually the topmost layer, not just that its text exists in `innerText` (red-verified by temporarily raising the QR modal above the alert).

**DingTalk (`fix(connectors): allowlist DingTalk login page for browser open`)**

- `dws auth login --device` uses a device-code flow: the captured URL (`https://login.dingtalk.com/...?user_code=...`) is already the directly scannable auth page, so no QR change is needed. Added `https://login.dingtalk.com/` to the allowlist so its browser-open button works, with the same test pattern.

## Verification

- `cargo fmt --check`, `cargo clippy --lib --all-features` (clean for the app crate)
- Targeted `cargo test --lib`: wecom module (9, incl. new `poll_qr_png`), `png_data_url`, allowlist suite (8, incl. both gate tests)
- Frontend: `lint:ui`, `oxlint`, `knip`, `build:ui`, `npm test` (519 tests, 0 failed); `architecture-guard.py` passes
- Manually verified against the real CLI: `--output-qrcode` PNG decodes (CoreImage) to the direct auth URL `https://work.weixin.qq.com/ai/qc/c?s=...&for_native=true`; gen page has no `X-Frame-Options` and its iframe renders in Safari but not reliably in the app webview, motivating the PNG approach

## Notes

- Full end-to-end confirmation (actual phone scan → authorized) still needs a real device; the QR content itself was verified by decoding.
- DingTalk allowlist entry is deliberately minimal (`login.dingtalk.com` only — the host the CLI actually prints). If a future CLI version prints a different host, the button now fails visibly instead of silently.
- `Cargo.lock` member-version drift was intentionally left out; fixed on main by #380, and this branch is rebased on top of it.

Signed-off-by: asto <asto18089@126.com>
