### PR TITLE
fix(chat): hide serialized runtime messages

### DIFF
--- a/pinvou3-app/src/features/codex/code-native-lane.js
+++ b/pinvou3-app/src/features/codex/code-native-lane.js
@@ -537,10 +537,10 @@ function messageText(blocks) {
     .trim();
 }
 
-// 与 platform/{tauri,web}/bridge.js 的 userMessageDisplayText 判定保持一致：
-// CodeWhale 内部运行时信封（subagent handoff / background shell 完成等）以
-// role=user 持久化供父模型上下文使用，展示层不得渲染为用户气泡。
-// 共享 ESM 实现见 src/shared/internal-message.mjs（bridge 闭包不可 import）。
+// 与 src/shared/internal-message.mjs 的内部运行时消息判定同源（bridge 侧的
+// 超集实现见 src/shared/bridge-messages.js）：CodeWhale 内部运行时信封
+// （subagent handoff / background shell 完成等）以 role=user 持久化供父模型
+// 上下文使用，展示层不得渲染为用户气泡。
 
 /// SavedSession messages → lane.items（hydration 是 rerenderFromMessages 的精简版：
 /// 覆盖 user / assistant text / thinking / tool_use+tool_result / request_user_input /

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1631,30 +1631,15 @@
   }
 
   function userMessageInputProvenance(blocks) {
-    const textBlocks = Array.isArray(blocks) ? blocks : [];
-    for (let i = 0; i < textBlocks.length; i++) {
-      const block = textBlocks[i];
-      if (!block || block.type !== "text") continue;
-      const text = String(block.text || "").trim();
-      if (text.indexOf("<turn_meta>") !== 0) continue;
-      // CodeWhale appends human-readable authority detail after the stable
-      // provenance identifier. Parse only that identifier so both the current
-      // one-line shape and legacy two-line metadata remain compatible.
-      const match = text.match(/(?:^|\n)Input provenance:\s*([a-z0-9_-]+)/i);
-      if (match && match[1]) return match[1].toLowerCase();
-    }
-    return "";
+    return window.PinvouBridgeMessages.userMessageInputProvenance(blocks);
   }
 
   function isInternalUserMessageProvenance(provenance) {
-    // shell_completion 同为 CodeWhale 非权威内部来源（SHELL_COMPLETION_HANDOFF_TURN_META）。
-    return ["runtime", "subagent_handoff", "shell_completion"].includes(provenance);
+    return window.PinvouBridgeMessages.isInternalUserMessageProvenance(provenance);
   }
 
   function isInternalRuntimeEnvelopeText(value) {
-    const text = String(value || "").trim();
-    return /^<codewhale:runtime_event\b[^>]*\bvisibility=(["'])internal\1[^>]*>/i.test(text) &&
-      /<\/codewhale:runtime_event>\s*$/i.test(text);
+    return window.PinvouBridgeMessages.isInternalRuntimeUserMessage(value);
   }
 
   // Engine 的运行时恢复提示为了兼容模型协议会以 role=user 持久化，但它不是用户输入。

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4003,24 +4003,11 @@
   }
 
   function userMessageInputProvenance(blocks) {
-    const textBlocks = Array.isArray(blocks) ? blocks : [];
-    for (let i = 0; i < textBlocks.length; i++) {
-      const block = textBlocks[i];
-      if (!block || block.type !== "text") continue;
-      const text = String(block.text || "").trim();
-      if (text.indexOf("<turn_meta>") !== 0) continue;
-      // CodeWhale appends human-readable authority detail after the stable
-      // provenance identifier. Parse only that identifier so both the current
-      // one-line shape and legacy two-line metadata remain compatible.
-      const match = text.match(/(?:^|\n)Input provenance:\s*([a-z0-9_-]+)/i);
-      if (match && match[1]) return match[1].toLowerCase();
-    }
-    return "";
+    return window.PinvouBridgeMessages.userMessageInputProvenance(blocks);
   }
 
   function isInternalUserMessageProvenance(provenance) {
-    // shell_completion 同为 CodeWhale 非权威内部来源（SHELL_COMPLETION_HANDOFF_TURN_META）。
-    return ["runtime", "subagent_handoff", "shell_completion"].includes(provenance);
+    return window.PinvouBridgeMessages.isInternalUserMessageProvenance(provenance);
   }
   // isInternalRuntimeUserMessage（下方 live 路径同一判定）与本函数等价：
   // 历史重载与实时事件两条展示路径共用同一信封判定，避免两处实现漂移。
@@ -5501,9 +5488,7 @@
   // 后台临时切工作集跑完再切回。下面每个监听器的 body 与旧单 session 版逐字一致,
   // 只是包了一层路由,所以 active session 行为零变化。
   function isInternalRuntimeUserMessage(value) {
-    const text = String(value || "").trim();
-    return /^<codewhale:runtime_event\b[^>]*\bvisibility=(["'])internal\1[^>]*>/i.test(text) &&
-      /<\/codewhale:runtime_event>\s*$/i.test(text);
+    return window.PinvouBridgeMessages.isInternalRuntimeUserMessage(value);
   }
 
   function applyRemoteUserMessageEvent(e, force) {

--- a/pinvou3-app/src/shared/bridge-messages.js
+++ b/pinvou3-app/src/shared/bridge-messages.js
@@ -16,7 +16,75 @@
       : shellCleanupFailed.zh;
   }
 
+  // Runtime-owned user-role turns may arrive with their trailing turn metadata
+  // flattened into the same text block. Keep that transport detail out of UI projections.
+  function inputProvenanceFromText(value) {
+    const text = String(value || "").trim();
+    if (!text) return "";
+    const lowerText = text.toLowerCase();
+    const openingTag = "<turn_meta>";
+    const closingTag = "</turn_meta>";
+    const openingIndex = lowerText.lastIndexOf(openingTag);
+    const closingIndex = lowerText.indexOf(closingTag, openingIndex + openingTag.length);
+    const hasTrailingMetadata = openingIndex > 0 && text[openingIndex - 1] === "\n" &&
+      closingIndex >= 0 && !text.slice(closingIndex + closingTag.length).trim();
+    const metadata = openingIndex === 0
+      ? text
+      : (hasTrailingMetadata ? text.slice(openingIndex, closingIndex + closingTag.length) : "");
+    if (!metadata) return "";
+    const match = metadata.match(/(?:^|\n)Input provenance:\s*([a-z0-9_-]+)/i);
+    return match && match[1] ? match[1].toLowerCase() : "";
+  }
+
+  function isInternalUserMessageProvenance(provenance) {
+    return ["runtime", "subagent_handoff", "shell_completion"].includes(provenance);
+  }
+
+  function consumeLeadingInternalRuntimeEnvelope(value) {
+    const text = String(value || "").trim();
+    const opening = text.match(/^<codewhale:runtime_event\b[^>]*\bvisibility=(["'])internal\1[^>]*>/i);
+    if (!opening) return null;
+    const remainder = text.slice(opening[0].length);
+    const closing = remainder.match(/<\/codewhale:runtime_event\s*>/i);
+    if (!closing) return null;
+    return remainder.slice(closing.index + closing[0].length).trim();
+  }
+
+  function containsOnlyInternalRuntimeMetadata(value) {
+    let remainder = String(value || "").trim();
+    let foundEnvelope = false;
+    while (remainder) {
+      const afterEnvelope = consumeLeadingInternalRuntimeEnvelope(remainder);
+      if (afterEnvelope === null) break;
+      foundEnvelope = true;
+      remainder = afterEnvelope;
+    }
+    if (!foundEnvelope) return false;
+    if (!remainder || /^<turn_meta_unchanged\s*\/>$/i.test(remainder)) return true;
+    const lowerRemainder = remainder.toLowerCase();
+    return lowerRemainder.startsWith("<turn_meta>") && lowerRemainder.endsWith("</turn_meta>");
+  }
+
+  function userMessageInputProvenance(blocks) {
+    const textBlocks = Array.isArray(blocks) ? blocks : [];
+    for (let i = 0; i < textBlocks.length; i++) {
+      const block = textBlocks[i];
+      if (!block || block.type !== "text") continue;
+      const provenance = inputProvenanceFromText(block.text);
+      if (provenance) return provenance;
+    }
+    return "";
+  }
+
+  function isInternalRuntimeUserMessage(value) {
+    return containsOnlyInternalRuntimeMetadata(value) ||
+      isInternalUserMessageProvenance(inputProvenanceFromText(value));
+  }
+
   window.PinvouBridgeMessages = Object.freeze({
+    isInternalRuntimeUserMessage,
+    isInternalUserMessageProvenance,
+    userMessageInputProvenance,
     showShellCleanupFailure: function (payload, state, addSystemItem) {
       if (!payload || !payload.shell_cleanup_failed) return;
       const notice = shellCleanupFailedText(state.settings && state.settings.language);

--- a/pinvou3-app/src/shared/internal-message.mjs
+++ b/pinvou3-app/src/shared/internal-message.mjs
@@ -3,15 +3,17 @@
  *
  * CodeWhale 把内部运行时信封（子智能体交接 subagent_handoff / 后台 shell 完成
  * shell_completion / 运行时恢复提示 runtime）以 role=user 持久化供父模型上下文
- * 使用，展示层不得渲染为用户气泡。判定规则与
- * platform/{tauri,web}/bridge.js 的 userMessageDisplayText 保持一致：
+ * 使用，展示层不得渲染为用户气泡。本模块识别两种形态：
  * - 完整信封：<codewhale:runtime_event ... visibility="internal">...</codewhale:runtime_event>
- * - 非权威 provenance：turn_meta 块内 "Input provenance: <id>"，白名单
- *   {runtime, subagent_handoff, shell_completion}
+ * - 非权威 provenance：以前导 <turn_meta> 开头的块内 "Input provenance: <id>"，
+ *   白名单 {runtime, subagent_handoff, shell_completion}
  *
  * 本模块供 ESM 车道（CodeX 原生车道 code-native-lane.js、子智能体 transcript
- * 面板 subagent-conversation.mjs）共享；tauri/web bridge 是 IIFE 自包含 bundle
- * 无法 import，各自维护等价实现（见两处 bridge.js）。扩展白名单时须同步三处。
+ * 面板 subagent-conversation.mjs）共享。tauri/web bridge 的同源判定已收拢到
+ * src/shared/bridge-messages.js（经典脚本，index.html 先于两个 bridge 加载），
+ * 其识别是本模块的超集——额外识别 envelope/正文与尾随 turn_meta 摊平进同一
+ * 文本块的形态。本模块仍保持保守的前导形态：当前 ESM 车道的消息源不产生摊平
+ * 形态，若引擎侧出现须先在此对齐。扩展白名单或信封形态时须同步两处。
  */
 
 const INTERNAL_PROVENANCE = new Set(['runtime', 'subagent_handoff', 'shell_completion']);

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -1711,6 +1711,18 @@ async function currentInternalProvenanceAndEnvelopeStayOutOfPresentation() {
     'internal shell completion payload',
     '</codewhale:runtime_event>',
   ].join('\n');
+  const runtimeTurnMeta = [
+    '<turn_meta>',
+    'Current workspace: /private/workspace',
+    'Input provenance: runtime (non-authoritative)',
+    '</turn_meta>',
+  ].join('\n');
+  const serializedEnvelopeAndMeta = completionText + '\n' + runtimeTurnMeta;
+  const serializedRuntimePromptAndMeta = [
+    'Tool calls have failed for 2 consecutive steps. Do not repeat the same call unchanged.',
+    'Switch to an alternate tool or source.',
+    runtimeTurnMeta,
+  ].join('\n');
 
   for (let bridgeIndex = 0; bridgeIndex < 2; bridgeIndex++) {
     const bridgeKind = bridgeIndex === 0 ? "tauri" : "web";
@@ -1744,6 +1756,9 @@ async function currentInternalProvenanceAndEnvelopeStayOutOfPresentation() {
           { role: "user", content: [
             { type: "text", text: "<turn_meta>\nInput provenance: shell_completion (non-authoritative)\n</turn_meta>" },
           ] },
+          // Some transports flatten the runtime payload and its metadata into one text block.
+          { role: "user", content: [{ type: "text", text: serializedEnvelopeAndMeta }] },
+          { role: "user", content: [{ type: "text", text: serializedRuntimePromptAndMeta }] },
           { role: "assistant", content: [{ type: "text", text: "parent final answer" }] },
         ],
         artifacts: [],
@@ -1760,6 +1775,7 @@ async function currentInternalProvenanceAndEnvelopeStayOutOfPresentation() {
       "current child-only completion summary",
       "current runtime recovery hint",
       "internal shell completion payload",
+      "Tool calls have failed for 2 consecutive steps",
       "codewhale:runtime_event",
       "Current workspace:",
       "Input provenance: shell_completion",
@@ -1777,6 +1793,34 @@ async function currentInternalProvenanceAndEnvelopeStayOutOfPresentation() {
       bridgeKind + " must preserve current provenance metadata");
     assert.ok(raw.includes("shell_completion (non-authoritative)"),
       bridgeKind + " must preserve shell_completion provenance metadata");
+    assert.ok(raw.includes("Tool calls have failed for 2 consecutive steps"),
+      bridgeKind + " must preserve serialized runtime guidance in model context");
+
+    await harness.emit("chat:user_message", {
+      session_id: sessionId,
+      content: serializedEnvelopeAndMeta,
+      operation: "append",
+    });
+    await harness.emit("chat:user_message", {
+      session_id: sessionId,
+      content: serializedRuntimePromptAndMeta,
+      operation: "append",
+    });
+    const afterLiveInternal = JSON.stringify(harness.bridge.state.get("chat").chatItems);
+    assert.ok(!afterLiveInternal.includes("Tool calls have failed for 2 consecutive steps"),
+      bridgeKind + " must hide a live runtime prompt with trailing provenance metadata");
+    assert.ok(!afterLiveInternal.includes("current child-only completion summary"),
+      bridgeKind + " must hide a live envelope with trailing metadata");
+
+    const quotedEnvelope = completionText + "\nPlease explain this literal runtime envelope.";
+    await harness.emit("chat:user_message", {
+      session_id: sessionId,
+      content: quotedEnvelope,
+      operation: "append",
+    });
+    const afterQuotedEnvelope = JSON.stringify(harness.bridge.state.get("chat").chatItems);
+    assert.ok(afterQuotedEnvelope.includes("Please explain this literal runtime envelope."),
+      bridgeKind + " must retain user text following an internal-looking quoted envelope");
   }
 }
 

--- a/pinvou3-app/tests/session_buffer_eviction.test.mjs
+++ b/pinvou3-app/tests/session_buffer_eviction.test.mjs
@@ -45,6 +45,10 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const bridgeDir = path.join(here, '..', 'src', 'platform', 'tauri', 'bridge');
 const webBridgeRoot = path.resolve(here, '..', 'src', 'platform', 'web');
 const read = relativePath => fs.readFileSync(path.join(webBridgeRoot, relativePath), 'utf8');
+const bridgeMessagesSource = fs.readFileSync(
+  path.resolve(here, '..', 'src', 'shared', 'bridge-messages.js'),
+  'utf8',
+);
 
 // ── tauri sessions.js factory boot ───────────────────────────────────
 
@@ -437,6 +441,7 @@ function bootWebBridge() {
     TextEncoder,
     TextDecoder,
   });
+  vm.runInContext(bridgeMessagesSource, context, { filename: 'shared/bridge-messages.js' });
   vm.runInContext(read('bridge.js'), context, { filename: 'platform/web/bridge.js' });
   const flat = windowObject.TauriBridge;
   // Cold switches go through loadSessionForClient's chunk protocol: a

--- a/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
+++ b/pinvou3-app/tests/web_bridge_domain_contract.test.mjs
@@ -298,6 +298,14 @@ assert.ok(
   indexSource.indexOf('platform/web/bridge.js') < indexSource.indexOf('platform/web/bridge/domain-adapter.js'),
   'Web domain adapter must load after the flat transport',
 );
+assert.ok(
+  indexSource.indexOf('shared/bridge-messages.js') < indexSource.indexOf('platform/tauri/bridge/chat-events.js'),
+  'shared bridge messages must load before the tauri bridge chat events',
+);
+assert.ok(
+  indexSource.indexOf('shared/bridge-messages.js') < indexSource.indexOf('platform/tauri/bridge.js'),
+  'shared bridge messages must load before the tauri bridge',
+);
 
 const stableCombined = [];
 const unsubscribeStableCombined = api.state.subscribeMany(['sessions', 'chat'], snapshot => { stableCombined.push(snapshot); });


### PR DESCRIPTION
## Background

Internal runtime messages are persisted with a user wire role for model-protocol compatibility, but serialized runtime guidance could be flattened together with trailing turn metadata and bypass the presentation filter. This exposed internal instructions as user chat bubbles while artifacts were being updated.

## Changes

- centralize internal runtime-message classification for the Tauri and Web bridges;
- recognize runtime envelopes followed by serialized turn metadata and runtime-provenance payloads;
- preserve raw internal messages for model context while excluding them from live and restored chat projections;
- retain user-authored text when an internal-looking envelope is followed by real user content;
- add Tauri and Web regression coverage for live events and session recovery.

## Verification

- `node pinvou3-app/tests/scheduled_tasks_unit.test.js`
- `npm --prefix pinvou3-app run test:bridge-protocol`
- `npm --prefix pinvou3-app run lint:ui`
- `npm --prefix pinvou3-app run build:ui`
- `python scripts/architecture-guard.py`
- JavaScript syntax checks and `git diff --check`
- deterministic three-artifact update reproduction on both Tauri and Web: three cards retained and no internal user bubble created

## Risk

Low and limited to chat presentation filtering. Raw transcript/model context remains unchanged. A live-model end-to-end reproduction is nondeterministic and was not used as a release gate; deterministic bridge-level coverage exercises the affected event and recovery paths.