### PR TITLE
fix(codex): keep streaming conversations pinned to bottom

### DIFF
--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -27,13 +27,15 @@ import {
   conversationItemsForMode,
   projectDeepSeekConversation,
 } from '../conversation/deepseek-conversation.js';
-import { startConversationBottomFollower } from '../conversation/conversation-scroll.js';
+import {
+  measureConversationScrollGeometry,
+  startConversationBottomFollower,
+  transitionConversationScrollState,
+} from '../conversation/conversation-scroll.js';
 import {
   captureConversationScrollPosition,
   isFetchTool,
-  isNearConversationBottom,
   isSearchTool,
-  isShrinkClampedToBottom,
   restoreConversationScrollPosition,
 } from '../conversation/conversation-model.js';
 import { AttachmentChips } from '../attachments/AttachmentChips.jsx';
@@ -1045,18 +1047,15 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
         const el = scrollRef.current;
         if (!el) return;
         const onScroll = () => {
-          const near = isNearConversationBottom(el);
-          // A content shrink (e.g. content-visibility replacing its 600px estimate with a
-          // smaller real height) makes the browser clamp scrollTop down to the new maximum.
-          // That programmatic jump carries no user intent, so it must neither disable
-          // auto-follow (the bottom follower and streaming effect depend on it) nor
-          // re-enable it for a user who was browsing history.
-          const shrinkClamped = isShrinkClampedToBottom(el, lastScrollHeightRef.current);
-          const movingUp = el.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped;
-          lastScrollTopRef.current = el.scrollTop;
-          lastScrollHeightRef.current = el.scrollHeight;
-          if (movingUp) autoScrollRef.current = false;
-          else if (!shrinkClamped && near) autoScrollRef.current = true;
+          const transition = transitionConversationScrollState({
+            scrollElement: el,
+            following: autoScrollRef.current,
+            previousScrollTop: lastScrollTopRef.current,
+            previousScrollHeight: lastScrollHeightRef.current,
+          });
+          lastScrollTopRef.current = transition.scrollTop;
+          lastScrollHeightRef.current = transition.scrollHeight;
+          autoScrollRef.current = transition.following;
           const shouldShow = !autoScrollRef.current && el.scrollHeight > el.clientHeight + 4;
           setShowScrollBottom(v => v === shouldShow ? v : shouldShow);
         };
@@ -1130,6 +1129,16 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
           scrollElement,
           contentElement,
           isFollowing: () => autoScrollRef.current,
+          onMeasured: () => {
+            const measurement = measureConversationScrollGeometry({
+              scrollElement,
+              following: autoScrollRef.current,
+              previousScrollTop: lastScrollTopRef.current,
+              previousScrollHeight: lastScrollHeightRef.current,
+            });
+            lastScrollTopRef.current = measurement.scrollTop;
+            lastScrollHeightRef.current = measurement.scrollHeight;
+          },
           onRestored: (scrollTop) => {
             lastScrollTopRef.current = scrollTop;
             lastScrollHeightRef.current = scrollElement.scrollHeight;

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1253,6 +1253,7 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
         if (!el) return;
         restoreConversationScrollPosition(el, snapshot);
         lastScrollTopRef.current = el.scrollTop;
+        lastScrollHeightRef.current = el.scrollHeight;
         if (snapshot.stickToBottom) {
           autoScrollRef.current = true;
           setShowScrollBottom(false);

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -74,7 +74,11 @@ import {
   ConversationTurn,
   WorkspaceResourceButtons,
 } from '../conversation/ConversationTimeline.jsx';
-import { startConversationBottomFollower } from '../conversation/conversation-scroll.js';
+import {
+  measureConversationScrollGeometry,
+  startConversationBottomFollower,
+  transitionConversationScrollState,
+} from '../conversation/conversation-scroll.js';
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 import { assistantResponseAvailable, assistantResponseText } from '../conversation/message-clipboard.js';
 import { ComposerModelSelector, ComposerToolMenu } from '../settings/composer-shared.jsx';
@@ -89,9 +93,7 @@ import {
   captureConversationScrollPosition,
   collectToolWorkspaceResources,
   isFetchTool,
-  isNearConversationBottom,
   isSearchTool,
-  isShrinkClampedToBottom,
   restoreConversationScrollPosition,
   toolWorkspaceResources,
 } from '../conversation/conversation-model.js';
@@ -2517,13 +2519,15 @@ export function CodexAcpView({
     const element = scroller.current;
     if (!element) return;
     const onScroll = () => {
-      const near = isNearConversationBottom(element);
-      const shrinkClamped = isShrinkClampedToBottom(element, lastScrollHeightRef.current);
-      const movingUp = element.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped;
-      lastScrollTopRef.current = element.scrollTop;
-      lastScrollHeightRef.current = element.scrollHeight;
-      if (movingUp) autoScrollRef.current = false;
-      else if (!shrinkClamped && near) autoScrollRef.current = true;
+      const transition = transitionConversationScrollState({
+        scrollElement: element,
+        following: autoScrollRef.current,
+        previousScrollTop: lastScrollTopRef.current,
+        previousScrollHeight: lastScrollHeightRef.current,
+      });
+      lastScrollTopRef.current = transition.scrollTop;
+      lastScrollHeightRef.current = transition.scrollHeight;
+      autoScrollRef.current = transition.following;
       const shouldShow = !autoScrollRef.current
         && element.scrollHeight > element.clientHeight + 4;
       setShowScrollBottom(current => current === shouldShow ? current : shouldShow);
@@ -2569,6 +2573,16 @@ export function CodexAcpView({
       scrollElement,
       contentElement,
       isFollowing: () => autoScrollRef.current,
+      onMeasured: () => {
+        const measurement = measureConversationScrollGeometry({
+          scrollElement,
+          following: autoScrollRef.current,
+          previousScrollTop: lastScrollTopRef.current,
+          previousScrollHeight: lastScrollHeightRef.current,
+        });
+        lastScrollTopRef.current = measurement.scrollTop;
+        lastScrollHeightRef.current = measurement.scrollHeight;
+      },
       onRestored: (scrollTop) => {
         lastScrollTopRef.current = scrollTop;
         lastScrollHeightRef.current = scrollElement.scrollHeight;

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -74,6 +74,7 @@ import {
   ConversationTurn,
   WorkspaceResourceButtons,
 } from '../conversation/ConversationTimeline.jsx';
+import { startConversationBottomFollower } from '../conversation/conversation-scroll.js';
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 import { assistantResponseAvailable, assistantResponseText } from '../conversation/message-clipboard.js';
 import { ComposerModelSelector, ComposerToolMenu } from '../settings/composer-shared.jsx';
@@ -90,6 +91,7 @@ import {
   isFetchTool,
   isNearConversationBottom,
   isSearchTool,
+  isShrinkClampedToBottom,
   restoreConversationScrollPosition,
   toolWorkspaceResources,
 } from '../conversation/conversation-model.js';
@@ -1090,9 +1092,11 @@ export function CodexAcpView({
   const [draftConfigSelections, setDraftConfigSelections] = useState({});
   const [showScrollBottom, setShowScrollBottom] = useState(false);
   const scroller = useRef(null);
+  const conversationContentRef = useRef(null);
   const rightPanelScrollRef = useRef(null);
   const autoScrollRef = useRef(true);
   const lastScrollTopRef = useRef(0);
+  const lastScrollHeightRef = useRef(0);
   const attachmentIdRef = useRef(0);
   const attachmentMenuTriggerRef = useRef(null);
   const deviceFileInputRef = useRef(null);
@@ -1343,6 +1347,7 @@ export function CodexAcpView({
     if (!element) return;
     restoreConversationScrollPosition(element, snapshot);
     lastScrollTopRef.current = element.scrollTop;
+    lastScrollHeightRef.current = element.scrollHeight;
     if (snapshot.stickToBottom) {
       autoScrollRef.current = true;
       setShowScrollBottom(false);
@@ -2513,10 +2518,12 @@ export function CodexAcpView({
     if (!element) return;
     const onScroll = () => {
       const near = isNearConversationBottom(element);
-      const movingUp = element.scrollTop < lastScrollTopRef.current - 1;
+      const shrinkClamped = isShrinkClampedToBottom(element, lastScrollHeightRef.current);
+      const movingUp = element.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped;
       lastScrollTopRef.current = element.scrollTop;
+      lastScrollHeightRef.current = element.scrollHeight;
       if (movingUp) autoScrollRef.current = false;
-      else if (near) autoScrollRef.current = true;
+      else if (!shrinkClamped && near) autoScrollRef.current = true;
       const shouldShow = !autoScrollRef.current
         && element.scrollHeight > element.clientHeight + 4;
       setShowScrollBottom(current => current === shouldShow ? current : shouldShow);
@@ -2548,9 +2555,26 @@ export function CodexAcpView({
       if (element) {
         element.scrollTop = element.scrollHeight;
         lastScrollTopRef.current = element.scrollTop;
+        lastScrollHeightRef.current = element.scrollHeight;
       }
     });
     return () => window.cancelAnimationFrame(frame);
+  }, [activeId]);
+
+  useEffect(() => {
+    const scrollElement = scroller.current;
+    const contentElement = conversationContentRef.current;
+    if (!scrollElement || !contentElement) return;
+    return startConversationBottomFollower({
+      scrollElement,
+      contentElement,
+      isFollowing: () => autoScrollRef.current,
+      onRestored: (scrollTop) => {
+        lastScrollTopRef.current = scrollTop;
+        lastScrollHeightRef.current = scrollElement.scrollHeight;
+        setShowScrollBottom(false);
+      },
+    });
   }, [activeId]);
 
   function scrollConversationToBottom() {
@@ -3262,7 +3286,7 @@ export function CodexAcpView({
         <div className="flex-1 min-h-0 flex">
         <div className="relative min-w-0 flex-1 min-h-0 flex flex-col">
         <div ref={scroller} className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
-          <div className="w-full max-w-[920px] min-h-full mx-auto px-6 py-6 flex flex-col gap-7">
+          <div ref={conversationContentRef} className="w-full max-w-[920px] min-h-full mx-auto px-6 py-6 flex flex-col gap-7">
             {workspaceUnavailable ? (
               <div
                 data-testid="codex-workspace-unavailable"

--- a/pinvou3-app/src/features/conversation/conversation-scroll.js
+++ b/pinvou3-app/src/features/conversation/conversation-scroll.js
@@ -1,9 +1,70 @@
-import { restoreConversationScrollPosition } from './conversation-model.js';
+import {
+  isNearConversationBottom,
+  isShrinkClampedToBottom,
+  restoreConversationScrollPosition,
+} from './conversation-model.js';
+
+export function transitionConversationScrollState({
+  scrollElement,
+  following,
+  previousScrollTop,
+  previousScrollHeight,
+}) {
+  if (!scrollElement) {
+    return {
+      following,
+      movingUp: false,
+      nearBottom: true,
+      shrinkClamped: false,
+      scrollTop: Number(previousScrollTop) || 0,
+      scrollHeight: Number(previousScrollHeight) || 0,
+    };
+  }
+
+  const nearBottom = isNearConversationBottom(scrollElement);
+  const shrinkClamped = isShrinkClampedToBottom(scrollElement, previousScrollHeight);
+  const movingUp = scrollElement.scrollTop < (Number(previousScrollTop) || 0) - 1
+    && !shrinkClamped;
+  return {
+    following: movingUp ? false : ((!shrinkClamped && nearBottom) || following),
+    movingUp,
+    nearBottom,
+    shrinkClamped,
+    scrollTop: scrollElement.scrollTop,
+    scrollHeight: scrollElement.scrollHeight,
+  };
+}
+
+export function measureConversationScrollGeometry({
+  scrollElement,
+  following,
+  previousScrollTop,
+  previousScrollHeight,
+}) {
+  const previous = {
+    scrollTop: Number(previousScrollTop) || 0,
+    scrollHeight: Number(previousScrollHeight) || 0,
+  };
+  if (!scrollElement) return previous;
+
+  // Preserve the pre-shrink baseline when the browser has clamped a history
+  // reader to the new bottom. A scroll event may still arrive after ResizeObserver;
+  // retaining the old height lets the transition identify that event as layout-owned
+  // instead of incorrectly resuming follow mode.
+  if (!following && isShrinkClampedToBottom(scrollElement, previous.scrollHeight)) {
+    return previous;
+  }
+  return {
+    scrollTop: scrollElement.scrollTop,
+    scrollHeight: scrollElement.scrollHeight,
+  };
+}
 
 export function startConversationBottomFollower({
   scrollElement,
   contentElement,
   isFollowing,
+  onMeasured,
   onRestored,
   windowObject = typeof window === 'undefined' ? null : window,
   documentObject = typeof document === 'undefined' ? null : document,
@@ -12,6 +73,10 @@ export function startConversationBottomFollower({
 
   let frame = null;
   const restoreBottomIfFollowing = () => {
+    // ResizeObserver runs after layout has updated scrollTop/scrollHeight. Record that
+    // baseline even while history browsing, so the next user scroll is not compared
+    // with stale pre-reflow geometry and mistaken for a shrink-induced clamp.
+    if (onMeasured) onMeasured(scrollElement);
     if (!isFollowing()) return;
     if (frame !== null) windowObject.cancelAnimationFrame(frame);
     frame = windowObject.requestAnimationFrame(() => {

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -833,18 +833,17 @@ try {
     && codexView.includes('data-testid="acp-account-menu"')
     && codexView.includes('switchAccountAffectsSessions'),
   'every ACP Agent must expose an account menu and a force account-switch action');
-  assert.ok(codexView.includes('const movingUp = element.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped')
-    && codexView.includes('if (movingUp) autoScrollRef.current = false')
+  assert.ok(codexView.includes('const transition = transitionConversationScrollState({')
+    && codexView.includes('autoScrollRef.current = transition.following')
     && codexView.includes('if (autoScrollRef.current)')
     && codexView.includes('scrollConversationToBottom')
     && codexView.includes('codexCopy.latest')
     && codexView.includes('bottom-full')
     && !codexView.includes('bottom-[106px]'),
   'Codex streaming must pause auto-follow and place the return action above, not over, the composer');
-  assert.ok(codexView.includes('const shrinkClamped = isShrinkClampedToBottom(element, lastScrollHeightRef.current)')
-    && codexView.includes('else if (!shrinkClamped && near) autoScrollRef.current = true')
-    && codexView.includes('const contentElement = conversationContentRef.current')
+  assert.ok(codexView.includes('const contentElement = conversationContentRef.current')
     && codexView.includes('return startConversationBottomFollower({')
+    && codexView.includes('onMeasured: () => {')
     && codexView.includes('lastScrollHeightRef.current = scrollElement.scrollHeight'),
   'Codex streaming must retain bottom following across content shrink and asynchronous layout changes');
   assert.ok(!codexView.includes('<JsonBlock'), 'raw ACP JSON must not leak into normal command UI');

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -833,7 +833,7 @@ try {
     && codexView.includes('data-testid="acp-account-menu"')
     && codexView.includes('switchAccountAffectsSessions'),
   'every ACP Agent must expose an account menu and a force account-switch action');
-  assert.ok(codexView.includes('const movingUp = element.scrollTop < lastScrollTopRef.current - 1')
+  assert.ok(codexView.includes('const movingUp = element.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped')
     && codexView.includes('if (movingUp) autoScrollRef.current = false')
     && codexView.includes('if (autoScrollRef.current)')
     && codexView.includes('scrollConversationToBottom')
@@ -841,6 +841,12 @@ try {
     && codexView.includes('bottom-full')
     && !codexView.includes('bottom-[106px]'),
   'Codex streaming must pause auto-follow and place the return action above, not over, the composer');
+  assert.ok(codexView.includes('const shrinkClamped = isShrinkClampedToBottom(element, lastScrollHeightRef.current)')
+    && codexView.includes('else if (!shrinkClamped && near) autoScrollRef.current = true')
+    && codexView.includes('const contentElement = conversationContentRef.current')
+    && codexView.includes('return startConversationBottomFollower({')
+    && codexView.includes('lastScrollHeightRef.current = scrollElement.scrollHeight'),
+  'Codex streaming must retain bottom following across content shrink and asynchronous layout changes');
   assert.ok(!codexView.includes('<JsonBlock'), 'raw ACP JSON must not leak into normal command UI');
   assert.ok(codexView.includes('await submitAcpPrompt({')
     && codexView.includes('attachments: readyAttachments.map(attachment => attachment.result)')

--- a/pinvou3-app/tests/conversation_scroll_follow.test.mjs
+++ b/pinvou3-app/tests/conversation_scroll_follow.test.mjs
@@ -16,7 +16,11 @@ for (const file of ['conversation-model.js', 'conversation-scroll.js']) {
     path.join(conversationDir, file),
   );
 }
-const { startConversationBottomFollower } = await import(
+const {
+  measureConversationScrollGeometry,
+  startConversationBottomFollower,
+  transitionConversationScrollState,
+} = await import(
   `${pathToFileURL(path.join(conversationDir, 'conversation-scroll.js')).href}?t=${Date.now()}`
 );
 const { isShrinkClampedToBottom } = await import(
@@ -182,6 +186,88 @@ try {
     'content growth must never be treated as a shrink clamp');
   assert.equal(isShrinkClampedToBottom(null, 1000), false,
     'a missing element must not be reported as clamped');
+
+  // Exercise the state transition shared by Chat and Codex: the user first leaves
+  // the bottom, then content shrinks without a scroll event, and finally the user
+  // deliberately returns to the new bottom. The resize measurement must replace the
+  // stale height before that last scroll so future output resumes bottom following.
+  const recoveryElement = { scrollHeight: 1200, scrollTop: 1000, clientHeight: 200 };
+  let recoveryState = { following: true, scrollTop: 1000, scrollHeight: 1200 };
+  const applyRecoveryScroll = () => {
+    const transition = transitionConversationScrollState({
+      scrollElement: recoveryElement,
+      following: recoveryState.following,
+      previousScrollTop: recoveryState.scrollTop,
+      previousScrollHeight: recoveryState.scrollHeight,
+    });
+    recoveryState = {
+      following: transition.following,
+      scrollTop: transition.scrollTop,
+      scrollHeight: transition.scrollHeight,
+    };
+  };
+  const stopRecovery = startConversationBottomFollower({
+    scrollElement: recoveryElement,
+    contentElement: recoveryElement,
+    isFollowing: () => recoveryState.following,
+    onMeasured: () => {
+      const measurement = measureConversationScrollGeometry({
+        scrollElement: recoveryElement,
+        following: recoveryState.following,
+        previousScrollTop: recoveryState.scrollTop,
+        previousScrollHeight: recoveryState.scrollHeight,
+      });
+      recoveryState.scrollTop = measurement.scrollTop;
+      recoveryState.scrollHeight = measurement.scrollHeight;
+    },
+    onRestored: (scrollTop) => {
+      recoveryState.scrollTop = scrollTop;
+      recoveryState.scrollHeight = recoveryElement.scrollHeight;
+    },
+    windowObject: fakeWindow,
+    documentObject: fakeDocument,
+  });
+  const recoveryObserver = observers[2];
+  flushFrame();
+
+  recoveryElement.scrollTop = 600;
+  applyRecoveryScroll();
+  assert.equal(recoveryState.following, false, 'scrolling up must pause bottom following');
+
+  recoveryElement.scrollHeight = 1000;
+  recoveryObserver.trigger(recoveryElement);
+  flushFrame();
+  assert.deepEqual(recoveryState, { following: false, scrollTop: 600, scrollHeight: 1000 },
+    'a resize without a scroll event must refresh geometry without pulling history browsing to the bottom');
+
+  recoveryElement.scrollTop = 800;
+  applyRecoveryScroll();
+  assert.equal(recoveryState.following, true,
+    'a deliberate downward scroll to the new bottom must resume following after content shrink');
+
+  recoveryElement.scrollHeight = 1300;
+  recoveryObserver.trigger(recoveryElement);
+  flushFrame();
+  assert.equal(recoveryElement.scrollTop, 1100,
+    'later content growth must remain pinned after the user resumes following');
+  stopRecovery();
+
+  const clampedMeasurement = measureConversationScrollGeometry({
+    scrollElement: shrinkClamped,
+    following: false,
+    previousScrollTop: 800,
+    previousScrollHeight: 1000,
+  });
+  assert.deepEqual(clampedMeasurement, { scrollTop: 800, scrollHeight: 1000 },
+    'resize measurement must preserve a shrink-clamp baseline until its possible scroll event arrives');
+  const clampedTransition = transitionConversationScrollState({
+    scrollElement: shrinkClamped,
+    following: false,
+    previousScrollTop: clampedMeasurement.scrollTop,
+    previousScrollHeight: clampedMeasurement.scrollHeight,
+  });
+  assert.equal(clampedTransition.following, false,
+    'a delayed shrink-clamp scroll event must not resume following for a history reader');
 
   console.log('conversation_scroll_follow: ok');
 } finally {

--- a/pinvou3-app/tests/conversation_scroll_follow.test.mjs
+++ b/pinvou3-app/tests/conversation_scroll_follow.test.mjs
@@ -268,6 +268,14 @@ try {
   });
   assert.equal(clampedTransition.following, false,
     'a delayed shrink-clamp scroll event must not resume following for a history reader');
+  const followedShrink = transitionConversationScrollState({
+    scrollElement: shrinkClamped,
+    following: true,
+    previousScrollTop: clampedMeasurement.scrollTop,
+    previousScrollHeight: clampedMeasurement.scrollHeight,
+  });
+  assert.equal(followedShrink.following, true,
+    'a shrink-clamp scroll event while following must keep pinning instead of pausing the follower');
 
   console.log('conversation_scroll_follow: ok');
 } finally {

--- a/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
+++ b/pinvou3-app/tests/deepseek_conversation_timeline.test.mjs
@@ -373,15 +373,15 @@ try {
     && !conversationView.includes('setOpen(autoOpen)')
     && !chatView.includes('shouldAutoOpenToolGroup='),
   'tool groups must keep a user-owned expansion state instead of opening and closing with execution status');
-  assert.ok(chatView.includes('isNearConversationBottom(el)')
-    && chatView.includes('const movingUp = el.scrollTop < lastScrollTopRef.current - 1 && !shrinkClamped')
-    && chatView.includes('if (movingUp) autoScrollRef.current = false'),
+  assert.ok(chatView.includes('const transition = transitionConversationScrollState({')
+    && chatView.includes('autoScrollRef.current = transition.following'),
     'DeepSeek streaming must pause auto-follow while the user reads history');
-  assert.ok(chatView.includes('const shrinkClamped = isShrinkClampedToBottom(el, lastScrollHeightRef.current)')
-    && chatView.includes('lastScrollHeightRef.current = el.scrollHeight'),
+  assert.ok(chatView.includes('previousScrollHeight: lastScrollHeightRef.current')
+    && chatView.includes('lastScrollHeightRef.current = transition.scrollHeight'),
     'a shrink-induced scrollTop clamp must not be mistaken for the user browsing history');
   assert.ok(chatView.includes('startConversationBottomFollower({')
-    && chatView.includes('isFollowing: () => autoScrollRef.current'),
+    && chatView.includes('isFollowing: () => autoScrollRef.current')
+    && chatView.includes('onMeasured: () => {'),
     'bottom-following conversations must recover after delayed layout and window visibility changes');
   assert.ok(chatView.includes('<ThinkingBubble'), 'the original rendering path must remain available as a fallback');
   assert.ok(chatView.includes("pinvou_conversation_ui_v2"), 'the local rollback switch must be explicit');


### PR DESCRIPTION
## Summary

- keep Code mode conversations pinned to the bottom while streamed content changes height
- distinguish layout shrink from an intentional upward scroll
- observe conversation content size and preserve follow mode across session and panel transitions
- add regression coverage for the Code mode wiring

## Root cause

Code mode only reacted to scroll events. When streamed PowerShell or other tool output changed the virtualized layout without a matching scroll event, the viewport could stop following the bottom. A layout shrink could also be mistaken for an intentional user scroll and disable automatic following.

## Testing

- `node pinvou3-app/tests/conversation_scroll_follow.test.mjs`
- `node pinvou3-app/tests/codex_acp_timeline.test.mjs`
- `node pinvou3-app/tests/deepseek_conversation_timeline.test.mjs`
- `npm --prefix pinvou3-app run lint:ui`
- `npm --prefix pinvou3-app run build:ui`
- `npm --prefix pinvou3-app test`
- `python scripts/architecture-guard.py`
- `./scripts/fork-guard.sh --fast`