### PR TITLE
fix(chat): drop the 32K placeholder context denominator

### DIFF
--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -276,8 +276,10 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    // token 预算（input_tokens / maxModelLen）。max=0 表示窗口未知（首个 chat:usage
-    // 的 context_window 或本地后端 max_model_len 到达前显示「—」），不用假分母。
+    // Token budget (input_tokens / maxModelLen). max=0 means the window is
+    // unknown: the context meter line stays hidden (its render guard needs
+    // max > 0) until a real window lands — a chat:usage context_window or a
+    // local backend max_model_len. No fabricated denominator.
     tokens: { input: 0, max: 0 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
     thinking: { active: false, phase: "thinking", toolName: "", startedAt: 0 },

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -276,8 +276,9 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    // token 预算（input_tokens / maxModelLen）
-    tokens: { input: 0, max: 32768 },
+    // token 预算（input_tokens / maxModelLen）。max=0 表示窗口未知（首个 chat:usage
+    // 的 context_window 或本地后端 max_model_len 到达前显示「—」），不用假分母。
+    tokens: { input: 0, max: 0 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
     thinking: { active: false, phase: "thinking", toolName: "", startedAt: 0 },
     // 卡片池: 专家面具。activePersona = 当前 session 加持的专家卡(完整对象)或 null,

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -16,8 +16,9 @@
     let monitorIntervalId = null;
     let monitorPollInFlight = false;
     let gpuUtilHistory = [];
-    // 0 = 尚未从 get_backend_status / monitor 快照拿到真实 max_model_len；
-    // 只在有真实值时写回 state.tokens.max（两个赋值点均有真值守卫）。
+    // 0 = no real max_model_len received yet from get_backend_status or the
+    // monitor snapshot; write state.tokens.max back only for real values
+    // (both assignment sites are truthiness-guarded).
     let maxModelLen = state.tokens.max || 0;
     const MONITOR_BASELINE_KEY = "pinvou3.monitorStatsBaseline.self";
     let monitorBaseline = null;

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -16,7 +16,9 @@
     let monitorIntervalId = null;
     let monitorPollInFlight = false;
     let gpuUtilHistory = [];
-    let maxModelLen = state.tokens.max || 32768;
+    // 0 = 尚未从 get_backend_status / monitor 快照拿到真实 max_model_len；
+    // 只在有真实值时写回 state.tokens.max（两个赋值点均有真值守卫）。
+    let maxModelLen = state.tokens.max || 0;
     const MONITOR_BASELINE_KEY = "pinvou3.monitorStatsBaseline.self";
     let monitorBaseline = null;
     try {

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -234,8 +234,9 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    // token 预算（input_tokens / maxModelLen）
-    tokens: { input: 0, max: 32768 },
+    // token 预算（input_tokens / maxModelLen）。max=0 表示窗口未知（首个 chat:usage
+    // 的 context_window 或本地后端 max_model_len 到达前显示「—」），不用假分母。
+    tokens: { input: 0, max: 0 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
     thinking: { active: false, phase: "thinking", toolName: "", startedAt: 0 },
     // 卡片池: 专家面具。activePersona = 当前 session 加持的专家卡(完整对象)或 null,
@@ -349,7 +350,9 @@
   let monitorIntervalId = null;
   let monitorPollInFlight = false;
   let gpuUtilHistory = [];
-  let maxModelLen = 32768;
+  // 0 = 尚未从 get_backend_status / monitor 快照拿到真实 max_model_len；
+  // 只在有真实值时写回 state.tokens.max（两个赋值点均有真值守卫）。
+  let maxModelLen = 0;
   // 监控页「清除统计」基准点：vLLM 的几个累计 counter（TTFT/TPOT/tokens/prefix
   // cache）无法真正清零（它们跟随远端 vLLM 进程生命周期，归零要重启共享进程）。
   // 改为记一个基准快照，显示值 = 当前 counter − 基准。换模型 / vLLM 重启 → counter

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -234,8 +234,10 @@
     queued: [],
     // 输入框待发附件 [{ id, basename, status:'parsing'|'ready'|'error', result, error }]
     attachments: [],
-    // token 预算（input_tokens / maxModelLen）。max=0 表示窗口未知（首个 chat:usage
-    // 的 context_window 或本地后端 max_model_len 到达前显示「—」），不用假分母。
+    // Token budget (input_tokens / maxModelLen). max=0 means the window is
+    // unknown: the context meter line stays hidden (its render guard needs
+    // max > 0) until a real window lands — a chat:usage context_window or a
+    // local backend max_model_len. No fabricated denominator.
     tokens: { input: 0, max: 0 },
     // 思考指示器：active 时 React 渲染计时气泡（Braille + 思考中/调用工具 + 秒数）
     thinking: { active: false, phase: "thinking", toolName: "", startedAt: 0 },
@@ -350,8 +352,9 @@
   let monitorIntervalId = null;
   let monitorPollInFlight = false;
   let gpuUtilHistory = [];
-  // 0 = 尚未从 get_backend_status / monitor 快照拿到真实 max_model_len；
-  // 只在有真实值时写回 state.tokens.max（两个赋值点均有真值守卫）。
+  // 0 = no real max_model_len received yet from get_backend_status or the
+  // monitor snapshot; write state.tokens.max back only for real values
+  // (both assignment sites are truthiness-guarded).
   let maxModelLen = 0;
   // 监控页「清除统计」基准点：vLLM 的几个累计 counter（TTFT/TPOT/tokens/prefix
   // cache）无法真正清零（它们跟随远端 vLLM 进程生命周期，归零要重启共享进程）。

--- a/pinvou3-app/tests/chat_usage_context_window.test.mjs
+++ b/pinvou3-app/tests/chat_usage_context_window.test.mjs
@@ -101,6 +101,19 @@ emitUsage({ input_tokens: 100 }); // 无 context_window 字段
 assert.equal(state.tokens.max, maxBefore, '旧端不带 context_window 时保留旧值');
 assert.equal(state.tokens.input, 100);
 
+// 场景 6：未知窗口起点（bridge 初始 max=0，不再用 32K 假分母）——
+// 无 context_window 的 usage 不得引入假分母，也不得显示无分母背书的 input。
+state.tokens = { input: 0, max: 0 };
+context.turnUsageDirty['session-1'] = false;
+emitUsage({ input_tokens: 100 }); // 旧端不带 context_window
+assert.equal(state.tokens.max, 0, '窗口未知时保持 0，不得引入假分母');
+assert.equal(state.tokens.input, 0, '无真实分母背书时不得显示 input（100 > 0=max 被守卫跳过）');
+
+// 场景 7：窗口未知的会话随后拿到真实窗口 → 分母落位、input 正常消费。
+emitUsage({ input_tokens: 5000, context_window: 262144 });
+assert.equal(state.tokens.max, 262144, '真实窗口到达后分母落位');
+assert.equal(state.tokens.input, 5000);
+
 // ── tauri/web 双端源码断言：窗口消费必须先于 dirty guard ──
 const tauriSection = source.slice(source.indexOf('listen("chat:usage"'), source.indexOf('listen("chat:compaction"'));
 const webSource = read('src', 'platform', 'web', 'bridge.js');
@@ -114,5 +127,13 @@ for (const [label, section] of [['tauri', tauriSection], ['web', webSection]]) {
   assert.ok(section.includes('windowTok !== state.tokens.max'), `${label}: 窗口变化才更新分母`);
   assert.ok(section.includes('windowTok > 0'), `${label}: 窗口 0 守卫保留`);
 }
+
+// ── 初始态源码断言：不再用 32K 假分母初始化（窗口未知 = 0，UI 隐藏占用表）──
+const tauriBridgeSource = read('src', 'platform', 'tauri', 'bridge.js');
+const tauriMonitorSource = read('src', 'platform', 'tauri', 'bridge', 'monitor.js');
+assert.ok(tauriBridgeSource.includes('tokens: { input: 0, max: 0 }'), 'tauri bridge 初始 max=0（窗口未知）');
+assert.ok(webSource.includes('tokens: { input: 0, max: 0 }'), 'web bridge 初始 max=0（窗口未知）');
+assert.ok(!webSource.includes('let maxModelLen = 32768'), 'web monitor 不得以 32K 假窗口兜底');
+assert.ok(tauriMonitorSource.includes('state.tokens.max || 0'), 'tauri monitor 不得以 32K 假窗口兜底');
 
 console.log('chat_usage_context_window.test.mjs: OK');

--- a/pinvou3-app/tests/chat_usage_context_window.test.mjs
+++ b/pinvou3-app/tests/chat_usage_context_window.test.mjs
@@ -26,7 +26,7 @@ const state = {
   activeSessionId: 'session-1',
   chatItems: [],
   messages: [],
-  tokens: { input: 0, max: 32768 }, // 云端无 vLLM probe 时的假分母起点
+  tokens: { input: 0, max: 32768 }, // 种子值：模拟「窗口已知」的会话（历史版本曾以 32K 假分母起步）
   thinking: { active: false },
 };
 const context = {
@@ -70,7 +70,7 @@ const emitUsage = payload => listeners.get('chat:usage')({
 // 这是最常见 Agent 场景：PR #213 修复前此处提前 return，真实窗口永不消费。
 context.turnUsageDirty['session-1'] = true;
 emitUsage({ input_tokens: 45000, context_window: 131072 });
-assert.equal(state.tokens.max, 131072, 'dirty 工具轮仍必须消费真实窗口，替代 32K 假分母');
+assert.equal(state.tokens.max, 131072, 'dirty 工具轮仍必须消费真实窗口');
 assert.equal(state.tokens.input, 0, 'dirty 工具轮不得更新累计 input（本轮累加值不可信）');
 assert.ok(notifyCount >= 1, '窗口变化时必须通知 UI 刷新分母');
 
@@ -101,17 +101,19 @@ emitUsage({ input_tokens: 100 }); // 无 context_window 字段
 assert.equal(state.tokens.max, maxBefore, '旧端不带 context_window 时保留旧值');
 assert.equal(state.tokens.input, 100);
 
-// 场景 6：未知窗口起点（bridge 初始 max=0，不再用 32K 假分母）——
-// 无 context_window 的 usage 不得引入假分母，也不得显示无分母背书的 input。
+// Scenario 6: unknown-window start (bridge initializes max=0, no more 32K
+// fake denominator) — a usage without context_window must not introduce a
+// fake denominator, nor surface input without denominator backing.
 state.tokens = { input: 0, max: 0 };
 context.turnUsageDirty['session-1'] = false;
 emitUsage({ input_tokens: 100 }); // 旧端不带 context_window
-assert.equal(state.tokens.max, 0, '窗口未知时保持 0，不得引入假分母');
-assert.equal(state.tokens.input, 0, '无真实分母背书时不得显示 input（100 > 0=max 被守卫跳过）');
+assert.equal(state.tokens.max, 0, 'unknown window stays 0; no fake denominator may be introduced');
+assert.equal(state.tokens.input, 0, 'input must not surface without a real denominator (100 > 0=max is skipped by the guard)');
 
-// 场景 7：窗口未知的会话随后拿到真实窗口 → 分母落位、input 正常消费。
+// Scenario 7: a session that started with an unknown window later receives
+// a real one → the denominator lands and input is consumed normally.
 emitUsage({ input_tokens: 5000, context_window: 262144 });
-assert.equal(state.tokens.max, 262144, '真实窗口到达后分母落位');
+assert.equal(state.tokens.max, 262144, 'denominator lands once the real window arrives');
 assert.equal(state.tokens.input, 5000);
 
 // ── tauri/web 双端源码断言：窗口消费必须先于 dirty guard ──
@@ -128,12 +130,13 @@ for (const [label, section] of [['tauri', tauriSection], ['web', webSection]]) {
   assert.ok(section.includes('windowTok > 0'), `${label}: 窗口 0 守卫保留`);
 }
 
-// ── 初始态源码断言：不再用 32K 假分母初始化（窗口未知 = 0，UI 隐藏占用表）──
+// ── Initial-state source assertions: neither bridge initializes with the
+// 32K fake denominator (unknown window = 0; the UI hides the meter) ──
 const tauriBridgeSource = read('src', 'platform', 'tauri', 'bridge.js');
 const tauriMonitorSource = read('src', 'platform', 'tauri', 'bridge', 'monitor.js');
-assert.ok(tauriBridgeSource.includes('tokens: { input: 0, max: 0 }'), 'tauri bridge 初始 max=0（窗口未知）');
-assert.ok(webSource.includes('tokens: { input: 0, max: 0 }'), 'web bridge 初始 max=0（窗口未知）');
-assert.ok(!webSource.includes('let maxModelLen = 32768'), 'web monitor 不得以 32K 假窗口兜底');
-assert.ok(tauriMonitorSource.includes('state.tokens.max || 0'), 'tauri monitor 不得以 32K 假窗口兜底');
+assert.ok(tauriBridgeSource.includes('tokens: { input: 0, max: 0 }'), 'tauri bridge initializes max=0 (unknown window)');
+assert.ok(webSource.includes('tokens: { input: 0, max: 0 }'), 'web bridge initializes max=0 (unknown window)');
+assert.ok(!webSource.includes('let maxModelLen = 32768'), 'web monitor must not fall back to a fake 32K window');
+assert.ok(tauriMonitorSource.includes('state.tokens.max || 0'), 'tauri monitor must not fall back to a fake 32K window');
 
 console.log('chat_usage_context_window.test.mjs: OK');


### PR DESCRIPTION
## Summary

- The bridge state initialized `tokens.max` to `32768`, so the context meter showed a fabricated 32.8K window until a real value arrived (fresh sessions, restored sessions, cloud models without a vLLM probe).
- The initial denominator is now `0` = unknown: `ChatView` already renders the meter only when `ctxTokens.max > 0`, so the line simply stays hidden until the first `chat:usage` `context_window` (or a local backend `max_model_len`) lands.
- The existing `input <= max` guard then also keeps unbacked input numbers out of the display while the window is unknown; both monitor paths (`tauri/bridge/monitor.js`, web bridge `maxModelLen`) keep writing only real values back, so the placeholder cannot be resurrected.

This closes the remaining display item of the #352 follow-up list (the cumulative-input defenses landed earlier in #213).

## Changes

- `pinvou3-app/src/platform/tauri/bridge.js` — initial `tokens: { input: 0, max: 0 }`.
- `pinvou3-app/src/platform/web/bridge.js` — same initial state; module-level `maxModelLen` starts at `0` instead of `32768` (session-state creation at bridge.js:939 inherits it, so sessions created after a real window is learned still start correct).
- `pinvou3-app/src/platform/tauri/bridge/monitor.js` — fallback `state.tokens.max || 0` instead of `|| 32768`.

## Testing

- `tests/chat_usage_context_window.test.mjs` extended: unknown-window start keeps `max: 0` (no fake denominator resurrection via legacy `chat:usage` without `context_window`), no unbacked input display, and a later real window lands correctly; plus source assertions that neither bridge initializes with the 32K placeholder and neither monitor falls back to it.
- `node tests/chat_usage_context_window.test.mjs` passes; `npm run lint` clean (pre-existing warnings only); `npm run test:node` shows the same two pre-existing failures as clean `origin/main` (`stock_quote_unit_fixture`, `classic_runtime_scripts` — verified via stash, unrelated); `python3 scripts/architecture-guard.py` passes.