### PR TITLE
fix(test): root-cause dingtalk skill-gate flake and local test baseline

### DIFF
--- a/pinvou3-app/src-tauri/src/features/codex_acp/attachments.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/attachments.rs
@@ -197,9 +197,10 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            // `prepare_codex_prompt` 经 `validate_path` 强制附件位于 `$HOME` 下
-            // (validate_upload_location)。fixture 必须跟随,否则从 $HOME 外的
-            // 检出(如 /tmp worktree)跑测试时守卫会把合法 fixture 拒之门外。
+            // `prepare_codex_prompt` forces attachments to live under `$HOME`
+            // via `validate_path` (validate_upload_location). The fixture must
+            // follow suit, or the guard rejects the legitimate fixture when the
+            // tests run from a checkout outside $HOME (e.g. a /tmp worktree).
             let path = crate::platform::os::user_home_dir().join(format!(
                 ".pinvou3-codex-attachment-test-{label}-{}-{nonce}",
                 std::process::id()

--- a/pinvou3-app/src-tauri/src/features/codex_acp/attachments.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/attachments.rs
@@ -197,13 +197,13 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let path = std::env::current_dir()
-                .unwrap()
-                .join("target")
-                .join(format!(
-                    "pinvou3-codex-attachment-{label}-{}-{nonce}",
-                    std::process::id()
-                ));
+            // `prepare_codex_prompt` 经 `validate_path` 强制附件位于 `$HOME` 下
+            // (validate_upload_location)。fixture 必须跟随,否则从 $HOME 外的
+            // 检出(如 /tmp worktree)跑测试时守卫会把合法 fixture 拒之门外。
+            let path = crate::platform::os::user_home_dir().join(format!(
+                ".pinvou3-codex-attachment-test-{label}-{}-{nonce}",
+                std::process::id()
+            ));
             fs::create_dir_all(&path).unwrap();
             Self(path)
         }

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -1729,18 +1729,20 @@ mod tests {
         // 显式指定优先；未指定时由平台适配层给出首选解释器（posix: PATH 里
         // python3→python；windows: PINVOU3_PYTHON/bundled python），再兜底另一
         // 常见名——开发机可能只装其一，缺省环境下不再要求设 PINVOU3_TEST_PYTHON。
+        let explicit = std::env::var("PINVOU3_TEST_PYTHON").ok();
         let mut candidates: Vec<String> = Vec::new();
-        if let Ok(python) = std::env::var("PINVOU3_TEST_PYTHON") {
-            candidates.push(python);
-        } else {
-            let primary = crate::platform::os::python_command();
-            let alternate = if primary == "python3" {
-                "python"
-            } else {
-                "python3"
-            };
-            candidates.push(primary);
-            candidates.push(alternate.to_string());
+        match &explicit {
+            Some(python) => candidates.push(python.clone()),
+            None => {
+                let primary = crate::platform::os::python_command();
+                let alternate = if primary == "python3" {
+                    "python"
+                } else {
+                    "python3"
+                };
+                candidates.push(primary);
+                candidates.push(alternate.to_string());
+            }
         }
         for python in &candidates {
             let output = std::process::Command::new(python)
@@ -1756,6 +1758,13 @@ mod tests {
                 let version = String::from_utf8(output.stdout).unwrap().trim().to_string();
                 return (python.clone(), version);
             }
+        }
+        // 显式指定但不可用,与缺省探测全失败是两种故障:前者该修(或去掉)现有
+        // 设置,提示"再去显式设置"反而误导。
+        if let Some(python) = explicit {
+            panic!(
+                "PINVOU3_TEST_PYTHON={python} is set but not usable; fix it or unset it to auto-probe"
+            );
         }
         panic!(
             "no usable Python interpreter (tried {candidates:?}); set PINVOU3_TEST_PYTHON explicitly"

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -1726,9 +1726,12 @@ mod tests {
     }
 
     fn test_python() -> (String, String) {
-        // 显式指定优先；未指定时由平台适配层给出首选解释器（posix: PATH 里
-        // python3→python；windows: PINVOU3_PYTHON/bundled python），再兜底另一
-        // 常见名——开发机可能只装其一，缺省环境下不再要求设 PINVOU3_TEST_PYTHON。
+        // An explicit PINVOU3_TEST_PYTHON wins. Without it, start from the
+        // platform adapter's preferred interpreter (posix: python3→python on
+        // PATH; windows: PINVOU3_PYTHON/bundled python), then fall back to the
+        // other common name — a dev machine may have either one installed, so
+        // the default environment no longer requires setting
+        // PINVOU3_TEST_PYTHON.
         let explicit = std::env::var("PINVOU3_TEST_PYTHON").ok();
         let mut candidates: Vec<String> = Vec::new();
         match &explicit {
@@ -1759,8 +1762,9 @@ mod tests {
                 return (python.clone(), version);
             }
         }
-        // 显式指定但不可用,与缺省探测全失败是两种故障:前者该修(或去掉)现有
-        // 设置,提示"再去显式设置"反而误导。
+        // An explicit but unusable setting is a different failure from a fully
+        // failed default probe: the former should be fixed (or dropped), so
+        // telling the user to "set it explicitly" again would mislead.
         if let Some(python) = explicit {
             panic!(
                 "PINVOU3_TEST_PYTHON={python} is set but not usable; fix it or unset it to auto-probe"

--- a/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/mod.rs
@@ -1726,21 +1726,40 @@ mod tests {
     }
 
     fn test_python() -> (String, String) {
-        let python = std::env::var("PINVOU3_TEST_PYTHON").unwrap_or_else(|_| "python".to_string());
-        let output = std::process::Command::new(&python)
-            .args([
-                "-I",
-                "-S",
-                "-c",
-                "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
-            ])
-            .output()
-            .expect("test Python must start");
-        assert!(output.status.success());
-        (
-            python,
-            String::from_utf8(output.stdout).unwrap().trim().to_string(),
-        )
+        // 显式指定优先；未指定时由平台适配层给出首选解释器（posix: PATH 里
+        // python3→python；windows: PINVOU3_PYTHON/bundled python），再兜底另一
+        // 常见名——开发机可能只装其一，缺省环境下不再要求设 PINVOU3_TEST_PYTHON。
+        let mut candidates: Vec<String> = Vec::new();
+        if let Ok(python) = std::env::var("PINVOU3_TEST_PYTHON") {
+            candidates.push(python);
+        } else {
+            let primary = crate::platform::os::python_command();
+            let alternate = if primary == "python3" {
+                "python"
+            } else {
+                "python3"
+            };
+            candidates.push(primary);
+            candidates.push(alternate.to_string());
+        }
+        for python in &candidates {
+            let output = std::process::Command::new(python)
+                .args([
+                    "-I",
+                    "-S",
+                    "-c",
+                    "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')",
+                ])
+                .output();
+            let Ok(output) = output else { continue };
+            if output.status.success() {
+                let version = String::from_utf8(output.stdout).unwrap().trim().to_string();
+                return (python.clone(), version);
+            }
+        }
+        panic!(
+            "no usable Python interpreter (tried {candidates:?}); set PINVOU3_TEST_PYTHON explicitly"
+        );
     }
 
     struct LockedPythonToolFixture {

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -1891,6 +1891,13 @@ mod tests {
             .into_owned()
     }
 
+    /// Removes a test fixture directory and unsets `PINVOU3_HOME` in-process.
+    ///
+    /// Contract: the caller must hold `bridge::paths::tests::ENV_LOCK` for the
+    /// whole call — only that lock serializes the unconditional `remove_var`
+    /// against tests that set the variable under it. A test that never sets
+    /// `PINVOU3_HOME` must not borrow this helper; remove its directory
+    /// directly instead.
     fn cleanup(dir: &str) {
         // SAFETY: holding platform::paths::tests::ENV_LOCK; env writes serialized in-process.
         unsafe { std::env::remove_var("PINVOU3_HOME") };

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -1305,7 +1305,10 @@ mod tests {
             );
         }
 
-        cleanup(&tmp);
+        // 本测试不持 ENV_LOCK 也不设 PINVOU3_HOME,不能走 cleanup()(其契约要求
+        // 调用方持锁,且会无条件 remove_var)——否则并行测试的持锁窗口会被这次
+        // 无锁移除砸穿,dingtalk/wecom 技能门控测试会以断言读错根目录的形式偶发失败。
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// 已下架预置技能的清理:市场标记的删、无标记裸残留的删、用户上传(upload:)的保。

--- a/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/runtime_bundle/platform/mod.rs
@@ -1305,9 +1305,12 @@ mod tests {
             );
         }
 
-        // 本测试不持 ENV_LOCK 也不设 PINVOU3_HOME,不能走 cleanup()(其契约要求
-        // 调用方持锁,且会无条件 remove_var)——否则并行测试的持锁窗口会被这次
-        // 无锁移除砸穿,dingtalk/wecom 技能门控测试会以断言读错根目录的形式偶发失败。
+        // This test neither holds ENV_LOCK nor sets PINVOU3_HOME, so it must
+        // not use cleanup() — its contract requires the caller to hold the
+        // lock, and it unconditionally removes the variable. A lock-free
+        // removal here would punch through a parallel test's lock-holding
+        // window, and the dingtalk/wecom skill-gate tests then fail
+        // intermittently with assertions reading the wrong root.
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/pinvou3-app/tests/ui_test_server.js
+++ b/pinvou3-app/tests/ui_test_server.js
@@ -1,4 +1,4 @@
-const { createReadStream, existsSync, statSync } = require('fs');
+const { createReadStream, existsSync, readdirSync, statSync } = require('fs');
 const { createServer } = require('http');
 const { extname, isAbsolute, join, relative, resolve } = require('path');
 
@@ -15,10 +15,45 @@ const mime = {
   '.webp': 'image/webp',
 };
 
+// An existing but outdated dist silently renders the previous UI and produces
+// confusing selector-miss failures (the "UI build not found" error above only
+// covers a fully missing dist). Reject the default dist when any file under
+// src/ is newer than dist/index.html — a rebase or branch switch after the
+// last build is enough to trigger it. Explicit PINVOU3_UI_TEST_ROOT roots are
+// exempt: their owner controls freshness (e.g. hand-written fixtures).
+function assertFreshBuild() {
+  if (process.env.PINVOU3_UI_TEST_ROOT) return;
+  const builtAt = statSync(join(root, 'index.html')).mtimeMs;
+  let newestSource = null;
+  let newestMtime = 0;
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      const mtime = statSync(path).mtimeMs;
+      if (mtime > newestMtime) {
+        newestMtime = mtime;
+        newestSource = path;
+      }
+    }
+  };
+  walk(resolve(__dirname, '../src'));
+  if (newestMtime > builtAt) {
+    throw new Error(
+      `UI build is stale: ${relative(resolve(__dirname, '..'), newestSource)} is newer than ` +
+        'dist/index.html; run `npm run build:ui` before browser smoke tests'
+    );
+  }
+}
+
 function startUiTestServer() {
   if (!existsSync(join(root, 'index.html'))) {
     throw new Error('UI build not found; run `npm run build:ui` before browser smoke tests');
   }
+  assertFreshBuild();
   return new Promise((resolveReady, reject) => {
     const server = createServer((req, res) => {
       const pathname = decodeURIComponent(new URL(req.url || '/', 'http://127.0.0.1').pathname);


### PR DESCRIPTION
## Summary

Re-verified all flaky and locally-environmental failures recorded in memory/review notes (baseline `36ddb79dd`): 4 still reproduce, all fixed.

| # | Problem | Recorded in | Status |
|---|---|---|---|
| 1 | `dingtalk_skill_gate_extracts_and_removes_official_mono_skill` fails intermittently (~50% on full runs) | #343 review notes ("pre-existing on main, 3/4 baseline repro, suggest a dedicated issue") | **Root-caused and fixed** |
| 2 | `codex_acp::attachments` — 3 tests fail in /tmp worktrees (HOME guard) | #328/#336/#339/#341, all noted as "environmental" | Fixed |
| 3 | 11 marketplace locked-python tests panic locally ("test Python must start") | #249/#335, noted as "requires PINVOU3_TEST_PYTHON" | Fixed |
| 4 | Browser smokes silently serve a stale dist and fail misleadingly | internal working notes | Tool-enforced guard |

No longer reproducing after re-verification: the 3 pre-existing frontend failures from the pr-277 era (now 521/0); the local codewhale-tui compile SIGBUS (not reproducible with sufficient disk + the workaround trio; the avoidance recipe stays on record).

## 1. dingtalk flake: root cause and forensics

**Mechanism**: the shared `cleanup()` in `runtime_bundle/platform/mod.rs` assumes per its SAFETY contract that the caller holds ENV_LOCK, and unconditionally runs `remove_var("PINVOU3_HOME")`. `shell_env_hook_keeps_cli_context_and_filters_credentials` **never takes the lock and never sets that variable** — it only borrowed the helper to delete its directory. That lock-free remove landed inside the lock-held window of a concurrently running dingtalk test, after which `paths::bundles_root()` re-resolved to the real `~/.pinvou3` and the assertion necessarily failed. The fixture was never deleted; the assertion was simply reading the wrong root.

**Forensics** (not speculation): an in-test probe dumped environment state + an lldb `unsetenv` breakpoint with a python callback (reading `x0`, filtering variable names) with epoch-ms timestamps. A single repro run caught the one lock-free remove inside the window — call stack `remove_var ← cleanup ← shell_env_hook…`, timestamp 5010 within window [4886, 5737].

**Fix**: `shell_env_hook` now removes its directory directly (`730a2e4e8`). After the fix, full runs are **4× 1792/0** (vs ~50% failure rate before).

## 2-4. Remaining fixes

- **`cd8066bc9`** — attachments fixture moved from `CWD/target` to `$HOME/.pinvou3-codex-attachment-test-*` (following the `scoped_home_dir` pattern of the file_ingest tests); verified by running the test binary with cwd=/tmp; Drop cleanup leaves no residue.
- **`6f9d1545a`** — `test_python()`'s default interpreter now goes through the platform adapter `python_command()` (posix: PATH probe python3→python; windows: PINVOU3_PYTHON/bundled), then falls back to the other common name; explicit `PINVOU3_TEST_PYTHON` priority unchanged. The 11 tests go green locally; the Windows targeting is unchanged.
- **`f4cf570a9`** — `ui_test_server.js` adds a staleness guard for the default dist: any file under src newer than `dist/index.html` errors out with a pointer to `npm run build:ui`; an explicit `PINVOU3_UI_TEST_ROOT` is exempt (self-managed fixture). CI builds before smoking, so this only affects local runs. Verified both ways: touch src → exit 1; rebuild → 53/53.

## Verification

- Rust lib full suite: `1792 passed; 0 failed` × 4 (including the final code shape)
- attachments with cwd=/tmp: 3/3; `fmt --check`; clippy exactly as CI rust-lint's two commands (`--lib --bins --no-deps --features dev-tools -- -D warnings` + `--lib --bins --tests`); architecture-guard passes; fork-guard --fast passes at the fingerprint layer; lint:node 0 errors (0 warnings in changed files)

## Scope

- All changes are limited to tests and test infrastructure; zero production code-path changes.
- No CodeWhale gitlink change, no version file change, no CHANGES entry needed (no user-visible behavior change).
