### PR TITLE
build: bump toolchain to Rust 1.98.0 and Node 24

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pinvou3-app/package-lock.json
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: 版本与 CI 路由脚本测试
         run: >-
@@ -387,7 +387,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: |
             pinvou3-app/package-lock.json
@@ -486,7 +486,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: remote-control-relay/package-lock.json
 
@@ -509,7 +509,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: pinvou3-app/package-lock.json
 
@@ -541,7 +541,7 @@ jobs:
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.0
           components: clippy, rustfmt
 
       - name: Cargo cache
@@ -839,7 +839,7 @@ jobs:
         if: ${{ github.event_name != 'push' }}
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: remote-control-relay/package-lock.json
 
@@ -1147,7 +1147,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: pinvou3-app/package-lock.json
 
@@ -1183,7 +1183,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: 准备 macOS universal ACP Bridge
         run: ./pinvou3-app/scripts/prepare-codex-bridge-runtime.sh

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: 版本同步脚本测试
         run: node --test scripts/tests/sync-version.test.mjs
@@ -137,7 +137,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pinvou3-app/package-lock.json
 
@@ -249,7 +249,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pinvou3-app/package-lock.json
 
@@ -355,7 +355,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pinvou3-app/package-lock.json
 
@@ -475,7 +475,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: pinvou3-app/package-lock.json
 

--- a/pinvou-knowledge/rust-toolchain.toml
+++ b/pinvou-knowledge/rust-toolchain.toml
@@ -4,5 +4,5 @@
 # Cargo.toml; bump this one number to upgrade. clippy / rustfmt
 # components back the lint gates.
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 components = ["clippy", "rustfmt"]

--- a/pinvou3-app/scripts/prepare-codex-bridge-runtime.sh
+++ b/pinvou3-app/scripts/prepare-codex-bridge-runtime.sh
@@ -27,7 +27,7 @@ else
   DD="--"
 fi
 
-NODE_VERSION="22.22.0"
+NODE_VERSION="24.20.0"
 CODEX_ACP_VERSION="1.6.2"
 CODEX_ACP_PACKAGE="@agentclientprotocol/codex-acp"
 CLAUDE_ACP_VERSION="0.70.0"
@@ -130,10 +130,10 @@ node_archive_ext() {
 
 node_sha256() {
   case "$1" in
-    linux-x64) echo "9aa8e9d2298ab68c600bd6fb86a6c13bce11a4eca1ba9b39d79fa021755d7c37" ;;
-    linux-arm64) echo "1bf1eb9ee63ffc4e5d324c0b9b62cf4a289f44332dfef9607cea1a0d9596ba6f" ;;
-    darwin-x64) echo "5ea50c9d6dea3dfa3abb66b2656f7a4e1c8cef23432b558d45fb538c7b5dedce" ;;
-    darwin-arm64) echo "5ed4db0fcf1eaf84d91ad12462631d73bf4576c1377e192d222e48026a902640" ;;
+    linux-x64) echo "2f2c0da162318f0de47665410c7c8c2ed3d36c8f3105de4bbc61176c70a7cbf2" ;;
+    linux-arm64) echo "5f4ddab610c1ab2016b3c227cebdbf6d9495161487e4739c7b90090595f465f7" ;;
+    darwin-x64) echo "9e5b2644cf107befb6aefca676b96d3296bc10138096f022ed378d6233ed81f4" ;;
+    darwin-arm64) echo "40e5607e5ecb3db9192723776da2d75d966260fc74a7a9e731c1bd67dda96bc8" ;;
     *) return 1 ;;
   esac
 }

--- a/pinvou3-app/src-tauri/rust-toolchain.toml
+++ b/pinvou3-app/src-tauri/rust-toolchain.toml
@@ -4,5 +4,5 @@
 # 升级方式:改这里一个数字即可,CI(dtolnay/rust-toolchain 读取本文件)与本地自动一致。
 # 带上 clippy / rustfmt 组件，配合 lint 门禁。
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 components = ["clippy", "rustfmt"]

--- a/scripts/asr/setup-sensevoice.sh
+++ b/scripts/asr/setup-sensevoice.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 QUANT="${1:-q4_k}"
 SENSEVOICE_COMMIT="c78e6919351ac83255e96de46169f518097f1ef3"
-CMAKE_VERSION="3.30.5"
+CMAKE_VERSION="4.4.2"
 ASR_DIR="$HOME/.pinvou3/asr"
 MODEL_FILE="sense-voice-small-${QUANT}.gguf"
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -38,8 +38,8 @@ if command -v cmake >/dev/null; then
 else
   echo "    cmake 缺失，下载预编译(免 root)…"
   case "$(uname -m)" in
-    aarch64) CMAKE_SHA256="da7dead2c92c1747b40d506d7f7d68590f5bab175316d2e7af73e48a2e417e48" ;;
-    x86_64) CMAKE_SHA256="f747d9b23e1a252a8beafb4ed2bc2ddf78cff7f04a8e4de19f4ff88e9b51dc9d" ;;
+    aarch64) CMAKE_SHA256="9ca1aadb4451c5dcbdc67f9b4aff42dab52abbaebd8db9e2900026502dbed671" ;;
+    x86_64) CMAKE_SHA256="3ada9a3f5d8a85413579bdd0ea6aa8e8da86efdd6d15c91a1afa517f2021956c" ;;
     *) echo "❌ cmake 自动下载暂不支持架构: $(uname -m)"; exit 1 ;;
   esac
   curl --retry 4 --retry-all-errors -fsSL -o "$WORK/cmake.tgz" \


### PR DESCRIPTION
## What changed and why

Upgrade pinned build toolchain versions to the latest stable releases:

- **Rust 1.97.1 → 1.98.0** (stable, released 2026-08-20): `pinvou3-app/src-tauri/rust-toolchain.toml`, `pinvou-knowledge/rust-toolchain.toml`, and the duplicated hardcoded bootstrap pin in `pr-check.yml` (rust-test job).
- **Node.js 22 → 24** (24.x is the current active LTS; 26.x does not enter LTS until 2026-10): all 14 `actions/setup-node` occurrences across `pr-check.yml`, `release-packages.yml`, and `mac-build.yml`.
- **Codex bridge bundled Node 22.22.0 → 24.20.0** in `prepare-codex-bridge-runtime.sh`, with the hardcoded SHA-256 sums updated from the official `SHASUMS256.txt` for linux-x64/arm64 and darwin-x64/arm64 (also aligns with the Windows payload, which already ships Node 24).

## Deliberately unchanged

- MSRV (`rust-version = "1.89"`) — a compatibility policy floor, not the toolchain in use.
- `ubuntu-22.04` runners and the glibc 2.35 floor, macOS 11.0 deployment target — platform compatibility baselines pinned by policy.
- Windows private-runtime payload (Node 24.18.0 / Python 3.13.14 embed) — locked by gitlink + lock + manifest SHA-256; bumping it requires a payload rebuild in the submodule, out of scope here.
- CodeWhale submodule — untouched.

## Tests actually run

- `rustup toolchain install 1.98.0` + `cargo check` in `pinvou-knowledge` (resolves to the pinned 1.98.0): passes.
- Bridge runtime script: official SHASUMS256.txt cross-checked for all four platform archives; platform archives verified to exist on nodejs.org; `bash -n` passes; contract tests `codex_acp_platform_contract`, `codex_acp_windows_contract`, `windows_runtime_packaging_contract`, `tauri_effective_config` all pass.
- All three modified workflows parse as valid YAML.
- `python3 scripts/architecture-guard.py`: passes.

## Not verified / limitations

- `./scripts/fork-guard.sh --fast` fails **locally only** because the local CodeWhale checkout has drifted from the recorded gitlink (local `9c5f4f1` vs recorded `f853f8f`; the fingerprint anchors exist at the recorded commit). This drift predates this PR; CI checks out the recorded gitlink and is unaffected.
- `pinvou3-app/src-tauri` was not recompiled locally with 1.98.0 (left to CI).
- `prepare-codex-bridge-runtime.sh` was not executed end-to-end (downloads hundreds of MB); URLs and hashes were verified independently.

## CMake 3.30.5 → 4.4.2 (added in 9b59e6d1)

- `scripts/asr/setup-sensevoice.sh`: bumped the fallback precompiled CMake download (`CMAKE_VERSION`) from 3.30.5 to 4.4.2 and updated the hardcoded linux aarch64/x86_64 `CMAKE_SHA256` sums from the official Kitware `cmake-4.4.2-SHA-256.txt` (https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-SHA-256.txt).

### Verification

- Hash authenticity: downloaded `cmake-4.4.2-linux-x86_64.tar.gz` and confirmed its SHA-256 matches both the official SHA-256.txt and the value written into the script (all three identical).
- Real build with CMake 4.x: ran `bash scripts/asr/setup-sensevoice.sh` on macOS arm64 with system CMake 4.4.3 (the script uses the system cmake when present). SenseVoice.cpp `c78e691` configured and compiled cleanly with CMake 4.x — no `cmake_minimum_required` or policy incompatibilities; `sense-voice-main` built and installed to `~/.pinvou3/asr/`.

### Note (pre-existing, unrelated to this change)

- On macOS the script aborts at step [4/5] (model download) with `MODEL_FILE: unbound variable`: the system bash 3.2 mis-parses a bare `$MODEL_FILE` directly followed by a full-width `（`. The script targets Linux (per its header) and this predates the CMake bump; the model was already installed locally, so nothing is missing. Left unchanged as out of scope.
