### PR TITLE
feat(chat): probe more local servers, floor always-on effort

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/settings.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/settings.rs
@@ -307,6 +307,13 @@ pub async fn probe_local_server_kind(
     Ok(match kind {
         crate::core::model_endpoint::LocalServerKind::Vllm => "vllm".to_string(),
         crate::core::model_endpoint::LocalServerKind::Ollama => "ollama".to_string(),
+        crate::core::model_endpoint::LocalServerKind::Sglang => "sglang".to_string(),
+        crate::core::model_endpoint::LocalServerKind::LlamaCpp => "llamacpp".to_string(),
+        crate::core::model_endpoint::LocalServerKind::KoboldCpp => "koboldcpp".to_string(),
+        crate::core::model_endpoint::LocalServerKind::LmDeploy => "lmdeploy".to_string(),
+        crate::core::model_endpoint::LocalServerKind::DockerModelRunner => {
+            "dockermodelrunner".to_string()
+        }
         crate::core::model_endpoint::LocalServerKind::LmStudio => "lmstudio".to_string(),
         crate::core::model_endpoint::LocalServerKind::Generic => "generic".to_string(),
     })

--- a/pinvou3-app/src-tauri/src/core/always_thinking.rs
+++ b/pinvou3-app/src-tauri/src/core/always_thinking.rs
@@ -18,13 +18,27 @@ pub enum AlwaysThinkingSpec {
     NoControl,
 }
 
-/// 按模型 id 查知识表。匹配口径：id 小写化并把 `_`/空格归一为 `-` 后做子串
-/// 匹配（覆盖 `vendor/Model_Name`、tag、量化后缀等常见书写形态）。
+/// 按模型 id 查知识表。匹配口径：id trim 后小写化，并把 `_`/空白字符的连续
+/// 段折叠为单个 `-`，再做子串匹配（覆盖 `vendor/Model_Name`、tag、量化后缀
+/// 等常见书写形态）。与前端 `model-catalog.js alwaysThinkingSpecForModel`
+/// 的归一口径（`trim().toLowerCase().replaceAll(/[\s_]+/g, '-')`）对齐。
 pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
-    let normalized = model_id
-        .to_ascii_lowercase()
-        .replace('_', "-")
-        .replace(' ', "-");
+    let trimmed = model_id.trim();
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut pending_sep = false;
+    for ch in trimmed.chars() {
+        if ch == '_' || ch.is_whitespace() {
+            pending_sep = true;
+        } else {
+            // 折叠分隔符连续段为单个 '-'；前导分隔符（trim 后仅剩 `_`）不产生
+            // 前导 '-'，对子串匹配无影响（表内条目均不以 '-' 开头）。
+            if pending_sep && !normalized.is_empty() {
+                normalized.push('-');
+            }
+            pending_sep = false;
+            normalized.push(ch.to_ascii_lowercase());
+        }
+    }
     let id = normalized.as_str();
     // Kimi K3：官方仅 low/high/max 档位且思考永开；底座 vllm wire 会把 max
     // 钳到 high，故只暴露 low/high。
@@ -128,6 +142,24 @@ mod tests {
             always_thinking_spec("MINIMAX_M2"),
             Some(AlwaysThinkingSpec::NoControl)
         );
+    }
+
+    /// 归一与前端 JS 口径对齐：trim + 连续 `_`/空白段折叠为单个 `-`。
+    #[test]
+    fn matching_trims_and_collapses_separator_runs() {
+        assert_eq!(
+            always_thinking_spec("  Kimi  K3  "),
+            Some(AlwaysThinkingSpec::Tiers(&["low", "high"]))
+        );
+        assert_eq!(
+            always_thinking_spec("deepseek__r1"),
+            Some(AlwaysThinkingSpec::NoControl)
+        );
+        assert_eq!(
+            always_thinking_spec("Qwen3-235B-A22B_Thinking"),
+            Some(AlwaysThinkingSpec::NoControl)
+        );
+        assert_eq!(always_thinking_spec("   "), None);
     }
 
     /// qwen3 只有 Thinking 变体命中：普通 qwen3（qwen3-32b、qwen3:8b）可控

--- a/pinvou3-app/src-tauri/src/core/always_thinking.rs
+++ b/pinvou3-app/src-tauri/src/core/always_thinking.rs
@@ -1,27 +1,41 @@
-//! 思考不可关闭（always-thinking）模型的知识表与运行时归一。
+//! Knowledge table and runtime normalization for always-thinking models
+//! (thinking cannot be disabled).
 //!
-//! 本地路由默认关思考（防 SSE timeout / 首包抢占），但有一类模型思考永开、
-//! 关不掉也无档位可控，或只允许部分档位——把 "off" 或越界档位发过去只会被
-//! 服务端忽略/报错。本表按模型名识别这类模型，供
-//! `features::assistant::platform::bridge::request_reasoning_effort` 归一。
+//! Local routing defaults to thinking off (to guard against SSE timeouts /
+//! first-chunk preemption), but one class of models is always-thinking —
+//! thinking cannot be disabled and there is no controllable effort tier, or
+//! only some tiers are allowed. Sending "off" or an out-of-range tier would
+//! only be ignored/rejected by the server. This table identifies such models
+//! by name for `features::assistant::platform::bridge::request_reasoning_effort`
+//! to normalize.
 //!
-//! 设计约定：框架明确回报可关性时以框架为准，本表只是兜底；目前各部署框架
-//! （vLLM / SGLang / Ollama 等）均不回报思考可关性，运行时只能靠模型名匹配。
+//! Design convention: when a framework explicitly reports whether thinking can
+//! be disabled, the framework wins; this table is only a fallback. Currently
+//! none of the deployment frameworks (vLLM / SGLang / Ollama, etc.) report
+//! thinking toggleability, so at runtime we can only match by model name.
 
-/// 思考不可关闭模型的可控形态。
+/// Controllable shape of always-thinking models.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AlwaysThinkingSpec {
-    /// 思考永开但档位可控：只允许列出的档位（首项为越界/缺省时的归一目标，
-    /// 即该模型允许的最低档）。
+    /// Always-thinking but tiers are controllable: only the listed tiers are
+    /// allowed (the first entry is the normalization target for out-of-range
+    /// or missing tiers, i.e. the lowest tier the model allows).
     Tiers(&'static [&'static str]),
-    /// 思考永开且无任何可控档位：运行时不发任何思考参数，让模型原生思考。
+    /// Always-thinking with no controllable tier at all: the runtime sends no
+    /// thinking parameter and lets the model think natively.
     NoControl,
 }
 
-/// 按模型 id 查知识表。匹配口径：id trim 后小写化，并把 `_`/空白字符的连续
-/// 段折叠为单个 `-`，再做子串匹配（覆盖 `vendor/Model_Name`、tag、量化后缀
-/// 等常见书写形态）。与前端 `model-catalog.js alwaysThinkingSpecForModel`
-/// 的归一口径（`trim().toLowerCase().replaceAll(/[\s_]+/g, '-')`）对齐。
+/// Look up the knowledge table by model id. Matching rules: trim the id,
+/// lowercase it, collapse runs of `_`/whitespace into a single `-`, then do a
+/// substring match (covers common spellings such as `vendor/Model_Name`, tags,
+/// and quantization suffixes). Aligned with the frontend normalization rules of
+/// `model-catalog.js alwaysThinkingSpecForModel`
+/// (`trim().toLowerCase().replaceAll(/[\s_]+/g, '-')`).
+///
+/// Accepted risk: substring matching also covers future names (e.g. a future
+/// `kimi-k3.5` matches the `kimi-k3` entry); entries are re-reviewed as new
+/// models ship.
 pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
     let trimmed = model_id.trim();
     let mut normalized = String::with_capacity(trimmed.len());
@@ -30,8 +44,9 @@ pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
         if ch == '_' || ch.is_whitespace() {
             pending_sep = true;
         } else {
-            // 折叠分隔符连续段为单个 '-'；前导分隔符（trim 后仅剩 `_`）不产生
-            // 前导 '-'，对子串匹配无影响（表内条目均不以 '-' 开头）。
+            // Collapse separator runs into a single '-'; a leading separator
+            // (only `_` left after trim) produces no leading '-', which does
+            // not affect substring matching (no table entry starts with '-').
             if pending_sep && !normalized.is_empty() {
                 normalized.push('-');
             }
@@ -40,41 +55,48 @@ pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
         }
     }
     let id = normalized.as_str();
-    // Kimi K3：官方仅 low/high/max 档位且思考永开；底座 vllm wire 会把 max
-    // 钳到 high，故只暴露 low/high。
+    // Kimi K3: officially only low/high/max tiers and always-thinking; the
+    // engine's vllm wire clamps max to high, so only low/high are exposed.
     if id.contains("kimi-k3") {
         return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
     }
-    // GLM-5.3：同 Kimi K3——官方仅 low/high/max 且思考永开，max 被底座钳到
-    // high，只暴露 low/high。
+    // GLM-5.3: same as Kimi K3 — officially only low/high/max and
+    // always-thinking, max is clamped to high by the engine, so only low/high
+    // are exposed. Scope note: this entry applies to local routes only; the
+    // cloud exact route (z.ai first-party) deliberately keeps its own
+    // ['off', 'high', 'max'] tiers from the hosted API contract.
     if id.contains("glm-5.3") {
         return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
     }
-    // GLM-4.7：同上（low/high/max 且思考永开，max 钳到 high）。
+    // GLM-4.7: same as above (low/high/max and always-thinking, max clamped to
+    // high).
     if id.contains("glm-4.7") {
         return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
     }
-    // GPT-OSS：官方仅 low/medium/high 档位，思考永开（无 off）。
+    // GPT-OSS: officially only low/medium/high tiers, always-thinking (no off).
     if id.contains("gpt-oss") {
         return Some(AlwaysThinkingSpec::Tiers(&["low", "medium", "high"]));
     }
-    // Kimi K2 Thinking / K2.5 Thinking / K2.7：思考不可关且无档位可控。
+    // Kimi K2 Thinking / K2.5 Thinking / K2.7: thinking cannot be disabled and
+    // no tiers are controllable.
     if id.contains("kimi-k2-thinking")
         || id.contains("kimi-k2.5-thinking")
         || id.contains("kimi-k2.7")
     {
         return Some(AlwaysThinkingSpec::NoControl);
     }
-    // DeepSeek-R1 系列（含 distill）：思考不可关且无档位可控。
+    // DeepSeek-R1 family (including distill): thinking cannot be disabled and
+    // no tiers are controllable.
     if id.contains("deepseek-r1") {
         return Some(AlwaysThinkingSpec::NoControl);
     }
-    // Qwen3 Thinking 变体：思考不可关且无档位可控。普通 qwen3（如
-    // qwen3-32b）可控可关，不含 "thinking" 不命中。
+    // Qwen3 Thinking variants: thinking cannot be disabled and no tiers are
+    // controllable. Plain qwen3 (e.g. qwen3-32b) is controllable and can be
+    // disabled; it does not contain "thinking", so it does not match.
     if id.contains("qwen3") && id.contains("thinking") {
         return Some(AlwaysThinkingSpec::NoControl);
     }
-    // MiniMax-M2：思考不可关且无档位可控。
+    // MiniMax-M2: thinking cannot be disabled and no tiers are controllable.
     if id.contains("minimax-m2") {
         return Some(AlwaysThinkingSpec::NoControl);
     }
@@ -85,7 +107,8 @@ pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
 mod tests {
     use super::*;
 
-    /// 档位可控条目：精确档位表与归一目标（首项）。
+    /// Tier-controllable entries: exact tier tables and the normalization
+    /// target (first entry).
     #[test]
     fn tiers_entries_match_expected_tables() {
         for model in ["kimi-k3", "moonshotai/Kimi-K3-Instruct"] {
@@ -108,7 +131,8 @@ mod tests {
         );
     }
 
-    /// NoControl 条目：思考不可关且无档位可控。
+    /// NoControl entries: thinking cannot be disabled and no tiers are
+    /// controllable.
     #[test]
     fn no_control_entries_match() {
         for model in [
@@ -127,7 +151,8 @@ mod tests {
         }
     }
 
-    /// 匹配口径：大小写不敏感，`_`/空格归一为 `-` 后子串匹配。
+    /// Matching rules: case-insensitive; `_`/spaces are normalized to `-`
+    /// before substring matching.
     #[test]
     fn matching_normalizes_case_underscores_and_spaces() {
         assert_eq!(
@@ -144,7 +169,8 @@ mod tests {
         );
     }
 
-    /// 归一与前端 JS 口径对齐：trim + 连续 `_`/空白段折叠为单个 `-`。
+    /// Normalization aligned with the frontend JS rules: trim + collapse runs
+    /// of `_`/whitespace into a single `-`.
     #[test]
     fn matching_trims_and_collapses_separator_runs() {
         assert_eq!(
@@ -162,8 +188,9 @@ mod tests {
         assert_eq!(always_thinking_spec("   "), None);
     }
 
-    /// qwen3 只有 Thinking 变体命中：普通 qwen3（qwen3-32b、qwen3:8b）可控
-    /// 可关，不命中；qwen3-thinking 命中 NoControl。
+    /// Only qwen3 Thinking variants match: plain qwen3 (qwen3-32b, qwen3:8b) is
+    /// controllable and can be disabled, so it does not match; qwen3-thinking
+    /// matches NoControl.
     #[test]
     fn qwen3_matches_only_thinking_variants() {
         assert_eq!(always_thinking_spec("qwen3-32b"), None);
@@ -175,7 +202,7 @@ mod tests {
         );
     }
 
-    /// 未知/可控模型不命中。
+    /// Unknown/controllable models do not match.
     #[test]
     fn unrelated_models_do_not_match() {
         assert_eq!(always_thinking_spec("llama3.2:3b"), None);

--- a/pinvou3-app/src-tauri/src/core/always_thinking.rs
+++ b/pinvou3-app/src-tauri/src/core/always_thinking.rs
@@ -1,0 +1,154 @@
+//! 思考不可关闭（always-thinking）模型的知识表与运行时归一。
+//!
+//! 本地路由默认关思考（防 SSE timeout / 首包抢占），但有一类模型思考永开、
+//! 关不掉也无档位可控，或只允许部分档位——把 "off" 或越界档位发过去只会被
+//! 服务端忽略/报错。本表按模型名识别这类模型，供
+//! `features::assistant::platform::bridge::request_reasoning_effort` 归一。
+//!
+//! 设计约定：框架明确回报可关性时以框架为准，本表只是兜底；目前各部署框架
+//! （vLLM / SGLang / Ollama 等）均不回报思考可关性，运行时只能靠模型名匹配。
+
+/// 思考不可关闭模型的可控形态。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlwaysThinkingSpec {
+    /// 思考永开但档位可控：只允许列出的档位（首项为越界/缺省时的归一目标，
+    /// 即该模型允许的最低档）。
+    Tiers(&'static [&'static str]),
+    /// 思考永开且无任何可控档位：运行时不发任何思考参数，让模型原生思考。
+    NoControl,
+}
+
+/// 按模型 id 查知识表。匹配口径：id 小写化并把 `_`/空格归一为 `-` 后做子串
+/// 匹配（覆盖 `vendor/Model_Name`、tag、量化后缀等常见书写形态）。
+pub fn always_thinking_spec(model_id: &str) -> Option<AlwaysThinkingSpec> {
+    let normalized = model_id
+        .to_ascii_lowercase()
+        .replace('_', "-")
+        .replace(' ', "-");
+    let id = normalized.as_str();
+    // Kimi K3：官方仅 low/high/max 档位且思考永开；底座 vllm wire 会把 max
+    // 钳到 high，故只暴露 low/high。
+    if id.contains("kimi-k3") {
+        return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
+    }
+    // GLM-5.3：同 Kimi K3——官方仅 low/high/max 且思考永开，max 被底座钳到
+    // high，只暴露 low/high。
+    if id.contains("glm-5.3") {
+        return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
+    }
+    // GLM-4.7：同上（low/high/max 且思考永开，max 钳到 high）。
+    if id.contains("glm-4.7") {
+        return Some(AlwaysThinkingSpec::Tiers(&["low", "high"]));
+    }
+    // GPT-OSS：官方仅 low/medium/high 档位，思考永开（无 off）。
+    if id.contains("gpt-oss") {
+        return Some(AlwaysThinkingSpec::Tiers(&["low", "medium", "high"]));
+    }
+    // Kimi K2 Thinking / K2.5 Thinking / K2.7：思考不可关且无档位可控。
+    if id.contains("kimi-k2-thinking")
+        || id.contains("kimi-k2.5-thinking")
+        || id.contains("kimi-k2.7")
+    {
+        return Some(AlwaysThinkingSpec::NoControl);
+    }
+    // DeepSeek-R1 系列（含 distill）：思考不可关且无档位可控。
+    if id.contains("deepseek-r1") {
+        return Some(AlwaysThinkingSpec::NoControl);
+    }
+    // Qwen3 Thinking 变体：思考不可关且无档位可控。普通 qwen3（如
+    // qwen3-32b）可控可关，不含 "thinking" 不命中。
+    if id.contains("qwen3") && id.contains("thinking") {
+        return Some(AlwaysThinkingSpec::NoControl);
+    }
+    // MiniMax-M2：思考不可关且无档位可控。
+    if id.contains("minimax-m2") {
+        return Some(AlwaysThinkingSpec::NoControl);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 档位可控条目：精确档位表与归一目标（首项）。
+    #[test]
+    fn tiers_entries_match_expected_tables() {
+        for model in ["kimi-k3", "moonshotai/Kimi-K3-Instruct"] {
+            assert_eq!(
+                always_thinking_spec(model),
+                Some(AlwaysThinkingSpec::Tiers(&["low", "high"])),
+                "{model}"
+            );
+        }
+        for model in ["glm-5.3", "glm-4.7"] {
+            assert_eq!(
+                always_thinking_spec(model),
+                Some(AlwaysThinkingSpec::Tiers(&["low", "high"])),
+                "{model}"
+            );
+        }
+        assert_eq!(
+            always_thinking_spec("gpt-oss-120b"),
+            Some(AlwaysThinkingSpec::Tiers(&["low", "medium", "high"]))
+        );
+    }
+
+    /// NoControl 条目：思考不可关且无档位可控。
+    #[test]
+    fn no_control_entries_match() {
+        for model in [
+            "kimi-k2-thinking",
+            "kimi-k2.5-thinking",
+            "kimi-k2.7",
+            "deepseek-r1",
+            "deepseek-r1-distill-qwen-32b",
+            "minimax-m2",
+        ] {
+            assert_eq!(
+                always_thinking_spec(model),
+                Some(AlwaysThinkingSpec::NoControl),
+                "{model}"
+            );
+        }
+    }
+
+    /// 匹配口径：大小写不敏感，`_`/空格归一为 `-` 后子串匹配。
+    #[test]
+    fn matching_normalizes_case_underscores_and_spaces() {
+        assert_eq!(
+            always_thinking_spec("Kimi_K3"),
+            Some(AlwaysThinkingSpec::Tiers(&["low", "high"]))
+        );
+        assert_eq!(
+            always_thinking_spec("DeepSeek R1 0528"),
+            Some(AlwaysThinkingSpec::NoControl)
+        );
+        assert_eq!(
+            always_thinking_spec("MINIMAX_M2"),
+            Some(AlwaysThinkingSpec::NoControl)
+        );
+    }
+
+    /// qwen3 只有 Thinking 变体命中：普通 qwen3（qwen3-32b、qwen3:8b）可控
+    /// 可关，不命中；qwen3-thinking 命中 NoControl。
+    #[test]
+    fn qwen3_matches_only_thinking_variants() {
+        assert_eq!(always_thinking_spec("qwen3-32b"), None);
+        assert_eq!(always_thinking_spec("qwen3:8b"), None);
+        assert_eq!(always_thinking_spec("qwen3-coder-480b"), None);
+        assert_eq!(
+            always_thinking_spec("qwen3-thinking-2507"),
+            Some(AlwaysThinkingSpec::NoControl)
+        );
+    }
+
+    /// 未知/可控模型不命中。
+    #[test]
+    fn unrelated_models_do_not_match() {
+        assert_eq!(always_thinking_spec("llama3.2:3b"), None);
+        assert_eq!(always_thinking_spec("glm-5.2"), None);
+        assert_eq!(always_thinking_spec("kimi-k2"), None);
+        assert_eq!(always_thinking_spec(""), None);
+    }
+}

--- a/pinvou3-app/src-tauri/src/core/mod.rs
+++ b/pinvou3-app/src-tauri/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod always_thinking;
 pub mod mode_state;
 pub mod model_context;
 pub mod model_endpoint;

--- a/pinvou3-app/src-tauri/src/core/model_endpoint.rs
+++ b/pinvou3-app/src-tauri/src/core/model_endpoint.rs
@@ -11,8 +11,9 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 
 /// 探测结果 TTL 缓存：同一 base_url 的本地服务类型在短时间内不会变化。
-/// 探测最坏 ~12-15s 串行（挂起端点），多会话/多入口（EnginePool spawn、
-/// 连接测试、前端探测）重复探测会放大开销；按 base_url 缓存可合并。
+/// 探测经 `tokio::join!` 并行发出（各请求共享 3s 超时，挂起端点最坏 ~3s），
+/// 多会话/多入口（EnginePool spawn、连接测试、前端探测）重复探测仍会放大
+/// 开销；按 base_url 缓存可合并。
 const PROBE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 static PROBE_KIND_CACHE: std::sync::OnceLock<
@@ -264,9 +265,11 @@ pub fn strip_v1_suffix(url: &str) -> Option<String> {
 
 /// 本地推理服务类型（决定思考控制走哪套 wire 协议）。
 ///
-/// 只有前两类有底座现成能力：Ollama 经 `think` 布尔开关（无档位）、vLLM 经
-/// `chat_template_kwargs` 支持 off/low/medium/high 档位；LM Studio 与通用
-/// OpenAI 兼容端点走 openai wire route，底座暂不注入思考控制。
+/// Ollama 经 `think` 布尔开关（无档位）；vLLM 及 wire 同构的 SGLang /
+/// llama.cpp / KoboldCpp / LMDeploy / Docker Model Runner 经
+/// `chat_template_kwargs.enable_thinking` + `reasoning_effort` 支持
+/// off/low/medium/high 档位（bridge 统一映射到底座 vllm provider）；LM Studio
+/// 与通用 OpenAI 兼容端点走 openai wire route，底座暂不注入思考控制。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalServerKind {
     /// vLLM：底座经 `chat_template_kwargs.enable_thinking` + `reasoning_effort`
@@ -274,6 +277,19 @@ pub enum LocalServerKind {
     Vllm,
     /// Ollama：底座经 `think` 布尔支持开关（off=think:false，其余 think:true）。
     Ollama,
+    /// SGLang：特征端点 `/get_server_info`；思考控制 wire 与 vLLM 同构。
+    Sglang,
+    /// llama.cpp（llama-server）：特征端点 `/props`；思考控制 wire 与 vLLM 同构。
+    LlamaCpp,
+    /// KoboldCpp：特征端点 `/api/extra/version`；兼容 llama.cpp 的 `/props`，
+    /// 判别优先级高于 LlamaCpp；思考控制 wire 与 vLLM 同构。
+    KoboldCpp,
+    /// LMDeploy：`/v1/models` 的 `owned_by == "lmdeploy"`（中等置信度特征）；
+    /// 思考控制 wire 与 vLLM 同构。
+    LmDeploy,
+    /// Docker Model Runner：仅 12434 端口的 `/models` JSON 数组管理 API
+    /// （端口门控）；思考控制 wire 与 vLLM 同构。
+    DockerModelRunner,
     /// LM Studio：底座 openai wire route 暂不注入思考控制（保持旧行为）。
     LmStudio,
     /// 其他通用 OpenAI 兼容服务（探测不到任何特征端点）。
@@ -281,8 +297,12 @@ pub enum LocalServerKind {
 }
 
 /// 探测本地推理服务类型。只应在本地端点（`base_url_uses_local_or_private`）上
-/// 调用；判定顺序按特征端点互斥性排列：Ollama（`/api/tags`）→ LM Studio
-/// （`/api/v0/models`）→ vLLM（`/v1/models` 的 `owned_by`）→ 通用。探测失败
+/// 调用；所有候选特征端点并行探测（`tokio::join!`，共享 3s 超时，挂起端点最坏
+/// ~3s），全部完成后按特征互斥性优先级挑选：Ollama（`/api/tags`）> LM Studio
+/// （`/api/v0/models`）> KoboldCpp（`/api/extra/version`）> LlamaCpp（`/props`）
+/// > Sglang（`/get_server_info`）> LmDeploy（`/v1/models` 的 `owned_by`）>
+/// DockerModelRunner（12434 端口 `/models` 数组）> Vllm（`owned_by`）> 通用。
+/// 探测失败
 /// (service not started/timeout/auth 401) returns `Generic`; callers keep the
 /// existing openai wire route and do not change behavior on probe failure.
 ///
@@ -292,7 +312,7 @@ pub enum LocalServerKind {
 /// Generic misclassification, losing default-off thinking and the real
 /// effort tiers. Pass `None` for endpoints without auth.
 ///
-/// 结果按 base_url 缓存 `PROBE_CACHE_TTL`：探测最坏 ~12-15s 串行（挂起端点），
+/// 结果按 base_url 缓存 `PROBE_CACHE_TTL`：即使并行后挂起端点仍要付一次 ~3s，
 /// repeated probes across sessions/entry points amplify the cost; a hit
 /// within the TTL returns the cached value directly. The cache/in-flight key
 /// contains only base_url, never credentials: a positive identification
@@ -487,20 +507,53 @@ pub(crate) fn clear_probe_kind_cache() {
 }
 
 /// 无缓存的实际探测（TTL 缓存命中时直接返回，见 `probe_local_server_kind`）。
+/// 所有候选探测经 `tokio::join!` 并行发出（各自共享 `shared_probe_client` 的
+/// 3s 超时，挂起端点最坏 ~3s 而非串行累加）；`/v1/models` 只抓取一次，供
+/// LMDeploy 与 vLLM 的 `owned_by` 判别共用。全部完成后按特征互斥性优先级挑选。
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_local_server_kind_uncached(base_url: &str, bearer: Option<&str>) -> LocalServerKind {
-    // Ollama 特征端点 /api/tags 存在且模型列表非空（probe_ollama_models 内部要求）。
-    if probe_ollama_models(base_url, bearer).await.is_some() {
+    let (ollama, lmstudio, koboldcpp, llamacpp, sglang, v1_models, docker) = tokio::join!(
+        probe_ollama_tags(base_url, bearer),
+        probe_lmstudio_v0_only(base_url, bearer),
+        probe_koboldcpp_version(base_url, bearer),
+        probe_llamacpp_props(base_url, bearer),
+        probe_sglang_server_info(base_url, bearer),
+        fetch_v1_models(base_url, bearer),
+        probe_docker_model_runner(base_url, bearer),
+    );
+    // 优先级按特征互斥性排列：KoboldCpp 兼容 llama.cpp 的 /props，必须先于
+    // LlamaCpp 判定；LMDeploy 与 vLLM 共用 owned_by 特征，LMDeploy 优先。
+    if ollama {
         return LocalServerKind::Ollama;
     }
-    // LM Studio 原生端点 /api/v0/models 存在且形状认识。注意不能复用
-    // probe_lmstudio_models：它失败时回退 /v1/models，而 /v1/models 是通用端点
-    // （Ollama/通用服务也有），会把非 LM Studio 误判成 LM Studio。
-    if probe_lmstudio_v0_only(base_url, bearer).await.is_some() {
+    if lmstudio.is_some() {
         return LocalServerKind::LmStudio;
     }
+    if koboldcpp {
+        return LocalServerKind::KoboldCpp;
+    }
+    if llamacpp {
+        return LocalServerKind::LlamaCpp;
+    }
+    if sglang {
+        return LocalServerKind::Sglang;
+    }
+    // LMDeploy：/v1/models 中任一 owned_by == "lmdeploy"。中等置信度特征：
+    // owned_by 是各实现自报字段，非 LMDeploy 独有约定，仅作为弱标识。
+    if v1_models
+        .as_ref()
+        .is_some_and(|v| v1_models_owned_by_matches(v, "lmdeploy"))
+    {
+        return LocalServerKind::LmDeploy;
+    }
+    if docker {
+        return LocalServerKind::DockerModelRunner;
+    }
     // vLLM：/v1/models 响应中模型 `owned_by == "vllm"`（vLLM 标准实现字段）。
-    if probe_vllm_owned(base_url, bearer).await {
+    if v1_models
+        .as_ref()
+        .is_some_and(|v| v1_models_owned_by_matches(v, "vllm"))
+    {
         return LocalServerKind::Vllm;
     }
     LocalServerKind::Generic
@@ -529,7 +582,8 @@ async fn probe_lmstudio_v0_only(base_url: &str, bearer: Option<&str>) -> Option<
 /// 抓取 OpenAI 兼容 `/v1/models` 响应体。探测地址口径与
 /// `features::monitor::probe_vllm_model_info` 一致：upstream 带 `/v1` 直接拼
 /// `/models`，不带则补 `/v1/models`。失败/非 2xx/解析失败返回 `None`，调用方
-/// 按探测失败处理。共享给 `probe_vllm_owned` 与 monitor 的 vLLM served-name
+/// 按探测失败处理。共享给 kind 探测链（`probe_local_server_kind_uncached` 一次
+/// 抓取供 LMDeploy/vLLM 的 owned_by 判别共用）与 monitor 的 vLLM served-name
 /// probe, so the `/v1/models` URL assembly stays consistent in both places.
 /// See [`apply_bearer`] for `bearer` semantics: an authenticated vLLM
 /// returns 401 on `/v1/models` without credentials.
@@ -554,18 +608,151 @@ pub(crate) async fn fetch_v1_models(
     resp.json::<serde_json::Value>().await.ok()
 }
 
-/// 探测 vLLM：`/v1/models` 响应中任一模型 `owned_by == "vllm"`（vLLM 标准实现）。
-async fn probe_vllm_owned(base_url: &str, bearer: Option<&str>) -> bool {
-    let Some(v) = fetch_v1_models(base_url, bearer).await else {
+/// 判别用的轻量 Ollama 探测：只查 `/api/tags`（200 且模型列表非空），判定口径
+/// 与 `probe_ollama_models` 一致但不抓 `/api/ps`——kind 探测不需要 loaded 状态，
+/// 模型列表组装逻辑仍归 `probe_ollama_models` 独有。
+/// See [`apply_bearer`] for `bearer` semantics.
+async fn probe_ollama_tags(base_url: &str, bearer: Option<&str>) -> bool {
+    let Some(host) = strip_v1_suffix(base_url) else {
         return false;
     };
+    let Some(client) = shared_probe_client() else {
+        return false;
+    };
+    let Ok(resp) = apply_bearer(client.get(format!("{host}/api/tags")), bearer)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    else {
+        return false;
+    };
+    let Ok(v) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    !parse_ollama_tag_names(v).is_empty()
+}
+
+/// 探测 KoboldCpp：`/api/extra/version` 200 且 JSON `result` 字符串包含
+/// "koboldcpp"（大小写不敏感）。
+/// See [`apply_bearer`] for `bearer` semantics.
+async fn probe_koboldcpp_version(base_url: &str, bearer: Option<&str>) -> bool {
+    let Some(host) = strip_v1_suffix(base_url) else {
+        return false;
+    };
+    let Some(client) = shared_probe_client() else {
+        return false;
+    };
+    let Ok(resp) = apply_bearer(client.get(format!("{host}/api/extra/version")), bearer)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    else {
+        return false;
+    };
+    let Ok(v) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    v.get("result")
+        .and_then(Value::as_str)
+        .is_some_and(|s| s.to_ascii_lowercase().contains("koboldcpp"))
+}
+
+/// 探测 llama.cpp：`/props` 200 且 JSON 对象同时含 `default_generation_settings`
+/// 与 `total_slots`。注意 KoboldCpp 也兼容 `/props`，判别优先级必须低于
+/// KoboldCpp（见 `probe_local_server_kind_uncached` 的挑选顺序）。
+/// See [`apply_bearer`] for `bearer` semantics.
+async fn probe_llamacpp_props(base_url: &str, bearer: Option<&str>) -> bool {
+    let Some(host) = strip_v1_suffix(base_url) else {
+        return false;
+    };
+    let Some(client) = shared_probe_client() else {
+        return false;
+    };
+    let Ok(resp) = apply_bearer(client.get(format!("{host}/props")), bearer)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    else {
+        return false;
+    };
+    let Ok(v) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    v.as_object().is_some_and(|obj| {
+        obj.contains_key("default_generation_settings") && obj.contains_key("total_slots")
+    })
+}
+
+/// 探测 SGLang：`/get_server_info` 200 且 JSON 对象含 `version` 字符串字段
+/// （响应是 ServerArgs 序列化大 JSON，宽松解析，只看 version 存在）。
+/// See [`apply_bearer`] for `bearer` semantics.
+async fn probe_sglang_server_info(base_url: &str, bearer: Option<&str>) -> bool {
+    let Some(host) = strip_v1_suffix(base_url) else {
+        return false;
+    };
+    let Some(client) = shared_probe_client() else {
+        return false;
+    };
+    let Ok(resp) = apply_bearer(client.get(format!("{host}/get_server_info")), bearer)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    else {
+        return false;
+    };
+    let Ok(v) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    v.get("version").and_then(Value::as_str).is_some()
+}
+
+/// Docker Model Runner 端口门控：其管理 API 固定在 12434 端口，其他端口
+/// 一律不探测（避免对任意本地端点多发一次 `/models` 请求）。
+fn is_docker_model_runner_port(base_url: &str) -> bool {
+    reqwest::Url::parse(base_url.trim())
+        .ok()
+        .and_then(|url| url.port_or_known_default())
+        == Some(12434)
+}
+
+/// 探测 Docker Model Runner：仅当 base_url 有效端口为 12434（端口门控，见
+/// [`is_docker_model_runner_port`]）时 GET `/models`；200 且响应是 JSON 数组
+/// 才命中——这是 Docker 管理 API 的形状，OpenAI 兼容形状是含 "data" 的对象，
+/// 以此区分。
+/// See [`apply_bearer`] for `bearer` semantics.
+async fn probe_docker_model_runner(base_url: &str, bearer: Option<&str>) -> bool {
+    if !is_docker_model_runner_port(base_url) {
+        return false;
+    }
+    let Some(host) = strip_v1_suffix(base_url) else {
+        return false;
+    };
+    let Some(client) = shared_probe_client() else {
+        return false;
+    };
+    let Ok(resp) = apply_bearer(client.get(format!("{host}/models")), bearer)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    else {
+        return false;
+    };
+    resp.json::<serde_json::Value>()
+        .await
+        .ok()
+        .is_some_and(|v| v.is_array())
+}
+
+/// `/v1/models` 响应体中任一模型 `owned_by` 等于期望值（大小写不敏感）。
+/// 供 vLLM（`"vllm"`）与 LMDeploy（`"lmdeploy"`）判别共用同一次抓取结果。
+fn v1_models_owned_by_matches(v: &serde_json::Value, expected: &str) -> bool {
     v.get("data")
         .and_then(Value::as_array)
         .is_some_and(|items| {
             items.iter().any(|item| {
                 item.get("owned_by")
                     .and_then(Value::as_str)
-                    .is_some_and(|owned| owned.eq_ignore_ascii_case("vllm"))
+                    .is_some_and(|owned| owned.eq_ignore_ascii_case(expected))
             })
         })
 }
@@ -971,6 +1158,130 @@ mod tests {
             probe_local_server_kind(&server.url, None).await,
             LocalServerKind::Generic
         );
+    }
+
+    /// KoboldCpp 特征命中：/api/extra/version 的 result 字段含 "koboldcpp"
+    /// （大小写不敏感）→ 判定 KoboldCpp。
+    #[tokio::test]
+    async fn probe_local_kind_detects_koboldcpp_via_extra_version() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        let server = spawn_probe_server(vec![(
+            "/api/extra/version",
+            r#"{"result":"KoboldCpp 1.74","version":"1.74"}"#,
+        )])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::KoboldCpp
+        );
+    }
+
+    /// llama.cpp 特征命中：/props 同时含 default_generation_settings 与
+    /// total_slots → 判定 LlamaCpp；缺任一字段不命中（宽松解析防误判）。
+    #[tokio::test]
+    async fn probe_local_kind_detects_llamacpp_via_props() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        let server = spawn_probe_server(vec![(
+            "/props",
+            r#"{"default_generation_settings":{"n_ctx":4096},"total_slots":1}"#,
+        )])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::LlamaCpp
+        );
+        clear_probe_kind_cache();
+        // 缺 total_slots：形状不完整，不判 LlamaCpp（其余端点 404 → Generic）。
+        let partial = spawn_probe_server(vec![(
+            "/props",
+            r#"{"default_generation_settings":{"n_ctx":4096}}"#,
+        )])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&partial.url, None).await,
+            LocalServerKind::Generic
+        );
+    }
+
+    /// 优先级：KoboldCpp 兼容 llama.cpp 的 /props，两个特征同时命中时必须
+    /// 判为 KoboldCpp（KoboldCpp 优先级高于 LlamaCpp）。
+    #[tokio::test]
+    async fn probe_local_kind_koboldcpp_wins_over_llamacpp_props() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        let server = spawn_probe_server(vec![
+            (
+                "/api/extra/version",
+                r#"{"result":"koboldcpp-1.74","version":"1.74"}"#,
+            ),
+            (
+                "/props",
+                r#"{"default_generation_settings":{},"total_slots":1}"#,
+            ),
+        ])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::KoboldCpp
+        );
+    }
+
+    /// SGLang 特征命中：/get_server_info 是 ServerArgs 序列化大 JSON，宽松
+    /// 解析只看 version 字符串字段存在 → 判定 Sglang。
+    #[tokio::test]
+    async fn probe_local_kind_detects_sglang_via_server_info() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        let server = spawn_probe_server(vec![(
+            "/get_server_info",
+            r#"{"model_path":"qwen3","version":"0.4.9","max_total_num_tokens":32768,"internal_states":[{"memory_usage":0.5}]}"#,
+        )])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::Sglang
+        );
+    }
+
+    /// LMDeploy 命中：/v1/models 中 owned_by == "lmdeploy"（大小写不敏感，
+    /// 中等置信度特征）。与 vLLM 共用同一次 /v1/models 抓取，LMDeploy 优先。
+    #[tokio::test]
+    async fn probe_local_kind_detects_lmdeploy_via_owned_by() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        let server = spawn_probe_server(vec![(
+            "/v1/models",
+            r#"{"object":"list","data":[{"id":"internlm3-8b","owned_by":"LMDeploy"}]}"#,
+        )])
+        .await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::LmDeploy
+        );
+    }
+
+    /// Docker Model Runner 端口门控：/models 返回 JSON 数组（管理 API 形状）
+    /// 但端口不是 12434 → 不探测该端点，不判 DockerModelRunner（落 Generic）。
+    #[tokio::test]
+    async fn probe_local_kind_docker_model_runner_gated_by_port_12434() {
+        let _state = PROBE_STATE_TEST_MUTEX.lock().await;
+        // mock 绑定随机端口（必 ≠ 12434 门控值时跳过探测）。
+        let server = spawn_probe_server(vec![("/models", r#"[{"id":"qwen3"}]"#)]).await;
+        assert_eq!(
+            probe_local_server_kind(&server.url, None).await,
+            LocalServerKind::Generic,
+            "非 12434 端口不尝试 Docker Model Runner 管理 API"
+        );
+    }
+
+    /// 端口门控纯函数：仅有效端口 == 12434 才允许探测；无显式端口按协议
+    /// 默认（http=80）不命中；非法 URL 不命中。
+    #[test]
+    fn docker_model_runner_port_gate_requires_12434() {
+        assert!(is_docker_model_runner_port("http://localhost:12434/v1"));
+        assert!(is_docker_model_runner_port(
+            "http://host.docker.internal:12434/engines/v1"
+        ));
+        assert!(!is_docker_model_runner_port("http://127.0.0.1:11434/v1"));
+        assert!(!is_docker_model_runner_port("http://localhost/v1"));
+        assert!(!is_docker_model_runner_port("not a url"));
     }
 
     /// Authenticated-endpoint probing (round-6 P1 regression): vLLM

--- a/pinvou3-app/src-tauri/src/core/model_endpoint.rs
+++ b/pinvou3-app/src-tauri/src/core/model_endpoint.rs
@@ -301,7 +301,10 @@ pub enum LocalServerKind {
 /// ~3s），全部完成后按特征互斥性优先级挑选：Ollama（`/api/tags`）> LM Studio
 /// （`/api/v0/models`）> KoboldCpp（`/api/extra/version`）> LlamaCpp（`/props`）
 /// > Sglang（`/get_server_info`）> LmDeploy（`/v1/models` 的 `owned_by`）>
-/// DockerModelRunner（12434 端口 `/models` 数组）> Vllm（`owned_by`）> 通用。
+/// Vllm（`owned_by`）> 通用。唯一例外是 DockerModelRunner 端口门控优先：
+/// DMR 同时暴露 Ollama 兼容的 `/api/tags`，仅 12434 端口在 Ollama 判定之前
+/// 先查主机根 `/models` 的管理 API 形状（JSON 数组），命中即判
+/// DockerModelRunner，未命中按原顺序继续。
 /// 探测失败
 /// (service not started/timeout/auth 401) returns `Generic`; callers keep the
 /// existing openai wire route and do not change behavior on probe failure.
@@ -506,13 +509,77 @@ pub(crate) fn clear_probe_kind_cache() {
     }
 }
 
+/// 各候选探测的命中结果，供 [`select_local_server_kind`] 做优先级挑选。
+/// 拆成纯数据结构的目的是：端口门控优先的顺序决策不依赖真实 12434 端口绑定，
+/// 可以在测试里直接构造命中组合覆盖。
+struct ProbeCandidateHits {
+    /// base_url 有效端口为 12434（Docker Model Runner 端口门控）。
+    docker_port_gated: bool,
+    /// 12434 端口主机根 `/models` 返回 JSON 数组（DMR 管理 API 形状）。
+    docker_mgmt_shape: bool,
+    ollama: bool,
+    lmstudio_v0: bool,
+    koboldcpp: bool,
+    llamacpp: bool,
+    sglang: bool,
+    /// `/v1/models` 响应体（LMDeploy 与 vLLM 的 owned_by 判别共用一次抓取）。
+    v1_models: Option<serde_json::Value>,
+}
+
+/// 探测结果的优先级挑选（纯函数，不发请求）。顺序：Docker Model Runner
+/// 端口门控优先（DMR 同时暴露 Ollama 兼容的 `/api/tags`，若按通用优先级会
+/// 先命中 Ollama 分支，DockerModelRunner 永远不可达；仅 12434 端口在 Ollama
+/// 判定前检查管理 API 形状，未命中按原顺序继续）> Ollama > LM Studio >
+/// KoboldCpp > LlamaCpp > Sglang > LmDeploy > Vllm > 通用。KoboldCpp 兼容
+/// llama.cpp 的 `/props` 必须先于 LlamaCpp；LMDeploy 与 vLLM 共用 owned_by
+/// 特征，LMDeploy 优先。
+fn select_local_server_kind(hits: ProbeCandidateHits) -> LocalServerKind {
+    if hits.docker_port_gated && hits.docker_mgmt_shape {
+        return LocalServerKind::DockerModelRunner;
+    }
+    if hits.ollama {
+        return LocalServerKind::Ollama;
+    }
+    if hits.lmstudio_v0 {
+        return LocalServerKind::LmStudio;
+    }
+    if hits.koboldcpp {
+        return LocalServerKind::KoboldCpp;
+    }
+    if hits.llamacpp {
+        return LocalServerKind::LlamaCpp;
+    }
+    if hits.sglang {
+        return LocalServerKind::Sglang;
+    }
+    // LMDeploy：/v1/models 中任一 owned_by == "lmdeploy"。中等置信度特征：
+    // owned_by 是各实现自报字段，非 LMDeploy 独有约定，仅作为弱标识。
+    if hits
+        .v1_models
+        .as_ref()
+        .is_some_and(|v| v1_models_owned_by_matches(v, "lmdeploy"))
+    {
+        return LocalServerKind::LmDeploy;
+    }
+    // vLLM：/v1/models 响应中模型 `owned_by == "vllm"`（vLLM 标准实现字段）。
+    if hits
+        .v1_models
+        .as_ref()
+        .is_some_and(|v| v1_models_owned_by_matches(v, "vllm"))
+    {
+        return LocalServerKind::Vllm;
+    }
+    LocalServerKind::Generic
+}
+
 /// 无缓存的实际探测（TTL 缓存命中时直接返回，见 `probe_local_server_kind`）。
 /// 所有候选探测经 `tokio::join!` 并行发出（各自共享 `shared_probe_client` 的
 /// 3s 超时，挂起端点最坏 ~3s 而非串行累加）；`/v1/models` 只抓取一次，供
 /// LMDeploy 与 vLLM 的 `owned_by` 判别共用。全部完成后按特征互斥性优先级挑选。
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_local_server_kind_uncached(base_url: &str, bearer: Option<&str>) -> LocalServerKind {
-    let (ollama, lmstudio, koboldcpp, llamacpp, sglang, v1_models, docker) = tokio::join!(
+    let docker_port_gated = is_docker_model_runner_port(base_url);
+    let (ollama, lmstudio, koboldcpp, llamacpp, sglang, v1_models, docker_mgmt) = tokio::join!(
         probe_ollama_tags(base_url, bearer),
         probe_lmstudio_v0_only(base_url, bearer),
         probe_koboldcpp_version(base_url, bearer),
@@ -521,42 +588,16 @@ async fn probe_local_server_kind_uncached(base_url: &str, bearer: Option<&str>) 
         fetch_v1_models(base_url, bearer),
         probe_docker_model_runner(base_url, bearer),
     );
-    // 优先级按特征互斥性排列：KoboldCpp 兼容 llama.cpp 的 /props，必须先于
-    // LlamaCpp 判定；LMDeploy 与 vLLM 共用 owned_by 特征，LMDeploy 优先。
-    if ollama {
-        return LocalServerKind::Ollama;
-    }
-    if lmstudio.is_some() {
-        return LocalServerKind::LmStudio;
-    }
-    if koboldcpp {
-        return LocalServerKind::KoboldCpp;
-    }
-    if llamacpp {
-        return LocalServerKind::LlamaCpp;
-    }
-    if sglang {
-        return LocalServerKind::Sglang;
-    }
-    // LMDeploy：/v1/models 中任一 owned_by == "lmdeploy"。中等置信度特征：
-    // owned_by 是各实现自报字段，非 LMDeploy 独有约定，仅作为弱标识。
-    if v1_models
-        .as_ref()
-        .is_some_and(|v| v1_models_owned_by_matches(v, "lmdeploy"))
-    {
-        return LocalServerKind::LmDeploy;
-    }
-    if docker {
-        return LocalServerKind::DockerModelRunner;
-    }
-    // vLLM：/v1/models 响应中模型 `owned_by == "vllm"`（vLLM 标准实现字段）。
-    if v1_models
-        .as_ref()
-        .is_some_and(|v| v1_models_owned_by_matches(v, "vllm"))
-    {
-        return LocalServerKind::Vllm;
-    }
-    LocalServerKind::Generic
+    select_local_server_kind(ProbeCandidateHits {
+        docker_port_gated,
+        docker_mgmt_shape: docker_mgmt,
+        ollama,
+        lmstudio_v0: lmstudio.is_some(),
+        koboldcpp,
+        llamacpp,
+        sglang,
+        v1_models,
+    })
 }
 
 /// 仅探测 LM Studio 独有原生端点 `/api/v0/models`（不回退 `/v1/models`，后者
@@ -715,22 +756,37 @@ fn is_docker_model_runner_port(base_url: &str) -> bool {
         == Some(12434)
 }
 
+/// Docker Model Runner 管理 API 根地址：管理端点在主机根（`/models`），不在
+/// OpenAI 兼容前缀之下。按 `/engines/v1` → `/engines` → `/v1` 的顺序去掉
+/// 尾部前缀（`/engines/v1` 必须先于 `/engines`，否则残留 `/engines`），使
+/// `http://host:12434/engines/v1`、`http://host:12434/v1`、裸主机等文档地址
+/// 都归一到主机根。
+fn strip_docker_model_runner_root(url: &str) -> Option<String> {
+    let trimmed = url.trim_end_matches('/');
+    for suffix in ["/engines/v1", "/engines", "/v1"] {
+        if let Some(root) = trimmed.strip_suffix(suffix) {
+            return Some(root.to_string());
+        }
+    }
+    Some(trimmed.to_string())
+}
+
 /// 探测 Docker Model Runner：仅当 base_url 有效端口为 12434（端口门控，见
-/// [`is_docker_model_runner_port`]）时 GET `/models`；200 且响应是 JSON 数组
-/// 才命中——这是 Docker 管理 API 的形状，OpenAI 兼容形状是含 "data" 的对象，
-/// 以此区分。
+/// [`is_docker_model_runner_port`]）时 GET 主机根的 `/models`（地址归一见
+/// [`strip_docker_model_runner_root`]）；200 且响应是 JSON 数组才命中——这是
+/// Docker 管理 API 的形状，OpenAI 兼容形状是含 "data" 的对象，以此区分。
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_docker_model_runner(base_url: &str, bearer: Option<&str>) -> bool {
     if !is_docker_model_runner_port(base_url) {
         return false;
     }
-    let Some(host) = strip_v1_suffix(base_url) else {
+    let Some(root) = strip_docker_model_runner_root(base_url) else {
         return false;
     };
     let Some(client) = shared_probe_client() else {
         return false;
     };
-    let Ok(resp) = apply_bearer(client.get(format!("{host}/models")), bearer)
+    let Ok(resp) = apply_bearer(client.get(format!("{root}/models")), bearer)
         .send()
         .await
         .and_then(|r| r.error_for_status())
@@ -1101,8 +1157,8 @@ mod tests {
         }
     }
 
-    /// Ollama 特征端点命中：/api/ps 404（容忍，按空集）→ /api/tags 返回模型列表
-    /// → 判定 Ollama。
+    /// Ollama 特征端点命中：/api/tags 返回模型列表 → 判定 Ollama（kind 探测
+    /// 只查 /api/tags，不抓 /api/ps，loaded 状态归 probe_ollama_models）。
     #[tokio::test]
     async fn probe_local_kind_detects_ollama_via_api_tags() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1284,6 +1340,76 @@ mod tests {
         assert!(!is_docker_model_runner_port("not a url"));
     }
 
+    /// DMR 管理 API 地址归一：管理端点在主机根 `/models`，`/engines/v1`、
+    /// `/engines`、`/v1`（按此顺序，避免 `/engines/v1` 残留 `/engines`）与
+    /// 裸主机都归一到主机根。
+    #[test]
+    fn docker_model_runner_root_strips_openai_prefixes() {
+        assert_eq!(
+            strip_docker_model_runner_root("http://host.docker.internal:12434/engines/v1")
+                .as_deref(),
+            Some("http://host.docker.internal:12434")
+        );
+        assert_eq!(
+            strip_docker_model_runner_root("http://localhost:12434/engines").as_deref(),
+            Some("http://localhost:12434")
+        );
+        assert_eq!(
+            strip_docker_model_runner_root("http://localhost:12434/v1").as_deref(),
+            Some("http://localhost:12434")
+        );
+        assert_eq!(
+            strip_docker_model_runner_root("http://localhost:12434/v1/").as_deref(),
+            Some("http://localhost:12434")
+        );
+        assert_eq!(
+            strip_docker_model_runner_root("http://localhost:12434").as_deref(),
+            Some("http://localhost:12434")
+        );
+        assert_eq!(
+            strip_docker_model_runner_root("http://localhost:12434/").as_deref(),
+            Some("http://localhost:12434")
+        );
+    }
+
+    /// 顺序决策（纯函数，无需绑定 12434 端口）：DMR 暴露 Ollama 兼容的
+    /// /api/tags，端口门控内管理 API 形状命中时必须优先于 Ollama 判为
+    /// DockerModelRunner；形状未命中或不在门控端口时按原顺序落 Ollama。
+    #[test]
+    fn select_local_server_kind_docker_model_runner_wins_over_ollama_when_gated() {
+        let both_hit = || ProbeCandidateHits {
+            docker_port_gated: true,
+            docker_mgmt_shape: true,
+            ollama: true,
+            lmstudio_v0: false,
+            koboldcpp: false,
+            llamacpp: false,
+            sglang: false,
+            v1_models: None,
+        };
+        assert_eq!(
+            select_local_server_kind(both_hit()),
+            LocalServerKind::DockerModelRunner,
+            "12434 端口管理 API 形状命中应优先于 Ollama"
+        );
+        // 管理 API 形状未命中：按原顺序继续，Ollama 特征生效。
+        assert_eq!(
+            select_local_server_kind(ProbeCandidateHits {
+                docker_mgmt_shape: false,
+                ..both_hit()
+            }),
+            LocalServerKind::Ollama
+        );
+        // 非 12434 端口：管理形状不被采信（探测本身已被门控跳过）。
+        assert_eq!(
+            select_local_server_kind(ProbeCandidateHits {
+                docker_port_gated: false,
+                ..both_hit()
+            }),
+            LocalServerKind::Ollama
+        );
+    }
+
     /// Authenticated-endpoint probing (round-6 P1 regression): vLLM
     /// `--api-key` returns 401 on `/v1/models` without credentials. Probing
     /// with an inference-same-origin key → vllm identified correctly; no key
@@ -1426,7 +1552,7 @@ mod tests {
 
     /// in-flight 合并：并发多次调用同一 base_url 共享一次探测。
     /// mock server 统计 /api/tags 命中次数——合并生效时无论并发多少调用，
-    /// 特征端点只被打一次（Ollama 判定在第一个端点即短路返回）。
+    /// 特征端点只被打一次（候选探测并行发出、无短路，每个端点每次探测各命中一次）。
     #[tokio::test]
     async fn probe_local_kind_merges_concurrent_calls_into_one_probe() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;

--- a/pinvou3-app/src-tauri/src/core/model_endpoint.rs
+++ b/pinvou3-app/src-tauri/src/core/model_endpoint.rs
@@ -11,9 +11,10 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 
 /// 探测结果 TTL 缓存：同一 base_url 的本地服务类型在短时间内不会变化。
-/// 探测经 `tokio::join!` 并行发出（各请求共享 3s 超时，挂起端点最坏 ~3s），
-/// 多会话/多入口（EnginePool spawn、连接测试、前端探测）重复探测仍会放大
-/// 开销；按 base_url 缓存可合并。
+/// Probes are issued in parallel via `tokio::join!` (all requests share a 3s
+/// timeout; a hung endpoint costs ~3s at worst). Repeated probes across
+/// sessions/entry points (EnginePool spawn, connection test, frontend probe)
+/// still amplify the cost; caching by base_url merges them.
 const PROBE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 static PROBE_KIND_CACHE: std::sync::OnceLock<
@@ -265,11 +266,13 @@ pub fn strip_v1_suffix(url: &str) -> Option<String> {
 
 /// 本地推理服务类型（决定思考控制走哪套 wire 协议）。
 ///
-/// Ollama 经 `think` 布尔开关（无档位）；vLLM 及 wire 同构的 SGLang /
-/// llama.cpp / KoboldCpp / LMDeploy / Docker Model Runner 经
-/// `chat_template_kwargs.enable_thinking` + `reasoning_effort` 支持
-/// off/low/medium/high 档位（bridge 统一映射到底座 vllm provider）；LM Studio
-/// 与通用 OpenAI 兼容端点走 openai wire route，底座暂不注入思考控制。
+/// Ollama uses the `think` boolean switch (no effort tiers); vLLM and the
+/// wire-identical SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker Model
+/// Runner support off/low/medium/high effort tiers via
+/// `chat_template_kwargs.enable_thinking` + `reasoning_effort` (the bridge
+/// maps them uniformly to the engine vllm provider); LM Studio and generic
+/// OpenAI-compatible endpoints take the openai wire route, where the engine
+/// does not yet inject thinking control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocalServerKind {
     /// vLLM：底座经 `chat_template_kwargs.enable_thinking` + `reasoning_effort`
@@ -277,18 +280,21 @@ pub enum LocalServerKind {
     Vllm,
     /// Ollama：底座经 `think` 布尔支持开关（off=think:false，其余 think:true）。
     Ollama,
-    /// SGLang：特征端点 `/get_server_info`；思考控制 wire 与 vLLM 同构。
+    /// SGLang: signature endpoint `/get_server_info`; thinking-control wire
+    /// is identical to vLLM.
     Sglang,
-    /// llama.cpp（llama-server）：特征端点 `/props`；思考控制 wire 与 vLLM 同构。
+    /// llama.cpp (llama-server): signature endpoint `/props`;
+    /// thinking-control wire is identical to vLLM.
     LlamaCpp,
-    /// KoboldCpp：特征端点 `/api/extra/version`；兼容 llama.cpp 的 `/props`，
-    /// 判别优先级高于 LlamaCpp；思考控制 wire 与 vLLM 同构。
+    /// KoboldCpp: signature endpoint `/api/extra/version`; also compatible
+    /// with llama.cpp's `/props`, so its identification priority ranks above
+    /// LlamaCpp; thinking-control wire is identical to vLLM.
     KoboldCpp,
-    /// LMDeploy：`/v1/models` 的 `owned_by == "lmdeploy"`（中等置信度特征）；
-    /// 思考控制 wire 与 vLLM 同构。
+    /// LMDeploy: `owned_by == "lmdeploy"` in `/v1/models` (medium-confidence
+    /// signature); thinking-control wire is identical to vLLM.
     LmDeploy,
-    /// Docker Model Runner：仅 12434 端口的 `/models` JSON 数组管理 API
-    /// （端口门控）；思考控制 wire 与 vLLM 同构。
+    /// Docker Model Runner: `/models` JSON-array management API on port 12434
+    /// only (port-gated); thinking-control wire is identical to vLLM.
     DockerModelRunner,
     /// LM Studio：底座 openai wire route 暂不注入思考控制（保持旧行为）。
     LmStudio,
@@ -297,15 +303,18 @@ pub enum LocalServerKind {
 }
 
 /// 探测本地推理服务类型。只应在本地端点（`base_url_uses_local_or_private`）上
-/// 调用；所有候选特征端点并行探测（`tokio::join!`，共享 3s 超时，挂起端点最坏
-/// ~3s），全部完成后按特征互斥性优先级挑选：Ollama（`/api/tags`）> LM Studio
-/// （`/api/v0/models`）> KoboldCpp（`/api/extra/version`）> LlamaCpp（`/props`）
-/// > Sglang（`/get_server_info`）> LmDeploy（`/v1/models` 的 `owned_by`）>
-/// Vllm（`owned_by`）> 通用。唯一例外是 DockerModelRunner 端口门控优先：
-/// DMR 同时暴露 Ollama 兼容的 `/api/tags`，仅 12434 端口在 Ollama 判定之前
-/// 先查主机根 `/models` 的管理 API 形状（JSON 数组），命中即判
-/// DockerModelRunner，未命中按原顺序继续。
-/// 探测失败
+/// called; all candidate signature endpoints are probed in parallel
+/// (`tokio::join!`, shared 3s timeout, a hung endpoint costs ~3s at worst),
+/// and once all complete the result is picked by signature-exclusivity
+/// priority: Ollama (`/api/tags`) > LM Studio (`/api/v0/models`) > KoboldCpp
+/// (`/api/extra/version`) > LlamaCpp (`/props`) > Sglang
+/// (`/get_server_info`) > LmDeploy (`owned_by` in `/v1/models`) > Vllm
+/// (`owned_by`) > Generic. The only exception is DockerModelRunner
+/// port-gate priority: DMR also exposes an Ollama-compatible `/api/tags`, so
+/// on port 12434 only, the management API shape (JSON array) at the host
+/// root `/models` is checked before the Ollama decision — a hit means
+/// DockerModelRunner, a miss continues in the original order.
+/// Probe failure
 /// (service not started/timeout/auth 401) returns `Generic`; callers keep the
 /// existing openai wire route and do not change behavior on probe failure.
 ///
@@ -315,7 +324,8 @@ pub enum LocalServerKind {
 /// Generic misclassification, losing default-off thinking and the real
 /// effort tiers. Pass `None` for endpoints without auth.
 ///
-/// 结果按 base_url 缓存 `PROBE_CACHE_TTL`：即使并行后挂起端点仍要付一次 ~3s，
+/// Results are cached by base_url for `PROBE_CACHE_TTL`: even with parallel
+/// probes a hung endpoint still costs one ~3s,
 /// repeated probes across sessions/entry points amplify the cost; a hit
 /// within the TTL returns the cached value directly. The cache/in-flight key
 /// contains only base_url, never credentials: a positive identification
@@ -509,30 +519,35 @@ pub(crate) fn clear_probe_kind_cache() {
     }
 }
 
-/// 各候选探测的命中结果，供 [`select_local_server_kind`] 做优先级挑选。
-/// 拆成纯数据结构的目的是：端口门控优先的顺序决策不依赖真实 12434 端口绑定，
-/// 可以在测试里直接构造命中组合覆盖。
+/// Hit results of each candidate probe, for [`select_local_server_kind`] to
+/// pick by priority. Kept as a plain data structure so the port-gate-first
+/// ordering decision does not depend on a real port-12434 binding and tests
+/// can construct hit combinations directly.
 struct ProbeCandidateHits {
-    /// base_url 有效端口为 12434（Docker Model Runner 端口门控）。
+    /// base_url's effective port is 12434 (Docker Model Runner port gate).
     docker_port_gated: bool,
-    /// 12434 端口主机根 `/models` 返回 JSON 数组（DMR 管理 API 形状）。
+    /// Host-root `/models` on port 12434 returns a JSON array (DMR
+    /// management API shape).
     docker_mgmt_shape: bool,
     ollama: bool,
     lmstudio_v0: bool,
     koboldcpp: bool,
     llamacpp: bool,
     sglang: bool,
-    /// `/v1/models` 响应体（LMDeploy 与 vLLM 的 owned_by 判别共用一次抓取）。
+    /// `/v1/models` response body (one fetch shared by the LMDeploy and vLLM
+    /// owned_by decisions).
     v1_models: Option<serde_json::Value>,
 }
 
-/// 探测结果的优先级挑选（纯函数，不发请求）。顺序：Docker Model Runner
-/// 端口门控优先（DMR 同时暴露 Ollama 兼容的 `/api/tags`，若按通用优先级会
-/// 先命中 Ollama 分支，DockerModelRunner 永远不可达；仅 12434 端口在 Ollama
-/// 判定前检查管理 API 形状，未命中按原顺序继续）> Ollama > LM Studio >
-/// KoboldCpp > LlamaCpp > Sglang > LmDeploy > Vllm > 通用。KoboldCpp 兼容
-/// llama.cpp 的 `/props` 必须先于 LlamaCpp；LMDeploy 与 vLLM 共用 owned_by
-/// 特征，LMDeploy 优先。
+/// Priority selection over probe results (pure function, no requests).
+/// Order: Docker Model Runner port gate first (DMR also exposes an
+/// Ollama-compatible `/api/tags`; under the generic priority the Ollama
+/// branch would hit first and DockerModelRunner would be unreachable, so on
+/// port 12434 only, the management API shape is checked before the Ollama
+/// decision — a miss continues in the original order) > Ollama > LM Studio >
+/// KoboldCpp > LlamaCpp > Sglang > LmDeploy > Vllm > Generic. KoboldCpp is
+/// also compatible with llama.cpp's `/props`, so it must come before
+/// LlamaCpp; LMDeploy and vLLM share the owned_by signature, LMDeploy first.
 fn select_local_server_kind(hits: ProbeCandidateHits) -> LocalServerKind {
     if hits.docker_port_gated && hits.docker_mgmt_shape {
         return LocalServerKind::DockerModelRunner;
@@ -552,8 +567,9 @@ fn select_local_server_kind(hits: ProbeCandidateHits) -> LocalServerKind {
     if hits.sglang {
         return LocalServerKind::Sglang;
     }
-    // LMDeploy：/v1/models 中任一 owned_by == "lmdeploy"。中等置信度特征：
-    // owned_by 是各实现自报字段，非 LMDeploy 独有约定，仅作为弱标识。
+    // LMDeploy: any owned_by == "lmdeploy" in /v1/models. Medium-confidence
+    // signature: owned_by is a self-reported field of each implementation,
+    // not an LMDeploy-only convention, so it serves only as a weak marker.
     if hits
         .v1_models
         .as_ref()
@@ -572,10 +588,13 @@ fn select_local_server_kind(hits: ProbeCandidateHits) -> LocalServerKind {
     LocalServerKind::Generic
 }
 
-/// 无缓存的实际探测（TTL 缓存命中时直接返回，见 `probe_local_server_kind`）。
-/// 所有候选探测经 `tokio::join!` 并行发出（各自共享 `shared_probe_client` 的
-/// 3s 超时，挂起端点最坏 ~3s 而非串行累加）；`/v1/models` 只抓取一次，供
-/// LMDeploy 与 vLLM 的 `owned_by` 判别共用。全部完成后按特征互斥性优先级挑选。
+/// The actual probe without cache (a TTL cache hit returns directly; see
+/// `probe_local_server_kind`). All candidate probes are issued in parallel
+/// via `tokio::join!` (each shares `shared_probe_client`'s 3s timeout, so a
+/// hung endpoint costs ~3s at worst instead of accumulating serially);
+/// `/v1/models` is fetched only once, shared by the LMDeploy and vLLM
+/// `owned_by` decisions. Once all complete, the result is picked by
+/// signature-exclusivity priority.
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_local_server_kind_uncached(base_url: &str, bearer: Option<&str>) -> LocalServerKind {
     let docker_port_gated = is_docker_model_runner_port(base_url);
@@ -623,8 +642,9 @@ async fn probe_lmstudio_v0_only(base_url: &str, bearer: Option<&str>) -> Option<
 /// 抓取 OpenAI 兼容 `/v1/models` 响应体。探测地址口径与
 /// `features::monitor::probe_vllm_model_info` 一致：upstream 带 `/v1` 直接拼
 /// `/models`，不带则补 `/v1/models`。失败/非 2xx/解析失败返回 `None`，调用方
-/// 按探测失败处理。共享给 kind 探测链（`probe_local_server_kind_uncached` 一次
-/// 抓取供 LMDeploy/vLLM 的 owned_by 判别共用）与 monitor 的 vLLM served-name
+/// treated as probe failure. Shared with the kind-probe chain
+/// (`probe_local_server_kind_uncached` fetches once for the LMDeploy/vLLM
+/// owned_by decisions) and monitor's vLLM served-name
 /// probe, so the `/v1/models` URL assembly stays consistent in both places.
 /// See [`apply_bearer`] for `bearer` semantics: an authenticated vLLM
 /// returns 401 on `/v1/models` without credentials.
@@ -649,9 +669,10 @@ pub(crate) async fn fetch_v1_models(
     resp.json::<serde_json::Value>().await.ok()
 }
 
-/// 判别用的轻量 Ollama 探测：只查 `/api/tags`（200 且模型列表非空），判定口径
-/// 与 `probe_ollama_models` 一致但不抓 `/api/ps`——kind 探测不需要 loaded 状态，
-/// 模型列表组装逻辑仍归 `probe_ollama_models` 独有。
+/// Lightweight Ollama probe for identification: checks only `/api/tags` (200
+/// with a non-empty model list); the decision matches `probe_ollama_models`
+/// but does not fetch `/api/ps` — kind probing does not need loaded state,
+/// and model-list assembly remains exclusive to `probe_ollama_models`.
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_ollama_tags(base_url: &str, bearer: Option<&str>) -> bool {
     let Some(host) = strip_v1_suffix(base_url) else {
@@ -673,8 +694,8 @@ async fn probe_ollama_tags(base_url: &str, bearer: Option<&str>) -> bool {
     !parse_ollama_tag_names(v).is_empty()
 }
 
-/// 探测 KoboldCpp：`/api/extra/version` 200 且 JSON `result` 字符串包含
-/// "koboldcpp"（大小写不敏感）。
+/// Probe KoboldCpp: `/api/extra/version` returns 200 and the JSON `result`
+/// string contains "koboldcpp" (case-insensitive).
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_koboldcpp_version(base_url: &str, bearer: Option<&str>) -> bool {
     let Some(host) = strip_v1_suffix(base_url) else {
@@ -698,9 +719,11 @@ async fn probe_koboldcpp_version(base_url: &str, bearer: Option<&str>) -> bool {
         .is_some_and(|s| s.to_ascii_lowercase().contains("koboldcpp"))
 }
 
-/// 探测 llama.cpp：`/props` 200 且 JSON 对象同时含 `default_generation_settings`
-/// 与 `total_slots`。注意 KoboldCpp 也兼容 `/props`，判别优先级必须低于
-/// KoboldCpp（见 `probe_local_server_kind_uncached` 的挑选顺序）。
+/// Probe llama.cpp: `/props` returns 200 and the JSON object contains both
+/// `default_generation_settings` and `total_slots`. Note KoboldCpp is also
+/// compatible with `/props`, so this probe's identification priority must
+/// rank below KoboldCpp (see the selection order in
+/// `probe_local_server_kind_uncached`).
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_llamacpp_props(base_url: &str, bearer: Option<&str>) -> bool {
     let Some(host) = strip_v1_suffix(base_url) else {
@@ -724,8 +747,9 @@ async fn probe_llamacpp_props(base_url: &str, bearer: Option<&str>) -> bool {
     })
 }
 
-/// 探测 SGLang：`/get_server_info` 200 且 JSON 对象含 `version` 字符串字段
-/// （响应是 ServerArgs 序列化大 JSON，宽松解析，只看 version 存在）。
+/// Probe SGLang: `/get_server_info` returns 200 and the JSON object has a
+/// `version` string field (the response is a large serialized ServerArgs
+/// JSON; parse loosely and only check that version exists).
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_sglang_server_info(base_url: &str, bearer: Option<&str>) -> bool {
     let Some(host) = strip_v1_suffix(base_url) else {
@@ -747,8 +771,9 @@ async fn probe_sglang_server_info(base_url: &str, bearer: Option<&str>) -> bool 
     v.get("version").and_then(Value::as_str).is_some()
 }
 
-/// Docker Model Runner 端口门控：其管理 API 固定在 12434 端口，其他端口
-/// 一律不探测（避免对任意本地端点多发一次 `/models` 请求）。
+/// Docker Model Runner port gate: its management API is fixed on port 12434;
+/// no other port is probed (avoids an extra `/models` request against
+/// arbitrary local endpoints).
 fn is_docker_model_runner_port(base_url: &str) -> bool {
     reqwest::Url::parse(base_url.trim())
         .ok()
@@ -756,11 +781,13 @@ fn is_docker_model_runner_port(base_url: &str) -> bool {
         == Some(12434)
 }
 
-/// Docker Model Runner 管理 API 根地址：管理端点在主机根（`/models`），不在
-/// OpenAI 兼容前缀之下。按 `/engines/v1` → `/engines` → `/v1` 的顺序去掉
-/// 尾部前缀（`/engines/v1` 必须先于 `/engines`，否则残留 `/engines`），使
-/// `http://host:12434/engines/v1`、`http://host:12434/v1`、裸主机等文档地址
-/// 都归一到主机根。
+/// Docker Model Runner management API root: the management endpoint lives at
+/// the host root (`/models`), not under the OpenAI-compatible prefix. Strip
+/// trailing prefixes in the order `/engines/v1` → `/engines` → `/v1`
+/// (`/engines/v1` must come before `/engines`, otherwise `/engines` is left
+/// behind), normalizing documented addresses such as
+/// `http://host:12434/engines/v1`, `http://host:12434/v1`, and the bare host
+/// to the host root.
 fn strip_docker_model_runner_root(url: &str) -> Option<String> {
     let trimmed = url.trim_end_matches('/');
     for suffix in ["/engines/v1", "/engines", "/v1"] {
@@ -771,10 +798,12 @@ fn strip_docker_model_runner_root(url: &str) -> Option<String> {
     Some(trimmed.to_string())
 }
 
-/// 探测 Docker Model Runner：仅当 base_url 有效端口为 12434（端口门控，见
-/// [`is_docker_model_runner_port`]）时 GET 主机根的 `/models`（地址归一见
-/// [`strip_docker_model_runner_root`]）；200 且响应是 JSON 数组才命中——这是
-/// Docker 管理 API 的形状，OpenAI 兼容形状是含 "data" 的对象，以此区分。
+/// Probe Docker Model Runner: only when base_url's effective port is 12434
+/// (port gate, see [`is_docker_model_runner_port`]), GET `/models` at the
+/// host root (address normalization in [`strip_docker_model_runner_root`]);
+/// a hit requires 200 with a JSON-array response — that is the Docker
+/// management API shape, whereas the OpenAI-compatible shape is an object
+/// with "data", which distinguishes them.
 /// See [`apply_bearer`] for `bearer` semantics.
 async fn probe_docker_model_runner(base_url: &str, bearer: Option<&str>) -> bool {
     if !is_docker_model_runner_port(base_url) {
@@ -799,8 +828,9 @@ async fn probe_docker_model_runner(base_url: &str, bearer: Option<&str>) -> bool
         .is_some_and(|v| v.is_array())
 }
 
-/// `/v1/models` 响应体中任一模型 `owned_by` 等于期望值（大小写不敏感）。
-/// 供 vLLM（`"vllm"`）与 LMDeploy（`"lmdeploy"`）判别共用同一次抓取结果。
+/// Whether any model's `owned_by` in the `/v1/models` response body equals
+/// the expected value (case-insensitive). Lets vLLM (`"vllm"`) and LMDeploy
+/// (`"lmdeploy"`) identification share the same fetch result.
 fn v1_models_owned_by_matches(v: &serde_json::Value, expected: &str) -> bool {
     v.get("data")
         .and_then(Value::as_array)
@@ -1157,8 +1187,9 @@ mod tests {
         }
     }
 
-    /// Ollama 特征端点命中：/api/tags 返回模型列表 → 判定 Ollama（kind 探测
-    /// 只查 /api/tags，不抓 /api/ps，loaded 状态归 probe_ollama_models）。
+    /// Ollama signature endpoint hit: /api/tags returns a model list →
+    /// identified as Ollama (kind probing only checks /api/tags and does not
+    /// fetch /api/ps; loaded state belongs to probe_ollama_models).
     #[tokio::test]
     async fn probe_local_kind_detects_ollama_via_api_tags() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1216,8 +1247,8 @@ mod tests {
         );
     }
 
-    /// KoboldCpp 特征命中：/api/extra/version 的 result 字段含 "koboldcpp"
-    /// （大小写不敏感）→ 判定 KoboldCpp。
+    /// KoboldCpp signature hit: the result field of /api/extra/version
+    /// contains "koboldcpp" (case-insensitive) → identified as KoboldCpp.
     #[tokio::test]
     async fn probe_local_kind_detects_koboldcpp_via_extra_version() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1232,8 +1263,10 @@ mod tests {
         );
     }
 
-    /// llama.cpp 特征命中：/props 同时含 default_generation_settings 与
-    /// total_slots → 判定 LlamaCpp；缺任一字段不命中（宽松解析防误判）。
+    /// llama.cpp signature hit: /props contains both
+    /// default_generation_settings and total_slots → identified as LlamaCpp;
+    /// missing either field is not a hit (loose parsing prevents
+    /// misidentification).
     #[tokio::test]
     async fn probe_local_kind_detects_llamacpp_via_props() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1247,7 +1280,7 @@ mod tests {
             LocalServerKind::LlamaCpp
         );
         clear_probe_kind_cache();
-        // 缺 total_slots：形状不完整，不判 LlamaCpp（其余端点 404 → Generic）。
+        // Missing total_slots: incomplete shape, not LlamaCpp (all other endpoints 404 → Generic).
         let partial = spawn_probe_server(vec![(
             "/props",
             r#"{"default_generation_settings":{"n_ctx":4096}}"#,
@@ -1259,8 +1292,9 @@ mod tests {
         );
     }
 
-    /// 优先级：KoboldCpp 兼容 llama.cpp 的 /props，两个特征同时命中时必须
-    /// 判为 KoboldCpp（KoboldCpp 优先级高于 LlamaCpp）。
+    /// Priority: KoboldCpp is also compatible with llama.cpp's /props, so
+    /// when both signatures hit it must be identified as KoboldCpp
+    /// (KoboldCpp ranks above LlamaCpp).
     #[tokio::test]
     async fn probe_local_kind_koboldcpp_wins_over_llamacpp_props() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1281,8 +1315,9 @@ mod tests {
         );
     }
 
-    /// SGLang 特征命中：/get_server_info 是 ServerArgs 序列化大 JSON，宽松
-    /// 解析只看 version 字符串字段存在 → 判定 Sglang。
+    /// SGLang signature hit: /get_server_info is a large serialized
+    /// ServerArgs JSON; loose parsing only checks that the version string
+    /// field exists → identified as Sglang.
     #[tokio::test]
     async fn probe_local_kind_detects_sglang_via_server_info() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1297,8 +1332,9 @@ mod tests {
         );
     }
 
-    /// LMDeploy 命中：/v1/models 中 owned_by == "lmdeploy"（大小写不敏感，
-    /// 中等置信度特征）。与 vLLM 共用同一次 /v1/models 抓取，LMDeploy 优先。
+    /// LMDeploy hit: owned_by == "lmdeploy" in /v1/models (case-insensitive,
+    /// medium-confidence signature). Shares the same /v1/models fetch with
+    /// vLLM; LMDeploy takes priority.
     #[tokio::test]
     async fn probe_local_kind_detects_lmdeploy_via_owned_by() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
@@ -1313,22 +1349,24 @@ mod tests {
         );
     }
 
-    /// Docker Model Runner 端口门控：/models 返回 JSON 数组（管理 API 形状）
-    /// 但端口不是 12434 → 不探测该端点，不判 DockerModelRunner（落 Generic）。
+    /// Docker Model Runner port gate: /models returns a JSON array
+    /// (management API shape) but the port is not 12434 → the endpoint is
+    /// not probed and DockerModelRunner is not selected (falls to Generic).
     #[tokio::test]
     async fn probe_local_kind_docker_model_runner_gated_by_port_12434() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;
-        // mock 绑定随机端口（必 ≠ 12434 门控值时跳过探测）。
+        // The mock binds a random port (never the 12434 gate value, so probing is skipped).
         let server = spawn_probe_server(vec![("/models", r#"[{"id":"qwen3"}]"#)]).await;
         assert_eq!(
             probe_local_server_kind(&server.url, None).await,
             LocalServerKind::Generic,
-            "非 12434 端口不尝试 Docker Model Runner 管理 API"
+            "non-12434 ports must not attempt the Docker Model Runner management API"
         );
     }
 
-    /// 端口门控纯函数：仅有效端口 == 12434 才允许探测；无显式端口按协议
-    /// 默认（http=80）不命中；非法 URL 不命中。
+    /// Port-gate pure function: only an effective port == 12434 allows
+    /// probing; no explicit port falls back to the protocol default
+    /// (http=80) and misses; invalid URLs miss.
     #[test]
     fn docker_model_runner_port_gate_requires_12434() {
         assert!(is_docker_model_runner_port("http://localhost:12434/v1"));
@@ -1340,9 +1378,10 @@ mod tests {
         assert!(!is_docker_model_runner_port("not a url"));
     }
 
-    /// DMR 管理 API 地址归一：管理端点在主机根 `/models`，`/engines/v1`、
-    /// `/engines`、`/v1`（按此顺序，避免 `/engines/v1` 残留 `/engines`）与
-    /// 裸主机都归一到主机根。
+    /// DMR management API address normalization: the management endpoint
+    /// lives at the host root `/models`; `/engines/v1`, `/engines`, `/v1`
+    /// (in this order, so `/engines/v1` does not leave `/engines` behind)
+    /// and the bare host all normalize to the host root.
     #[test]
     fn docker_model_runner_root_strips_openai_prefixes() {
         assert_eq!(
@@ -1372,9 +1411,11 @@ mod tests {
         );
     }
 
-    /// 顺序决策（纯函数，无需绑定 12434 端口）：DMR 暴露 Ollama 兼容的
-    /// /api/tags，端口门控内管理 API 形状命中时必须优先于 Ollama 判为
-    /// DockerModelRunner；形状未命中或不在门控端口时按原顺序落 Ollama。
+    /// Ordering decision (pure function, no real port-12434 binding needed):
+    /// DMR exposes an Ollama-compatible /api/tags, so within the port gate a
+    /// management API shape hit must beat Ollama and select
+    /// DockerModelRunner; on a shape miss or a non-gated port, the original
+    /// order applies and it falls to Ollama.
     #[test]
     fn select_local_server_kind_docker_model_runner_wins_over_ollama_when_gated() {
         let both_hit = || ProbeCandidateHits {
@@ -1390,9 +1431,9 @@ mod tests {
         assert_eq!(
             select_local_server_kind(both_hit()),
             LocalServerKind::DockerModelRunner,
-            "12434 端口管理 API 形状命中应优先于 Ollama"
+            "a management API shape hit on port 12434 should beat Ollama"
         );
-        // 管理 API 形状未命中：按原顺序继续，Ollama 特征生效。
+        // Management API shape miss: continue in the original order; the Ollama signature wins.
         assert_eq!(
             select_local_server_kind(ProbeCandidateHits {
                 docker_mgmt_shape: false,
@@ -1400,7 +1441,7 @@ mod tests {
             }),
             LocalServerKind::Ollama
         );
-        // 非 12434 端口：管理形状不被采信（探测本身已被门控跳过）。
+        // Non-12434 port: the management shape is not trusted (the probe itself was skipped by the gate).
         assert_eq!(
             select_local_server_kind(ProbeCandidateHits {
                 docker_port_gated: false,
@@ -1552,7 +1593,8 @@ mod tests {
 
     /// in-flight 合并：并发多次调用同一 base_url 共享一次探测。
     /// mock server 统计 /api/tags 命中次数——合并生效时无论并发多少调用，
-    /// 特征端点只被打一次（候选探测并行发出、无短路，每个端点每次探测各命中一次）。
+    /// each signature endpoint is hit exactly once (candidate probes run in
+    /// parallel with no short-circuit, so each endpoint is hit once per probe).
     #[tokio::test]
     async fn probe_local_kind_merges_concurrent_calls_into_one_probe() {
         let _state = PROBE_STATE_TEST_MUTEX.lock().await;

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -32,6 +32,7 @@ use deepseek_tui::tui::app::AppMode;
 
 use self::bundle::{Pinvou3Bundle, instructions_code_md, instructions_md};
 use self::prefs::{ModelPreset, SavedModel, UserPrefs};
+use crate::core::always_thinking::{AlwaysThinkingSpec, always_thinking_spec};
 use crate::core::model_endpoint::LocalServerKind;
 use crate::core::session_mode::SessionMode;
 use crate::features::assistant::expert_roster::ExpertRosterSnapshot;
@@ -811,7 +812,19 @@ impl Pinvou3Bridge {
                 if base_url_uses_local_or_private(&self.base_url()) {
                     match self.probed_local_kind {
                         Some(LocalServerKind::Ollama) => return "ollama".to_string(),
-                        Some(LocalServerKind::Vllm) => return "vllm".to_string(),
+                        // SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker
+                        // Model Runner 都支持 chat_template_kwargs.enable_thinking
+                        // 与 reasoning_effort 透传，与 vLLM wire 同构；底座自带的
+                        // sglang provider 目前是 DeepSeek 兼容路由、不适合本地通用
+                        // 服务，故统一映射到 vllm provider。
+                        Some(
+                            LocalServerKind::Vllm
+                            | LocalServerKind::Sglang
+                            | LocalServerKind::LlamaCpp
+                            | LocalServerKind::KoboldCpp
+                            | LocalServerKind::LmDeploy
+                            | LocalServerKind::DockerModelRunner,
+                        ) => return "vllm".to_string(),
                         _ => {}
                     }
                 }
@@ -862,6 +875,9 @@ impl Pinvou3Bridge {
     /// 优先级：用户显式设置的 `SavedModel.reasoning_effort` > provider 默认
     /// （本地模型——vLLM 与探测出的 Ollama——默认 off 防 SSE timeout；其余默认
     /// high——底座自身默认是 Max，品悟统一收口到 high，符合产品默认思考强度）。
+    /// 例外是本地路由上的思考不可关闭模型：命中 `core::always_thinking` 知识表
+    /// 时按表归一（NoControl 不发任何思考参数；Tiers 只允许表内档位，stored
+    /// 越界/缺省归一到最低档），覆盖 stored 值与本地默认 off。
     ///
     /// 本地 OpenAI 兼容端点（loopback 的 LM Studio 等，探测不出服务类型或判定为
     /// LM Studio/通用）保持旧行为不注入档位（None），避免底座 openai wire route
@@ -875,13 +891,47 @@ impl Pinvou3Bridge {
     /// `thinking: {"type":"enabled"}`，天然满足该要求，无需特判模型名
     /// （探测 payload 仍需显式注入 thinking，见 image_capability.rs）。
     fn request_reasoning_effort(&self) -> Option<String> {
+        let provider = self.provider();
+        // 「本地路由」：vllm/ollama provider，或 openai wire 指向本地/私网端点。
+        // 云端精确路由（moonshot/zai 等）不进知识表归一。
+        let is_local_route = matches!(provider.as_str(), "vllm" | "ollama")
+            || (provider == "openai" && base_url_uses_local_or_private(&self.base_url()));
+        if is_local_route {
+            let model = self.effective_model();
+            if let Some(spec) = model.and_then(|m| always_thinking_spec(&m.model)) {
+                let stored = model.and_then(|m| m.reasoning_effort.as_deref());
+                return match spec {
+                    // 思考不可关且无档位可控：不发任何思考参数，让模型原生
+                    // 思考（覆盖用户存储值）。
+                    AlwaysThinkingSpec::NoControl => None,
+                    // 思考永开但档位可控：stored 在允许档位内则用 stored，否则
+                    // （含 stored=="off"、缺省、越界如 medium 之于 kimi-k3）
+                    // 归一为允许的最低档。
+                    AlwaysThinkingSpec::Tiers(tiers) => {
+                        // 底座 ollama wire 只有布尔 think（off=think:false，其余
+                        // 一律 think:true），不发送档位字符串；思考永开模型在
+                        // ollama 路由下唯一有意义的暴露是 "high"（前端
+                        // `localReasoningTiers` 同口径只给 ['high']）。
+                        if provider == "ollama" {
+                            return Some("high".to_string());
+                        }
+                        Some(
+                            stored
+                                .filter(|effort| tiers.contains(effort))
+                                .unwrap_or(tiers[0])
+                                .to_string(),
+                        )
+                    }
+                };
+            }
+        }
         if let Some(effort) = self
             .effective_model()
             .and_then(|model| model.reasoning_effort.as_deref())
         {
             return Some(effort.to_string());
         }
-        match self.provider().as_str() {
+        match provider.as_str() {
             // 本地模型默认关思考：vLLM 防 SSE timeout；Ollama 防思考 trace 抢占首包。
             "vllm" | "ollama" => Some("off".to_string()),
             // 本地 OpenAI 兼容端点（loopback/私网的 LM Studio/通用服务）不注入，
@@ -6503,6 +6553,273 @@ mod tests {
             bridge.request_reasoning_effort().as_deref(),
             Some("high"),
             "显式档位必须覆盖本地默认 off"
+        );
+    }
+
+    /// SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker Model Runner 探测
+    /// 结果统一映射到底座 vllm provider（chat_template_kwargs + reasoning_effort
+    /// wire 同构），本地默认关思考。
+    #[test]
+    fn local_reasoning_frameworks_map_to_vllm_wire_and_default_off() {
+        for kind in [
+            LocalServerKind::Sglang,
+            LocalServerKind::LlamaCpp,
+            LocalServerKind::KoboldCpp,
+            LocalServerKind::LmDeploy,
+            LocalServerKind::DockerModelRunner,
+        ] {
+            let (_lock, _env) = locked_env(&[
+                "DEEPSEEK_MODEL",
+                "DEEPSEEK_PROVIDER",
+                "DEEPSEEK_BASE_URL",
+                "DEEPSEEK_API_KEY",
+            ]);
+            let mut bridge = fixture_bridge();
+            set_active_model(
+                &mut bridge,
+                ModelPreset::OpenaiCompatible,
+                "local-model",
+                "http://127.0.0.1:8000/v1",
+                "",
+            );
+            bridge.probed_local_kind = Some(kind);
+            assert_eq!(bridge.provider(), "vllm", "{kind:?}");
+            assert_eq!(
+                bridge.request_reasoning_effort().as_deref(),
+                Some("off"),
+                "{kind:?}"
+            );
+        }
+    }
+
+    /// 本地 vLLM 上的思考不可关闭模型（kimi-k3，仅 low/high 档）：stored "off"
+    /// 是关不掉的，归一为允许的最低档 "low"。
+    #[test]
+    fn local_vllm_kimi_k3_stored_off_normalizes_to_low() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "kimi-k3",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("off".to_string()));
+        assert_eq!(
+            bridge.request_reasoning_effort().as_deref(),
+            Some("low"),
+            "kimi-k3 思考永开，stored off 必须归一到最低档"
+        );
+    }
+
+    /// kimi-k3 stored 档位在允许表内（high）时保留 stored。
+    #[test]
+    fn local_vllm_kimi_k3_stored_high_is_kept() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "kimi-k3",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("high".to_string()));
+        assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("high"));
+    }
+
+    /// kimi-k3 无 stored：归一为最低档 "low"（不套本地默认 off）。
+    #[test]
+    fn local_vllm_kimi_k3_without_stored_defaults_to_low() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "kimi-k3",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("low"));
+    }
+
+    /// kimi-k3 越界档位（medium 不在 low/high 表内）归一为最低档 "low"。
+    #[test]
+    fn local_vllm_kimi_k3_out_of_tier_medium_normalizes_to_low() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "kimi-k3",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("medium".to_string()));
+        assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("low"));
+    }
+
+    /// NoControl 模型（deepseek-r1）：思考不可关且无档位可控，不发任何思考
+    /// 参数（None），覆盖 stored 值。
+    #[test]
+    fn local_vllm_deepseek_r1_sends_no_thinking_params() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "deepseek-r1",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("off".to_string()));
+        assert_eq!(
+            bridge.request_reasoning_effort(),
+            None,
+            "deepseek-r1 不发任何思考参数，让模型原生思考"
+        );
+    }
+
+    /// ollama 路由上的思考永开模型（gpt-oss）：底座 ollama wire 只有布尔
+    /// think，档位字符串发不出去，stored 任意值（含 off）都归一为 "high"。
+    #[test]
+    fn local_ollama_gpt_oss_normalizes_to_high() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "gpt-oss-120b",
+            "http://127.0.0.1:11434/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Ollama);
+        assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("high"));
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("off".to_string()));
+        assert_eq!(
+            bridge.request_reasoning_effort().as_deref(),
+            Some("high"),
+            "gpt-oss 在 ollama 下关不掉思考，stored off 也必须归一为 high"
+        );
+    }
+
+    /// 不命中知识表的普通本地模型（qwen3-32b 不含 thinking）：保持本地默认
+    /// off 不变。
+    #[test]
+    fn local_vllm_plain_model_keeps_default_off() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "qwen3-32b",
+            "http://127.0.0.1:8000/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Vllm);
+        assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("off"));
+    }
+
+    /// 远端官方 moonshot 的 kimi-k3 不进本地归一：无 stored 默认 high，
+    /// stored off 照常透传（显式选择优先，云端路由不受知识表影响）。
+    #[test]
+    fn remote_moonshot_kimi_k3_not_affected_by_local_normalization() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::Kimi,
+            "kimi-k3",
+            "https://api.moonshot.cn/v1",
+            "sk-test",
+        );
+        assert_eq!(bridge.provider(), "moonshot");
+        assert_eq!(
+            bridge.request_reasoning_effort().as_deref(),
+            Some("high"),
+            "云端精确路由保持默认 high"
+        );
+        bridge
+            .prefs
+            .advanced
+            .saved_models
+            .last_mut()
+            .map(|m| m.reasoning_effort = Some("off".to_string()));
+        assert_eq!(
+            bridge.request_reasoning_effort().as_deref(),
+            Some("off"),
+            "云端 stored off 照常透传，不被知识表归一"
         );
     }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -813,10 +813,13 @@ impl Pinvou3Bridge {
                     match self.probed_local_kind {
                         Some(LocalServerKind::Ollama) => return "ollama".to_string(),
                         // SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker
-                        // Model Runner 都支持 chat_template_kwargs.enable_thinking
-                        // 与 reasoning_effort 透传，与 vLLM wire 同构；底座自带的
-                        // sglang provider 目前是 DeepSeek 兼容路由、不适合本地通用
-                        // 服务，故统一映射到 vllm provider。
+                        // Model Runner all support passthrough of
+                        // chat_template_kwargs.enable_thinking and
+                        // reasoning_effort, structurally identical to the vLLM
+                        // wire; the engine's built-in sglang provider is
+                        // currently a DeepSeek-compatible route and unsuitable
+                        // for generic local servers, so all of them map to the
+                        // vllm provider.
                         Some(
                             LocalServerKind::Vllm
                             | LocalServerKind::Sglang
@@ -875,18 +878,25 @@ impl Pinvou3Bridge {
     /// 优先级：用户显式设置的 `SavedModel.reasoning_effort` > provider 默认
     /// （本地模型——vLLM 与探测出的 Ollama——默认 off 防 SSE timeout；其余默认
     /// high——底座自身默认是 Max，品悟统一收口到 high，符合产品默认思考强度）。
-    /// 例外是本地路由上的思考不可关闭模型：命中 `core::always_thinking` 知识表
-    /// 时按表归一（NoControl 不发任何思考参数；Tiers 只允许表内档位，stored
-    /// 越界/缺省归一到最低档），覆盖 stored 值与本地默认 off。
+    /// The exception is models whose thinking cannot be disabled on local
+    /// routes: when the `core::always_thinking` knowledge table matches,
+    /// normalize per the table (NoControl sends no thinking parameters; Tiers
+    /// only allows the tiers in the table — out-of-tier/missing stored values
+    /// normalize to the lowest tier), overriding the stored value and the
+    /// local default off.
     ///
-    /// 本地 OpenAI 兼容端点（loopback 的 LM Studio 等，探测不出服务类型或判定为
-    /// LM Studio/通用）保持旧行为不注入档位（None），避免底座 openai wire route
-    /// 对 `reasoning_effort` 的空操作与不认识的请求参数引起漂移。思考永开知识表
-    /// 归一同样不作用于该路由（wire 空操作，注入无效；前端 `localReasoningTiers`
-    /// 对 lmstudio/generic 同口径不提供档位）。注意底座对 openai 的
-    /// `reasoning_effort` 空操作仅对普通模型成立：gpt-5.5/5.6/codex
-    /// 家族会经 `apply_openai_reasoning_effort` 注入档位（本地端点模型名不匹配
-    /// 该家族，此处不注入不受影响）。
+    /// Local OpenAI-compatible endpoints (loopback LM Studio etc., where the
+    /// probe cannot identify the server type or resolves to LM Studio/generic)
+    /// keep the legacy behavior of not injecting a tier (None), to avoid drift
+    /// from the engine's openai wire route no-op on `reasoning_effort` and
+    /// from unrecognized request parameters. The always-thinking knowledge
+    /// table normalization likewise does not apply to this route (the wire is
+    /// a no-op, so injection is ineffective; the frontend `localReasoningTiers`
+    /// likewise offers no tiers for lmstudio/generic). Note that the engine's
+    /// openai `reasoning_effort` no-op only holds for plain models: the
+    /// gpt-5.5/5.6/codex family gets tiers injected via
+    /// `apply_openai_reasoning_effort` (local endpoint model names do not match
+    /// that family, so not injecting here is unaffected).
     ///
     /// 注意：Kimi Code 的 `kimi-for-coding` 等是 always-thinking 模型，官方
     /// 接入要求 Thinking 保持开启；默认 high 由底座翻译成
@@ -894,27 +904,36 @@ impl Pinvou3Bridge {
     /// （探测 payload 仍需显式注入 thinking，见 image_capability.rs）。
     fn request_reasoning_effort(&self) -> Option<String> {
         let provider = self.provider();
-        // 「本地路由」：vllm/ollama provider。openai wire 指向本地/私网端点
-        // （LM Studio/通用服务）时底座对 reasoning_effort 是空操作，知识表归一
-        // 注入无效，不进归一（stored 值仍按下方「显式选择优先」透传，不影响
-        // 后续探测为 vllm 时生效）；云端精确路由（moonshot/zai 等）同样不进。
+        // "Local route": the vllm/ollama providers. When the openai wire
+        // points at a local/private endpoint (LM Studio/generic server), the
+        // engine treats reasoning_effort as a no-op, so knowledge-table
+        // normalization would be ineffective and is skipped (the stored value
+        // is still passed through per "explicit user choice wins" below, so it
+        // takes effect once a later probe resolves to vllm); precise cloud
+        // routes (moonshot/zai etc.) are likewise skipped.
         let is_local_route = matches!(provider.as_str(), "vllm" | "ollama");
         if is_local_route {
             let model = self.effective_model();
             if let Some(spec) = model.and_then(|m| always_thinking_spec(&m.model)) {
                 let stored = model.and_then(|m| m.reasoning_effort.as_deref());
                 return match spec {
-                    // 思考不可关且无档位可控：不发任何思考参数，让模型原生
-                    // 思考（覆盖用户存储值）。
+                    // Thinking cannot be disabled and no tiers are
+                    // controllable: send no thinking parameters and let the
+                    // model think natively (overrides the user's stored
+                    // value).
                     AlwaysThinkingSpec::NoControl => None,
-                    // 思考永开但档位可控：stored 在允许档位内则用 stored，否则
-                    // （含 stored=="off"、缺省、越界如 medium 之于 kimi-k3）
-                    // 归一为允许的最低档。
+                    // Always-thinking but tiers are controllable: use the
+                    // stored value if it is within the allowed tiers,
+                    // otherwise (including stored=="off", missing, or
+                    // out-of-tier such as medium for kimi-k3) normalize to the
+                    // lowest allowed tier.
                     AlwaysThinkingSpec::Tiers(tiers) => {
-                        // 底座 ollama wire 只有布尔 think（off=think:false，其余
-                        // 一律 think:true），不发送档位字符串；思考永开模型在
-                        // ollama 路由下唯一有意义的暴露是 "high"（前端
-                        // `localReasoningTiers` 同口径只给 ['high']）。
+                        // The engine's ollama wire only has a boolean think
+                        // (off=think:false, everything else think:true) and
+                        // never sends tier strings; for an always-thinking
+                        // model on the ollama route the only meaningful
+                        // exposure is "high" (the frontend
+                        // `localReasoningTiers` likewise only gives ['high']).
                         if provider == "ollama" {
                             return Some("high".to_string());
                         }
@@ -6459,11 +6478,16 @@ mod tests {
         }
     }
 
-    /// 思考永开知识表归一不作用于 openai wire route（LM Studio/通用服务）：
-    /// 底座对 openai 的 reasoning_effort 是空操作，注入无效——kimi-k3 无 stored
-    /// 时保持 None 默认，不做最低档归一；stored 值（含 off）仍按「显式选择优先」
-    /// 透传，不改动 prefs，后续探测为 vllm 时 stored 档位照常经知识表归一生效。
-    /// 前端 `localReasoningTiers` 对 lmstudio/generic 同口径不提供档位。
+    /// Always-thinking knowledge table normalization does not apply to the
+    /// openai wire route (LM Studio/generic servers): the engine treats
+    /// openai reasoning_effort as a no-op, so injection is ineffective —
+    /// kimi-k3 without a stored value keeps the None default and is not
+    /// normalized to the lowest tier; the stored value (including off) is
+    /// still passed through per "explicit user choice wins" without rewriting
+    /// prefs, and the stored tier still takes effect via knowledge-table
+    /// normalization once a later probe resolves to vllm.
+    /// The frontend `localReasoningTiers` likewise offers no tiers for
+    /// lmstudio/generic.
     #[test]
     fn local_lmstudio_or_generic_probe_skips_always_thinking_normalization() {
         for kind in [LocalServerKind::LmStudio, LocalServerKind::Generic] {
@@ -6486,9 +6510,10 @@ mod tests {
             assert_eq!(
                 bridge.request_reasoning_effort(),
                 None,
-                "{kind:?}: openai wire 空操作，知识表不注入最低档"
+                "{kind:?}: openai wire is a no-op, knowledge table does not inject the lowest tier"
             );
-            // stored off 透传（显式选择优先），不被知识表归一为 low。
+            // stored off passes through (explicit user choice wins), not
+            // normalized to low by the knowledge table.
             bridge
                 .prefs
                 .advanced
@@ -6498,13 +6523,14 @@ mod tests {
             assert_eq!(
                 bridge.request_reasoning_effort().as_deref(),
                 Some("off"),
-                "{kind:?}: stored 值透传，prefs 不被知识表改写"
+                "{kind:?}: stored value passes through, prefs are not rewritten by the knowledge table"
             );
         }
     }
 
-    /// NoControl 模型（deepseek-r1）在 openai wire route 同样不发思考参数
-    /// （None）——与 vllm/ollama 路由的归一结果一致，无行为差异。
+    /// NoControl models (deepseek-r1) likewise send no thinking parameters
+    /// (None) on the openai wire route — identical to the normalization result
+    /// on the vllm/ollama routes, no behavior difference.
     #[test]
     fn local_generic_probe_no_control_model_sends_no_thinking_params() {
         let (_lock, _env) = locked_env(&[
@@ -6626,9 +6652,10 @@ mod tests {
         );
     }
 
-    /// SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker Model Runner 探测
-    /// 结果统一映射到底座 vllm provider（chat_template_kwargs + reasoning_effort
-    /// wire 同构），本地默认关思考。
+    /// SGLang / llama.cpp / KoboldCpp / LMDeploy / Docker Model Runner probe
+    /// results all map to the engine's vllm provider (chat_template_kwargs +
+    /// reasoning_effort wire are structurally identical), defaulting to
+    /// thinking off locally.
     #[test]
     fn local_reasoning_frameworks_map_to_vllm_wire_and_default_off() {
         for kind in [
@@ -6662,8 +6689,9 @@ mod tests {
         }
     }
 
-    /// 本地 vLLM 上的思考不可关闭模型（kimi-k3，仅 low/high 档）：stored "off"
-    /// 是关不掉的，归一为允许的最低档 "low"。
+    /// A model whose thinking cannot be disabled on local vLLM (kimi-k3,
+    /// low/high tiers only): stored "off" cannot actually turn thinking off,
+    /// so it normalizes to the lowest allowed tier "low".
     #[test]
     fn local_vllm_kimi_k3_stored_off_normalizes_to_low() {
         let (_lock, _env) = locked_env(&[
@@ -6690,11 +6718,12 @@ mod tests {
         assert_eq!(
             bridge.request_reasoning_effort().as_deref(),
             Some("low"),
-            "kimi-k3 思考永开，stored off 必须归一到最低档"
+            "kimi-k3 is always-thinking, stored off must normalize to the lowest tier"
         );
     }
 
-    /// kimi-k3 stored 档位在允许表内（high）时保留 stored。
+    /// kimi-k3 keeps the stored value when the stored tier is in the allowed
+    /// table (high).
     #[test]
     fn local_vllm_kimi_k3_stored_high_is_kept() {
         let (_lock, _env) = locked_env(&[
@@ -6721,7 +6750,8 @@ mod tests {
         assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("high"));
     }
 
-    /// kimi-k3 无 stored：归一为最低档 "low"（不套本地默认 off）。
+    /// kimi-k3 without a stored value: normalizes to the lowest tier "low"
+    /// (the local default off does not apply).
     #[test]
     fn local_vllm_kimi_k3_without_stored_defaults_to_low() {
         let (_lock, _env) = locked_env(&[
@@ -6742,7 +6772,8 @@ mod tests {
         assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("low"));
     }
 
-    /// kimi-k3 越界档位（medium 不在 low/high 表内）归一为最低档 "low"。
+    /// kimi-k3 with an out-of-tier stored value (medium is not in the
+    /// low/high table) normalizes to the lowest tier "low".
     #[test]
     fn local_vllm_kimi_k3_out_of_tier_medium_normalizes_to_low() {
         let (_lock, _env) = locked_env(&[
@@ -6769,8 +6800,9 @@ mod tests {
         assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("low"));
     }
 
-    /// NoControl 模型（deepseek-r1）：思考不可关且无档位可控，不发任何思考
-    /// 参数（None），覆盖 stored 值。
+    /// NoControl models (deepseek-r1): thinking cannot be disabled and no
+    /// tiers are controllable, so no thinking parameters are sent (None),
+    /// overriding the stored value.
     #[test]
     fn local_vllm_deepseek_r1_sends_no_thinking_params() {
         let (_lock, _env) = locked_env(&[
@@ -6797,12 +6829,13 @@ mod tests {
         assert_eq!(
             bridge.request_reasoning_effort(),
             None,
-            "deepseek-r1 不发任何思考参数，让模型原生思考"
+            "deepseek-r1 sends no thinking parameters, letting the model think natively"
         );
     }
 
-    /// ollama 路由上的思考永开模型（gpt-oss）：底座 ollama wire 只有布尔
-    /// think，档位字符串发不出去，stored 任意值（含 off）都归一为 "high"。
+    /// An always-thinking model on the ollama route (gpt-oss): the engine's
+    /// ollama wire only has a boolean think and cannot send tier strings, so
+    /// any stored value (including off) normalizes to "high".
     #[test]
     fn local_ollama_gpt_oss_normalizes_to_high() {
         let (_lock, _env) = locked_env(&[
@@ -6830,12 +6863,12 @@ mod tests {
         assert_eq!(
             bridge.request_reasoning_effort().as_deref(),
             Some("high"),
-            "gpt-oss 在 ollama 下关不掉思考，stored off 也必须归一为 high"
+            "gpt-oss cannot turn off thinking under ollama, stored off must also normalize to high"
         );
     }
 
-    /// 不命中知识表的普通本地模型（qwen3-32b 不含 thinking）：保持本地默认
-    /// off 不变。
+    /// A plain local model that does not match the knowledge table
+    /// (qwen3-32b without thinking): keeps the local default off unchanged.
     #[test]
     fn local_vllm_plain_model_keeps_default_off() {
         let (_lock, _env) = locked_env(&[
@@ -6856,8 +6889,10 @@ mod tests {
         assert_eq!(bridge.request_reasoning_effort().as_deref(), Some("off"));
     }
 
-    /// 远端官方 moonshot 的 kimi-k3 不进本地归一：无 stored 默认 high，
-    /// stored off 照常透传（显式选择优先，云端路由不受知识表影响）。
+    /// kimi-k3 on the official remote moonshot route does not enter local
+    /// normalization: defaults to high without a stored value, and stored off
+    /// passes through as-is (explicit user choice wins; cloud routes are not
+    /// affected by the knowledge table).
     #[test]
     fn remote_moonshot_kimi_k3_not_affected_by_local_normalization() {
         let (_lock, _env) = locked_env(&[
@@ -6878,7 +6913,7 @@ mod tests {
         assert_eq!(
             bridge.request_reasoning_effort().as_deref(),
             Some("high"),
-            "云端精确路由保持默认 high"
+            "precise cloud route keeps the default high"
         );
         bridge
             .prefs
@@ -6889,7 +6924,7 @@ mod tests {
         assert_eq!(
             bridge.request_reasoning_effort().as_deref(),
             Some("off"),
-            "云端 stored off 照常透传，不被知识表归一"
+            "cloud stored off passes through as-is, not normalized by the knowledge table"
         );
     }
 

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -881,8 +881,10 @@ impl Pinvou3Bridge {
     ///
     /// 本地 OpenAI 兼容端点（loopback 的 LM Studio 等，探测不出服务类型或判定为
     /// LM Studio/通用）保持旧行为不注入档位（None），避免底座 openai wire route
-    /// 对 `reasoning_effort` 的空操作与不认识的请求参数引起漂移。注意底座对
-    /// openai 的 `reasoning_effort` 空操作仅对普通模型成立：gpt-5.5/5.6/codex
+    /// 对 `reasoning_effort` 的空操作与不认识的请求参数引起漂移。思考永开知识表
+    /// 归一同样不作用于该路由（wire 空操作，注入无效；前端 `localReasoningTiers`
+    /// 对 lmstudio/generic 同口径不提供档位）。注意底座对 openai 的
+    /// `reasoning_effort` 空操作仅对普通模型成立：gpt-5.5/5.6/codex
     /// 家族会经 `apply_openai_reasoning_effort` 注入档位（本地端点模型名不匹配
     /// 该家族，此处不注入不受影响）。
     ///
@@ -892,10 +894,11 @@ impl Pinvou3Bridge {
     /// （探测 payload 仍需显式注入 thinking，见 image_capability.rs）。
     fn request_reasoning_effort(&self) -> Option<String> {
         let provider = self.provider();
-        // 「本地路由」：vllm/ollama provider，或 openai wire 指向本地/私网端点。
-        // 云端精确路由（moonshot/zai 等）不进知识表归一。
-        let is_local_route = matches!(provider.as_str(), "vllm" | "ollama")
-            || (provider == "openai" && base_url_uses_local_or_private(&self.base_url()));
+        // 「本地路由」：vllm/ollama provider。openai wire 指向本地/私网端点
+        // （LM Studio/通用服务）时底座对 reasoning_effort 是空操作，知识表归一
+        // 注入无效，不进归一（stored 值仍按下方「显式选择优先」透传，不影响
+        // 后续探测为 vllm 时生效）；云端精确路由（moonshot/zai 等）同样不进。
+        let is_local_route = matches!(provider.as_str(), "vllm" | "ollama");
         if is_local_route {
             let model = self.effective_model();
             if let Some(spec) = model.and_then(|m| always_thinking_spec(&m.model)) {
@@ -6454,6 +6457,73 @@ mod tests {
             assert_eq!(bridge.request_reasoning_effort(), None, "{kind:?}");
             assert_eq!(bridge.build_dt_config().reasoning_effort, None, "{kind:?}");
         }
+    }
+
+    /// 思考永开知识表归一不作用于 openai wire route（LM Studio/通用服务）：
+    /// 底座对 openai 的 reasoning_effort 是空操作，注入无效——kimi-k3 无 stored
+    /// 时保持 None 默认，不做最低档归一；stored 值（含 off）仍按「显式选择优先」
+    /// 透传，不改动 prefs，后续探测为 vllm 时 stored 档位照常经知识表归一生效。
+    /// 前端 `localReasoningTiers` 对 lmstudio/generic 同口径不提供档位。
+    #[test]
+    fn local_lmstudio_or_generic_probe_skips_always_thinking_normalization() {
+        for kind in [LocalServerKind::LmStudio, LocalServerKind::Generic] {
+            let (_lock, _env) = locked_env(&[
+                "DEEPSEEK_MODEL",
+                "DEEPSEEK_PROVIDER",
+                "DEEPSEEK_BASE_URL",
+                "DEEPSEEK_API_KEY",
+            ]);
+            let mut bridge = fixture_bridge();
+            set_active_model(
+                &mut bridge,
+                ModelPreset::OpenaiCompatible,
+                "kimi-k3",
+                "http://127.0.0.1:1234/v1",
+                "",
+            );
+            bridge.probed_local_kind = Some(kind);
+            assert_eq!(bridge.provider(), "openai", "{kind:?}");
+            assert_eq!(
+                bridge.request_reasoning_effort(),
+                None,
+                "{kind:?}: openai wire 空操作，知识表不注入最低档"
+            );
+            // stored off 透传（显式选择优先），不被知识表归一为 low。
+            bridge
+                .prefs
+                .advanced
+                .saved_models
+                .last_mut()
+                .map(|m| m.reasoning_effort = Some("off".to_string()));
+            assert_eq!(
+                bridge.request_reasoning_effort().as_deref(),
+                Some("off"),
+                "{kind:?}: stored 值透传，prefs 不被知识表改写"
+            );
+        }
+    }
+
+    /// NoControl 模型（deepseek-r1）在 openai wire route 同样不发思考参数
+    /// （None）——与 vllm/ollama 路由的归一结果一致，无行为差异。
+    #[test]
+    fn local_generic_probe_no_control_model_sends_no_thinking_params() {
+        let (_lock, _env) = locked_env(&[
+            "DEEPSEEK_MODEL",
+            "DEEPSEEK_PROVIDER",
+            "DEEPSEEK_BASE_URL",
+            "DEEPSEEK_API_KEY",
+        ]);
+        let mut bridge = fixture_bridge();
+        set_active_model(
+            &mut bridge,
+            ModelPreset::OpenaiCompatible,
+            "deepseek-r1",
+            "http://127.0.0.1:1234/v1",
+            "",
+        );
+        bridge.probed_local_kind = Some(LocalServerKind::Generic);
+        assert_eq!(bridge.provider(), "openai");
+        assert_eq!(bridge.request_reasoning_effort(), None);
     }
 
     /// 显式保存的档位优先于「本地 generic 端点不注入」默认：用户在 LM Studio/

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -17,7 +17,7 @@ import {
   groupModelsForSelector,
   selectorMainLabel,
   reasoningEffortTiersForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort,
-  localProbeTiersForKind, reasoningEffortDisplayForTiers, baseUrlUsesLocalOrPrivate,
+  alwaysThinkingSpecForModel, localReasoningTiers, reasoningEffortDisplayForTiers, baseUrlUsesLocalOrPrivate,
 } from './model-catalog.js';
 import { CommunityPanel } from './CommunityPanel.jsx';
 import { COMMUNITY_DISCUSSIONS_URL, COMMUNITY_QQ_GROUP_NAME, COMMUNITY_QQ_GROUP_NUMBER, COMMUNITY_QQ_QR_IMAGE_SRC } from './community-config.js';
@@ -840,8 +840,12 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
         return () => { cancelled = true; clearTimeout(timer); };
       }, [isLocalCompatible, baseUrl, apiKey, initial.id, initial.__new, probeSupported]);
       const reasoningEffortTiers = isLocalCompatible
-        ? (probePending ? [] : (localProbeTiersForKind(probedKind) || []))
+        ? (probePending ? [] : (localReasoningTiers(model, probedKind) || []))
         : (reasoningEffortTiersForModel({ preset, model, vendor, base_url: baseUrl, provider_kind: providerKind }) || []);
+      // 本地路由（vllm preset / 本地兼容端点）命中「思考永开、不可控」知识表：
+      // 档位区显示「思考始终开启」提示而非探测不支持。
+      const localNoControlThinking = (preset === 'local_vllm' || isLocalCompatible)
+        && !!(alwaysThinkingSpecForModel(model) || {}).noControl;
       // Highlight fallback: the form value is normalized against the static
       // four tiers (stored low/medium keep their values), but once ollama is
       // probed only the off/high tiers render, so those values would land on
@@ -1746,7 +1750,7 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
                 </section>
               )}
               {renderImageInputSection()}
-              {(showConfigFields && (reasoningEffortTiers.length > 0 || isLocalCompatible)) && (
+              {(showConfigFields && (reasoningEffortTiers.length > 0 || isLocalCompatible || localNoControlThinking)) && (
                 <section>
                   <div className={formGroup}>
                     <div className="min-h-[54px] flex items-center gap-3 px-4 py-2.5">
@@ -1770,7 +1774,9 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
                         <span className={`ml-auto text-right text-[12px] leading-4 ${probePending ? 'text-[#8A8A8E] dark:text-[#98989D]' : 'text-[#FF9500] dark:text-[#FFB340]'}`}>
                           {probePending
                             ? (settingsCopy.reasoningProbePending || '正在探测服务类型…')
-                            : (settingsCopy.reasoningProbeUnsupported || '该端点不支持思考档位调节')}
+                            : localNoControlThinking
+                              ? (settingsCopy.reasoningThinkingAlwaysOn || '该模型思考始终开启，无法关闭')
+                              : (settingsCopy.reasoningProbeUnsupported || '该端点不支持思考档位调节')}
                         </span>
                       )}
                     </div>

--- a/pinvou3-app/src/features/settings/SettingsView.jsx
+++ b/pinvou3-app/src/features/settings/SettingsView.jsx
@@ -842,8 +842,8 @@ const SCard = React.forwardRef( // eslint-disable-line react/display-name -- for
       const reasoningEffortTiers = isLocalCompatible
         ? (probePending ? [] : (localReasoningTiers(model, probedKind) || []))
         : (reasoningEffortTiersForModel({ preset, model, vendor, base_url: baseUrl, provider_kind: providerKind }) || []);
-      // 本地路由（vllm preset / 本地兼容端点）命中「思考永开、不可控」知识表：
-      // 档位区显示「思考始终开启」提示而非探测不支持。
+      // Local routes (vllm preset / local-compatible endpoints) hit the "always-thinking,
+      // no-control" knowledge table: the effort-tier area shows an "always on" hint instead of probe-unsupported.
       const localNoControlThinking = (preset === 'local_vllm' || isLocalCompatible)
         && !!(alwaysThinkingSpecForModel(model) || {}).noControl;
       // Highlight fallback: the form value is normalized against the static

--- a/pinvou3-app/src/features/settings/composer-shared.jsx
+++ b/pinvou3-app/src/features/settings/composer-shared.jsx
@@ -20,7 +20,7 @@ import {
 import {
   groupModelsForSelector, selectorMainLabel, selectorSubLabel,
   reasoningEffortTiersForModel, normalizeStoredReasoningEffort,
-  localProbeTiersForKind, reasoningEffortDisplayForTiers, baseUrlUsesLocalOrPrivate,
+  alwaysThinkingSpecForModel, localReasoningTiers, reasoningEffortDisplayForTiers, baseUrlUsesLocalOrPrivate,
 } from './model-catalog.js';
 
 // 会话中「打开」是未提交态：新一轮对话发出前允许改回（误开可撤销），发出后
@@ -147,8 +147,13 @@ window.addEventListener('pinvou:chat-round-committed', (event) => {
         return () => { cancelled = true; };
       }, [isLocalCompatible, currentBaseUrl, currentModelId]);
       const reasoningEffortTiers = isLocalCompatible
-        ? (currentProbePending ? [] : (localProbeTiersForKind(currentProbedKind) || []))
+        ? (currentProbePending ? [] : (localReasoningTiers(current ? current.model : null, currentProbedKind) || []))
         : (current ? (reasoningEffortTiersForModel(current) || []) : []);
+      // 本地路由（vllm preset / 本地兼容端点）命中「思考永开、不可控」知识表：
+      // 档位区显示「思考始终开启」提示而非探测不支持。
+      const currentNoControlThinking = !!current
+        && (current.preset === 'local_vllm' || isLocalCompatible)
+        && !!(alwaysThinkingSpecForModel(current.model) || {}).noControl;
       // 存量档位（可能保存过底座归一前的旧值，如 deepseek 的 medium）先归一到
       // 档位表内等价档位再高亮，避免「档位表不含该值 → 下拉无高亮」。
       const reasoningEffortValue = current ? normalizeStoredReasoningEffort(current, current.reasoning_effort) : null;
@@ -233,7 +238,7 @@ window.addEventListener('pinvou:chat-round-committed', (event) => {
                     </>
                   );
                 })()}
-                {current && (reasoningEffortTiers.length > 0 || isLocalCompatible) && (
+                {current && (reasoningEffortTiers.length > 0 || isLocalCompatible || currentNoControlThinking) && (
                   <>
                     <div className="h-px bg-black/5 dark:bg-white/10 my-1.5 mx-2" />
                     <div className="px-3 pt-1 pb-1">
@@ -255,7 +260,9 @@ window.addEventListener('pinvou:chat-round-committed', (event) => {
                         <div className={`text-[11px] leading-4 ${currentProbePending ? 'text-gray-400 dark:text-gray-500' : 'text-[#FF9500] dark:text-[#FFB340]'}`}>
                           {currentProbePending
                             ? ((t.uiSettingsDetail && t.uiSettingsDetail.reasoningProbePending) || '正在探测服务类型…')
-                            : ((t.uiSettingsDetail && t.uiSettingsDetail.reasoningProbeUnsupported) || '该端点不支持思考档位调节')}
+                            : currentNoControlThinking
+                              ? ((t.uiSettingsDetail && t.uiSettingsDetail.reasoningThinkingAlwaysOn) || '该模型思考始终开启，无法关闭')
+                              : ((t.uiSettingsDetail && t.uiSettingsDetail.reasoningProbeUnsupported) || '该端点不支持思考档位调节')}
                         </div>
                       )}
                       {effortSaveError && (

--- a/pinvou3-app/src/features/settings/composer-shared.jsx
+++ b/pinvou3-app/src/features/settings/composer-shared.jsx
@@ -149,8 +149,8 @@ window.addEventListener('pinvou:chat-round-committed', (event) => {
       const reasoningEffortTiers = isLocalCompatible
         ? (currentProbePending ? [] : (localReasoningTiers(current ? current.model : null, currentProbedKind) || []))
         : (current ? (reasoningEffortTiersForModel(current) || []) : []);
-      // 本地路由（vllm preset / 本地兼容端点）命中「思考永开、不可控」知识表：
-      // 档位区显示「思考始终开启」提示而非探测不支持。
+      // Local routes (vllm preset / local-compatible endpoints) hit the "always-thinking,
+      // no-control" knowledge table: the effort-tier area shows an "always on" hint instead of probe-unsupported.
       const currentNoControlThinking = !!current
         && (current.preset === 'local_vllm' || isLocalCompatible)
         && !!(alwaysThinkingSpecForModel(current.model) || {}).noControl;

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -962,18 +962,26 @@ function reasoningProviderForModel(model) {
   }
 }
 
-// 「思考始终开启」模型的本地部署知识表（兜底）。仅作用于本地路由
-// （vllm / 本地 loopback 端点 / 探测出的 ollama），云端精确路由不走此表。
-// 依据：
-// - Kimi K3 思考永开，官方档位 low/high/max；底座 wire 层把 max 钳到 high，
-//   故只暴露 low/high。
-// - GLM-5.3 / GLM-4.7 思考永开，同理暴露 low/high。
-// - GPT-OSS 思考不可关，官方只有 low/medium/high 三档。
+// Local-deployment knowledge table (fallback) for "thinking always on" models.
+// Only applies to local routes (vllm / local loopback endpoints / probed
+// ollama); exact cloud routes do not use this table.
+// Basis:
+// - Kimi K3 is always-thinking, official effort tiers low/high/max; the engine
+//   wire layer clamps max to high, so only low/high are exposed.
+// - GLM-5.3 / GLM-4.7 are always-thinking and likewise expose low/high.
+// - GPT-OSS thinking cannot be disabled; officially only three tiers low/medium/high.
 // - kimi-k2-thinking / kimi-k2.5-thinking / kimi-k2.7 / deepseek-r1 /
-//   minimax-m2 / qwen3 thinking 系：思考不可关且无档位可控（noControl）。
-// 当框架（探测结果）明确回报可关时以框架为准——本表只在本地路由的档位
-// 解析中作为兜底叠加，不覆盖云端精确路由。
-// modelId 小写化并把 `_`/空格归一为 `-` 后做子串匹配。
+//   minimax-m2 / qwen3 thinking family: thinking cannot be disabled and has no
+//   tier control (noControl).
+// When a framework (probe result) explicitly reports thinking can be disabled,
+// the framework wins — this table only overlays as a fallback during effort
+// tier resolution on local routes; it never overrides exact cloud routes.
+// modelId is lowercased with `_`/whitespace normalized to `-`, then substring-matched.
+// Accepted risk: substring matching also covers future names (e.g. a future
+// kimi-k3.5 matches the kimi-k3 entry); entries are re-reviewed as new models ship.
+// GLM-5.3 scope note: this table applies to local routes only; the cloud exact
+// route (z.ai first-party) deliberately keeps its own ['off','high','max'] tiers
+// from the hosted API contract.
 function alwaysThinkingSpecForModel(modelId) {
   const normalized = String(modelId || '').trim().toLowerCase().replaceAll(/[\s_]+/g, '-');
   if (!normalized) return null;
@@ -1010,11 +1018,13 @@ function reasoningEffortTiersForModel(model) {
   if (!tiers) return null;
   const modelName = String((model && model.model) || '').trim().toLowerCase();
   const baseUrl = (model && model.base_url) || '';
-  // 本地路由（vllm preset / 本地 loopback openai_compatible 端点）命中思考
-  // 永开知识表：noControl → null（沿用「不支持调节」语义出口）；tiers → 以
-  // 知识表档位替代默认档位表。云端精确路由（zai/moonshot/minimax）不受影响。
-  // （探测出的 ollama 不走这里：本地兼容端点的档位由 localReasoningTiers 按
-  // 探测 kind 叠加知识表下发。）
+  // Local routes (vllm preset / local loopback openai_compatible endpoint) that
+  // hit the always-thinking knowledge table: noControl → null (reusing the
+  // "not adjustable" semantic exit); tiers → the knowledge-table tiers replace
+  // the default tier table. Exact cloud routes (zai/moonshot/minimax) are
+  // unaffected. (Probed ollama does not go through here: tiers for local
+  // compatible endpoints are issued by localReasoningTiers, which overlays the
+  // knowledge table on the probed kind.)
   const localSpec = ['vllm', 'local'].includes(provider)
     ? alwaysThinkingSpecForModel(model && model.model)
     : null;
@@ -1057,7 +1067,8 @@ function isAlwaysThinkingK3Route(model) {
 function defaultReasoningEffortForModel(model) {
   const provider = reasoningProviderForModel(model);
   if (provider === 'vllm' || provider === 'local') {
-    // 思考永开且档位可控的模型（知识表）：off 不可用，默认最低档。
+    // Always-thinking models with controllable tiers (knowledge table): off is
+    // unavailable, default to the lowest tier.
     const spec = alwaysThinkingSpecForModel(model && model.model);
     if (spec && spec.tiers) return spec.tiers[0];
     return 'off';
@@ -1086,8 +1097,9 @@ const REASONING_EFFORT_CANONICAL = {
 // 存量档位归一：用户可能保存过底座归一前的旧值（别名或不在档位表内的档位，
 // 如 deepseek 的 medium → 底座归一为 high）。展示与表单初始值都取归一后的档位，
 // 避免「档位表不含该值 → 下拉无高亮 / 残留无法选中的脏值」；无档位模型返回 null。
-// 本地思考永开知识表模型（tiers 来自 alwaysThinkingSpecForModel）无需特判：
-// 存量 off 等不在 spec.tiers 内的值会落到末尾的默认档（spec.tiers[0]）。
+// Local always-thinking knowledge-table models (tiers from alwaysThinkingSpecForModel)
+// need no special case: stored values outside spec.tiers (e.g. off) fall
+// through to the trailing default tier (spec.tiers[0]).
 function normalizeStoredReasoningEffort(model, stored) {
   const tiers = reasoningEffortTiersForModel(model) || [];
   if (!tiers.length) return null;
@@ -1108,9 +1120,9 @@ function normalizeStoredReasoningEffort(model, stored) {
 // 本地 OpenAI 兼容端点按探测服务类型可切换的档位。与 Rust
 // `probe_local_server_kind` 结果对齐：
 // - vllm → 底座 `chat_template_kwargs` 支持四档
-// - sglang / llamacpp / koboldcpp / lmdeploy / dockermodelrunner → 思考控制
-//   wire 与 vLLM 同构（chat_template_kwargs + reasoning_effort 透传），
-//   档位集合与 vllm 相同
+// - sglang / llamacpp / koboldcpp / lmdeploy / dockermodelrunner → thinking
+//   control wire is structurally identical to vLLM (chat_template_kwargs +
+//   reasoning_effort passthrough); the tier set is the same as vllm
 // - ollama → 底座 `think` 布尔开关：off=think:false，其余档位一律归一 think=true，
 //   只暴露 off/high 避免「看起来不同、实际相同」的误导
 // - lmstudio / generic → 底座 openai wire route 对 reasoning_effort 是空操作，
@@ -1134,12 +1146,15 @@ function localProbeTiersForKind(kind) {
   }
 }
 
-// 探测档位 × 模型知识表的叠加（SettingsView 模型编辑弹窗与聊天输入区模型
-// 弹层共用）：模型命中思考永开知识表时以知识表为准——noControl → null
-// （前端显示「思考始终开启」提示，而非探测不支持）；tiers → 覆盖探测档位。
-// 例外：lmstudio/generic 端点底座 openai wire route 对 reasoning_effort 是
-// 空操作，知识表档位同样调了个寂寞——回落探测结果（null），不提供切换。
-// 未命中时按探测结果下发档位。
+// Overlay of probed tiers × the model knowledge table (shared by the
+// SettingsView model-edit dialog and the chat input model popover): when the
+// model hits the always-thinking knowledge table, the table wins — noControl →
+// null (frontend shows the "thinking always on" hint rather than "probe
+// unsupported"); tiers → override the probed tiers.
+// Exception: on lmstudio/generic endpoints the engine openai wire route treats
+// reasoning_effort as a no-op, so the knowledge-table tiers would equally
+// change nothing — fall back to the probe result (null), no switching offered.
+// On a miss, tiers are issued per the probe result.
 function localReasoningTiers(modelId, probedKind) {
   const spec = alwaysThinkingSpecForModel(modelId);
   if (spec) {
@@ -1147,10 +1162,11 @@ function localReasoningTiers(modelId, probedKind) {
     if (probedKind === 'lmstudio' || probedKind === 'generic') {
       return localProbeTiersForKind(probedKind);
     }
-    // 底座 ollama wire 只有布尔 think（off=think:false，其余档位一律归一
-    // think:true），不发送档位字符串；思考永开模型在 ollama 路由下唯一有意义
-    // 的暴露是 high（如 GPT-OSS 只认 low/medium/high 字符串，true/false 被
-    // 忽略，思考本就关不掉）。
+    // The engine ollama wire only has the boolean think (off=think:false, all
+    // other tiers normalize to think:true) and never sends a tier string; for
+    // always-thinking models on the ollama route the only meaningful exposure
+    // is high (e.g. GPT-OSS only accepts the low/medium/high strings —
+    // true/false is ignored, and thinking cannot be disabled anyway).
     if (probedKind === 'ollama') return ['high'];
     return spec.tiers;
   }

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -1010,11 +1010,12 @@ function reasoningEffortTiersForModel(model) {
   if (!tiers) return null;
   const modelName = String((model && model.model) || '').trim().toLowerCase();
   const baseUrl = (model && model.base_url) || '';
-  // 本地路由（vllm / 本地 loopback 端点；ollama 为探测 kind，此处一并覆盖）
-  // 命中思考永开知识表：noControl → null（沿用「不支持调节」语义出口）；
-  // tiers → 以知识表档位替代默认档位表。云端精确路由（zai/moonshot/minimax）
-  // 不受影响。
-  const localSpec = ['vllm', 'local', 'ollama'].includes(provider)
+  // 本地路由（vllm preset / 本地 loopback openai_compatible 端点）命中思考
+  // 永开知识表：noControl → null（沿用「不支持调节」语义出口）；tiers → 以
+  // 知识表档位替代默认档位表。云端精确路由（zai/moonshot/minimax）不受影响。
+  // （探测出的 ollama 不走这里：本地兼容端点的档位由 localReasoningTiers 按
+  // 探测 kind 叠加知识表下发。）
+  const localSpec = ['vllm', 'local'].includes(provider)
     ? alwaysThinkingSpecForModel(model && model.model)
     : null;
   if (localSpec) return localSpec.noControl ? null : localSpec.tiers;
@@ -1136,11 +1137,16 @@ function localProbeTiersForKind(kind) {
 // 探测档位 × 模型知识表的叠加（SettingsView 模型编辑弹窗与聊天输入区模型
 // 弹层共用）：模型命中思考永开知识表时以知识表为准——noControl → null
 // （前端显示「思考始终开启」提示，而非探测不支持）；tiers → 覆盖探测档位。
+// 例外：lmstudio/generic 端点底座 openai wire route 对 reasoning_effort 是
+// 空操作，知识表档位同样调了个寂寞——回落探测结果（null），不提供切换。
 // 未命中时按探测结果下发档位。
 function localReasoningTiers(modelId, probedKind) {
   const spec = alwaysThinkingSpecForModel(modelId);
   if (spec) {
     if (spec.noControl) return null;
+    if (probedKind === 'lmstudio' || probedKind === 'generic') {
+      return localProbeTiersForKind(probedKind);
+    }
     // 底座 ollama wire 只有布尔 think（off=think:false，其余档位一律归一
     // think:true），不发送档位字符串；思考永开模型在 ollama 路由下唯一有意义
     // 的暴露是 high（如 GPT-OSS 只认 low/medium/high 字符串，true/false 被

--- a/pinvou3-app/src/features/settings/model-catalog.js
+++ b/pinvou3-app/src/features/settings/model-catalog.js
@@ -962,6 +962,35 @@ function reasoningProviderForModel(model) {
   }
 }
 
+// 「思考始终开启」模型的本地部署知识表（兜底）。仅作用于本地路由
+// （vllm / 本地 loopback 端点 / 探测出的 ollama），云端精确路由不走此表。
+// 依据：
+// - Kimi K3 思考永开，官方档位 low/high/max；底座 wire 层把 max 钳到 high，
+//   故只暴露 low/high。
+// - GLM-5.3 / GLM-4.7 思考永开，同理暴露 low/high。
+// - GPT-OSS 思考不可关，官方只有 low/medium/high 三档。
+// - kimi-k2-thinking / kimi-k2.5-thinking / kimi-k2.7 / deepseek-r1 /
+//   minimax-m2 / qwen3 thinking 系：思考不可关且无档位可控（noControl）。
+// 当框架（探测结果）明确回报可关时以框架为准——本表只在本地路由的档位
+// 解析中作为兜底叠加，不覆盖云端精确路由。
+// modelId 小写化并把 `_`/空格归一为 `-` 后做子串匹配。
+function alwaysThinkingSpecForModel(modelId) {
+  const normalized = String(modelId || '').trim().toLowerCase().replaceAll(/[\s_]+/g, '-');
+  if (!normalized) return null;
+  if (normalized.includes('kimi-k3')) return { tiers: ['low', 'high'] };
+  if (normalized.includes('glm-5.3') || normalized.includes('glm-4.7')) return { tiers: ['low', 'high'] };
+  if (normalized.includes('gpt-oss')) return { tiers: ['low', 'medium', 'high'] };
+  if (normalized.includes('kimi-k2-thinking')
+    || normalized.includes('kimi-k2.5-thinking')
+    || normalized.includes('kimi-k2.7')
+    || normalized.includes('deepseek-r1')
+    || normalized.includes('minimax-m2')
+    || (normalized.includes('qwen3') && normalized.includes('thinking'))) {
+    return { noControl: true };
+  }
+  return null;
+}
+
 // 该模型可切换的思考深度档位（无则 null = 不提供切换）。
 // 路由/模型级细分（仅品悟目录收录的模型）：
 // - zai：first-party z.ai 端点上 GLM-5.2/5.3 提供 tiered effort（off/high/max），
@@ -981,6 +1010,14 @@ function reasoningEffortTiersForModel(model) {
   if (!tiers) return null;
   const modelName = String((model && model.model) || '').trim().toLowerCase();
   const baseUrl = (model && model.base_url) || '';
+  // 本地路由（vllm / 本地 loopback 端点；ollama 为探测 kind，此处一并覆盖）
+  // 命中思考永开知识表：noControl → null（沿用「不支持调节」语义出口）；
+  // tiers → 以知识表档位替代默认档位表。云端精确路由（zai/moonshot/minimax）
+  // 不受影响。
+  const localSpec = ['vllm', 'local', 'ollama'].includes(provider)
+    ? alwaysThinkingSpecForModel(model && model.model)
+    : null;
+  if (localSpec) return localSpec.noControl ? null : localSpec.tiers;
   if (provider === 'zai') {
     if (!isExactZaiChatBaseUrl(baseUrl)) return null;
     if (modelName === 'glm-5.2' || modelName === 'glm-5.3') return ['off', 'high', 'max'];
@@ -1018,7 +1055,12 @@ function isAlwaysThinkingK3Route(model) {
 // （防 SSE timeout / 思考 trace 抢占首包），其余 high。
 function defaultReasoningEffortForModel(model) {
   const provider = reasoningProviderForModel(model);
-  if (provider === 'vllm' || provider === 'local') return 'off';
+  if (provider === 'vllm' || provider === 'local') {
+    // 思考永开且档位可控的模型（知识表）：off 不可用，默认最低档。
+    const spec = alwaysThinkingSpecForModel(model && model.model);
+    if (spec && spec.tiers) return spec.tiers[0];
+    return 'off';
+  }
   return reasoningEffortTiersForModel(model) ? 'high' : null;
 }
 
@@ -1043,6 +1085,8 @@ const REASONING_EFFORT_CANONICAL = {
 // 存量档位归一：用户可能保存过底座归一前的旧值（别名或不在档位表内的档位，
 // 如 deepseek 的 medium → 底座归一为 high）。展示与表单初始值都取归一后的档位，
 // 避免「档位表不含该值 → 下拉无高亮 / 残留无法选中的脏值」；无档位模型返回 null。
+// 本地思考永开知识表模型（tiers 来自 alwaysThinkingSpecForModel）无需特判：
+// 存量 off 等不在 spec.tiers 内的值会落到末尾的默认档（spec.tiers[0]）。
 function normalizeStoredReasoningEffort(model, stored) {
   const tiers = reasoningEffortTiersForModel(model) || [];
   if (!tiers.length) return null;
@@ -1063,6 +1107,9 @@ function normalizeStoredReasoningEffort(model, stored) {
 // 本地 OpenAI 兼容端点按探测服务类型可切换的档位。与 Rust
 // `probe_local_server_kind` 结果对齐：
 // - vllm → 底座 `chat_template_kwargs` 支持四档
+// - sglang / llamacpp / koboldcpp / lmdeploy / dockermodelrunner → 思考控制
+//   wire 与 vLLM 同构（chat_template_kwargs + reasoning_effort 透传），
+//   档位集合与 vllm 相同
 // - ollama → 底座 `think` 布尔开关：off=think:false，其余档位一律归一 think=true，
 //   只暴露 off/high 避免「看起来不同、实际相同」的误导
 // - lmstudio / generic → 底座 openai wire route 对 reasoning_effort 是空操作，
@@ -1070,7 +1117,13 @@ function normalizeStoredReasoningEffort(model, stored) {
 // - null（尚未探测/探测失败）→ 返回默认四档，前端在探测完成前不提供误导档位
 function localProbeTiersForKind(kind) {
   switch (kind) {
-    case 'vllm': return ['off', 'low', 'medium', 'high'];
+    case 'vllm':
+    case 'sglang':
+    case 'llamacpp':
+    case 'koboldcpp':
+    case 'lmdeploy':
+    case 'dockermodelrunner':
+      return ['off', 'low', 'medium', 'high'];
     case 'ollama': return ['off', 'high'];
     case 'lmstudio':
     case 'generic':
@@ -1078,6 +1131,24 @@ function localProbeTiersForKind(kind) {
     default:
       return ['off', 'low', 'medium', 'high'];
   }
+}
+
+// 探测档位 × 模型知识表的叠加（SettingsView 模型编辑弹窗与聊天输入区模型
+// 弹层共用）：模型命中思考永开知识表时以知识表为准——noControl → null
+// （前端显示「思考始终开启」提示，而非探测不支持）；tiers → 覆盖探测档位。
+// 未命中时按探测结果下发档位。
+function localReasoningTiers(modelId, probedKind) {
+  const spec = alwaysThinkingSpecForModel(modelId);
+  if (spec) {
+    if (spec.noControl) return null;
+    // 底座 ollama wire 只有布尔 think（off=think:false，其余档位一律归一
+    // think:true），不发送档位字符串；思考永开模型在 ollama 路由下唯一有意义
+    // 的暴露是 high（如 GPT-OSS 只认 low/medium/high 字符串，true/false 被
+    // 忽略，思考本就关不掉）。
+    if (probedKind === 'ollama') return ['high'];
+    return spec.tiers;
+  }
+  return localProbeTiersForKind(probedKind);
 }
 
 // Visual fallback of stored tiers against the probed tier table: normalization
@@ -1123,7 +1194,9 @@ export {
   defaultReasoningEffortForModel,
   reasoningEffortForModelSwitch,
   normalizeStoredReasoningEffort,
+  alwaysThinkingSpecForModel,
   localProbeTiersForKind,
+  localReasoningTiers,
   reasoningEffortDisplayForTiers,
   baseUrlUsesLocalOrPrivate,
 };

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -873,6 +873,7 @@ dictEn.uiSettingsDetail.memoryTopicCleanupRequired = 'Memory was updated. The pr
 Object.assign(dictEn.uiSettingsDetail, {
   reasoningEffort:'Thinking depth', reasoningEffortTiers:{ off:'Off', low:'Low', medium:'Medium', high:'High', max:'Max' },
   reasoningProbePending:'Detecting server type…', reasoningProbeUnsupported:'This endpoint does not support thinking-depth control',
+  reasoningThinkingAlwaysOn:'This model always thinks and cannot be turned off',
   saving:'Saving', localDetectionTargets:'Detect vLLM, Ollama, and LM Studio',
   redetect:'Detect again', detect:'Detect', noRunningLocalModel:'No running local model detected', modelNotLoadedTag:'Not loaded', modelNotLoadedHint:'Not in memory yet; it will load automatically on first use',
   add:'Add', manualLocalModel:'Add a local model manually',

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -875,6 +875,7 @@ dictJa.uiSettingsDetail.memoryTopicCleanupRequired = 'メモリは更新され�
 Object.assign(dictJa.uiSettingsDetail, {
   reasoningEffort:'思考の深さ', reasoningEffortTiers:{ off:'オフ', low:'低', medium:'中', high:'高', max:'最大' },
   reasoningProbePending:'サーバータイプを検出中…', reasoningProbeUnsupported:'このエンドポイントは思考深度の調整をサポートしていません',
+  reasoningThinkingAlwaysOn:'このモデルは常に思考を行い、オフにできません',
   saving:'保存中', localDetectionTargets:'vLLM、Ollama、LM Studio を検出',
   redetect:'再検出', detect:'検出', noRunningLocalModel:'実行中のローカルモデルが見つかりません', modelNotLoadedTag:'未読み込み', modelNotLoadedHint:'メモリ未読み込み。初回使用時に自動でロードされます',
   add:'追加', manualLocalModel:'ローカルモデルを手動追加',

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -914,6 +914,7 @@ dictZh.uiSettingsDetail.memoryTopicCleanupRequired = '记忆已更新，旧主�
 Object.assign(dictZh.uiSettingsDetail, {
   reasoningEffort:'思考深度', reasoningEffortTiers:{ off:'关闭', low:'低', medium:'中', high:'高', max:'最深' },
   reasoningProbePending:'正在探测服务类型…', reasoningProbeUnsupported:'该端点不支持思考档位调节',
+  reasoningThinkingAlwaysOn:'该模型思考始终开启，无法关闭',
   addProvider:provider=>`添加 ${provider}`, editProvider:provider=>`编辑 ${provider}`,
   autoDetectLocalModel:'自动检测本地模型',
   codingPlanTestUnavailable:'当前厂商接口暂时无法完成测试，但不影响保存配置',

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -35,13 +35,15 @@ vm.runInContext(
   `this.baseUrlUsesLoopback = baseUrlUsesLoopback;\n` +
   `this.baseUrlUsesLocalOrPrivate = baseUrlUsesLocalOrPrivate;\n` +
   `this.localProbeTiersForKind = localProbeTiersForKind;\n` +
+  `this.alwaysThinkingSpecForModel = alwaysThinkingSpecForModel;\n` +
+  `this.localReasoningTiers = localReasoningTiers;\n` +
   `this.reasoningEffortDisplayForTiers = reasoningEffortDisplayForTiers;\n` +
   `this.catalogImageCapableForModel = catalogImageCapableForModel;\n`,
   ctx,
   { filename: srcPath },
 );
 
-const { isPresetModel, catalogItemMatchesModel, MODEL_CATALOG, groupModelsForSelector, localUserNamed, selectorMainLabel, selectorSubLabel, providerLabelForModel, reasoningEffortTiersForModel, defaultReasoningEffortForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort, baseUrlUsesLoopback, baseUrlUsesLocalOrPrivate, localProbeTiersForKind, catalogImageCapableForModel, reasoningEffortDisplayForTiers } = ctx;
+const { isPresetModel, catalogItemMatchesModel, MODEL_CATALOG, groupModelsForSelector, localUserNamed, selectorMainLabel, selectorSubLabel, providerLabelForModel, reasoningEffortTiersForModel, defaultReasoningEffortForModel, reasoningEffortForModelSwitch, normalizeStoredReasoningEffort, baseUrlUsesLoopback, baseUrlUsesLocalOrPrivate, localProbeTiersForKind, alwaysThinkingSpecForModel, localReasoningTiers, catalogImageCapableForModel, reasoningEffortDisplayForTiers } = ctx;
 
 // i18n 测试替身:复刻实际字典里会用到的字段
 const t = {
@@ -457,12 +459,87 @@ test('localProbeTiersForKind 按探测结果映射真实档位', () => {
   // vllm → 四档；ollama → think 开关两档（避免 low/medium/high 归一误导）
   assert.deepStrictEqual([...localProbeTiersForKind('vllm')], ['off', 'low', 'medium', 'high']);
   assert.deepStrictEqual([...localProbeTiersForKind('ollama')], ['off', 'high']);
+  // 与 vLLM 思考控制 wire 同构的框架 → 与 vllm 相同四档
+  for (const kind of ['sglang', 'llamacpp', 'koboldcpp', 'lmdeploy', 'dockermodelrunner']) {
+    assert.deepStrictEqual([...localProbeTiersForKind(kind)], ['off', 'low', 'medium', 'high'], kind);
+  }
   // lmstudio/generic 底座空操作 → null（前端显示不支持提示）
   assert.strictEqual(localProbeTiersForKind('lmstudio'), null);
   assert.strictEqual(localProbeTiersForKind('generic'), null);
   // 未探测/未知 → 默认四档（前端探测完成前不误报不支持）
   assert.deepStrictEqual([...localProbeTiersForKind(null)], ['off', 'low', 'medium', 'high']);
   assert.deepStrictEqual([...localProbeTiersForKind('unknown')], ['off', 'low', 'medium', 'high']);
+});
+
+test('alwaysThinkingSpecForModel：思考永开模型知识表匹配', () => {
+  // vm realm 对象与测试 realm 原型不同，按 JSON 结构比较
+  const specJson = (modelId) => JSON.stringify(alwaysThinkingSpecForModel(modelId));
+  // 大小写不敏感 + 下划线/空格归一为 '-'
+  assert.strictEqual(specJson('kimi-k3'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('Kimi-K3'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('kimi_k3'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('Kimi K3 Instruct'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('glm-5.3'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('GLM-4.7'), '{"tiers":["low","high"]}');
+  assert.strictEqual(specJson('gpt-oss-120b'), '{"tiers":["low","medium","high"]}');
+  // noControl：思考不可关且无档位可控
+  assert.strictEqual(specJson('kimi-k2-thinking'), '{"noControl":true}');
+  assert.strictEqual(specJson('Kimi-K2.5-Thinking'), '{"noControl":true}');
+  assert.strictEqual(specJson('kimi-k2.7'), '{"noControl":true}');
+  assert.strictEqual(specJson('deepseek-r1-0528'), '{"noControl":true}');
+  assert.strictEqual(specJson('MiniMax-M2'), '{"noControl":true}');
+  assert.strictEqual(specJson('Qwen3-235B-A22B-Thinking'), '{"noControl":true}');
+  // 不命中：普通 qwen3（无 thinking）、其它模型、空值
+  assert.strictEqual(alwaysThinkingSpecForModel('qwen3-32b'), null);
+  assert.strictEqual(alwaysThinkingSpecForModel('qwen36_35b_256k'), null);
+  assert.strictEqual(alwaysThinkingSpecForModel('glm-5.2'), null);
+  assert.strictEqual(alwaysThinkingSpecForModel(''), null);
+  assert.strictEqual(alwaysThinkingSpecForModel(null), null);
+});
+
+test('本地路由命中知识表：档位/默认值/存量归一', () => {
+  // spec.tiers 模型（本地 vllm preset）：档位表被知识表替代，无 off 档
+  const k3Local = { preset: 'local_vllm', model: 'kimi-k3' };
+  assert.deepStrictEqual([...reasoningEffortTiersForModel(k3Local)], ['low', 'high']);
+  assert.strictEqual(defaultReasoningEffortForModel(k3Local), 'low');
+  // 存量 off 不在 spec.tiers 内 → 归一为最低档 low；合法值 high 原样保留
+  assert.strictEqual(normalizeStoredReasoningEffort(k3Local, 'off'), 'low');
+  assert.strictEqual(normalizeStoredReasoningEffort(k3Local, 'high'), 'high');
+  assert.strictEqual(normalizeStoredReasoningEffort(k3Local, null), 'low');
+  // 本地 loopback openai_compatible 端点同样走知识表
+  const gptOssLocal = { preset: 'openai_compatible', model: 'gpt-oss-20b', base_url: 'http://127.0.0.1:8000/v1' };
+  assert.deepStrictEqual([...reasoningEffortTiersForModel(gptOssLocal)], ['low', 'medium', 'high']);
+  assert.strictEqual(defaultReasoningEffortForModel(gptOssLocal), 'low');
+  // noControl 模型 → null（不提供切换，沿用「不支持调节」语义出口）
+  const r1Local = { preset: 'local_vllm', model: 'deepseek-r1:14b' };
+  assert.strictEqual(reasoningEffortTiersForModel(r1Local), null);
+  assert.strictEqual(normalizeStoredReasoningEffort(r1Local, 'high'), null);
+  // 普通本地模型不受影响：仍默认 off、四档
+  const qwenLocal = { preset: 'local_vllm', model: 'qwen3-32b' };
+  assert.deepStrictEqual([...reasoningEffortTiersForModel(qwenLocal)], ['off', 'low', 'medium', 'high']);
+  assert.strictEqual(defaultReasoningEffortForModel(qwenLocal), 'off');
+  // 云端精确路由不受影响：z.ai first-party 的 glm-5.3 仍是 off/high/max
+  const glmCloud = { preset: 'glm', vendor: 'glm', model: 'glm-5.3', base_url: 'https://api.z.ai/api/paas/v4' };
+  assert.deepStrictEqual([...reasoningEffortTiersForModel(glmCloud)], ['off', 'high', 'max']);
+  // 云端 moonshot K3 直连路由不变：low/high/max
+  const k3Direct = { preset: 'kimi', vendor: 'kimi', model: 'kimi-k3', base_url: 'https://api.moonshot.ai/v1' };
+  assert.deepStrictEqual([...reasoningEffortTiersForModel(k3Direct)], ['low', 'high', 'max']);
+});
+
+test('localReasoningTiers：探测档位 × 模型知识表叠加', () => {
+  // spec.tiers 覆盖探测档位（即使探测回报四档框架）
+  assert.deepStrictEqual([...localReasoningTiers('kimi-k3', 'vllm')], ['low', 'high']);
+  assert.deepStrictEqual([...localReasoningTiers('gpt-oss-120b', 'sglang')], ['low', 'medium', 'high']);
+  // ollama 路由下底座 wire 只有布尔 think，思考永开模型唯一有意义的暴露是 high
+  assert.deepStrictEqual([...localReasoningTiers('gpt-oss-120b', 'ollama')], ['high']);
+  // noControl → null（前端显示「思考始终开启」提示）
+  assert.strictEqual(localReasoningTiers('deepseek-r1:14b', 'vllm'), null);
+  assert.strictEqual(localReasoningTiers('Qwen3-235B-A22B-Thinking', 'ollama'), null);
+  // 未命中知识表 → 按探测结果下发
+  assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'ollama')], ['off', 'high']);
+  assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'llamacpp')], ['off', 'low', 'medium', 'high']);
+  assert.strictEqual(localReasoningTiers('qwen3-32b', 'generic'), null);
+  assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', null)], ['off', 'low', 'medium', 'high']);
 });
 
 test('reasoningEffortDisplayForTiers: display fallback of stored tiers against probed tiers', () => {

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -535,6 +535,12 @@ test('localReasoningTiers：探测档位 × 模型知识表叠加', () => {
   // noControl → null（前端显示「思考始终开启」提示）
   assert.strictEqual(localReasoningTiers('deepseek-r1:14b', 'vllm'), null);
   assert.strictEqual(localReasoningTiers('Qwen3-235B-A22B-Thinking', 'ollama'), null);
+  // lmstudio/generic：底座 openai wire route 对 reasoning_effort 是空操作，
+  // 知识表档位同样不提供——回落探测结果（null），恢复「端点不支持」提示
+  assert.strictEqual(localReasoningTiers('kimi-k3', 'lmstudio'), null);
+  assert.strictEqual(localReasoningTiers('gpt-oss-120b', 'generic'), null);
+  // noControl 在 lmstudio/generic 同样为 null（提示逻辑不变）
+  assert.strictEqual(localReasoningTiers('deepseek-r1:14b', 'generic'), null);
   // 未命中知识表 → 按探测结果下发
   assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'ollama')], ['off', 'high']);
   assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'llamacpp')], ['off', 'low', 'medium', 'high']);

--- a/pinvou3-app/tests/model_catalog_grouping.test.js
+++ b/pinvou3-app/tests/model_catalog_grouping.test.js
@@ -459,7 +459,7 @@ test('localProbeTiersForKind 按探测结果映射真实档位', () => {
   // vllm → 四档；ollama → think 开关两档（避免 low/medium/high 归一误导）
   assert.deepStrictEqual([...localProbeTiersForKind('vllm')], ['off', 'low', 'medium', 'high']);
   assert.deepStrictEqual([...localProbeTiersForKind('ollama')], ['off', 'high']);
-  // 与 vLLM 思考控制 wire 同构的框架 → 与 vllm 相同四档
+  // Frameworks wire-isomorphic with vLLM thinking control → same four tiers as vllm
   for (const kind of ['sglang', 'llamacpp', 'koboldcpp', 'lmdeploy', 'dockermodelrunner']) {
     assert.deepStrictEqual([...localProbeTiersForKind(kind)], ['off', 'low', 'medium', 'high'], kind);
   }
@@ -471,10 +471,10 @@ test('localProbeTiersForKind 按探测结果映射真实档位', () => {
   assert.deepStrictEqual([...localProbeTiersForKind('unknown')], ['off', 'low', 'medium', 'high']);
 });
 
-test('alwaysThinkingSpecForModel：思考永开模型知识表匹配', () => {
-  // vm realm 对象与测试 realm 原型不同，按 JSON 结构比较
+test('alwaysThinkingSpecForModel: always-thinking model knowledge table matching', () => {
+  // vm realm objects have different prototypes from the test realm; compare via JSON structure
   const specJson = (modelId) => JSON.stringify(alwaysThinkingSpecForModel(modelId));
-  // 大小写不敏感 + 下划线/空格归一为 '-'
+  // case-insensitive + underscores/spaces normalized to '-'
   assert.strictEqual(specJson('kimi-k3'), '{"tiers":["low","high"]}');
   assert.strictEqual(specJson('Kimi-K3'), '{"tiers":["low","high"]}');
   assert.strictEqual(specJson('kimi_k3'), '{"tiers":["low","high"]}');
@@ -482,14 +482,14 @@ test('alwaysThinkingSpecForModel：思考永开模型知识表匹配', () => {
   assert.strictEqual(specJson('glm-5.3'), '{"tiers":["low","high"]}');
   assert.strictEqual(specJson('GLM-4.7'), '{"tiers":["low","high"]}');
   assert.strictEqual(specJson('gpt-oss-120b'), '{"tiers":["low","medium","high"]}');
-  // noControl：思考不可关且无档位可控
+  // noControl: thinking cannot be disabled and no effort tier is controllable
   assert.strictEqual(specJson('kimi-k2-thinking'), '{"noControl":true}');
   assert.strictEqual(specJson('Kimi-K2.5-Thinking'), '{"noControl":true}');
   assert.strictEqual(specJson('kimi-k2.7'), '{"noControl":true}');
   assert.strictEqual(specJson('deepseek-r1-0528'), '{"noControl":true}');
   assert.strictEqual(specJson('MiniMax-M2'), '{"noControl":true}');
   assert.strictEqual(specJson('Qwen3-235B-A22B-Thinking'), '{"noControl":true}');
-  // 不命中：普通 qwen3（无 thinking）、其它模型、空值
+  // no match: plain qwen3 (no thinking), other models, empty values
   assert.strictEqual(alwaysThinkingSpecForModel('qwen3-32b'), null);
   assert.strictEqual(alwaysThinkingSpecForModel('qwen36_35b_256k'), null);
   assert.strictEqual(alwaysThinkingSpecForModel('glm-5.2'), null);
@@ -497,51 +497,51 @@ test('alwaysThinkingSpecForModel：思考永开模型知识表匹配', () => {
   assert.strictEqual(alwaysThinkingSpecForModel(null), null);
 });
 
-test('本地路由命中知识表：档位/默认值/存量归一', () => {
-  // spec.tiers 模型（本地 vllm preset）：档位表被知识表替代，无 off 档
+test('local routes hitting the knowledge table: tiers/defaults/stored-value normalization', () => {
+  // spec.tiers model (local vllm preset): tier table replaced by the knowledge table, no off tier
   const k3Local = { preset: 'local_vllm', model: 'kimi-k3' };
   assert.deepStrictEqual([...reasoningEffortTiersForModel(k3Local)], ['low', 'high']);
   assert.strictEqual(defaultReasoningEffortForModel(k3Local), 'low');
-  // 存量 off 不在 spec.tiers 内 → 归一为最低档 low；合法值 high 原样保留
+  // stored off is not in spec.tiers → normalized to the lowest tier low; valid high is kept as-is
   assert.strictEqual(normalizeStoredReasoningEffort(k3Local, 'off'), 'low');
   assert.strictEqual(normalizeStoredReasoningEffort(k3Local, 'high'), 'high');
   assert.strictEqual(normalizeStoredReasoningEffort(k3Local, null), 'low');
-  // 本地 loopback openai_compatible 端点同样走知识表
+  // local loopback openai_compatible endpoints also go through the knowledge table
   const gptOssLocal = { preset: 'openai_compatible', model: 'gpt-oss-20b', base_url: 'http://127.0.0.1:8000/v1' };
   assert.deepStrictEqual([...reasoningEffortTiersForModel(gptOssLocal)], ['low', 'medium', 'high']);
   assert.strictEqual(defaultReasoningEffortForModel(gptOssLocal), 'low');
-  // noControl 模型 → null（不提供切换，沿用「不支持调节」语义出口）
+  // noControl model → null (no switch offered, reusing the "not adjustable" semantic exit)
   const r1Local = { preset: 'local_vllm', model: 'deepseek-r1:14b' };
   assert.strictEqual(reasoningEffortTiersForModel(r1Local), null);
   assert.strictEqual(normalizeStoredReasoningEffort(r1Local, 'high'), null);
-  // 普通本地模型不受影响：仍默认 off、四档
+  // plain local models are unaffected: still default off, four tiers
   const qwenLocal = { preset: 'local_vllm', model: 'qwen3-32b' };
   assert.deepStrictEqual([...reasoningEffortTiersForModel(qwenLocal)], ['off', 'low', 'medium', 'high']);
   assert.strictEqual(defaultReasoningEffortForModel(qwenLocal), 'off');
-  // 云端精确路由不受影响：z.ai first-party 的 glm-5.3 仍是 off/high/max
+  // exact cloud routes are unaffected: z.ai first-party glm-5.3 is still off/high/max
   const glmCloud = { preset: 'glm', vendor: 'glm', model: 'glm-5.3', base_url: 'https://api.z.ai/api/paas/v4' };
   assert.deepStrictEqual([...reasoningEffortTiersForModel(glmCloud)], ['off', 'high', 'max']);
-  // 云端 moonshot K3 直连路由不变：low/high/max
+  // direct moonshot cloud route for K3 unchanged: low/high/max
   const k3Direct = { preset: 'kimi', vendor: 'kimi', model: 'kimi-k3', base_url: 'https://api.moonshot.ai/v1' };
   assert.deepStrictEqual([...reasoningEffortTiersForModel(k3Direct)], ['low', 'high', 'max']);
 });
 
-test('localReasoningTiers：探测档位 × 模型知识表叠加', () => {
-  // spec.tiers 覆盖探测档位（即使探测回报四档框架）
+test('localReasoningTiers: probed tiers overlaid with the model knowledge table', () => {
+  // spec.tiers overrides the probed tiers (even when the probe reports a four-tier framework)
   assert.deepStrictEqual([...localReasoningTiers('kimi-k3', 'vllm')], ['low', 'high']);
   assert.deepStrictEqual([...localReasoningTiers('gpt-oss-120b', 'sglang')], ['low', 'medium', 'high']);
-  // ollama 路由下底座 wire 只有布尔 think，思考永开模型唯一有意义的暴露是 high
+  // under the ollama route the engine wire only has boolean think, so the only meaningful exposure for an always-thinking model is high
   assert.deepStrictEqual([...localReasoningTiers('gpt-oss-120b', 'ollama')], ['high']);
-  // noControl → null（前端显示「思考始终开启」提示）
+  // noControl → null (frontend shows a "thinking is always on" notice)
   assert.strictEqual(localReasoningTiers('deepseek-r1:14b', 'vllm'), null);
   assert.strictEqual(localReasoningTiers('Qwen3-235B-A22B-Thinking', 'ollama'), null);
-  // lmstudio/generic：底座 openai wire route 对 reasoning_effort 是空操作，
-  // 知识表档位同样不提供——回落探测结果（null），恢复「端点不支持」提示
+  // lmstudio/generic: the engine's openai wire route is a no-op for reasoning_effort,
+  // and knowledge-table tiers are likewise not offered — fall back to the probe result (null), restoring the "endpoint unsupported" notice
   assert.strictEqual(localReasoningTiers('kimi-k3', 'lmstudio'), null);
   assert.strictEqual(localReasoningTiers('gpt-oss-120b', 'generic'), null);
-  // noControl 在 lmstudio/generic 同样为 null（提示逻辑不变）
+  // noControl on lmstudio/generic is likewise null (notice logic unchanged)
   assert.strictEqual(localReasoningTiers('deepseek-r1:14b', 'generic'), null);
-  // 未命中知识表 → 按探测结果下发
+  // no knowledge-table match → apply the probed tiers as-is
   assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'ollama')], ['off', 'high']);
   assert.deepStrictEqual([...localReasoningTiers('qwen3-32b', 'llamacpp')], ['off', 'low', 'medium', 'high']);
   assert.strictEqual(localReasoningTiers('qwen3-32b', 'generic'), null);

--- a/pinvou3-app/tests/settings_ui_smoke.js
+++ b/pinvou3-app/tests/settings_ui_smoke.js
@@ -1054,6 +1054,47 @@ async function modalWidth(page, headingText) {
   await clickExact(page, '取消');
   await sleep(200);
 
+  // noControl 模型（思考永开不可控，如 deepseek-r1）叠加在探测档位之上：探测
+  // 完成后档位区显示「思考始终开启」提示，而非档位按钮或「端点不支持」提示。
+  await clickExact(page, '添加模型');
+  await sleep(300);
+  await clickExact(page, '云端模型');
+  await sleep(150);
+  await clickExact(page, 'OpenAI Compatible');
+  await sleep(250);
+  const r1ModelInput = await page.evaluateHandle(() => {
+    const dialog = document.querySelector('[data-testid="model-form-dialog"]');
+    const label = dialog && [...dialog.querySelectorAll('label,span')].find(node => (node.textContent || '').trim() === '模型 ID');
+    const row = label && label.closest('div');
+    return row && row.querySelector('input');
+  });
+  await r1ModelInput.type('deepseek-r1:14b', { delay: 10 });
+  const r1BaseUrlInput = await page.evaluateHandle(() => {
+    const dialog = document.querySelector('[data-testid="model-form-dialog"]');
+    const label = dialog && [...dialog.querySelectorAll('label,span')].find(node => (node.textContent || '').trim() === 'API 地址');
+    const row = label && label.closest('div');
+    return row && row.querySelector('input');
+  });
+  await r1BaseUrlInput.type('http://127.0.0.1:8000/v1', { delay: 20 });
+  // 越过 400ms debounce，探测返回 null（mock 默认）→ 知识表 noControl 仍优先生效
+  await sleep(700);
+  const r1Effort = await page.evaluate(() => {
+    const dialog = document.querySelector('[data-testid="model-form-dialog"]');
+    const text = dialog ? dialog.innerText : '';
+    const effortRow = [...(dialog ? dialog.querySelectorAll('span') : [])].find(node => (node.textContent || '').trim() === '思考深度');
+    const buttons = effortRow && effortRow.parentElement ? [...effortRow.parentElement.querySelectorAll('button')].map(node => (node.textContent || '').trim()) : [];
+    return {
+      alwaysOnShown: text.includes('该模型思考始终开启，无法关闭'),
+      unsupportedHidden: !text.includes('该端点不支持思考档位调节'),
+      noTierButtons: buttons.length === 0,
+    };
+  });
+  rec('⑥.5e noControl 模型（deepseek-r1）本地路由显示「思考始终开启」提示，无档位按钮',
+    r1Effort.alwaysOnShown && r1Effort.unsupportedHidden && r1Effort.noTierButtons,
+    JSON.stringify(r1Effort));
+  await clickExact(page, '取消');
+  await sleep(200);
+
   await clickExact(page, '添加模型');
   await sleep(300);
   const cloudPickerWidth = await modalWidth(page, '添加模型');

--- a/pinvou3-app/tests/settings_ui_smoke.js
+++ b/pinvou3-app/tests/settings_ui_smoke.js
@@ -1054,8 +1054,10 @@ async function modalWidth(page, headingText) {
   await clickExact(page, '取消');
   await sleep(200);
 
-  // noControl 模型（思考永开不可控，如 deepseek-r1）叠加在探测档位之上：探测
-  // 完成后档位区显示「思考始终开启」提示，而非档位按钮或「端点不支持」提示。
+  // A noControl model (always-thinking and not controllable, e.g. deepseek-r1)
+  // takes precedence over the probed effort tier: after the probe completes, the
+  // effort tier area shows the "thinking always on" hint instead of tier buttons
+  // or the "endpoint not supported" hint.
   await clickExact(page, '添加模型');
   await sleep(300);
   await clickExact(page, '云端模型');
@@ -1076,7 +1078,8 @@ async function modalWidth(page, headingText) {
     return row && row.querySelector('input');
   });
   await r1BaseUrlInput.type('http://127.0.0.1:8000/v1', { delay: 20 });
-  // 越过 400ms debounce，探测返回 null（mock 默认）→ 知识表 noControl 仍优先生效
+  // Wait past the 400ms debounce; the probe returns null (mock default), so the
+  // knowledge table noControl entry still wins
   await sleep(700);
   const r1Effort = await page.evaluate(() => {
     const dialog = document.querySelector('[data-testid="model-form-dialog"]');
@@ -1089,7 +1092,7 @@ async function modalWidth(page, headingText) {
       noTierButtons: buttons.length === 0,
     };
   });
-  rec('⑥.5e noControl 模型（deepseek-r1）本地路由显示「思考始终开启」提示，无档位按钮',
+  rec('⑥.5e noControl model (deepseek-r1) local route shows "thinking always on" hint with no effort tier buttons',
     r1Effort.alwaysOnShown && r1Effort.unsupportedHidden && r1Effort.noTierButtons,
     JSON.stringify(r1Effort));
   await clickExact(page, '取消');


### PR DESCRIPTION
## What and why

Phase 2 of #218 (local model reasoning defaults). Two gaps are addressed:

1. **Local server detection coverage.** The probe chain only recognized Ollama, LM Studio, and vLLM. Investigation showed SGLang was not the only omission — llama.cpp (llama-server), KoboldCpp, LMDeploy, and Docker Model Runner are all widely used, detectable, and share vLLM's thinking-control wire.
2. **Models whose thinking cannot be disabled.** For always-thinking models (e.g. Kimi K3), defaulting to `off` sends a parameter the server will ignore or reject. These models now default to their lowest supported tier instead, and effort stays adjustable within the tiers the model actually accepts. If a deployment server reports that thinking can be disabled, the server wins — today no framework reports this, so a model knowledge table is the fallback.

## Changes

- `core/model_endpoint.rs`: all probe candidates now run in parallel via `tokio::join!` (worst case ~3s on a hung endpoint instead of ~24s serial), and five new server kinds are detected: SGLang (`/get_server_info`), llama.cpp (`/props`), KoboldCpp (`/api/extra/version`, ranked above llama.cpp since it also serves `/props`), LMDeploy (`/v1/models` `owned_by`, medium-confidence), Docker Model Runner (port-12434-gated `/models` management shape). TTL cache, in-flight coalescing, and no-caching-of-Generic semantics are unchanged.
- All five kinds map to the engine `vllm` provider (chat_template_kwargs + reasoning_effort passthrough, wire-compatible with these servers). **No CodeWhale fork change**: the base `sglang` provider is a DeepSeek-style hosted route and intentionally not used.
- New `core/always_thinking.rs` knowledge table (+ frontend mirror in `model-catalog.js`): on local routes, Kimi K3 / GLM-5.3 / GLM-4.7 expose `[low, high]` (the engine clamps `max` to `high`), GPT-OSS exposes `[low, medium, high]`; stored `off`/out-of-range/missing values normalize to the lowest tier in `request_reasoning_effort` (the single runtime authority). Kimi K2 Thinking family / DeepSeek R1 / Qwen3 Thinking variants / MiniMax M2 are uncontrollable: no thinking params are sent and the UI shows an always-on hint (zh/en/ja) instead of the unsupported-endpoint note.
- Ollama's bool-only `think` wire clamps always-on models to the single meaningful `high` tier on both the Rust and frontend sides.
- Cloud exact routes (moonshot/zai/minimax) are untouched.

## Tests run locally

- `cargo test -p pinvou3-tauri --lib`: 1818 passed; the 14 `features::marketplace` failures are a pre-existing environment issue (tests require a `python` binary; they pass with `PINVOU3_TEST_PYTHON=python3`, 222/222) and are unrelated to this diff.
- `cargo fmt --check`: clean. `./scripts/fork-guard.sh --fast` and `python3 scripts/architecture-guard.py`: pass.
- `npm run lint:ui`, `npm run build:ui`, `npm test` (505 pass, 0 fail), plus focused suites: `model_catalog_grouping` (52), `settings_ui_smoke` (71, incl. new always-on hint case).

## Known limitations / unverified

- Docker Model Runner's positive probe path is covered by a port-gating unit test plus a negative integration test only; a true positive requires binding port 12434 (CI-unsafe), so detection relies on the documented API shape.
- Detection signatures for the five new servers are based on official docs/source and issue reports, not yet exercised against live instances.
- Not adopted: TGI (in maintenance mode since 2025-12), MLX-LM / LocalAI / Xinference (no reliable detection signature) — these remain on the Generic fallback.
