### PR TITLE
feat(chat): add running background shell task indicator

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -61,6 +61,7 @@
     "test:session-management": "node tests/session_management_logic.test.mjs",
     "test:multiagent-plan": "node --test tests/multiagent_plan_normalize.test.mjs",
     "test:chat-input-limit": "node tests/chat_input_limit_logic.test.js",
+    "test:background-tasks": "node tests/background_tasks_logic.test.js",
     "test:ime-compose-guard": "node tests/ime_compose_guard.test.mjs",
     "test:assistant-message-actions": "node tests/assistant_message_actions.test.mjs",
     "test:chat-error-isolation": "node tests/chat_turn_error_isolation.test.mjs",

--- a/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
@@ -591,7 +591,14 @@ pub(crate) fn spawn_event_forwarder(
                         "agent_id": id,
                         "status": status,
                     });
-                    let _ = app.emit("multiagent:agent_progress", payload);
+                    // Web 端没有 chat:tool_start 的子智能体等价事件， bridge 靠该进展
+                    // 文本调度 shell 快照轮询（发现子 agent 的后台任务），必须转发。
+                    let _ = app.emit("multiagent:agent_progress", payload.clone());
+                    let _ = crate::features::remote_control::forward_app_event(
+                        &app,
+                        "multiagent:agent_progress",
+                        payload,
+                    );
                 }
                 // mailbox 信封同时维护 Shell scope 与通用子智能体审计。
                 Event::SubAgentMailbox { message, .. } => {
@@ -642,7 +649,13 @@ pub(crate) fn spawn_event_forwarder(
                                 "agent_id": agent_id,
                                 "status": format!("🔧 {tool_name} (step {step})"),
                             });
-                            let _ = app.emit("multiagent:agent_progress", payload);
+                            // 同 AgentProgress：Web 端靠它发现子 agent 的后台 shell 任务。
+                            let _ = app.emit("multiagent:agent_progress", payload.clone());
+                            let _ = crate::features::remote_control::forward_app_event(
+                                &app,
+                                "multiagent:agent_progress",
+                                payload,
+                            );
                         }
                         MM::Completed { agent_id, summary } => {
                             turn_shell_tasks.complete_agent(&agent_id);

--- a/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/remote_control/manager/mod.rs
@@ -201,6 +201,7 @@ const RUST_FORWARDED_EVENTS: &[&str] = &[
     "chat:usage",
     "chat:user_message",
     "chat:user_input_required",
+    "multiagent:agent_progress",
     "scheduled_task:run_updated",
     "session:deleted",
     "session:list_changed",
@@ -3552,6 +3553,8 @@ mod tests {
         assert!(RUST_FORWARDED_EVENTS.contains(&"session:model_changed"));
         assert!(policy.events.contains("session:persona_changed"));
         assert!(RUST_FORWARDED_EVENTS.contains(&"session:persona_changed"));
+        assert!(policy.events.contains("multiagent:agent_progress"));
+        assert!(RUST_FORWARDED_EVENTS.contains(&"multiagent:agent_progress"));
     }
 
     #[test]

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -46,6 +46,7 @@ import { ConversationAttachmentBubble } from '../attachments/ConversationAttachm
 import { splitAttachmentLine } from '../attachments/attachment-message.js';
 import { CHAT_INPUT_MAX_LENGTH, constrainChatInput } from './chat-input-limit.js';
 import { deriveRunningShellTasks, formatElapsedMs, tailOutputLines } from './background-tasks.js';
+import { useShellTaskCancel } from './shell-task-cancel.js';
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 // 重面板惰性化:ArtifactsPanel(design/产物场景才出现)与 SubagentTranscriptPanel
 // (专家卡点开才出现)各带一串专属依赖(design-runtime/EditableMarkdownPreview/
@@ -641,31 +642,35 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
     // 数据来自 bridge 轮询 reconcile 进 chatItems 的快照（terminal.js
     // applyShellSnapshots / markBackgroundToolItem），点击弹出列表可查看输出、取消任务。
     const BackgroundTaskRow = ({ task, t, chatCopy }) => {
-      const [cancelling, setCancelling] = useState(false);
-      const [cancelError, setCancelError] = useState('');
-      const cancel = async () => {
-        if (cancelling) return;
-        setCancelling(true);
-        setCancelError('');
-        try {
-          await bridge.chat.cancelShellTask(task.sessionId, task.taskId);
-        } catch (error) {
-          console.warn('cancel shell task failed', error);
-          setCancelError(`${t.shellCancelFailed || t.toolFailed}: ${String(error)}`);
-        } finally {
-          setCancelling(false);
-        }
-      };
+      const { cancelling, cancelError, cancel } = useShellTaskCancel(t);
+      // 计时基线：轮询 reconcile 只在有新输出时改卡片，安静任务的 elapsedMs
+      // 不会变化，走秒由指示器用"基线值 + 本地流逝"自推（每行一个 1s interval，
+      // 仅浮层展开时挂载）。不把秒级 tick 塞进全局 chatItems reconcile——那会让
+      // 整个 ChatView 在后台任务存续期间每秒重渲染一次（second-clock 曾因此
+      // 从 ChatView 顶层移走，见 LiveConversationActivityIndicator 上方注释）。
+      const [now, setNow] = useState(() => Date.now());
+      useEffect(() => {
+        const timer = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(timer);
+      }, []);
+      // 服务端 elapsedMs 变化（新输出触发 reconcile）时，渲染期同步换基线
+      // （React "adjust state when a prop changes" 模式）；基线时间戳直接用
+      // now 状态，保证渲染纯度。
+      const [elapsedBaseline, setElapsedBaseline] = useState(() => ({ elapsedMs: task.elapsedMs, at: now }));
+      if (elapsedBaseline.elapsedMs !== task.elapsedMs) {
+        setElapsedBaseline({ elapsedMs: task.elapsedMs, at: now });
+      }
+      const elapsedMs = elapsedBaseline.elapsedMs + Math.max(0, now - elapsedBaseline.at);
       const tail = tailOutputLines(task.output, 3);
       const lastLine = tailOutputLines(task.output, 1);
       return (
         <div className="px-3 py-2 hover:bg-black/[0.03] dark:hover:bg-white/[0.04]"
-          data-testid="bg-task-row" data-shell-task-id={task.taskId}>
+          data-testid="bg-task-row" data-bg-shell-task-id={task.taskId}>
           <div className="flex items-center gap-2 min-w-0">
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse shrink-0" />
             <span className={`flex-1 min-w-0 truncate font-mono text-[12px] ${'text-[#1F1F1F] dark:text-[#E3E3E3]'}`} title={task.command}>{task.command}</span>
-            <span className={`shrink-0 text-[11px] tabular-nums ${'text-[#85888D] dark:text-[#9AA0A6]'}`}>{formatElapsedMs(task.elapsedMs)}</span>
-            <button type="button" data-testid="cancel-shell-task" disabled={cancelling} onClick={cancel}
+            <span className={`shrink-0 text-[11px] tabular-nums ${'text-[#85888D] dark:text-[#9AA0A6]'}`}>{formatElapsedMs(elapsedMs)}</span>
+            <button type="button" data-testid="bg-cancel-shell-task" disabled={cancelling} onClick={() => cancel(task.sessionId, task.taskId)}
               aria-label={chatCopy.cancel} title={cancelling ? chatCopy.cancelling : chatCopy.cancel}
               className={`shrink-0 p-1 rounded-full disabled:opacity-50 transition-colors ${'text-[#85888D] hover:text-[#C5221F] hover:bg-black/5 dark:text-[#9AA0A6] dark:hover:text-[#F28B82] dark:hover:bg-white/10'}`}>
               <StopCircle size={14} />

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -4,7 +4,7 @@ import {
   invokeObservedPanelSelection,
   isSubagentPanelPublicationCurrent,
 } from './subagent-panel-publication.mjs';
-import { AlertTriangle, ArrowLeft, BarChart2, Brain, Briefcase, Check, ChevronDown, ChevronRight, ClipboardList, Copy, Edit2, FileText, Globe, ImageIcon, Mic, Monitor, Package, Paperclip, Presentation, Send, Sparkles, StopCircle, Trash2, Upload, X, Zap } from '../../components/icons.jsx';
+import { AlertTriangle, ArrowLeft, BarChart2, Brain, Briefcase, Check, ChevronDown, ChevronRight, ClipboardList, Copy, Edit2, FileText, Globe, ImageIcon, Mic, Monitor, Package, Paperclip, Presentation, Send, Sparkles, StopCircle, Terminal, Trash2, Upload, X, Zap } from '../../components/icons.jsx';
 import { bridge, activeModelIsLocal } from '../../hooks/useBridge.js';
 import { can, isWeb } from '../../shared/platform.js';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
@@ -12,7 +12,7 @@ import { getSyntaxHighlightVersion, subscribeSyntaxHighlight } from '../../share
 import { renderMarkdown } from '../../shared/markdown-renderer.js';
 import { AppIcon, DEPT_ORDER, deptLabelFor, personaText } from '../personas/persona-shared.jsx';
 import { ComposerModelSelector, ComposerToolMenu } from '../settings/composer-shared.jsx';
-import { ComposerPopover } from '../../components/ComposerPopover.jsx';
+import { ComposerPopover, POPOVER_SURFACE } from '../../components/ComposerPopover.jsx';
 import { PinvouLogo } from '../../components/PinvouLogo.jsx';
 import { ViewErrorBoundary } from '../../shared/ViewErrorBoundary.jsx';
 import { ArtifactCard, localizeTool, tsToolsData, tsToolWelcomeData } from '../tools/tool-common.jsx';
@@ -45,6 +45,7 @@ import { ComposerAttachmentDropOverlay } from '../attachments/ComposerAttachment
 import { ConversationAttachmentBubble } from '../attachments/ConversationAttachmentBubble.jsx';
 import { splitAttachmentLine } from '../attachments/attachment-message.js';
 import { CHAT_INPUT_MAX_LENGTH, constrainChatInput } from './chat-input-limit.js';
+import { deriveRunningShellTasks, formatElapsedMs, tailOutputLines } from './background-tasks.js';
 import { AssistantMessageActions, AssistantMessageFooter } from '../conversation/AssistantMessageActions.jsx';
 // 重面板惰性化:ArtifactsPanel(design/产物场景才出现)与 SubagentTranscriptPanel
 // (专家卡点开才出现)各带一串专属依赖(design-runtime/EditableMarkdownPreview/
@@ -636,6 +637,80 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
       );
     };
 
+    // 后台任务指示器（输入框上方"处理中"提示行右侧的蓝色胶囊）：仅当前会话有运行中后台 shell 任务时渲染。
+    // 数据来自 bridge 轮询 reconcile 进 chatItems 的快照（terminal.js
+    // applyShellSnapshots / markBackgroundToolItem），点击弹出列表可查看输出、取消任务。
+    const BackgroundTaskRow = ({ task, t, chatCopy }) => {
+      const [cancelling, setCancelling] = useState(false);
+      const [cancelError, setCancelError] = useState('');
+      const cancel = async () => {
+        if (cancelling) return;
+        setCancelling(true);
+        setCancelError('');
+        try {
+          await bridge.chat.cancelShellTask(task.sessionId, task.taskId);
+        } catch (error) {
+          console.warn('cancel shell task failed', error);
+          setCancelError(`${t.shellCancelFailed || t.toolFailed}: ${String(error)}`);
+        } finally {
+          setCancelling(false);
+        }
+      };
+      const tail = tailOutputLines(task.output, 3);
+      const lastLine = tailOutputLines(task.output, 1);
+      return (
+        <div className="px-3 py-2 hover:bg-black/[0.03] dark:hover:bg-white/[0.04]"
+          data-testid="bg-task-row" data-shell-task-id={task.taskId}>
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse shrink-0" />
+            <span className={`flex-1 min-w-0 truncate font-mono text-[12px] ${'text-[#1F1F1F] dark:text-[#E3E3E3]'}`} title={task.command}>{task.command}</span>
+            <span className={`shrink-0 text-[11px] tabular-nums ${'text-[#85888D] dark:text-[#9AA0A6]'}`}>{formatElapsedMs(task.elapsedMs)}</span>
+            <button type="button" data-testid="cancel-shell-task" disabled={cancelling} onClick={cancel}
+              aria-label={chatCopy.cancel} title={cancelling ? chatCopy.cancelling : chatCopy.cancel}
+              className={`shrink-0 p-1 rounded-full disabled:opacity-50 transition-colors ${'text-[#85888D] hover:text-[#C5221F] hover:bg-black/5 dark:text-[#9AA0A6] dark:hover:text-[#F28B82] dark:hover:bg-white/10'}`}>
+              <StopCircle size={14} />
+            </button>
+          </div>
+          {lastLine && (
+            <div className={`mt-0.5 pl-3.5 truncate font-mono text-[11px] ${'text-[#9AA0A6] dark:text-[#6E7276]'}`} title={tail}>{lastLine}</div>
+          )}
+          {cancelError && (
+            <div className={`mt-1 ml-3.5 px-2 py-1 rounded-lg text-[11px] truncate ${'bg-red-50 text-[#C5221F] dark:bg-red-500/10 dark:text-[#F28B82]'}`} title={cancelError}>{cancelError}</div>
+          )}
+        </div>
+      );
+    };
+
+    const BackgroundTasksIndicator = ({ tasks, t, chatCopy }) => {
+      const [open, setOpen] = useState(false);
+      const [prevTaskCount, setPrevTaskCount] = useState(tasks.length);
+      const triggerRef = useRef(null);
+      // 任务全部结束时自动收起，避免浮层停留在空列表（渲染期间同步调整 state）。
+      if (prevTaskCount !== tasks.length) {
+        setPrevTaskCount(tasks.length);
+        if (tasks.length === 0) setOpen(false);
+      }
+      if (tasks.length === 0) return null;
+      return (
+        <div className="relative pointer-events-auto">
+          <button type="button" ref={triggerRef} data-testid="chat-bg-tasks-entry"
+            onClick={() => setOpen(value => !value)}
+            aria-label={chatCopy.bgTasks} title={chatCopy.bgTasks}
+            className={`h-6 px-2.5 rounded-full text-[11px] font-medium flex items-center gap-1.5 whitespace-nowrap shrink-0 ${'bg-[#E8F0FE] text-[#1967D2] hover:bg-[#D2E3FC] dark:bg-[#A8C7FA] dark:text-[#062E6F] dark:hover:bg-[#8FB8F8]'}`}>
+            <Terminal size={12} /> <span>{chatCopy.bgTasks}</span>
+            <span className={`px-1 rounded-full text-[10px] ${'bg-white/70 dark:bg-black/15'}`}>{tasks.length}</span>
+          </button>
+          <ComposerPopover open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} compact={false}
+            desktopClassName={`absolute bottom-full left-0 mb-2 z-50 w-[360px] max-w-[calc(100vw-24px)] max-h-[420px] overflow-y-auto ${POPOVER_SURFACE}`}>
+            <div className={`px-3 py-2 text-[12px] font-medium ${'text-[#85888D] dark:text-[#9AA0A6]'}`}>{chatCopy.bgTasksRunning(tasks.length)}</div>
+            <div className={`divide-y ${'divide-black/5 dark:divide-white/5'}`}>
+              {tasks.map(task => <BackgroundTaskRow key={task.taskId} task={task} t={t} chatCopy={chatCopy} />)}
+            </div>
+          </ComposerPopover>
+        </div>
+      );
+    };
+
     // eslint-disable-next-line sonarjs/cognitive-complexity -- legacy main view: session/mode/artifact/browser state is highly cohesive; split refactor tracked separately
     const ChatView = ({ theme, t, bs, prefill, prefillAppend = false, focusComposerTick = 0, onPrefillConsumed, onOpenEditor, justInstalledTool, setJustInstalledTool, onGotoSettings, onGotoModelSettings, onGotoTools, onBackScheduledRun, codeModeAvailable = false, onSwitchHomeMode, browserDockAvailable = false, browserDockOpen = false, rightDockActivePanelId = null, onRightDockPanelSelectionChange, onOpenBrowserDock }) => {
       const chatCopy = t.uiChat;
@@ -779,6 +854,9 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
       const artifactItems = (bs && bs.artifacts) || [];
       const artifactCount = artifactItems.length;
       const latestArtifact = artifactItems[artifactItems.length - 1] || null;
+      // 当前会话仍在运行的后台 shell 任务（编译、下载等），驱动输入框上方的胶囊指示器。
+      // chatItems 只含当前会话条目，且由 bridge 轮询保持新鲜，直接派生即可。
+      const runningShellTasks = deriveRunningShellTasks(chatItems);
       const conversationStarted = chatItems.some(item => item && item.type === 'user') || artifactCount > 0;
       const pinvouMode = pinvouModeState.mode;
       const workSubtab = pinvouModeState.workSubtab;
@@ -2429,12 +2507,15 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
                   clearLabel={sceneCopy.clear(activeScene.label)}
                 />
               )}
-              <LiveConversationActivityIndicator
-                turn={activeConversationTurn}
-                onRequestAttention={scrollChatToBottom}
-                className="mb-0.5"
-                copy={t.uiConversation}
-              />
+              <div className="flex items-center gap-2 mb-0.5">
+                <LiveConversationActivityIndicator
+                  turn={activeConversationTurn}
+                  onRequestAttention={scrollChatToBottom}
+                  copy={t.uiConversation}
+                />
+                {/* 后台 shell 任务胶囊：跟随"处理中"提示行，任务存续期间常驻（轮次结束后仍运行时也保留入口） */}
+                <BackgroundTasksIndicator tasks={runningShellTasks} t={t} chatCopy={chatCopy} />
+              </div>
               {isMultiAgentReadOnly ? (
                 <div
                   role="note"

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -686,7 +686,7 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
       );
     };
 
-    const BackgroundTasksIndicator = ({ tasks, t, chatCopy }) => {
+    const BackgroundTasksIndicator = ({ tasks, t, chatCopy, compact }) => {
       const [open, setOpen] = useState(false);
       const [prevTaskCount, setPrevTaskCount] = useState(tasks.length);
       const triggerRef = useRef(null);
@@ -705,7 +705,8 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
             <Terminal size={12} /> <span>{chatCopy.bgTasks}</span>
             <span className={`px-1 rounded-full text-[10px] ${'bg-white/70 dark:bg-black/15'}`}>{tasks.length}</span>
           </button>
-          <ComposerPopover open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} compact={false}
+          {/* compact 跟随其他输入框弹层的视口契约：窄屏/移动 WebUI 走 portal 锚定路径 */}
+          <ComposerPopover open={open} onClose={() => setOpen(false)} triggerRef={triggerRef} compact={compact}
             desktopClassName={`absolute bottom-full left-0 mb-2 z-50 w-[360px] max-w-[calc(100vw-24px)] max-h-[420px] overflow-y-auto ${POPOVER_SURFACE}`}>
             <div className={`px-3 py-2 text-[12px] font-medium ${'text-[#85888D] dark:text-[#9AA0A6]'}`}>{chatCopy.bgTasksRunning(tasks.length)}</div>
             <div className={`divide-y ${'divide-black/5 dark:divide-white/5'}`}>
@@ -2519,7 +2520,7 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
                   copy={t.uiConversation}
                 />
                 {/* 后台 shell 任务胶囊：跟随"处理中"提示行，任务存续期间常驻（轮次结束后仍运行时也保留入口） */}
-                <BackgroundTasksIndicator tasks={runningShellTasks} t={t} chatCopy={chatCopy} />
+                <BackgroundTasksIndicator tasks={runningShellTasks} t={t} chatCopy={chatCopy} compact={composerCompact} />
               </div>
               {isMultiAgentReadOnly ? (
                 <div

--- a/pinvou3-app/src/features/chat/background-tasks.js
+++ b/pinvou3-app/src/features/chat/background-tasks.js
@@ -1,0 +1,55 @@
+// 会话内后台 shell 任务指示器的纯逻辑：从 chatItems 派生当前会话仍在运行的
+// 后台任务列表。抽成独立模块以便 node:test 直接单测
+// （见 tests/background_tasks_logic.test.js）。
+
+const COMMAND_SUMMARY_MAX = 80;
+
+// 后台 shell 任务在 chatItems 里的形态（terminal.js 的 applyShellSnapshots 与
+// markBackgroundToolItem 写入）：type='tool'、带 taskId、state='running'；
+// 子 agent 启动的 detached job 由轮询补建 shellSnapshot 卡，同样命中该过滤。
+function isRunningShellTaskItem(item) {
+  return Boolean(item && item.type === 'tool' && item.taskId && item.state === 'running');
+}
+
+function summarizeCommand(command) {
+  const text = String(command ?? '').trim();
+  if (text.length <= COMMAND_SUMMARY_MAX) return text;
+  return `${text.slice(0, COMMAND_SUMMARY_MAX)}…`;
+}
+
+// chatItems 是当前会话的工作集（切会话时整体换入换出），无需再按 sessionId 过滤。
+function deriveRunningShellTasks(chatItems) {
+  if (!Array.isArray(chatItems)) return [];
+  return chatItems.filter(isRunningShellTaskItem).map(item => ({
+    taskId: item.taskId,
+    sessionId: item.sessionId,
+    command: summarizeCommand(item.args && item.args.command),
+    elapsedMs: typeof item.elapsedMs === 'number' ? item.elapsedMs : 0,
+    output: typeof item.output === 'string' ? item.output : '',
+  }));
+}
+
+// 耗时格式化：秒级以下显示秒，分钟级显示 "Xm Ys"，更长显示 "Xh Ym"。
+function formatElapsedMs(ms) {
+  const totalSeconds = Math.max(0, Math.floor((Number(ms) || 0) / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+// 输出 tail：取最后 n 行（空行不计），供指示器浮层展示。
+function tailOutputLines(output, lineCount = 3) {
+  const lines = String(output ?? '').split('\n').filter(line => line.trim() !== '');
+  return lines.slice(-Math.max(1, lineCount)).join('\n');
+}
+
+export {
+  COMMAND_SUMMARY_MAX,
+  deriveRunningShellTasks,
+  formatElapsedMs,
+  isRunningShellTaskItem,
+  tailOutputLines,
+};

--- a/pinvou3-app/src/features/chat/background-tasks.js
+++ b/pinvou3-app/src/features/chat/background-tasks.js
@@ -4,11 +4,14 @@
 
 const COMMAND_SUMMARY_MAX = 80;
 
-// 后台 shell 任务在 chatItems 里的形态（terminal.js 的 applyShellSnapshots 与
-// markBackgroundToolItem 写入）：type='tool'、带 taskId、state='running'；
-// 子 agent 启动的 detached job 由轮询补建 shellSnapshot 卡，同样命中该过滤。
+// 后台 shell 任务在 chatItems 里的形态：type='tool'、带 taskId、state='running'，
+// 且必须带后台标记 —— background 由 markBackgroundToolItem（桌面端 backgrounded
+// 快速通道）和 tool_end 的 backgrounded 元数据写入，shellSnapshot 由轮询为子 agent
+// detached job 补建卡时写入。前台 shell 卡也会被 applyShellSnapshots 的命令匹配
+// 回退挂上 taskId，但没有这两个标记；指示器若不区分，会把前台命令误标成"后台任务"。
 function isRunningShellTaskItem(item) {
-  return Boolean(item && item.type === 'tool' && item.taskId && item.state === 'running');
+  return Boolean(item && item.type === 'tool' && item.taskId && item.state === 'running' &&
+    (item.background || item.shellSnapshot));
 }
 
 function summarizeCommand(command) {

--- a/pinvou3-app/src/features/chat/background-tasks.js
+++ b/pinvou3-app/src/features/chat/background-tasks.js
@@ -21,9 +21,17 @@ function summarizeCommand(command) {
 }
 
 // chatItems 是当前会话的工作集（切会话时整体换入换出），无需再按 sessionId 过滤。
+// 同一 taskId 可能短暂出现两张运行中卡片：轮询为命令匹配失败的任务补建了快照卡，
+// 随后 tool_end 快速通道又给原卡打上 background 标记，快照卡要等 tool_end 才被剪掉。
+// 按 taskId 去重，先出现的原卡（真实命令参数）优先。
 function deriveRunningShellTasks(chatItems) {
   if (!Array.isArray(chatItems)) return [];
-  return chatItems.filter(isRunningShellTaskItem).map(item => ({
+  const seenTaskIds = new Set();
+  return chatItems.filter(item => {
+    if (!isRunningShellTaskItem(item) || seenTaskIds.has(item.taskId)) return false;
+    seenTaskIds.add(item.taskId);
+    return true;
+  }).map(item => ({
     taskId: item.taskId,
     sessionId: item.sessionId,
     command: summarizeCommand(item.args && item.args.command),

--- a/pinvou3-app/src/features/chat/shell-task-cancel.js
+++ b/pinvou3-app/src/features/chat/shell-task-cancel.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { bridge } from '../../hooks/useBridge.js';
+
+// 取消后台 shell 任务的共享状态机：会话里的 shell ToolCard（features/tools/
+// tool-renderers.jsx）与后台任务指示器（ChatView 的浮层行）走同一个
+// bridge.chat.cancelShellTask 调用、同一套 cancelling 防抖与 i18n 错误文案，
+// 抽在这里避免两处各写一份。
+export function useShellTaskCancel(t) {
+  const [cancelling, setCancelling] = useState(false);
+  const [cancelError, setCancelError] = useState('');
+  const cancel = async (sessionId, taskId) => {
+    if (!taskId || cancelling) return;
+    setCancelling(true);
+    setCancelError('');
+    try {
+      await bridge.chat.cancelShellTask(sessionId, taskId);
+    } catch (error) {
+      console.warn('cancel shell task failed', error);
+      setCancelError(`${t.shellCancelFailed || t.toolFailed}: ${String(error)}`);
+    } finally {
+      setCancelling(false);
+    }
+  };
+  return { cancelling, cancelError, cancel };
+}

--- a/pinvou3-app/src/features/tools/tool-renderers.jsx
+++ b/pinvou3-app/src/features/tools/tool-renderers.jsx
@@ -12,6 +12,7 @@ import {
 } from '../multiagent/subagent-conversation.mjs';
 import { AppIcon } from '../personas/persona-shared.jsx';
 import { QuestionChoiceCard } from '../conversation/QuestionChoiceCard.jsx';
+import { useShellTaskCancel } from '../chat/shell-task-cancel.js';
 import { AcShieldCheck, AcSparkles, DiffView, GrepView, ListDirView, OutputError, OutputPre, ReceiptBlock, ShellTextView, ShellView, StockQuoteCard, TODO_TOOLS, TodoView, WeatherCard, isQuietTool, isReceipt, isStockQuoteTool, isWeatherTool, looksDiff, toolSummary, tryParseJson, tryTailJson } from './tool-common.jsx';
 
 const isShellExecutionTool = name => [
@@ -563,9 +564,7 @@ const ToolOutput = ({ item, t }) => {
       const isTimeline = variant === 'timeline';
       const isRunning = item.state === 'running';
       // eslint-disable-next-line react-hooks/rules-of-hooks -- the early-return branch is constant for an instance's lifetime (see the comment above); the per-instance Hook count is stable
-      const [cancelling, setCancelling] = useState(false);
-      // eslint-disable-next-line react-hooks/rules-of-hooks -- same as above
-      const [shellCancelError, setShellCancelError] = useState('');
+      const { cancelling, cancelError: shellCancelError, cancel: cancelShellTask } = useShellTaskCancel(t);
       // 有可视化卡片的工具(天气/股票)完成后直接展开,不折叠
       const hasCard = (isWeatherTool(item.name) || isStockQuoteTool(item.name)) && item.state === 'done';
       const hasLiveShellOutput = isShellExecutionTool(item.name)
@@ -602,19 +601,9 @@ const ToolOutput = ({ item, t }) => {
             : t.uiToolRender.failed
           : `${isDone ? t.uiToolRender.done : t.uiToolRender.failed} · exit ${item.exitCode}`;
       const mutedColor = 'text-[#757575] dark:text-[#8E8E8E]';
-      const cancelBackground = async (event) => {
+      const cancelBackground = (event) => {
         event.stopPropagation();
-        if (!item.taskId || cancelling) return;
-        setCancelling(true);
-        setShellCancelError('');
-        try {
-          await bridge.chat.cancelShellTask(item.sessionId, item.taskId);
-        } catch (error) {
-          console.warn('cancel shell task failed', error);
-          setShellCancelError(`${t.shellCancelFailed || t.toolFailed}: ${String(error)}`);
-        } finally {
-          setCancelling(false);
-        }
+        cancelShellTask(item.sessionId, item.taskId);
       };
       const cancelButton = item.taskId && isRunning ? (
         <button

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -2049,6 +2049,7 @@
   const terminalFeature = installBridgeFeature("terminal", { state, notify, invoke, bt, runSyncOnSession, addChatItem });
   const updateToolItem = terminalFeature.updateToolItem;
   const isShellExecutionTool = terminalFeature.isShellExecutionTool;
+  const mentionsShellTool = terminalFeature.mentionsShellTool;
   const scheduleShellPoll = terminalFeature.scheduleShellPoll;
   const scheduleShellNotify = terminalFeature.scheduleShellNotify;
   const markBackgroundToolItem = terminalFeature.markBackgroundToolItem;
@@ -2140,6 +2141,7 @@
     composePlanMarkdown,
     refreshHistoryList,
     isShellExecutionTool,
+    mentionsShellTool,
     scheduleShellPoll,
     appendToolItemOutput,
     scheduleShellNotify,

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -227,6 +227,7 @@
     const composePlanMarkdown = context.composePlanMarkdown;
     const refreshHistoryList = context.refreshHistoryList;
     const isShellExecutionTool = context.isShellExecutionTool;
+    const mentionsShellTool = context.mentionsShellTool;
     const scheduleShellPoll = context.scheduleShellPoll;
     const appendToolItemOutput = context.appendToolItemOutput;
     const scheduleShellNotify = context.scheduleShellNotify;
@@ -706,6 +707,17 @@
     scheduleShellNotify();
   }); });
 
+  // 子智能体不产生 chat:tool_start/chat:tool_end（forwarder 只转发 mailbox 进展），
+  // 它启动的后台 shell 任务若无人调度轮询，就要等到会话切换或顶层 shell 调用
+  // 才会被 applyShellSnapshots 发现。从进展文本认出 shell 工具即补一次调度；
+  // 轮询自身会在没有运行中任务时自停，不会常驻。
+  listen("multiagent:agent_progress", function (e) {
+    const p = e.payload || {};
+    if (p.session_id && mentionsShellTool(p.status)) {
+      scheduleShellPoll(p.session_id, true);
+    }
+  });
+
   // eslint-disable-next-line sonarjs/cognitive-complexity -- legacy bridge; refactor tracked separately
   listen("chat:tool_end", function (e) { onSessionEvent(e, function () {
     const p = e.payload || {};
@@ -808,6 +820,10 @@
       }
       updatedToolItem.taskId = shellTaskId;
       updatedToolItem.sessionId = p.session_id || state.activeSessionId;
+      // 通用路径也可能承载后台 shell 任务（未走上方 backgrounded 快速通道的平台/分支）：
+      // 补上 background 标记，供后台任务指示器区分"真后台"与被轮询命令匹配回退
+      // 挂上 taskId 的前台卡。
+      if (p.metadata && p.metadata.backgrounded === true) updatedToolItem.background = true;
       const shellStatus = String((p.metadata && p.metadata.status) || "").toLowerCase();
       if (shellStatus === "running" || /running|background/i.test(String(p.output || ""))) {
         updatedToolItem.state = "running";

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -26,8 +26,18 @@
     return null;
   }
 
+  const SHELL_TOOL_NAMES = ["exec_shell", "exec_shell_wait", "exec_wait", "task_shell_start", "task_shell_wait", "shell", "Bash"];
+
   function isShellExecutionTool(name) {
-    return ["exec_shell", "exec_shell_wait", "exec_wait", "task_shell_start", "task_shell_wait", "shell", "Bash"].includes(name);
+    return SHELL_TOOL_NAMES.includes(name);
+  }
+
+  function mentionsShellTool(text) {
+    // 子智能体的工具调用不产生 chat:tool_start（forwarder 只把 Mailbox 的
+    // ToolCallStarted 转成 multiagent:agent_progress），只能从进展文本里认出
+    // shell 工具并借此调度快照轮询。status 形如 "🔧 exec_shell (step 3)"。
+    const raw = String(text || "");
+    return SHELL_TOOL_NAMES.some((name) => raw.includes(name));
   }
 
   function utf8Length(text) {
@@ -70,9 +80,6 @@
     return JSON.stringify([
       job.id, job.status, job.exit_code, job.stdout_len, job.stderr_len,
       job.stdout_tail, job.stderr_tail,
-      // elapsed_ms 按秒分桶进 key：无输出的安静任务（sleep、编译静默期）也能让
-      // 卡片每秒刷新一次耗时，而不是等到有输出才更新（否则指示器读秒恒为 0s）。
-      Math.floor((Number(job.elapsed_ms) || 0) / 1000),
     ]);
   }
 
@@ -453,6 +460,7 @@
     return {
       updateToolItem,
       isShellExecutionTool,
+      mentionsShellTool,
       utf8Length,
       formatShellSnapshot,
       shellCommandForItem,

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -70,6 +70,9 @@
     return JSON.stringify([
       job.id, job.status, job.exit_code, job.stdout_len, job.stderr_len,
       job.stdout_tail, job.stderr_tail,
+      // elapsed_ms 按秒分桶进 key：无输出的安静任务（sleep、编译静默期）也能让
+      // 卡片每秒刷新一次耗时，而不是等到有输出才更新（否则指示器读秒恒为 0s）。
+      Math.floor((Number(job.elapsed_ms) || 0) / 1000),
     ]);
   }
 

--- a/pinvou3-app/src/platform/web/access-policy.json
+++ b/pinvou3-app/src/platform/web/access-policy.json
@@ -184,6 +184,7 @@
     "chat:usage",
     "chat:user_message",
     "chat:user_input_required",
+    "multiagent:agent_progress",
     "scheduled_task:run_updated",
     "session:deleted",
     "session:list_changed",

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4335,6 +4335,9 @@
     return JSON.stringify([
       job.id, job.status, job.exit_code, job.stdout_len, job.stderr_len,
       job.stdout_tail, job.stderr_tail,
+      // elapsed_ms 按秒分桶进 key：无输出的安静任务（sleep、编译静默期）也能让
+      // 卡片每秒刷新一次耗时，而不是等到有输出才更新（否则指示器读秒恒为 0s）。
+      Math.floor((Number(job.elapsed_ms) || 0) / 1000),
     ]);
   }
 

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4270,8 +4270,19 @@
     return null;
   }
 
+  const SHELL_TOOL_NAMES = ["exec_shell", "task_shell_start", "shell", "Bash"];
+
   function isShellExecutionTool(name) {
-    return ["exec_shell", "task_shell_start", "shell", "Bash"].includes(name);
+    return SHELL_TOOL_NAMES.includes(name);
+  }
+
+  function mentionsShellTool(text) {
+    // 子智能体的工具调用不产生 chat:tool_start，forwarder 把 mailbox 的
+    // ToolCallStarted 转成 multiagent:agent_progress（status 形如
+    // "🔧 exec_shell (step 3)"）。据此调度快照轮询，让子 agent 的后台
+    // shell 任务被 applyShellSnapshots 发现。
+    const raw = String(text || "");
+    return SHELL_TOOL_NAMES.some((name) => raw.includes(name));
   }
 
   function utf8Length(text) {
@@ -4335,9 +4346,6 @@
     return JSON.stringify([
       job.id, job.status, job.exit_code, job.stdout_len, job.stderr_len,
       job.stdout_tail, job.stderr_tail,
-      // elapsed_ms 按秒分桶进 key：无输出的安静任务（sleep、编译静默期）也能让
-      // 卡片每秒刷新一次耗时，而不是等到有输出才更新（否则指示器读秒恒为 0s）。
-      Math.floor((Number(job.elapsed_ms) || 0) / 1000),
     ]);
   }
 
@@ -5890,6 +5898,17 @@
     return fallbackPath;
   }
 
+  // 子智能体不产生 chat:tool_start/chat:tool_end（forwarder 只转发 mailbox 进展），
+  // 它启动的后台 shell 任务若无人调度轮询，就要等到会话切换或顶层 shell 调用
+  // 才会被 applyShellSnapshots 发现。从进展文本认出 shell 工具即补一次调度；
+  // 轮询自身会在没有运行中任务时自停，不会常驻。
+  listen("multiagent:agent_progress", function (e) {
+    const p = e.payload || {};
+    if (p.session_id && mentionsShellTool(p.status)) {
+      scheduleShellPoll(p.session_id, true);
+    }
+  });
+
   listen("chat:tool_start", function (e) { onSessionEvent(e, function () {
     const p = e.payload || {};
     // Relay reconnects and the desktop event bridge may replay the last frame.
@@ -6034,6 +6053,9 @@
       }
       updatedToolItem.taskId = shellTaskId;
       updatedToolItem.sessionId = p.session_id || state.activeSessionId;
+      // 后台 shell 任务标记：供后台任务指示器区分"真后台"与被轮询命令匹配
+      // 回退挂上 taskId 的前台卡（桌面端 backgrounded 快速通道等价逻辑）。
+      if (p.metadata && p.metadata.backgrounded === true) updatedToolItem.background = true;
       const shellStatus = String((p.metadata && p.metadata.status) || "").toLowerCase();
       if (shellStatus === "running" || /running|background/i.test(String(p.output || ""))) {
         updatedToolItem.state = "running";

--- a/pinvou3-app/src/shared/i18n/en.js
+++ b/pinvou3-app/src/shared/i18n/en.js
@@ -965,3 +965,9 @@ dictEn.uiSettingsDetail.customModelTitles = {
   openai_compatible:'Custom compatible model', glm_coding_plan:'Custom GLM Coding Plan model',
   tencent_coding_plan:'Custom Tencent Cloud Coding Plan model', tencent_token_plan:'Custom Tencent Cloud Token Plan model', kimi_coding_plan:'Custom Kimi Coding Plan model',
 };
+
+// features/chat background task indicator entries (uiChat exists, merge instead of overwrite)
+Object.assign(dictEn.uiChat, {
+  bgTasks: 'Background Tasks',
+  bgTasksRunning: n => `${n} background task${n === 1 ? '' : 's'} running`,
+});

--- a/pinvou3-app/src/shared/i18n/ja.js
+++ b/pinvou3-app/src/shared/i18n/ja.js
@@ -967,3 +967,9 @@ dictJa.uiSettingsDetail.customModelTitles = {
   openai_compatible:'カスタム互換モデル', glm_coding_plan:'カスタム GLM Coding Plan モデル',
   tencent_coding_plan:'カスタム Tencent Cloud Coding Plan モデル', tencent_token_plan:'カスタム Tencent Cloud Token Plan モデル', kimi_coding_plan:'カスタム Kimi Coding Plan モデル',
 };
+
+// features/chat バックグラウンドタスク表示の辞書項目（uiChat は既存のためマージ）
+Object.assign(dictJa.uiChat, {
+  bgTasks: 'バックグラウンドタスク',
+  bgTasksRunning: n => `${n} 件のバックグラウンドタスク実行中`,
+});

--- a/pinvou3-app/src/shared/i18n/zh.js
+++ b/pinvou3-app/src/shared/i18n/zh.js
@@ -950,3 +950,9 @@ dictZh.uiSettingsDetail.customModelTitles = {
   openai_compatible:'自定义兼容模型', glm_coding_plan:'自定义 GLM Coding Plan 模型',
   tencent_coding_plan:'自定义腾讯云 Coding Plan 模型', tencent_token_plan:'自定义腾讯云 Token Plan 模型', kimi_coding_plan:'自定义 Kimi Coding Plan 模型',
 };
+
+// features/chat 后台任务指示器词条（uiChat 已存在，合并而非覆盖）
+Object.assign(dictZh.uiChat, {
+  bgTasks: '后台任务',
+  bgTasksRunning: n => `${n} 个后台任务运行中`,
+});

--- a/pinvou3-app/tests/background_tasks_logic.test.js
+++ b/pinvou3-app/tests/background_tasks_logic.test.js
@@ -20,18 +20,22 @@ vm.runInContext(
 
 const { COMMAND_SUMMARY_MAX, deriveRunningShellTasks, formatElapsedMs, tailOutputLines } = context;
 
-// deriveRunningShellTasks：只保留带 taskId 且 running 的 tool 卡
+// deriveRunningShellTasks：只保留带后台标记（background / shellSnapshot）、
+// taskId 且 running 的 tool 卡
 const items = [
   // 轮询补建的 shell 快照卡（子 agent detached job）
-  { type: 'tool', toolId: 'shell-task:job-1', name: 'exec_shell', taskId: 'job-1', sessionId: 's1', state: 'running', args: { command: 'cargo build' }, elapsedMs: 61000, output: 'line1\nline2' },
+  { type: 'tool', toolId: 'shell-task:job-1', name: 'exec_shell', taskId: 'job-1', sessionId: 's1', state: 'running', shellSnapshot: true, args: { command: 'cargo build' }, elapsedMs: 61000, output: 'line1\nline2' },
   // 被标记为后台的工具卡
   { type: 'tool', toolId: 'tool-2', name: 'exec_shell', taskId: 'job-2', sessionId: 's1', state: 'running', background: true, args: { command: 'npm run dev' }, elapsedMs: 5000 },
   // 已完成 → 排除
-  { type: 'tool', toolId: 'shell-task:job-3', name: 'exec_shell', taskId: 'job-3', sessionId: 's1', state: 'done', args: { command: 'ls' } },
+  { type: 'tool', toolId: 'shell-task:job-3', name: 'exec_shell', taskId: 'job-3', sessionId: 's1', state: 'done', shellSnapshot: true, args: { command: 'ls' } },
   // 失败 → 排除
-  { type: 'tool', toolId: 'shell-task:job-4', name: 'exec_shell', taskId: 'job-4', sessionId: 's1', state: 'failed', args: { command: 'make' } },
+  { type: 'tool', toolId: 'shell-task:job-4', name: 'exec_shell', taskId: 'job-4', sessionId: 's1', state: 'failed', shellSnapshot: true, args: { command: 'make' } },
   // 无 taskId 的前台工具卡 → 排除
   { type: 'tool', toolId: 'tool-5', name: 'exec_shell', state: 'running', args: { command: 'pwd' } },
+  // 前台工具卡被轮询的命令匹配回退挂上 taskId（无后台标记）→ 排除，
+  // 不能把前台命令误标成"后台任务"
+  { type: 'tool', toolId: 'tool-5b', name: 'exec_shell', taskId: 'job-5', sessionId: 's1', state: 'running', args: { command: 'sleep 30' } },
   // 非 tool 条目 → 排除
   { type: 'user', text: 'hi' },
   null,
@@ -51,7 +55,7 @@ assert.strictEqual(JSON.stringify(deriveRunningShellTasks()), '[]');
 // 超长命令截断
 const longCommand = 'x'.repeat(COMMAND_SUMMARY_MAX + 10);
 const [truncated] = deriveRunningShellTasks([
-  { type: 'tool', taskId: 'job-9', sessionId: 's1', state: 'running', args: { command: longCommand } },
+  { type: 'tool', taskId: 'job-9', sessionId: 's1', state: 'running', shellSnapshot: true, args: { command: longCommand } },
 ]);
 assert.strictEqual(truncated.command.length, COMMAND_SUMMARY_MAX + 1);
 assert.ok(truncated.command.endsWith('…'));

--- a/pinvou3-app/tests/background_tasks_logic.test.js
+++ b/pinvou3-app/tests/background_tasks_logic.test.js
@@ -52,6 +52,16 @@ assert.strictEqual(tasks[1].output, '');
 assert.strictEqual(JSON.stringify(deriveRunningShellTasks(null)), '[]');
 assert.strictEqual(JSON.stringify(deriveRunningShellTasks()), '[]');
 
+// 同一 taskId 的重复卡片（轮询快照卡 + tool_end 快速通道打标的原卡）只计一次，
+// 先出现的原卡（真实命令参数）优先
+const duplicated = deriveRunningShellTasks([
+  { type: 'tool', toolId: 'tool-dup-real', name: 'exec_shell', taskId: 'job-dup', sessionId: 's1', state: 'running', background: true, args: { command: 'real card' }, elapsedMs: 1000 },
+  { type: 'tool', toolId: 'shell-task:job-dup', name: 'exec_shell', taskId: 'job-dup', sessionId: 's1', state: 'running', shellSnapshot: true, args: { command: 'synthetic card' }, elapsedMs: 900 },
+]);
+assert.strictEqual(duplicated.length, 1);
+assert.strictEqual(duplicated[0].command, 'real card');
+assert.strictEqual(duplicated[0].taskId, 'job-dup');
+
 // 超长命令截断
 const longCommand = 'x'.repeat(COMMAND_SUMMARY_MAX + 10);
 const [truncated] = deriveRunningShellTasks([

--- a/pinvou3-app/tests/background_tasks_logic.test.js
+++ b/pinvou3-app/tests/background_tasks_logic.test.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// features/chat/background-tasks.js 的纯逻辑单测（vm 拼接执行，与
+// chat_input_limit_logic.test.js 同约定）。
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const logicPath = path.join(__dirname, '..', 'src', 'features', 'chat', 'background-tasks.js');
+const code = fs.readFileSync(logicPath, 'utf8')
+  .replace(/\bexport\s+\{[^}]+\};?/g, '')
+  .replace(/\bexport\s+/g, '');
+const context = {};
+vm.createContext(context);
+vm.runInContext(
+  `${code}\nthis.deriveRunningShellTasks = deriveRunningShellTasks; this.formatElapsedMs = formatElapsedMs; this.tailOutputLines = tailOutputLines; this.COMMAND_SUMMARY_MAX = COMMAND_SUMMARY_MAX;`,
+  context,
+  { filename: logicPath },
+);
+
+const { COMMAND_SUMMARY_MAX, deriveRunningShellTasks, formatElapsedMs, tailOutputLines } = context;
+
+// deriveRunningShellTasks：只保留带 taskId 且 running 的 tool 卡
+const items = [
+  // 轮询补建的 shell 快照卡（子 agent detached job）
+  { type: 'tool', toolId: 'shell-task:job-1', name: 'exec_shell', taskId: 'job-1', sessionId: 's1', state: 'running', args: { command: 'cargo build' }, elapsedMs: 61000, output: 'line1\nline2' },
+  // 被标记为后台的工具卡
+  { type: 'tool', toolId: 'tool-2', name: 'exec_shell', taskId: 'job-2', sessionId: 's1', state: 'running', background: true, args: { command: 'npm run dev' }, elapsedMs: 5000 },
+  // 已完成 → 排除
+  { type: 'tool', toolId: 'shell-task:job-3', name: 'exec_shell', taskId: 'job-3', sessionId: 's1', state: 'done', args: { command: 'ls' } },
+  // 失败 → 排除
+  { type: 'tool', toolId: 'shell-task:job-4', name: 'exec_shell', taskId: 'job-4', sessionId: 's1', state: 'failed', args: { command: 'make' } },
+  // 无 taskId 的前台工具卡 → 排除
+  { type: 'tool', toolId: 'tool-5', name: 'exec_shell', state: 'running', args: { command: 'pwd' } },
+  // 非 tool 条目 → 排除
+  { type: 'user', text: 'hi' },
+  null,
+  undefined,
+];
+const tasks = deriveRunningShellTasks(items);
+assert.deepStrictEqual(tasks.map(t => t.taskId), ['job-1', 'job-2']);
+assert.strictEqual(tasks[0].command, 'cargo build');
+assert.strictEqual(tasks[0].elapsedMs, 61000);
+assert.strictEqual(tasks[0].sessionId, 's1');
+assert.strictEqual(tasks[1].output, '');
+
+// 非数组输入安全返回空（vm realm 的数组原型不同，用 JSON 比较）
+assert.strictEqual(JSON.stringify(deriveRunningShellTasks(null)), '[]');
+assert.strictEqual(JSON.stringify(deriveRunningShellTasks()), '[]');
+
+// 超长命令截断
+const longCommand = 'x'.repeat(COMMAND_SUMMARY_MAX + 10);
+const [truncated] = deriveRunningShellTasks([
+  { type: 'tool', taskId: 'job-9', sessionId: 's1', state: 'running', args: { command: longCommand } },
+]);
+assert.strictEqual(truncated.command.length, COMMAND_SUMMARY_MAX + 1);
+assert.ok(truncated.command.endsWith('…'));
+
+// formatElapsedMs
+assert.strictEqual(formatElapsedMs(0), '0s');
+assert.strictEqual(formatElapsedMs(999), '0s');
+assert.strictEqual(formatElapsedMs(61000), '1m 1s');
+assert.strictEqual(formatElapsedMs(3723000), '1h 2m');
+assert.strictEqual(formatElapsedMs(NaN), '0s');
+
+// tailOutputLines：取最后 n 行、忽略空行
+assert.strictEqual(tailOutputLines('a\nb\nc\nd', 3), 'b\nc\nd');
+assert.strictEqual(tailOutputLines('a\n\nb\n', 3), 'a\nb');
+assert.strictEqual(tailOutputLines('', 3), '');
+assert.strictEqual(tailOutputLines(null, 3), '');
+assert.strictEqual(tailOutputLines('only', 3), 'only');
+
+console.log('background_tasks_logic.test.js: all assertions passed');

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -94,8 +94,11 @@ const expectedProtocolHashes = {
   // fallback's legacy-chip pre-check (chat-events.js) and the zap
   // skip-resend settlement helper (chat.js). And again for the steer
   // persistence alignment: the steered-messages sidecar save/get invokes
-  // (bridge.js) and the position-capture load_session (chat.js).
-  chat: 'f83e0858b9502bce460e46d8e7bd97326110cb62f87fc996ab470eec2baac808',
+  // (bridge.js) and the position-capture load_session (chat.js). And again
+  // for the background-task indicator: the multiagent:agent_progress listen
+  // that schedules the shell snapshot poll for sub-agent spawned tasks
+  // (chat-events.js).
+  chat: '610c1acd32faa210b9269052789340b992e9b6bfe96b8bb18ea69b046e8e6ffe',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',
   knowledge: '9105a42c6b69f04d0bc28b6a72e0746648110a44823891ded3261cdcbc99766b',


### PR DESCRIPTION
## What

Show a light-blue capsule next to the "processing" activity label above the composer while the current session still has background shell tasks running (compiles, downloads, detached jobs). The capsule carries the running-task count and stays visible after the turn ends, since background jobs often outlive the turn.

Clicking the capsule opens an upward popover listing one row per task: a pulsing status dot, the command (truncated), a ticking elapsed time, a one-line output tail (full tail on hover), and an icon-only cancel button wired to `bridge.chat.cancelShellTask`. Rows are divided, the list scrolls beyond 420px, and copy is provided in zh/en/ja.

## How

- Tasks are derived purely from `chatItems` snapshots reconciled by the bridge poll (`terminal.js` `applyShellSnapshots` / `markBackgroundToolItem`); no new event channel. Sub-agent detached jobs are covered because the poll materializes shell-snapshot cards for them.
- Elapsed time ticks locally per row: each row keeps a baseline from the last reconciled `elapsedMs` and adds local wall-clock drift, so quiet jobs (sleep, silent build phases) keep counting instead of showing a frozen `0s` until new output arrives. The tick lives in the popover rows only, so `ChatView` is not re-rendered every second while a task runs.
- Pure derivation/formatting logic lives in `features/chat/background-tasks.js` with `node:test` coverage (`tests/background_tasks_logic.test.js`, also auto-discovered by `npm test`).

## Out of scope / known gaps

- Code mode (`CodexAcpView`) has no indicator; its sessions flow over ACP rather than `chatItems`, so it needs a separate derivation if desired.
- No cross-session visibility and no completion toast yet; candidates for follow-ups.

## Testing

- `node tests/background_tasks_logic.test.js` passes (also via `node --test`).
- `eslint` clean on all touched files; `scripts/architecture-guard.py` passes.
- Verified live in `run-dev.sh`: capsule appears while a background task runs, popover lists/cancels tasks, elapsed time ticks for both output-producing and quiet commands.

## Review supplements

Follow-up commit from the review pass:

- Add `multiagent:agent_progress` to `RUST_FORWARDED_EVENTS` with the paired policy test assertions: the new access-policy entry made the desktop WebView proxy forward the event while the Rust forwarder also forwards it directly, so web clients received every progress event twice and both copies were journaled.
- Dedupe derived running tasks by `taskId`: a poll-materialized snapshot card and the real tool card can briefly coexist before `tool_end` splices the synthetic card.
- Pass the viewport-derived `composerCompact` into the indicator popover so narrow/mobile WebUI uses the same portal-anchored path as the sibling composer menus.
- Corrected the "How" section above: the snapshot-key `elapsed_ms` bucketing from the first commit was replaced by local per-row ticking in the harden commit.
