### PR TITLE
chore: close build/lint/perf debt follow-up sweep

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -114,7 +114,12 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: pinvou3-app/src-tauri
+          # The pinvou-knowledge:knowledge-host server builds cold in an isolated
+          # target dir; without a cache every release recompiles it from scratch
+          # (one of the three ELFs in the deb).
+          workspaces: |
+            pinvou3-app/src-tauri
+            pinvou-knowledge
           # jammy 后缀:runner 从 24.04 降到 22.04 时必须换 key,防止 24.04
           # glibc 环境编译的 target 产物被复用进 22.04 构建混入新符号引用。
           shared-key: release-linux-x64-jammy
@@ -230,7 +235,10 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: pinvou3-app/src-tauri
+          # Same as x64: also cache the pinvou-knowledge isolated target dir.
+          workspaces: |
+            pinvou3-app/src-tauri
+            pinvou-knowledge
           # jammy 后缀:同 x64,换 runner 基座后必须换 key 防止旧 glibc 产物混链。
           shared-key: release-linux-arm64-jammy
           # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 1.2GB+ 缓存。
@@ -453,7 +461,11 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: pinvou3-app/src-tauri
+          # Same as the Linux release job: also cache the pinvou-knowledge
+          # isolated target dir.
+          workspaces: |
+            pinvou3-app/src-tauri
+            pinvou-knowledge
           shared-key: release-macos-universal
           # 只在 main 保存(对齐 pr-check 的配额保护策略);PR 侧只读,不写 2GB+ 缓存。
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/pinvou-cli/crates/adapter-gaia/src/dataset.rs
+++ b/pinvou-cli/crates/adapter-gaia/src/dataset.rs
@@ -842,6 +842,54 @@ fn verify_attachment(
     }))
 }
 
+fn looks_absolute(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    Path::new(value).is_absolute()
+        || value.starts_with('/')
+        || value.starts_with('\\')
+        || (bytes.len() >= 2 && bytes[1] == b':')
+}
+
+fn ensure_no_link_components(root: &Path, relative: &Path) -> Result<(), GaiaDatasetError> {
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(GaiaDatasetError::AttachmentUnsafe);
+        };
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if is_link_or_reparse(&metadata) => {
+                return Err(GaiaDatasetError::AttachmentUnsafe);
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(GaiaDatasetError::AttachmentMissing);
+            }
+            Err(_) => return Err(GaiaDatasetError::AttachmentUnsafe),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn is_link_or_reparse(metadata: &Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    metadata.file_type().is_symlink()
+        || windows_attributes_indicate_reparse(metadata.file_attributes())
+}
+
+#[cfg(windows)]
+fn windows_attributes_indicate_reparse(attributes: u32) -> bool {
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+    attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn is_link_or_reparse(metadata: &Metadata) -> bool {
+    metadata.file_type().is_symlink()
+}
+
 #[cfg(test)]
 mod level_schema_contract_tests {
     use super::*;
@@ -933,54 +981,6 @@ mod level_schema_contract_tests {
         ));
         assert!(level_schema_result(group).is_err());
     }
-}
-
-fn looks_absolute(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    Path::new(value).is_absolute()
-        || value.starts_with('/')
-        || value.starts_with('\\')
-        || (bytes.len() >= 2 && bytes[1] == b':')
-}
-
-fn ensure_no_link_components(root: &Path, relative: &Path) -> Result<(), GaiaDatasetError> {
-    let mut current = root.to_path_buf();
-    for component in relative.components() {
-        let Component::Normal(component) = component else {
-            return Err(GaiaDatasetError::AttachmentUnsafe);
-        };
-        current.push(component);
-        match fs::symlink_metadata(&current) {
-            Ok(metadata) if is_link_or_reparse(&metadata) => {
-                return Err(GaiaDatasetError::AttachmentUnsafe);
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Err(GaiaDatasetError::AttachmentMissing);
-            }
-            Err(_) => return Err(GaiaDatasetError::AttachmentUnsafe),
-        }
-    }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn is_link_or_reparse(metadata: &Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt;
-
-    metadata.file_type().is_symlink()
-        || windows_attributes_indicate_reparse(metadata.file_attributes())
-}
-
-#[cfg(windows)]
-fn windows_attributes_indicate_reparse(attributes: u32) -> bool {
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
-    attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0
-}
-
-#[cfg(not(windows))]
-fn is_link_or_reparse(metadata: &Metadata) -> bool {
-    metadata.file_type().is_symlink()
 }
 
 #[cfg(all(test, windows))]

--- a/pinvou-cli/crates/adapter-gaia/src/fetch.rs
+++ b/pinvou-cli/crates/adapter-gaia/src/fetch.rs
@@ -364,14 +364,32 @@ impl fmt::Debug for SnapshotFileMetadata {
     }
 }
 
+/// Downloader failures deliberately carry no payload: the error channel is
+/// redacted so repository paths or digests never leak through it (same
+/// discipline as [`SnapshotFileMetadata`]'s Debug impl).
+///
+/// Internal helpers keep plumbing `Result<_, ()>`; `From<()>` adapts them at
+/// the public trait boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SnapshotFetchFailure;
+
+impl From<()> for SnapshotFetchFailure {
+    fn from((): ()) -> Self {
+        SnapshotFetchFailure
+    }
+}
+
 pub trait SnapshotDownloader: Send + Sync {
     fn preflight(
         &self,
         request: &SnapshotPreflightRequest<'_>,
-    ) -> Result<Vec<SnapshotFileMetadata>, ()>;
+    ) -> Result<Vec<SnapshotFileMetadata>, SnapshotFetchFailure>;
 
-    fn download(&self, request: &SnapshotDownloadRequest<'_>, destination: &Path)
-    -> Result<(), ()>;
+    fn download(
+        &self,
+        request: &SnapshotDownloadRequest<'_>,
+        destination: &Path,
+    ) -> Result<(), SnapshotFetchFailure>;
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -381,9 +399,9 @@ impl SnapshotDownloader for HfSnapshotDownloader {
     fn preflight(
         &self,
         request: &SnapshotPreflightRequest<'_>,
-    ) -> Result<Vec<SnapshotFileMetadata>, ()> {
+    ) -> Result<Vec<SnapshotFileMetadata>, SnapshotFetchFailure> {
         if request.repo_id != GAIA_REPO_ID || request.revision != GAIA_DATASET_REVISION {
-            return Err(());
+            return Err(SnapshotFetchFailure);
         }
         let repo = hf_repo(
             request.token,
@@ -394,16 +412,16 @@ impl SnapshotDownloader for HfSnapshotDownloader {
         let requested = request
             .remote_paths
             .iter()
-            .map(|path| path.to_str().ok_or(()).map(str::to_owned))
+            .map(|path| path.to_str().ok_or(SnapshotFetchFailure).map(str::to_owned))
             .collect::<Result<HashSet<_>, _>>()?;
         if requested.len() != request.remote_paths.len() {
-            return Err(());
+            return Err(SnapshotFetchFailure);
         }
         let response = repo
             .info_request()
             .query("blobs", "true")
             .call()
-            .map_err(|_| ())?;
+            .map_err(|_| SnapshotFetchFailure)?;
         Ok(parse_hf_metadata(response.into_reader(), &requested)?.siblings)
     }
 
@@ -411,9 +429,9 @@ impl SnapshotDownloader for HfSnapshotDownloader {
         &self,
         request: &SnapshotDownloadRequest<'_>,
         destination: &Path,
-    ) -> Result<(), ()> {
+    ) -> Result<(), SnapshotFetchFailure> {
         if request.repo_id != GAIA_REPO_ID || request.revision != GAIA_DATASET_REVISION {
-            return Err(());
+            return Err(SnapshotFetchFailure);
         }
         let repo = hf_repo(
             request.token,
@@ -424,7 +442,7 @@ impl SnapshotDownloader for HfSnapshotDownloader {
         if request.expected.remote_path() != Path::new(request.remote_path)
             || request.expected.size() > request.remaining_budget
         {
-            return Err(());
+            return Err(SnapshotFetchFailure);
         }
         let url = repo.url(request.remote_path);
         let response = ureq::AgentBuilder::new()
@@ -436,12 +454,12 @@ impl SnapshotDownloader for HfSnapshotDownloader {
                 &format!("Bearer {}", request.token.expose_to_backend()),
             )
             .call()
-            .map_err(|_| ())?;
+            .map_err(|_| SnapshotFetchFailure)?;
         let content_length = response
             .header("Content-Length")
-            .map(|value| value.parse::<u64>().map_err(|_| ()))
+            .map(|value| value.parse::<u64>().map_err(|_| SnapshotFetchFailure))
             .transpose()?;
-        let parent = destination.parent().ok_or(())?;
+        let parent = destination.parent().ok_or(SnapshotFetchFailure)?;
         create_private_parent_directories(parent)?;
         stream_verified_file(
             response.into_reader(),
@@ -449,8 +467,8 @@ impl SnapshotDownloader for HfSnapshotDownloader {
             destination,
             request.expected,
             request.remaining_budget,
-        )
-        .map(|_| ())
+        )?;
+        Ok(())
     }
 }
 
@@ -716,10 +734,10 @@ impl<D: SnapshotDownloader> GaiaSnapshotManager<D> {
         expected_digest: [u8; 32],
     ) -> Result<GaiaAcquisition, GaiaFetchError> {
         let ready_root = self.ready_root();
-        if ready_root.exists() {
-            if let Ok(ready) = self.verify_ready(&ready_root, expected_size, expected_digest) {
-                return Ok(ready);
-            }
+        if ready_root.exists()
+            && let Ok(ready) = self.verify_ready(&ready_root, expected_size, expected_digest)
+        {
+            return Ok(ready);
         }
 
         let _lock = AcquisitionLock::claim(&self.acquisition_root)?;
@@ -2206,16 +2224,16 @@ mod review_contract_tests {
         fn preflight(
             &self,
             _request: &SnapshotPreflightRequest<'_>,
-        ) -> Result<Vec<SnapshotFileMetadata>, ()> {
-            Err(())
+        ) -> Result<Vec<SnapshotFileMetadata>, SnapshotFetchFailure> {
+            Err(SnapshotFetchFailure)
         }
 
         fn download(
             &self,
             _request: &SnapshotDownloadRequest<'_>,
             _destination: &Path,
-        ) -> Result<(), ()> {
-            Err(())
+        ) -> Result<(), SnapshotFetchFailure> {
+            Err(SnapshotFetchFailure)
         }
     }
 
@@ -2322,7 +2340,7 @@ mod review_contract_tests {
     #[test]
     fn fetch_remote_budget_rejects_oversized_file_total_and_count_before_download() {
         assert!(validate_remote_budget(&[MAX_FILE_BYTES + 1]).is_err());
-        assert!(validate_remote_budget(&vec![MAX_FILE_BYTES; 13]).is_err());
+        assert!(validate_remote_budget(&[MAX_FILE_BYTES; 13]).is_err());
         assert!(validate_remote_budget(&vec![1; MAX_TRANSFER_FILES + 1]).is_err());
         assert!(validate_remote_budget(&[GAIA_PARQUET_SIZE, 20]).is_ok());
     }

--- a/pinvou-cli/crates/adapter-gaia/src/lib.rs
+++ b/pinvou-cli/crates/adapter-gaia/src/lib.rs
@@ -24,8 +24,8 @@ use benchmark_core::{
 pub use dataset::{GAIA_REVISION_MARKER, GaiaAttachment, GaiaDataset, GaiaDatasetError, GaiaRow};
 pub use fetch::{
     GAIA_READY_MARKER, GaiaAcquisition, GaiaFetchError, GaiaSnapshotManager, GaiaSource,
-    HfSnapshotDownloader, SnapshotDownloadRequest, SnapshotDownloader, SnapshotFileMetadata,
-    SnapshotPreflightRequest,
+    HfSnapshotDownloader, SnapshotDownloadRequest, SnapshotDownloader, SnapshotFetchFailure,
+    SnapshotFileMetadata, SnapshotPreflightRequest,
 };
 pub use private_inputs::GaiaPrivateInputs;
 pub use scorer::{GAIA_SCORER_RUNTIME_PROFILE, question_scorer};

--- a/pinvou-cli/crates/adapter-gaia/tests/fetch_contract.rs
+++ b/pinvou-cli/crates/adapter-gaia/tests/fetch_contract.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use adapter_gaia::{
     GaiaFetchError, GaiaSnapshotManager, GaiaSource, SnapshotDownloadRequest, SnapshotDownloader,
-    SnapshotFileMetadata, SnapshotPreflightRequest,
+    SnapshotFetchFailure, SnapshotFileMetadata, SnapshotPreflightRequest,
 };
 
 static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -46,16 +46,16 @@ impl SnapshotDownloader for DenyDownloader {
     fn preflight(
         &self,
         _request: &SnapshotPreflightRequest<'_>,
-    ) -> Result<Vec<SnapshotFileMetadata>, ()> {
-        Err(())
+    ) -> Result<Vec<SnapshotFileMetadata>, SnapshotFetchFailure> {
+        Err(SnapshotFetchFailure)
     }
 
     fn download(
         &self,
         _request: &SnapshotDownloadRequest<'_>,
         _destination: &Path,
-    ) -> Result<(), ()> {
-        Err(())
+    ) -> Result<(), SnapshotFetchFailure> {
+        Err(SnapshotFetchFailure)
     }
 }
 

--- a/pinvou-cli/crates/cli/src/lib.rs
+++ b/pinvou-cli/crates/cli/src/lib.rs
@@ -434,11 +434,11 @@ fn named_options<'a>(
     values: &'a [String],
     allowed: &[&str],
 ) -> Result<Vec<(&'a str, &'a str)>, CliError> {
-    if values.len() % 2 != 0 {
+    if !values.len().is_multiple_of(2) {
         return Err(CliError::usage("benchmark option requires a value"));
     }
     let mut parsed = Vec::new();
-    for pair in values.chunks_exact(2) {
+    for pair in values.as_chunks::<2>().0 {
         let name = pair[0].as_str();
         let value = pair[1].as_str();
         if !allowed.contains(&name)

--- a/pinvou3-app/scripts/tauri/knowledge-host.js
+++ b/pinvou3-app/scripts/tauri/knowledge-host.js
@@ -7,6 +7,7 @@ const {
   writeFileSync,
 } = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 const { APP_ROOT } = require('./platform-config.js');
 
@@ -114,7 +115,11 @@ function prepareKnowledgeHost({
   if (!development) cargoArgs.push('--release');
   cargoArgs.push(
     '--manifest-path', manifest, '--bin', 'pinvou-knowledge-server',
-    '-j', process.env.PINVOU_KNOWLEDGE_BUILD_JOBS || '2',
+    // Default to all cores: knowledge-host builds in an isolated target dir that
+    // is always cold on release machines/CI, where -j 2 drags this step out to
+    // minutes; memory-constrained environments can still override via
+    // PINVOU_KNOWLEDGE_BUILD_JOBS (same name as pinvou-knowledge/deploy/install.sh).
+    '-j', process.env.PINVOU_KNOWLEDGE_BUILD_JOBS || String(os.availableParallelism()),
   );
   const result = spawn(
     process.env.CARGO || 'cargo',

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -337,6 +337,12 @@ missing_docs = "allow"
 # high-value subset is denied individually below.
 all = { level = "allow", priority = -1 }
 pedantic = { level = "allow", priority = -1 }
+# The perf group used to be allowed together with `all`; the measured backlog
+# in 2026-09 was only 3 warnings (result_large_err / large_enum_variant /
+# manual_ascii_case_insensitive) and has been cleared, so the group is
+# promoted to a hard deny gate to keep redundant_clone-class perf regressions
+# out (priority=1 overrides the -1 on `all`).
+perf = { level = "deny", priority = 1 }
 
 # —— Curated zero-backlog regression guards: deny hard gate (0 violations,
 # new hits fail CI) ——

--- a/pinvou3-app/src-tauri/src/app/commands/checkpoints.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/checkpoints.rs
@@ -761,7 +761,7 @@ mod tests {
                 None
             }
         }));
-        let code_ids = vec![alice_id.clone(), carol_id.clone()];
+        let code_ids = [alice_id.clone(), carol_id.clone()];
         store.set_code_session_predicate(Arc::new(move |id: &str| {
             code_ids.iter().any(|candidate| candidate == id)
         }));

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -3101,7 +3101,8 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        // edition 2024: env writes are unsafe — same pattern as lib.rs tests.
+        // SAFETY: holding ENV_LOCK via locked_env() (first statement of this
+        // test); env writes in the test process are serialized.
         unsafe { std::env::set_var("PINVOU3_HOME", &dir) };
 
         let mut bridge = fixture_bridge();

--- a/pinvou3-app/src-tauri/src/features/browser/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/browser/mod.rs
@@ -357,7 +357,9 @@ struct HostedPrepareJournal {
 
 enum HostedPrepareJournalMatch {
     Absent,
-    Matching(HostedPrepareJournal),
+    // Box keeps the no-data variants from paying the journal's size on every
+    // match (clippy::large_enum_variant).
+    Matching(Box<HostedPrepareJournal>),
     Superseded,
 }
 
@@ -6298,7 +6300,7 @@ fn matching_hosted_prepare_journal_for_cancellation(
     cancellation: &HostedBrowserCancellation,
 ) -> Result<Option<HostedPrepareJournal>, String> {
     match classify_hosted_prepare_journal_for_cancellation(cancellation)? {
-        HostedPrepareJournalMatch::Matching(journal) => Ok(Some(journal)),
+        HostedPrepareJournalMatch::Matching(journal) => Ok(Some(*journal)),
         HostedPrepareJournalMatch::Absent | HostedPrepareJournalMatch::Superseded => Ok(None),
     }
 }
@@ -6323,7 +6325,7 @@ fn classify_hosted_prepare_journal_for_cancellation(
         // cancellation is an idempotent no-op that can still be acknowledged.
         return Ok(HostedPrepareJournalMatch::Superseded);
     }
-    Ok(HostedPrepareJournalMatch::Matching(journal))
+    Ok(HostedPrepareJournalMatch::Matching(Box::new(journal)))
 }
 
 /// Read the cancellation path reserved for one durable Prepare generation and

--- a/pinvou3-app/src-tauri/src/features/browser/platform/host.rs
+++ b/pinvou3-app/src-tauri/src/features/browser/platform/host.rs
@@ -3102,24 +3102,30 @@ fn build_webview<P: PlatformWebviewConfig>(
     url: &str,
     control: Arc<WorkspaceControl>,
     published: bool,
-) -> Result<SurfaceEntry, WebviewBuildError> {
-    let window = app
-        .get_window("main")
-        .ok_or_else(|| WebviewBuildError::new("Main window is not ready".to_string()))?;
-    let parsed_url = url
-        .parse()
-        .map_err(|e| WebviewBuildError::new(format!("Initial browser URL is invalid: {e}")))?;
+) -> Result<SurfaceEntry, Box<WebviewBuildError>> {
+    let window = app.get_window("main").ok_or_else(|| {
+        Box::new(WebviewBuildError::new(
+            "Main window is not ready".to_string(),
+        ))
+    })?;
+    let parsed_url = url.parse().map_err(|e| {
+        Box::new(WebviewBuildError::new(format!(
+            "Initial browser URL is invalid: {e}"
+        )))
+    })?;
     let initial_last_known_url =
         validated_surface_url(url.to_string(), tab_token).ok_or_else(|| {
-            WebviewBuildError::new(
+            Box::new(WebviewBuildError::new(
                 "Initial browser URL cannot be written to restore state".to_string(),
-            )
+            ))
         })?;
-    let page_id = next_native_page_id().map_err(WebviewBuildError::new)?;
+    let page_id = next_native_page_id().map_err(|error| Box::new(WebviewBuildError::new(error)))?;
     let label = format!("{WEBVIEW_LABEL_PREFIX}{tab_token}");
     if let Some(stale) = app.get_webview(&label) {
         stale.close().map_err(|e| {
-            WebviewBuildError::new(format!("Failed to close invalid browser tab: {e}"))
+            Box::new(WebviewBuildError::new(format!(
+                "Failed to close invalid browser tab: {e}"
+            )))
         })?;
     }
 
@@ -3168,7 +3174,7 @@ fn build_webview<P: PlatformWebviewConfig>(
         &user_navigation,
         has_internal_marker_for_token(url, tab_token),
     )
-    .map_err(WebviewBuildError::new)?;
+    .map_err(|error| Box::new(WebviewBuildError::new(error)))?;
     let location_signal_nonce = format!("{:032x}", rand::random::<u128>());
     let navigation_location_signal_nonce = location_signal_nonce.clone();
     let init_script = browser_initialization_script(cdp_tab_token, &location_signal_nonce);
@@ -3177,7 +3183,7 @@ fn build_webview<P: PlatformWebviewConfig>(
         Ok(builder) => builder,
         Err(error) => {
             super::unregister_browser_core_webview_binding(&label);
-            return Err(WebviewBuildError::new(error));
+            return Err(Box::new(WebviewBuildError::new(error)));
         }
     }
         // BrowserCore runs in every frame on all three desktop engines. The
@@ -3557,9 +3563,9 @@ fn build_webview<P: PlatformWebviewConfig>(
         Ok(webview) => webview,
         Err(error) => {
             super::unregister_browser_core_webview_binding(&label);
-            return Err(WebviewBuildError::new(format!(
+            return Err(Box::new(WebviewBuildError::new(format!(
                 "Failed to create system-WebView browser tab: {error}"
-            )));
+            ))));
         }
     };
     let entry = SurfaceEntry {
@@ -3579,16 +3585,16 @@ fn build_webview<P: PlatformWebviewConfig>(
         return match webview.close() {
             Ok(()) => {
                 super::unregister_browser_core_webview_binding(&entry.label);
-                Err(WebviewBuildError::new(format!(
+                Err(Box::new(WebviewBuildError::new(format!(
                     "Failed to initialize hidden browser tab: {hide_error}"
-                )))
+                ))))
             }
-            Err(close_error) => Err(WebviewBuildError::with_survivor(
+            Err(close_error) => Err(Box::new(WebviewBuildError::with_survivor(
                 format!(
                     "Failed to initialize hidden browser tab: {hide_error}; compensating close failed: {close_error}"
                 ),
                 entry,
-            )),
+            ))),
         };
     }
     if let Err(attach_error) = super::attach_native_surface(&webview) {
@@ -3596,16 +3602,16 @@ fn build_webview<P: PlatformWebviewConfig>(
         return match webview.close() {
             Ok(()) => {
                 super::unregister_browser_core_webview_binding(&entry.label);
-                Err(WebviewBuildError::new(format!(
+                Err(Box::new(WebviewBuildError::new(format!(
                     "Failed to initialize native browser-tab container: {attach_error}"
-                )))
+                ))))
             }
-            Err(close_error) => Err(WebviewBuildError::with_survivor(
+            Err(close_error) => Err(Box::new(WebviewBuildError::with_survivor(
                 format!(
                     "Failed to initialize native browser-tab container: {attach_error}; compensating close failed: {close_error}"
                 ),
                 entry,
-            )),
+            ))),
         };
     }
     Ok(entry)

--- a/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
+++ b/pinvou3-app/src-tauri/src/features/marketplace/skill_marketplace.rs
@@ -1652,7 +1652,7 @@ pub(crate) fn read_skill_description_from_str(content: &str) -> Option<String> {
         };
         let value = value.trim();
         let is_block_scalar = matches!(value, ">" | "|" | ">-" | ">+" | "|-" | "|+");
-        if key.trim().to_ascii_lowercase() != "description" {
+        if !key.trim().eq_ignore_ascii_case("description") {
             // 引擎对**任意键**消费块状续行（is_block_scalar 判定在键过滤之前，
             // `|`/`>` 块整块进那个键的值）——其他键块内的 `description:` 行
             // 不是 description。镜像必须同样跳过这些续行，否则会读出引擎侧

--- a/pinvou3-app/src-tauri/src/platform/prefs/mod.rs
+++ b/pinvou3-app/src-tauri/src/platform/prefs/mod.rs
@@ -1077,6 +1077,8 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&temporary_home);
         std::fs::create_dir_all(&temporary_home).expect("create temporary prefs home");
+        // SAFETY: holding ENV_LOCK (first line of this test); env writes in the
+        // test process are serialized.
         unsafe { std::env::set_var("PINVOU3_HOME", &temporary_home) };
 
         // Fixture must pin LocalVllm explicitly: `ModelPreset::default()` is
@@ -1120,7 +1122,10 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&temporary_home);
         match old_home {
+            // SAFETY: holding ENV_LOCK (first line of this test); restore-side
+            // env writes serialized.
             Some(value) => unsafe { std::env::set_var("PINVOU3_HOME", value) },
+            // SAFETY: same as above; removal serialized under ENV_LOCK.
             None => unsafe { std::env::remove_var("PINVOU3_HOME") },
         }
     }

--- a/pinvou3-app/src/features/conversation/deepseek-conversation.js
+++ b/pinvou3-app/src/features/conversation/deepseek-conversation.js
@@ -188,7 +188,7 @@ export function pairDeepSeekTimeline(events = []) {
 //     than turns the surplus is record noise (a parked-steer resume
 //     continuation whose assistant_done attached to the original turn id), so
 //     prefer records that actually carry a terminal.
-function assignDeepSeekTimelines(turns, userTurns, timelineEvents, busy) {
+function assignDeepSeekTimelines(userTurns, timelineEvents, busy) {
   const timeline = pairDeepSeekTimeline(timelineEvents);
   const assigned = new Set();
   for (const record of timeline) {
@@ -329,7 +329,7 @@ export function projectDeepSeekConversation({
     ));
   }
 
-  assignDeepSeekTimelines(turns, userTurns, timelineEvents, busy);
+  assignDeepSeekTimelines(userTurns, timelineEvents, busy);
   if (!busy) transferSteeredRunTerminals(turns);
 
   const activeTurn = turns[turns.length - 1];

--- a/pinvou3-app/src/features/remote-knowledge/RemoteKnowledgeView.jsx
+++ b/pinvou3-app/src/features/remote-knowledge/RemoteKnowledgeView.jsx
@@ -1292,7 +1292,10 @@ function RemoteKnowledgeView({ t, embedded = false }) {
       refreshError = String(error);
     }
     setUploadInProgress(false);
-    const counts = nextQueue.reduce((output, item) => ({ ...output, [item.status]: (output[item.status] || 0) + 1 }), {});
+    const counts = {};
+    for (const item of nextQueue) {
+      counts[item.status] = (counts[item.status] || 0) + 1;
+    }
     const completed = counts.success || 0;
     const existing = counts.duplicate || 0;
     const processing = (counts.pending_index || 0) + (counts.duplicate_pending || 0);

--- a/pinvou3-app/src/platform/types/globals.d.ts
+++ b/pinvou3-app/src/platform/types/globals.d.ts
@@ -10,6 +10,14 @@
 // .d.ts (they are a silent no-op); only `declare global` blocks actually
 // augment the Window type.
 declare global {
+  // ES2022 API the ES2021 lib target doesn't know. The runtime polyfill for
+  // the Safari 14 floor lives in src/shared/legacy-polyfills.js (compat is
+  // gated by audit-compat.mjs); declaring it here teaches the type checker
+  // about the polyfilled member without raising the jsconfig lib.
+  interface ObjectConstructor {
+    hasOwn(object: object, propertyKey: PropertyKey): boolean;
+  }
+
   interface Window {
     PinvouPlatform: any;
     TauriBridge: any;

--- a/pinvou3-app/src/platform/types/vendor-modules.d.ts
+++ b/pinvou3-app/src/platform/types/vendor-modules.d.ts
@@ -1,0 +1,23 @@
+// turndown and turndown-plugin-gfm ship no type declarations (TS7016 in
+// check:types). Declare only the minimal API surface this repo actually uses
+// (src/shared/turndown-factory.js and its consumers), not full coverage.
+declare module 'turndown' {
+  interface TurndownOptions {
+    headingStyle?: string;
+    bulletListMarker?: string;
+    codeBlockStyle?: string;
+  }
+
+  interface TurndownService {
+    use(plugin: unknown): void;
+    keep(tags: string[]): void;
+    turndown(html: string): string;
+  }
+
+  const TurndownService: new (options?: TurndownOptions) => TurndownService;
+  export default TurndownService;
+}
+
+declare module 'turndown-plugin-gfm' {
+  export const gfm: unknown;
+}


### PR DESCRIPTION
## Summary

Follow-up to the 2026-07 backlog cleanup (#383). Four commits, each independently revertable:

1. **fix: resolve rust clippy warnings in workspaces** — the last clippy warnings outside the hard-gated src-tauri production targets: two in `pinvou-cli` (`is_multiple_of`, `as_chunks`), five in `adapter-gaia`. The `SnapshotDownloader` error channel switches from unit `()` to a named zero-payload `SnapshotFetchFailure` (+ `From<()>` for the internal helpers) to keep the existing error-redaction discipline while satisfying `result_unit_err`. Also adds four missing `SAFETY:` comments for edition-2024 env writes in src-tauri test code. (A `pinvoy-cli/Cargo.lock` version refresh that showed up here as a byproduct was split out into #415.)
2. **perf: enforce clippy perf group as deny gate** — the clippy `perf` group was silently disabled in src-tauri by the blanket `all = allow`. Measured backlog was only three warnings, all fixed (`WebviewBuildError` boxed in the `Result`, `HostedPrepareJournalMatch::Matching` boxes the journal, `eq_ignore_ascii_case`), and the group is re-enabled as `deny` (`priority = 1` over the `all`-group allow) so `redundant_clone`-class regressions fail CI.
3. **fix: resolve high-value js lint findings** — unused parameter in `assignDeepSeekTimelines` (biome), O(n²) accumulator-spread reduce → counting loop in `RemoteKnowledgeView`, an `ObjectConstructor.hasOwn` ambient augmentation so the type checker knows the Safari-14-polyfilled ES2022 API without raising the ES2021 lib baseline (kills the `Object.hasOwn` TS2550 false positives), minimal ambient declarations for `turndown`/`turndown-plugin-gfm` (TS7016).
4. **build: speed up knowledge-host cold builds** — the knowledge-host server compile used a hardcoded `-j 2` into an isolated target directory (always cold on release machines/CI); now defaults to `os.availableParallelism()` (env override kept), and the release rust-cache on Linux x64/arm64 + macOS now covers the `pinvou-knowledge` workspace so repeat publishes stop recompiling the deb's server binary from scratch.

## Deliberately not churned

- CodeWhale submodule's 19 clippy warnings (upstream backlog, CI never blocks) and ~5500 `unwrap`/`expect` in test targets (documented convention).
- oxlint's 316 advisory pedantic/perf warnings: eslint intentionally does not enable those rules; not debt by this repo's lint policy.
- The one vite classic-script bundling hint is by design and guarded by `assertClassicRuntimeScriptsCopied`.

## Disclosed / needs a separate decision

- `npm run check:types` still reports ~9969 strict-mode errors across ~150 files; the script is wired nowhere (not in CI or `npm test`), so this is a structural decision (stage into CI vs. drop), not fixable in a sweep.
- Windows bundle targets are `["msi", "nsis"]` but the repo (CI, OTA script) only ever consumes nsis; removing msi needs a maintainer call on external distribution.
- Further pipeline opportunities with real trade-offs, intentionally not implemented here: parallelizing the four independent `build.js` prepare steps (error aggregation/log interleaving), `actions/cache` for the Windows release runtime download (submodule-restore + cache-quota trade-offs), and verifying the cache-janitor rules actually protect the macOS release cache key.

## Verification

- `cargo clippy` across src-tauri (hard gate `-D warnings`, incl. the new perf-deny), pinvou-knowledge, and pinvou-cli workspace: clean; `cargo fmt --check` clean.
- `cargo test`: adapter-gaia 44, pinvou-cli 21, browser 216, marketplace 209 — all pass.
- `npm run lint:ui` / `lint:node` clean, biome clean on changed files, `vite build` clean; affected node tests (timeline, turn-error isolation, knowledge-host packaging, visual contract) pass.
- `python3 scripts/architecture-guard.py` and `./scripts/fork-guard.sh --fast` pass.
- Rebased onto latest `main` (eb2077be, includes #397 and the #415 lockfile sync) before push; no textual conflicts.
- Review follow-up (@zhuowp): the four new comment blocks flagged as non-English are translated to English inside their introducing commits, preserving the technical detail and keeping each commit independently revertable; no Chinese remains in any added line.
- Combined-tree adaptation: #397's new `checkpoints.rs` test used `vec![...]`, which the newly denied `perf` group rejects (`useless_vec`) — switched to an array in the perf-gate commit; that module re-run green (15/15). All clippy hard gates (src-tauri incl. `perf` deny + tests, pinvou-knowledge), fmt, pinvou-cli clippy/tests (adapter-gaia 44), eslint, biome, `build:ui`, affected node tests (24), and both guards re-verified on the combined tree; the browser/marketplace test counts were verified on the pre-rebase tree and are unaffected by the comment-only delta.

## DCO

All commits carry `Signed-off-by` per [DCO.md](DCO.md).

