### PR TITLE
chore: sync pinvou-cli lockfile versions

### DIFF
--- a/pinvou-cli/Cargo.lock
+++ b/pinvou-cli/Cargo.lock
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "pinvou-knowledge"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6356,7 +6356,7 @@ dependencies = [
 
 [[package]]
 name = "pinvou3-tauri"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "age",
  "agent-backend-api",


### PR DESCRIPTION
## Summary

The 0.9.1 release bump (#409) updated the `pinvou-knowledge` and `pinvou3-tauri` crate versions but left the standalone `pinvou-cli` workspace lockfile recording 0.9.0. Any cargo invocation in that workspace refreshes the lock (4 lines, two version entries); this lands that mechanical refresh so `--locked` builds stay reproducible.

Split out of #414, where it appeared as an unrelated byproduct of the lint sweep.

## Verification

- `cargo metadata` in the `pinvoy-cli` workspace regenerates exactly this diff (and nothing else).
- No code change; `cargo clippy -p pinvou-cli -p adapter-gaia` on this tree is unchanged.

## DCO

Commit carries `Signed-off-by` per [DCO.md](DCO.md).