### PR TITLE
test(bridge): pin PINVOU3_HOME in instructions isolation test

### DIFF
--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -5868,6 +5868,24 @@ mod tests {
     /// 必须使用不同 workspace 隔离产物,同时保持静态 instructions 前缀一致以便缓存复用。
     #[test]
     fn engine_config_for_session_keeps_isolation_without_prompt_variance() {
+        // This test reads env-derived paths (PINVOU3_HOME -> bundle_browser_wrapper)
+        // twice and asserts the static instructions are identical across the two calls.
+        // Without holding the crate-wide ENV_LOCK, a concurrent test writing
+        // PINVOU3_HOME could flip the "Browser capabilities" section between the two
+        // calls (flake observed on 2026-09-03, reproduced on a clean main checkout).
+        // locked_env pins PINVOU3_HOME to a fresh empty temp dir, so the wrapper is
+        // deterministically absent and the instructions stay byte-stable across calls.
+        let (_lock, _env) = locked_env(&["PINVOU3_HOME"]);
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-prompt-variance-{}-{}",
+            std::process::id(),
+            crate::bridge::paths::tests::unique_suffix()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create hermetic temp PINVOU3_HOME");
+        // SAFETY: platform::paths::tests::ENV_LOCK held; env writes are serialized.
+        unsafe { std::env::set_var("PINVOU3_HOME", &root) };
+
         let bridge = fixture_bridge();
         let (a, b) = ("sess-aaaa-1111", "sess-bbbb-2222");
         let cfg_a = bridge.build_engine_config_for_session(a);
@@ -5905,6 +5923,8 @@ mod tests {
         // (见 build_session_system_prompt 注释:per-session 变动进 cache 前缀会
         // 触发 vLLM prefix-cache MISS → 工具调用漂移)。session 隔离由不同 workspace
         // 和每个 session 独立的 EngineConfig/Engine 实例负责,name 仅是展示标签。
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

`engine_config_for_session_keeps_isolation_without_prompt_variance` calls `build_engine_config_for_session` twice and asserts the two static instruction strings are identical. The rendered instructions embed a "Browser capabilities" section computed per call from `browser_unavailability_reason()`, which stats `bundle_browser_wrapper()` = `pinvou3_home()/bundle/mcp-servers/browser-wrapper.mjs`, and `pinvou3_home()` reads the `PINVOU3_HOME` env var (falling back to `~/.pinvou3`). The test reads these env-derived paths **without holding the crate-wide `ENV_LOCK`**, while other tests concurrently set/unset `PINVOU3_HOME` while holding it. A writer flipping `PINVOU3_HOME` between the two calls makes one side see the wrapper and the other not, so the strings differ and the assert panics ("跨 session 的静态 instructions 必须一致").

Reproduced 3/3 under the full parallel `cargo test --lib` on 2026-09-03, including on a clean `origin/main` baseline (unrelated to any in-flight PR; the flake pre-dates them).

## Fix

Make the test hermetic and serialized, following the established `locked_env` pattern in the same file (as `engine_config_for_session_keeps_mcp_artifacts_public` does):

- hold `ENV_LOCK` for the test duration, so all convention-abiding env writers are excluded;
- pin `PINVOU3_HOME` to a fresh empty temp dir → the wrapper is deterministically absent → the instructions are byte-stable across both calls, and no longer depend on the dev machine's `~/.pinvou3` state;
- clean up the temp dir at the end; `SAFETY:` comment on the env write, per file convention.

Test-only change; no production code touched.

## Verification

- `cargo fmt --check` clean.
- Target test passes in isolation; whole `bridge::tests` module passes (107 tests) with no deadlock/hang.
- Full `cargo test --lib` run 3× back-to-back on the fix: all green (`1897 passed; 0 failed` each) — pre-fix this flake failed 3/3 full runs on this machine.
- `python3 scripts/architecture-guard.py` passes (no cfg added).
