### PR TITLE
test: disable vite file watching in one-shot servers

### DIFF
--- a/pinvou3-app/tests/code_viewer_diff_smoke.mjs
+++ b/pinvou3-app/tests/code_viewer_diff_smoke.mjs
@@ -42,7 +42,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/code_viewer_modal_smoke.mjs
+++ b/pinvou3-app/tests/code_viewer_modal_smoke.mjs
@@ -40,7 +40,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
+++ b/pinvou3-app/tests/diff_viewer_ui_smoke.mjs
@@ -40,7 +40,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/question_choice_card_smoke.mjs
+++ b/pinvou3-app/tests/question_choice_card_smoke.mjs
@@ -47,7 +47,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/question_choice_card_special_id_smoke.mjs
+++ b/pinvou3-app/tests/question_choice_card_special_id_smoke.mjs
@@ -52,7 +52,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/reader_app_diff_smoke.mjs
+++ b/pinvou3-app/tests/reader_app_diff_smoke.mjs
@@ -47,7 +47,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/reader_app_smoke.mjs
+++ b/pinvou3-app/tests/reader_app_smoke.mjs
@@ -44,7 +44,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/stock_quote_unit_fixture.test.mjs
+++ b/pinvou3-app/tests/stock_quote_unit_fixture.test.mjs
@@ -25,7 +25,9 @@ const vite = await createServer({
   // percent-encoded on POSIX; fileURLToPath is the portable form.
   root: fileURLToPath(new URL('..', import.meta.url)),
   logLevel: 'error',
-  server: { middlewareMode: true },
+  // One-shot SSR module load: file watching is never used and only ENOSPC-flakes
+  // server startup on hosts with low inotify limits.
+  server: { middlewareMode: true, watch: null },
   optimizeDeps: { noDiscovery: true },
 });
 const { StockQuoteCard } = await vite.ssrLoadModule('/src/features/tools/tool-common.jsx');

--- a/pinvou3-app/tests/workspace_panel_draft_smoke.mjs
+++ b/pinvou3-app/tests/workspace_panel_draft_smoke.mjs
@@ -40,7 +40,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();

--- a/pinvou3-app/tests/workspace_panel_session_smoke.mjs
+++ b/pinvou3-app/tests/workspace_panel_session_smoke.mjs
@@ -43,7 +43,9 @@ try {
     appType: 'mpa',
     logLevel: 'error',
     plugins: [react()],
-    server: { host: '127.0.0.1', port: 0, strictPort: false },
+    // One-shot smoke page: file watching is never used and only ENOSPC-flakes
+    // server startup on hosts with low inotify limits.
+    server: { host: '127.0.0.1', port: 0, strictPort: false, watch: null },
   });
   await vite.listen();
   const address = vite.httpServer.address();


### PR DESCRIPTION
## Summary

Stop the one-shot Vite dev servers started by the node test suites from watching the filesystem, so they no longer crash on Linux hosts with low inotify limits.

## Background

`pinvou3-app/tests/stock_quote_unit_fixture.test.mjs` was reported flaky: it starts a bare Vite dev server only to `ssrLoadModule` a component and closes it right after, but Vite still launched a chokidar watcher over the whole app root. On watcher-limited Linux hosts the server died at startup with:

```
Error: ENOSPC: System limit for number of file watchers reached, watch '.../pinvou3-app'
```

The failure was host-state dependent: it reproduced standalone on a low-watch-limit host (errno -28, syscall `watch`) and passed on other days and hosts. Every one-shot server here either serves a single fixture page once (the Puppeteer browser smokes) or only does an SSR module load (the stock-quote fixture), so HMR/file watching is dead weight that only consumes inotify watches.

## Changes

- pass `server: { watch: null }` in the inline config of every one-shot `createServer` call under `pinvou3-app/tests/` — this is Vite's documented way to disable FS watching (`watch?: WatchOptions | null`, "chokidar watch options or null to disable FS watching", confirmed against the installed vite 8.2.2 types):
  - `stock_quote_unit_fixture.test.mjs` (one-shot SSR load, alongside `middlewareMode: true`)
  - the nine Puppeteer browser smokes: `reader_app_smoke.mjs`, `reader_app_diff_smoke.mjs`, `diff_viewer_ui_smoke.mjs`, `code_viewer_modal_smoke.mjs`, `code_viewer_diff_smoke.mjs`, `workspace_panel_draft_smoke.mjs`, `workspace_panel_session_smoke.mjs`, `question_choice_card_smoke.mjs`, `question_choice_card_special_id_smoke.mjs`
- add a short comment at each site stating the constraint the code cannot show (one-shot load, watching is never used and only ENOSPC-flakes startup on hosts with low inotify limits)

## Verification

- pre-fix: `node --test tests/stock_quote_unit_fixture.test.mjs` failed standalone on this host with exactly the `ENOSPC: System limit for number of file watchers reached` crash above
- post-fix: `node --test tests/stock_quote_unit_fixture.test.mjs` — passed on 3 consecutive standalone runs (2 passed / 0 failed each)
- `npm run test:node` — 520 passed, 0 failed, 16 skipped (recent green baseline 518 passed / 0 failed; minor drift from tests merged to `main` since)
- the same suite under Node 24.20.0 (the version CI uses) — 520 passed, 0 failed, 16 skipped
- `npm run lint:node` — passed
- `python3 scripts/architecture-guard.py` — passed
- `git diff --check` — passed
- `node --check` on each modified smoke file — passed
- the Puppeteer browser smokes cannot run on this Linux host; they are exercised by the CI frontend smoke jobs, and their only change here is the one-line watcher option

## Impact and notes

Test-only change: no production code under `pinvou3-app/src/` or `pinvou3-app/src-tauri/` changed, no dependencies changed. Development servers (`npm run dev`, `npm run serve:src`) keep their normal watching behavior; only the throwaway servers inside the tests stop watching. The browser smoke suites gain the same determinism on watcher-limited hosts. No CodeWhale gitlink or fork behavior changed.

## Submission checklist

- [x] I based this PR on the latest `main`.
- [x] The PR title and description are written in English, and the title follows the commit subject convention.
- [x] Every commit includes a matching `Signed-off-by` trailer (`git commit -s`).
- [x] I removed credentials, private data, internal URLs, and sensitive logs.
- [x] The `CodeWhale` gitlink and fork behavior are unchanged.