### PR TITLE
fix(artifacts): surface presentation requests

### DIFF
--- a/pinvou3-app/src-tauri/resources/common/bundle/mcp-servers/present_artifact_server.py
+++ b/pinvou3-app/src-tauri/resources/common/bundle/mcp-servers/present_artifact_server.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """present_artifact — pinvou3 内置 MCP server(零第三方依赖,只用 stdlib)。
 
-把一个"阶段性成品"展示给用户:Pinvou 调 present_artifact 工具,pinvou3 前端
-在聊天区弹一张可点击的成品卡,客户点一下直接打开预览。
+把一个"阶段性成品"交给 Pinvou 客户端展示。工具成功只表示文件验证通过；客户端
+收到结果后会尝试展示，不是对用户当前可见界面的反向确认。
 
 协议:newline-delimited JSON-RPC 2.0 over stdio(对齐底座 mcp.rs 的 stdio
 transport:每条消息一行 JSON + '\\n',read_line 读)。protocolVersion 2024-11-05。
@@ -33,8 +33,9 @@ _KIND_BY_EXT = {
 TOOL_DEF = {
     "name": "present_artifact",
     "description": (
-        "把一个阶段性作品展示给用户 —— 聊天区会弹一张可点击的成品卡,客户点一下"
-        "直接打开预览。什么时候调:产出 html / markdown / 图片等单文件作品且打算"
+        "把一个阶段性作品交给 Pinvou 客户端展示。调用成功只表示文件验证通过；客户端"
+        "收到结果后会尝试展示，不代表已反向验证用户看到的界面；回复时不要声称已验证界面弹出。"
+        "什么时候调:产出 html / markdown / 图片等单文件作品且打算"
         "给客户看时,立刻调。什么时候别调:写中间文件、配置、脚本、做内部处理时不要调。"
         "标题要让客户一眼看懂这是什么作品(例:'SpaceX 产业趋势单页总结')。"
         "非阻塞,调完立即返回,继续对话。"

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1509,6 +1509,7 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
         showArtifactsPreview(latestArtifact && latestArtifact.path);
       }, [latestArtifact, showArtifactsPreview]);
       useEffect(() => {
+        if (typeof window === 'undefined') return;
         const onPresentArtifact = (event) => {
           const detail = event && event.detail;
           if (!detail || detail.sessionId !== activeSessionId || !detail.path) return;

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -1494,9 +1494,9 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
         setActiveArtifactPath(artifact && artifact.path ? artifact.path : null);
         setArtifactDockActivation((value) => value + 1);
       }, []);
-      const openArtifactsPreview = useCallback(() => {
+      const showArtifactsPreview = useCallback((path) => {
         prefetchChatPanel('artifacts');
-        if (latestArtifact && latestArtifact.path) setActiveArtifactPath(latestArtifact.path);
+        if (path) setActiveArtifactPath(path);
         setArtifactsOpen(true);
         setArtifactDockActivation((value) => value + 1);
         void invokeObservedPanelSelection(
@@ -1504,7 +1504,19 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
           ['artifact-preview', activeSessionId],
           reportRightDockSelectionFailure,
         );
-      }, [activeSessionId, latestArtifact, onRightDockPanelSelectionChange]);
+      }, [activeSessionId, onRightDockPanelSelectionChange]);
+      const openArtifactsPreview = useCallback(() => {
+        showArtifactsPreview(latestArtifact && latestArtifact.path);
+      }, [latestArtifact, showArtifactsPreview]);
+      useEffect(() => {
+        const onPresentArtifact = (event) => {
+          const detail = event && event.detail;
+          if (!detail || detail.sessionId !== activeSessionId || !detail.path) return;
+          showArtifactsPreview(detail.path);
+        };
+        window.addEventListener('pinvou:present-artifact', onPresentArtifact);
+        return () => window.removeEventListener('pinvou:present-artifact', onPresentArtifact);
+      }, [activeSessionId, showArtifactsPreview]);
       useEffect(() => {
         const previousCount = previousArtifactCountRef.current;
         previousArtifactCountRef.current = artifactCount;

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -768,7 +768,8 @@
           time: timeStr(),
           sessionId: p.session_id || state.activeSessionId,
         };
-        if (!updatePresentedArtifact(presentedCard)) addChatItem(presentedCard);
+        const presentationCard = updatePresentedArtifact(presentedCard) || presentedCard;
+        if (presentationCard === presentedCard) addChatItem(presentedCard);
         if (presentedPath) state.turnPresentedArtifacts.push(presentedPath); // 本 turn 已出成品卡,chat:done 不再兜底补
         // 同步进产物面板:present_artifact 出卡的产物也算「产出物」。修「自己生成文件、
         // 不走 write_file 的工具(如 make_pptx)→ 卡有、面板无」。trackArtifact 已去重。
@@ -776,6 +777,18 @@
         delete context.toolMeta[p.id];
         context.currentStreamText = ""; context.currentStreamId = 0;
         notify();
+        // Card identity and panel presentation are separate concerns: updating an
+        // existing card keeps its stable transcript position, so every explicit
+        // present_artifact call must still request a visible preview. Use the
+        // reconciled card path because a relative tool argument may have retained
+        // an older absolute path that the preview can actually open.
+        try {
+          window.dispatchEvent(new CustomEvent("pinvou:present-artifact", { detail: {
+            sessionId: presentedCard.sessionId,
+            path: presentationCard.path,
+            toolCallId: p.id,
+          } }));
+        } catch { /* DOM event dispatch failure leaves the artifact available from the dock */ }
         return;
       }
       // 失败:补一张工具卡承载错误输出(tool_start 时跳过了灰卡)

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -6060,7 +6060,8 @@
           time: timeStr(),
           sessionId: p.session_id || state.activeSessionId,
         };
-        if (!updatePresentedArtifact(presentedCard)) addChatItem(presentedCard);
+        const presentationCard = updatePresentedArtifact(presentedCard) || presentedCard;
+        if (presentationCard === presentedCard) addChatItem(presentedCard);
         if (presentedPath) state.turnPresentedArtifacts.push(presentedPath); // 本 turn 已出成品卡,chat:done 不再兜底补
         // 同步进产物面板:present_artifact 出卡的产物也算「产出物」。修「自己生成文件、
         // 不走 write_file 的工具(如 make_pptx)→ 卡有、面板无」。trackArtifact 已去重。
@@ -6068,6 +6069,15 @@
         delete toolMeta[p.id];
         currentStreamText = ""; currentStreamId = 0;
         notify();
+        // Keep the web adapter aligned with desktop: an in-place card update does
+        // not change artifactCount, but an explicit presentation must remain visible.
+        try {
+          window.dispatchEvent(new CustomEvent("pinvou:present-artifact", { detail: {
+            sessionId: presentedCard.sessionId,
+            path: presentationCard.path,
+            toolCallId: p.id,
+          } }));
+        } catch { /* DOM event dispatch failure leaves the artifact available from the dock */ }
         return;
       }
       // 失败:补一张工具卡承载错误输出(tool_start 时跳过了灰卡)

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -97,8 +97,10 @@ const expectedProtocolHashes = {
   // (bridge.js) and the position-capture load_session (chat.js). And again
   // for the background-task indicator: the multiagent:agent_progress listen
   // that schedules the shell snapshot poll for sub-agent spawned tasks
-  // (chat-events.js).
-  chat: '610c1acd32faa210b9269052789340b992e9b6bfe96b8bb18ea69b046e8e6ffe',
+  // (chat-events.js). Recomputed for explicit artifact presentation: a
+  // successful present_artifact tool_end now emits a session-scoped request
+  // that opens the preview even when the existing card is updated in place.
+  chat: 'e5a97c56781d34f0ea8d7ef17825fa45295abb10ce2a82cada6eadad5b2bf2ab',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',
   knowledge: '9105a42c6b69f04d0bc28b6a72e0746648110a44823891ded3261cdcbc99766b',

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -631,6 +631,7 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
   const bridgeKind = runtimeOptions.bridgeKind === "web" ? "web" : "tauri";
   const listeners = Object.create(null);
   const windowListeners = Object.create(null);
+  const dispatchedWindowEvents = [];
   const handlers = Object.create(null);
   const calls = [];
   const dialogCalls = [];
@@ -753,6 +754,7 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
       });
     },
     dispatchEvent: function (event) {
+      dispatchedWindowEvents.push(event);
       [...(windowListeners[event.type] || [])].forEach(function (listener) { listener(event); });
       return true;
     },
@@ -777,11 +779,17 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
   }
   window.window = window;
   window.document = document;
+  function CustomEvent(type, init) {
+    this.type = type;
+    this.detail = init && init.detail;
+  }
+  window.CustomEvent = CustomEvent;
   const context = {
     window,
     document,
     localStorage: storage,
     sessionStorage: storage,
+    CustomEvent,
     console: { log: function () {}, warn: function () {}, error: function () {} },
     setTimeout: runtimeOptions.setTimeout || setTimeout,
     clearTimeout: runtimeOptions.clearTimeout || clearTimeout,
@@ -829,6 +837,9 @@ function createBridgeHarness(sharedStorage, runtimeOptions) {
     storageData,
     dialogCalls,
     getStructuredCloneCalls: function () { return structuredCloneCalls; },
+    getWindowEvents: function (type) {
+      return dispatchedWindowEvents.filter(function (event) { return !type || event.type === type; });
+    },
     setDialogResult: function (value) { dialogResult = value; },
     emit: function (name, payload) {
       assert.ok(listeners[name] && listeners[name].length, "expected listener " + name);
@@ -7523,6 +7534,7 @@ async function presentationReconciliationUsesStableEventIdentity(bridgeKind) {
     success: true,
     output: "Updated snake-game.html",
   });
+  const presentationEventsBeforeUpdate = harness.getWindowEvents("pinvou:present-artifact").length;
   presentArtifact("tool-present-snake-update", "snake-game.html", "Snake game v2", null);
 
   const updatedCardState = bridge.state.get("chat");
@@ -7545,6 +7557,18 @@ async function presentationReconciliationUsesStableEventIdentity(bridgeKind) {
     "the existing card must receive the latest presentation metadata");
   assert.strictEqual(updatedSnakeCards[0].path, absoluteArtifactPath,
     "a relative presentation update must preserve the existing absolute openable path");
+  const presentationEventsAfterUpdate = harness.getWindowEvents("pinvou:present-artifact");
+  assert.strictEqual(presentationEventsAfterUpdate.length, presentationEventsBeforeUpdate + 1,
+    bridgeKind + " must emit a presentation request even when artifact count stays unchanged");
+  assert.deepStrictEqual(
+    JSON.parse(JSON.stringify(presentationEventsAfterUpdate[presentationEventsAfterUpdate.length - 1].detail)),
+    {
+      sessionId,
+      path: absoluteArtifactPath,
+      toolCallId: "tool-present-snake-update",
+    },
+    bridgeKind + " must present the reconciled absolute card path",
+  );
 
   // A same-named artifact from another absolute directory gets its own card.
   const exportSummaryPath = "C:\\Users\\tester\\exports\\summary.pptx";

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -356,14 +356,22 @@ async function expand(page) {
   const artifactPresentation = await page.evaluate(async () => {
     await window.TauriBridge.sessions.switchToSession('s1');
     await window.__uiWait__(() => !!document.querySelector('[data-testid="chat-scroll"]'));
-    const artifactPath = window.TauriBridge.state.get('chat').artifacts[0]?.path;
+    const stateArtifacts = () => window.TauriBridge.state.get('chat').artifacts;
+    const artifactPath = stateArtifacts()[0]?.path;
+    const countBefore = stateArtifacts().length;
     const panelVisible = () => document.querySelector('[data-testid="artifact-side-panel"]')
       ?.getAttribute('aria-hidden') === 'false';
     window.dispatchEvent(Object.assign(new Event('pinvou:present-artifact'), {
       detail: { sessionId: 's-browser-b', path: '/home/x/ignored.md', toolCallId: 'background-present' },
     }));
-    await new Promise(resolve => setTimeout(resolve, 80));
-    const backgroundIgnored = !panelVisible();
+    // Poll a full observation window instead of a single sleep so a late misfire
+    // from a lazy chunk or slow React commit cannot slip past the negative check.
+    let backgroundLeaked = false;
+    for (let tick = 0; tick < 20 && !backgroundLeaked; tick++) {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      backgroundLeaked = panelVisible();
+    }
+    const backgroundIgnored = !backgroundLeaked;
     window.dispatchEvent(Object.assign(new Event('pinvou:present-artifact'), {
       detail: { sessionId: 's1', path: artifactPath, toolCallId: 'active-present' },
     }));
@@ -376,12 +384,20 @@ async function expand(page) {
     await window.__uiWait__(() => !!document.querySelector('[data-testid="artifact-close"]'));
     document.querySelector('[data-testid="artifact-close"]')?.click();
     await window.__uiWait__(() => !panelVisible());
-    return { backgroundIgnored, activeOpened, previewRequested, closed: !panelVisible() };
+    return {
+      backgroundIgnored,
+      activeOpened,
+      previewRequested,
+      closed: !panelVisible(),
+      countBefore,
+      countAfter: stateArtifacts().length,
+    };
   });
   rec(
     'artifact presentation opens the active work-chat preview without changing the artifact count',
     artifactPresentation.backgroundIgnored && artifactPresentation.activeOpened
-      && artifactPresentation.previewRequested && artifactPresentation.closed,
+      && artifactPresentation.previewRequested && artifactPresentation.closed
+      && artifactPresentation.countBefore === artifactPresentation.countAfter,
     JSON.stringify(artifactPresentation),
   );
 

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -353,6 +353,38 @@ async function expand(page) {
     JSON.stringify(visualShell),
   );
 
+  const artifactPresentation = await page.evaluate(async () => {
+    await window.TauriBridge.sessions.switchToSession('s1');
+    await window.__uiWait__(() => !!document.querySelector('[data-testid="chat-scroll"]'));
+    const artifactPath = window.TauriBridge.state.get('chat').artifacts[0]?.path;
+    const panelVisible = () => document.querySelector('[data-testid="artifact-side-panel"]')
+      ?.getAttribute('aria-hidden') === 'false';
+    window.dispatchEvent(Object.assign(new Event('pinvou:present-artifact'), {
+      detail: { sessionId: 's-browser-b', path: '/home/x/ignored.md', toolCallId: 'background-present' },
+    }));
+    await new Promise(resolve => setTimeout(resolve, 80));
+    const backgroundIgnored = !panelVisible();
+    window.dispatchEvent(Object.assign(new Event('pinvou:present-artifact'), {
+      detail: { sessionId: 's1', path: artifactPath, toolCallId: 'active-present' },
+    }));
+    await window.__uiWait__(panelVisible);
+    const activeOpened = panelVisible();
+    await window.__uiWait__(() => [...window.__TAURI_INVOKES__].some(call =>
+      call.cmd === 'read_artifact_text' && call.args?.path === artifactPath));
+    const previewRequested = [...window.__TAURI_INVOKES__].some(call =>
+      call.cmd === 'read_artifact_text' && call.args?.path === artifactPath);
+    await window.__uiWait__(() => !!document.querySelector('[data-testid="artifact-close"]'));
+    document.querySelector('[data-testid="artifact-close"]')?.click();
+    await window.__uiWait__(() => !panelVisible());
+    return { backgroundIgnored, activeOpened, previewRequested, closed: !panelVisible() };
+  });
+  rec(
+    'artifact presentation opens the active work-chat preview without changing the artifact count',
+    artifactPresentation.backgroundIgnored && artifactPresentation.activeOpened
+      && artifactPresentation.previewRequested && artifactPresentation.closed,
+    JSON.stringify(artifactPresentation),
+  );
+
   // After the Agent starts the browser, desktop UI expands the owning task's side panel. The
   // native-surface command returns false in this headless mock, so the component must show an
   // explicit unavailable state and must not fall back to a screenshot stream.


### PR DESCRIPTION
## Summary

- emit a session-scoped presentation request whenever `present_artifact` successfully validates and updates an artifact, including same-path updates
- open the active chat artifact preview from that request in both Work and Design modes while ignoring background-session events
- keep Tauri and Web bridge behavior aligned and avoid claiming that the UI was visibly verified

## Root cause

The bridge updated the artifact record and showed a success notification, but the chat UI only auto-opened the preview when the artifact count increased. Updating an existing artifact keeps the count unchanged, so the success path did not actually surface the card.

## Verification

- `npm run lint`
- `npm run build:ui`
- `npm run test:ui-smoke` (54/54)
- `node tests/artifact_deliverable_logic.test.js`
- `node tests/scheduled_tasks_unit.test.js`
- `node --test tests/bridge_domain_protocol.test.mjs`
- `python scripts/architecture-guard.py`
- Python syntax compilation for `present_artifact_server.py`
- `git diff --check`

## Known unrelated test environment issue

A full `npm test` run reached 530 passing tests. Four Windows browser-wrapper lifecycle cases timed out while starting child processes; the isolated suite reproduced the same environment-level timeout. The bridge protocol fingerprint failure from that first run was updated and now passes independently.