### PR TITLE
fix(chat): keep responses across mode switches

### DIFF
--- a/pinvou3-app/src/features/chat/composer-controls.jsx
+++ b/pinvou3-app/src/features/chat/composer-controls.jsx
@@ -286,7 +286,6 @@ const ComposerModeChip = ({ t, bs, compact, mode: modeProp, busy: busyProp, onSw
     if (target === 'plan' && !isPlan) {
       await bridge.interaction.setPlanModeNext();
     } else if (target === 'yolo' && isPlan) {
-      if (busy) await bridge.chat.cancelGeneration();
       await bridge.interaction.exitPlanToYolo();
     }
   }

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -1273,7 +1273,7 @@ export function CodexAcpView({
   // code 会话权限模式全局偏好（{ last_mode, yolo_confirmed }，null=未拉到）：
   // 驱动草稿态/刷新途中的默认 mode 展示，以及首次切 yolo 的一次性确认门。
   const [codePermPrefs, setCodePermPrefs] = useState(null);
-  // 待确认的 yolo 切换请求（{ draft, chipBusy }）；非 null 时渲染确认卡。
+  // 待确认的 yolo 切换请求（{ draft }）；非 null 时渲染确认卡。
   const [pendingYoloSwitch, setPendingYoloSwitch] = useState(null);
   const [yoloConfirmBusy, setYoloConfirmBusy] = useState(false);
   // 知识库集合列表与 embedding 安装态由 ComposerKbSelector 内部经 bridge.knowledge
@@ -1755,21 +1755,21 @@ export function CodexAcpView({
     } catch (err) { showError(err); }
   }
 
-  /// Plan↔Yolo：对齐聊天页语义——切回 Yolo 时若 turn 在跑先取消
-  /// （用代码车道已有的 cancel_generation 显式 sessionId 调用，不经 bridge）。
+  /// Plan↔Yolo 只改变后续 turn 使用的模式。正在运行的 turn 保持提交时捕获
+  /// 的模式并继续流式输出，切换权限配置不应隐式取消用户的回答。
   ///
   /// 首次切 yolo 的一次性确认门（全局记忆，产品已拍板）：未确认先弹卡，
   /// 【确认】调 confirm_code_yolo 写入全局标志后按原路径切换；【取消】留在
   /// 当前 mode。确认是 UI 层语义，后端 exit_plan_to_yolo 不强制门控。
-  async function switchNativeMode(target, { isPlan, busy: chipBusy } = {}) {
+  async function switchNativeMode(target, { isPlan } = {}) {
     if (target === 'yolo' && isPlan) {
       const prefs = await refreshCodePermPrefs();
       if (needsYoloConfirmation(prefs)) {
-        setPendingYoloSwitch({ draft: !activeId, chipBusy: Boolean(chipBusy) });
+        setPendingYoloSwitch({ draft: !activeId });
         return;
       }
     }
-    await performNativeModeSwitch(target, { isPlan, chipBusy });
+    await performNativeModeSwitch(target, { isPlan });
   }
 
   /// 草稿态暂存 mode 选择：本地暂存（新建会话时应用）+ 刷新 code lane 全局
@@ -1782,7 +1782,7 @@ export function CodexAcpView({
   }
 
   /// mode chip 切换的实际执行路径（不含 yolo 确认门）。
-  async function performNativeModeSwitch(target, { isPlan, chipBusy } = {}) {
+  async function performNativeModeSwitch(target, { isPlan } = {}) {
     if (!activeId) {
       stageDraftMode(target);
       return;
@@ -1792,7 +1792,6 @@ export function CodexAcpView({
       if (target === 'plan' && !isPlan) {
         await invoke('set_plan_mode_next', { sessionId: activeId });
       } else if (target === 'yolo' && isPlan) {
-        if (chipBusy) await invoke('cancel_generation', { sessionId: activeId });
         await invoke('exit_plan_to_yolo', { sessionId: activeId });
       }
       await refreshNativeControls(activeId);
@@ -1811,7 +1810,7 @@ export function CodexAcpView({
       if (pending.draft) {
         stageDraftMode('yolo');
       } else {
-        await performNativeModeSwitch('yolo', { isPlan: true, chipBusy: pending.chipBusy });
+        await performNativeModeSwitch('yolo', { isPlan: true });
       }
     } catch (err) {
       showError(err);

--- a/pinvou3-app/tests/codex_acp_timeline.test.mjs
+++ b/pinvou3-app/tests/codex_acp_timeline.test.mjs
@@ -1008,8 +1008,7 @@ try {
     && codexView.includes("invoke('get_mode_state'")
     && codexView.includes("invoke('set_plan_mode_next'")
     && codexView.includes("invoke('exit_plan_to_yolo'")
-    && codexView.includes("invoke('set_multi_agent_mode'")
-    && codexView.includes("invoke('cancel_generation'"),
+    && codexView.includes("invoke('set_multi_agent_mode'"),
   'native composer controls must switch via per-session commands with an explicit sessionId');
   assert.ok(!codexView.includes('bridge.models.')
     && !codexView.includes('bridge.knowledge.')
@@ -1073,6 +1072,19 @@ try {
   // 冗余 refreshNativeControls（3 次 invoke）；ChatView bridge 路径同样受益。
   assert.ok(composerControls.includes("(target === 'plan' && isPlan) || (target === 'yolo' && !isPlan)"),
   'ComposerModeChip must early-return when the clicked mode equals the active mode');
+  const sharedModeSwitch = composerControls.slice(
+    composerControls.indexOf('async function switchTo(target)'),
+    composerControls.indexOf('const optCls'),
+  );
+  const nativeModeSwitch = codexView.slice(
+    codexView.indexOf('async function performNativeModeSwitch'),
+    codexView.indexOf('async function confirmPendingYoloSwitch'),
+  );
+  assert.ok(
+    !sharedModeSwitch.includes('cancelGeneration')
+      && !nativeModeSwitch.includes("invoke('cancel_generation'"),
+    'switching Plan to YOLO while a turn is running must not cancel the in-flight response',
+  );
 
   // ── buildElicitationContent：保留属性 answerKey 不被 Object.prototype 吞掉 ──
   // requestedSchema 的 property key 后端仅校验非空，constructor/toString/__proto__ 是合法输入。

--- a/pinvou3-app/tests/ui_smoke.js
+++ b/pinvou3-app/tests/ui_smoke.js
@@ -2357,6 +2357,44 @@ async function expand(page) {
   });
   rec('⑥ chip 渲染+下拉两项+点Plan切到Plan', chip.found && /YOLO/.test(chip.label || '') && chipMenu.yoloDesc && chipMenu.planDesc && /Plan/.test(afterLabel), JSON.stringify({ ...chip, ...chipMenu, afterLabel }));
 
+  // Switching the permission mode affects subsequent turns only. The active
+  // streaming turn must not be cancelled, and later deltas must remain visible.
+  const modeSwitchInvokeStart = await page.evaluate(async () => {
+    const handlers = window.__TAURI_EVENT_HANDLERS__['chat:turn_started'] || [];
+    for (const handler of handlers) await handler({ payload: { session_id: 's1' } });
+    return window.__TAURI_INVOKES__.length;
+  });
+  await page.evaluate(() => {
+    document.querySelector('[title^="切换工作模式"]')?.click();
+  });
+  await sleep(150);
+  await clickText(page, 'YOLO');
+  await sleep(300);
+  const modeSwitchDuringStream = await page.evaluate(async (invokeStart) => {
+    const deltaHandlers = window.__TAURI_EVENT_HANDLERS__['chat:delta'] || [];
+    for (const handler of deltaHandlers) {
+      await handler({ payload: { session_id: 's1', text: 'mode-switch-stream-continued' } });
+    }
+    const recent = window.__TAURI_INVOKES__.slice(invokeStart);
+    return {
+      exitedPlan: recent.some(entry => entry.cmd === 'exit_plan_to_yolo' && entry.args.sessionId === 's1'),
+      cancelled: recent.some(entry => entry.cmd === 'cancel_generation' && entry.args.sessionId === 's1'),
+      busy: window.TauriBridge.state.get('chat').busy,
+      continued: window.TauriBridge.state.get('chat').chatItems.some(item =>
+        item && item.type === 'assistant' && String(item.text || '').includes('mode-switch-stream-continued')),
+    };
+  }, modeSwitchInvokeStart);
+  rec('switching Plan to YOLO keeps the active response streaming',
+    modeSwitchDuringStream.exitedPlan && !modeSwitchDuringStream.cancelled &&
+      modeSwitchDuringStream.busy && modeSwitchDuringStream.continued,
+    JSON.stringify(modeSwitchDuringStream));
+  await page.evaluate(async () => {
+    const handlers = window.__TAURI_EVENT_HANDLERS__['chat:done'] || [];
+    for (const handler of handlers) {
+      await handler({ payload: { session_id: 's1', status: 'Completed' } });
+    }
+  });
+
   // ⑤b 收纳成功 toast 的「前往查看」必须直达对话管理页并展开「已收纳」面板，且按钮不折行。
   await expand(page); await sleep(200);
   const archiveMenuOpened = await page.evaluate(() => {


### PR DESCRIPTION
## Summary

- keep an in-flight answer streaming when the user switches from Plan to YOLO
- apply the same behavior to the shared Work/Design composer and native Code composer
- preserve explicit Stop controls and make the selected mode apply to subsequent turns
- add browser and source-contract regressions for both mode-switch paths

## Root cause

Both Plan-to-YOLO UI paths explicitly called `cancel_generation` whenever the current session was busy. This made the running answer stop immediately. YOLO-to-Plan did not call cancellation, which explains the asymmetric behavior.

## Verification

- `npm run lint`
- `npm run build:ui`
- `npm run test:ui-smoke` (54/54)
- `node tests/codex_acp_timeline.test.mjs`
- `node tests/code_permission_state.test.mjs`
- `node tests/interaction_write_routing.test.mjs`
- `python scripts/architecture-guard.py`
- `git diff --check`

## Known unrelated test environment issue

`npm run test:node` completed with 533 passing, 1 skipped, and 2 failing Windows browser lifecycle cases. Both failures were child-process startup/shutdown timeouts in Browser Host tests; neither path imports or exercises the mode-switch code changed here.