### PR TITLE
fix(platform): refuse user-wide process group kills

### DIFF
--- a/docs/architecture-guard.md
+++ b/docs/architecture-guard.md
@@ -21,6 +21,13 @@ python scripts/architecture-guard.py
 - `#[tauri::command]` 必须位于 `app/commands/` 路径下，`generate_handler!` 条目以
   `commands::`（或 `crate::app::commands::`）前缀引用。
 - `resources/common` 不得混入 PE、ELF 等平台专属二进制。
+- **禁止 spawn 外部 `kill` 可执行文件执行进程组/进程树终止**（`Command::new("kill")`、
+  `Path::new("kill")`、`connector_cli_command(_, "kill")` 等形态），组杀一律通过
+  `libc::kill(2)` 直调（`platform::process::kill_process_tree` /
+  `platform::os::kill_pid_tree`）。背景：procps-ng 4.0.4 会把 `kill -9 -<pgid>` 的
+  合法负 pid 错解析成 `kill(-1)`，杀光当前用户全部进程（2026-09-04 实际事故）。
+  仅参与编译、无实际平台绑定的合约存根可用
+  `architecture-guard: allow-external-group-kill-stub` 文件级例外。
 
 门禁只约束可以稳定、客观检测的架构边界，不以文件行数或仓库总代码量作为模块化
 合规条件。模块是否需要拆分，应依据职责、依赖、状态耦合和独立测试能力，遵循根目录
@@ -34,6 +41,7 @@ python scripts/architecture-guard.py
 ```rust
 // architecture-guard: allow-target-cfg -- 第三方类型仅在 Windows 目标存在
 // architecture-guard: allow-platform-detail -- 此处只负责解析外部平台标识
+// architecture-guard: allow-external-group-kill-stub -- 仅参与编译的合约存根,无实际平台绑定
 ```
 
 例外必须保持最小范围并补充覆盖该场景的测试；缺少理由、位于文件头之外或仅为绕过

--- a/docs/architecture-guard.md
+++ b/docs/architecture-guard.md
@@ -26,8 +26,8 @@ python scripts/architecture-guard.py
   `libc::kill(2)` 直调（`platform::process::kill_process_tree` /
   `platform::os::kill_pid_tree`）。背景：procps-ng 4.0.4 会把 `kill -9 -<pgid>` 的
   合法负 pid 错解析成 `kill(-1)`，杀光当前用户全部进程（2026-09-04 实际事故）。
-  仅参与编译、无实际平台绑定的合约存根可用
-  `architecture-guard: allow-external-group-kill-stub` 文件级例外。
+  此规则对所有 Rust 文件生效、无文件级例外：`unsupported.rs` 的 `cfg(unix)` 分支
+  就是 macOS 在用的 `kill_pid_tree` 实现，不得因「合约存根」豁免整个文件。
 
 门禁只约束可以稳定、客观检测的架构边界，不以文件行数或仓库总代码量作为模块化
 合规条件。模块是否需要拆分，应依据职责、依赖、状态耦合和独立测试能力，遵循根目录
@@ -41,7 +41,6 @@ python scripts/architecture-guard.py
 ```rust
 // architecture-guard: allow-target-cfg -- 第三方类型仅在 Windows 目标存在
 // architecture-guard: allow-platform-detail -- 此处只负责解析外部平台标识
-// architecture-guard: allow-external-group-kill-stub -- 仅参与编译的合约存根,无实际平台绑定
 ```
 
 例外必须保持最小范围并补充覆盖该场景的测试；缺少理由、位于文件头之外或仅为绕过

--- a/pinvou3-app/src-tauri/src/README.md
+++ b/pinvou3-app/src-tauri/src/README.md
@@ -17,6 +17,14 @@ Tauri 命令按 `app/commands/<domain>.rs` 组织，`app/mod.rs` 与 `app/comman
 3. 只有被多个 feature 共同使用的低层能力才能进入 `platform/`。
 4. 操作系统选择使用 `cfg(target_os)`；Cargo feature 不用于模拟操作系统。
 5. 未支持能力必须显式返回 unsupported，不得静默执行其他平台实现。
+6. **严禁**通过 spawn 外部 `kill` 可执行文件（`/usr/bin/kill`、
+   `connector_cli_command(_, "kill")` 等）执行进程组/进程树终止，后续模块
+   开发一律使用 `platform::process::kill_process_tree` /
+   `platform::os::kill_pid_tree`（内部直调 kill(2)）。背景：procps-ng
+   4.0.4 会把 `kill -9 -<pgid>` 的合法负 pid 错解析成 `kill(-1)`，杀光当前
+   用户全部进程（2026-09-04 本机桌面会话两次被整台带走，audit 取证实锤）。
+   该禁令由 `scripts/architecture-guard.py` 的
+   `rust_external_group_kill_spawn` 规则强制执行。
 
 上述依赖和平台边界由仓库根目录的 `scripts/architecture-guard.py` 检查。迁移期保留
 `#[path]`、`include!` 可以用于兼容公共路径或生成代码，语法本身不作为架构违规；是否

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
@@ -122,6 +122,12 @@ pub fn apply_user_npm_prefix(cmd: &mut Command) {
 /// 走 connector_cli_command 保持 PATH 解析一致)。若进程恰未成组(旧登记),
 /// 追加一次单 pid 兜底。
 pub fn kill_pid_tree(pid: u32) {
+    if pid <= 1 {
+        // pid≤1 拼出的 `kill -9 -pid` 命中内核 kill(0/-1) 语义，会杀光本用户
+        // 全部进程（曾导致整个桌面会话被带走）。拒绝并留调用栈现场。
+        crate::platform::process::log_refused_user_wide_kill("linux kill_pid_tree", pid);
+        return;
+    }
     let group_arg = format!("-{pid}");
     let out = connector_cli_command("", "kill")
         .args(["-9", group_arg.as_str()])

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
@@ -118,26 +118,25 @@ pub fn apply_user_npm_prefix(cmd: &mut Command) {
 
 /// 退出收割用的树杀。连接器 CLI 是 npm shim(shell 脚本→node 子进程),spawn 侧
 /// 已用 `process_group(0)` 让 shim 独立成组,这里按负 pid 杀整组,否则单杀 shim
-/// 的 pid 会把 node 孙进程孤儿化(与 platform::process::kill_process_tree 同语义,
-/// 走 connector_cli_command 保持 PATH 解析一致)。若进程恰未成组(旧登记),
-/// 追加一次单 pid 兜底。
+/// 的 pid 会把 node 孙进程孤儿化(与 platform::process::kill_process_tree 同语义)。
+/// 若进程恰未成组(旧登记),追加一次单 pid 兜底。
+///
+/// 直接走 kill(2),不再 spawn 外部 /usr/bin/kill:procps-ng 4.0.4 的参数解析会把
+/// `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理（向内核发起 kill(-1)，杀光当前
+/// 用户全部进程——本机桌面会话两次因此被整台带走，2026-09-04 audit 取证实锤）。
 pub fn kill_pid_tree(pid: u32) {
     if pid <= 1 {
         // pid<=1 expands to the kernel kill(0/-1) special semantics, which
-        // signals every process of this user (once took down the whole
-        // desktop session). Refuse and leave a backtrace on disk.
+        // signals every process of this user. Refuse and leave a backtrace
+        // on disk.
         crate::platform::process::log_refused_user_wide_kill("linux kill_pid_tree", pid);
         return;
     }
-    let group_arg = format!("-{pid}");
-    let out = connector_cli_command("", "kill")
-        .args(["-9", group_arg.as_str()])
-        .output();
-    let group_ok = out.map(|o| o.status.success()).unwrap_or(false);
+    // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+    let group_ok = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } == 0;
     if !group_ok {
-        let _ = connector_cli_command("", "kill")
-            .args(["-9", &pid.to_string()])
-            .output();
+        // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+        let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
     }
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
@@ -126,12 +126,19 @@ pub fn apply_user_npm_prefix(cmd: &mut Command) {
 /// `scripts/architecture-guard.py` 强制检查:procps-ng 4.0.4 的参数解析会把
 /// `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理(kill(-1) 杀光当前用户全部
 /// 进程,2026-09-04 本机桌面会话两次被整台带走,audit 取证实锤)。
+///
+/// `pid <= 1` 或无法以正数收入 `i32` 的 pid 直接忽略:kill(2) 对 0 与 -1 有
+/// 特殊语义(0 = 调用方所在整组,-1 = 当前用户全部进程),边界在本函数自检,
+/// 不依赖调用方审计。
 pub fn kill_pid_tree(pid: u32) {
+    let Some(group) = i32::try_from(pid).ok().filter(|group| *group > 1) else {
+        return;
+    };
     // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
-    let group_ok = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } == 0;
+    let group_ok = unsafe { libc::kill(-group, libc::SIGKILL) } == 0;
     if !group_ok {
         // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
-        let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        let _ = unsafe { libc::kill(group, libc::SIGKILL) };
     }
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
@@ -123,8 +123,9 @@ pub fn apply_user_npm_prefix(cmd: &mut Command) {
 /// 追加一次单 pid 兜底。
 pub fn kill_pid_tree(pid: u32) {
     if pid <= 1 {
-        // pid≤1 拼出的 `kill -9 -pid` 命中内核 kill(0/-1) 语义，会杀光本用户
-        // 全部进程（曾导致整个桌面会话被带走）。拒绝并留调用栈现场。
+        // pid<=1 expands to the kernel kill(0/-1) special semantics, which
+        // signals every process of this user (once took down the whole
+        // desktop session). Refuse and leave a backtrace on disk.
         crate::platform::process::log_refused_user_wide_kill("linux kill_pid_tree", pid);
         return;
     }

--- a/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/linux/linux_path.rs
@@ -121,17 +121,12 @@ pub fn apply_user_npm_prefix(cmd: &mut Command) {
 /// 的 pid 会把 node 孙进程孤儿化(与 platform::process::kill_process_tree 同语义)。
 /// 若进程恰未成组(旧登记),追加一次单 pid 兜底。
 ///
-/// 直接走 kill(2),不再 spawn 外部 /usr/bin/kill:procps-ng 4.0.4 的参数解析会把
-/// `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理（向内核发起 kill(-1)，杀光当前
-/// 用户全部进程——本机桌面会话两次因此被整台带走，2026-09-04 audit 取证实锤）。
+/// **严禁**委托外部 kill 可执行文件(直接 spawn 或经 connector_cli_command 间接
+/// 调用均含)执行组杀,后续模块开发一律直调系统调用,并由
+/// `scripts/architecture-guard.py` 强制检查:procps-ng 4.0.4 的参数解析会把
+/// `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理(kill(-1) 杀光当前用户全部
+/// 进程,2026-09-04 本机桌面会话两次被整台带走,audit 取证实锤)。
 pub fn kill_pid_tree(pid: u32) {
-    if pid <= 1 {
-        // pid<=1 expands to the kernel kill(0/-1) special semantics, which
-        // signals every process of this user. Refuse and leave a backtrace
-        // on disk.
-        crate::platform::process::log_refused_user_wide_kill("linux kill_pid_tree", pid);
-        return;
-    }
     // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
     let group_ok = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } == 0;
     if !group_ok {

--- a/pinvou3-app/src-tauri/src/platform/os/posix.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/posix.rs
@@ -6,7 +6,7 @@
 //!
 //! **不提取的 helper**（各有平台差异，保留在各自文件）：
 //! - `user_home_dir`：linux 硬编码 `/tmp`（品悟临时产物目录），macOS 用 `temp_dir()`
-//! - `kill_pid_tree`：linux 经 `connector_cli_command("", "kill")` 路由，macOS 用 `Command::new("kill")`
+//! - `kill_pid_tree`：linux 与 macOS 的组杀实现现已统一为直调 kill(2)，不再委托外部 kill 命令
 //! - `connector_cli_command` / `apply_user_npm_prefix`：有结构性差异
 //!
 //! `validate_upload_location` 不提取：其 body 调用 `user_home_dir()`，后者按平台不同。

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -232,6 +232,12 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// spawn 侧已 `process_group(0)` 成组,这里按负 pid 杀整组;单杀 shim pid 会把
 /// node 孙进程孤儿化。组杀失败(进程未成组的旧登记)追加单 pid 兜底。
 pub fn kill_pid_tree(pid: u32) {
+    if pid <= 1 {
+        // pid≤1 拼出的 `kill -9 -pid` 命中内核 kill(0/-1) 语义，会杀光本用户
+        // 全部进程（曾导致整个桌面会话被带走）。拒绝并留调用栈现场。
+        crate::platform::process::log_refused_user_wide_kill("unsupported kill_pid_tree", pid);
+        return;
+    }
     let group_arg = format!("-{pid}");
     let group_ok = Command::new("kill")
         .args(["-9", group_arg.as_str()])

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -239,19 +239,32 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// 合法负 pid 错路由成 kill(-1)(procps-ng 4.0.4 在 Linux 上即如此,曾杀光
 /// 整个桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 合约
 /// 分支仅参与编译、无实际平台绑定,保留外部调用形态。
+///
+/// `pid <= 1` 或无法以正数收入 `i32` 的 pid 一律拒绝:kill(2) 对 0 与 -1 有
+/// 特殊语义(0 = 调用方所在整组,-1 = 当前用户全部进程),边界在本函数自检,
+/// 不依赖调用方审计。
 pub fn kill_pid_tree(pid: u32) {
     #[cfg(unix)]
     {
+        let Some(group) = i32::try_from(pid).ok().filter(|group| *group > 1) else {
+            return;
+        };
         // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
-        let group_ok = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } == 0;
+        let group_ok = unsafe { libc::kill(-group, libc::SIGKILL) } == 0;
         if !group_ok {
             // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
-            let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+            let _ = unsafe { libc::kill(group, libc::SIGKILL) };
         }
         return;
     }
     #[cfg(not(unix))]
     {
+        // Compile-only contract branch; keep the same refusal so a future
+        // binding cannot inherit the kill(0/-1) special semantics through
+        // the external binary either.
+        if pid <= 1 {
+            return;
+        }
         let group_arg = format!("-{pid}");
         let group_ok = Command::new("kill")
             .args(["-9", group_arg.as_str()])

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -12,8 +12,6 @@ use std::process::Command;
 
 // macOS 侧由 `macos_system::current_system_locale` 显式实现阴影本符号,该目标下
 // unused(unused_imports=deny 会拦);其余 unsupported 平台它是唯一来源,保留。
-// architecture-guard: allow-external-group-kill-stub -- kill_pid_tree 的非 unix
-// 合约分支仅参与编译、无实际平台绑定(真实平台全部直调 kill(2));见其文档。
 #[cfg(not(target_os = "macos"))]
 pub(crate) use super::locale::current_system_locale;
 
@@ -237,8 +235,9 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// **严禁**委托外部 `/usr/bin/kill` 执行组杀,后续模块开发一律直调系统调用,
 /// 并由 `scripts/architecture-guard.py` 强制检查:外部工具的参数解析可能把
 /// 合法负 pid 错路由成 kill(-1)(procps-ng 4.0.4 在 Linux 上即如此,曾杀光
-/// 整个桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 合约
-/// 分支仅参与编译、无实际平台绑定,保留外部调用形态。
+/// 整个桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 目标
+/// 无 POSIX 进程组语义,合约分支遵循本文件「未支持能力」约定显式不做任何事,
+/// 全文件保持受 guard 检查,不得再引入外部 kill 调用形态。
 ///
 /// `pid <= 1` 或无法以正数收入 `i32` 的 pid 一律拒绝:kill(2) 对 0 与 -1 有
 /// 特殊语义(0 = 调用方所在整组,-1 = 当前用户全部进程),边界在本函数自检,
@@ -259,21 +258,11 @@ pub fn kill_pid_tree(pid: u32) {
     }
     #[cfg(not(unix))]
     {
-        // Compile-only contract branch; keep the same refusal so a future
-        // binding cannot inherit the kill(0/-1) special semantics through
-        // the external binary either.
-        if pid <= 1 {
-            return;
-        }
-        let group_arg = format!("-{pid}");
-        let group_ok = Command::new("kill")
-            .args(["-9", group_arg.as_str()])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if !group_ok {
-            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
-        }
+        // Non-unix targets have no POSIX process-group semantics; per this
+        // file's unsupported-capability contract the branch does nothing
+        // instead of delegating to an external tool. It stays under the
+        // architecture guard, so an external kill must never return here.
+        let _ = pid;
     }
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -231,22 +231,40 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// 退出收割用的树杀(macOS 走此实现)。连接器 CLI 是 npm shim(shell→node),
 /// spawn 侧已 `process_group(0)` 成组,这里按负 pid 杀整组;单杀 shim pid 会把
 /// node 孙进程孤儿化。组杀失败(进程未成组的旧登记)追加单 pid 兜底。
+///
+/// Unix 直接走 kill(2),不委托外部 /usr/bin/kill:外部工具的参数解析可能把合法
+/// 负 pid 错路由成 kill(-1)(procps-ng 4.0.4 在 Linux 上即如此,曾杀光整个
+/// 桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 合约分支
+/// 仅参与编译、无实际平台绑定,保留外部调用形态。
 pub fn kill_pid_tree(pid: u32) {
     if pid <= 1 {
         // pid<=1 expands to the kernel kill(0/-1) special semantics, which
-        // signals every process of this user (once took down the whole
-        // desktop session). Refuse and leave a backtrace on disk.
+        // signals every process of this user. Refuse and leave a backtrace
+        // on disk.
         crate::platform::process::log_refused_user_wide_kill("unsupported kill_pid_tree", pid);
         return;
     }
-    let group_arg = format!("-{pid}");
-    let group_ok = Command::new("kill")
-        .args(["-9", group_arg.as_str()])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !group_ok {
-        let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+    #[cfg(unix)]
+    {
+        // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+        let group_ok = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) } == 0;
+        if !group_ok {
+            // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+            let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        }
+        return;
+    }
+    #[cfg(not(unix))]
+    {
+        let group_arg = format!("-{pid}");
+        let group_ok = Command::new("kill")
+            .args(["-9", group_arg.as_str()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !group_ok {
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+        }
     }
 }
 

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -12,6 +12,8 @@ use std::process::Command;
 
 // macOS 侧由 `macos_system::current_system_locale` 显式实现阴影本符号,该目标下
 // unused(unused_imports=deny 会拦);其余 unsupported 平台它是唯一来源,保留。
+// architecture-guard: allow-external-group-kill-stub -- kill_pid_tree 的非 unix
+// 合约分支仅参与编译、无实际平台绑定(真实平台全部直调 kill(2));见其文档。
 #[cfg(not(target_os = "macos"))]
 pub(crate) use super::locale::current_system_locale;
 
@@ -232,18 +234,12 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// spawn 侧已 `process_group(0)` 成组,这里按负 pid 杀整组;单杀 shim pid 会把
 /// node 孙进程孤儿化。组杀失败(进程未成组的旧登记)追加单 pid 兜底。
 ///
-/// Unix 直接走 kill(2),不委托外部 /usr/bin/kill:外部工具的参数解析可能把合法
-/// 负 pid 错路由成 kill(-1)(procps-ng 4.0.4 在 Linux 上即如此,曾杀光整个
-/// 桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 合约分支
-/// 仅参与编译、无实际平台绑定,保留外部调用形态。
+/// **严禁**委托外部 `/usr/bin/kill` 执行组杀,后续模块开发一律直调系统调用,
+/// 并由 `scripts/architecture-guard.py` 强制检查:外部工具的参数解析可能把
+/// 合法负 pid 错路由成 kill(-1)(procps-ng 4.0.4 在 Linux 上即如此,曾杀光
+/// 整个桌面会话);kill(2) 语义与其完全一致且不经过任何解析器。非 unix 合约
+/// 分支仅参与编译、无实际平台绑定,保留外部调用形态。
 pub fn kill_pid_tree(pid: u32) {
-    if pid <= 1 {
-        // pid<=1 expands to the kernel kill(0/-1) special semantics, which
-        // signals every process of this user. Refuse and leave a backtrace
-        // on disk.
-        crate::platform::process::log_refused_user_wide_kill("unsupported kill_pid_tree", pid);
-        return;
-    }
     #[cfg(unix)]
     {
         // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.

--- a/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
+++ b/pinvou3-app/src-tauri/src/platform/os/unsupported.rs
@@ -233,8 +233,9 @@ pub fn apply_user_npm_prefix(_cmd: &mut Command) {}
 /// node 孙进程孤儿化。组杀失败(进程未成组的旧登记)追加单 pid 兜底。
 pub fn kill_pid_tree(pid: u32) {
     if pid <= 1 {
-        // pid≤1 拼出的 `kill -9 -pid` 命中内核 kill(0/-1) 语义，会杀光本用户
-        // 全部进程（曾导致整个桌面会话被带走）。拒绝并留调用栈现场。
+        // pid<=1 expands to the kernel kill(0/-1) special semantics, which
+        // signals every process of this user (once took down the whole
+        // desktop session). Refuse and leave a backtrace on disk.
         crate::platform::process::log_refused_user_wide_kill("unsupported kill_pid_tree", pid);
         return;
     }

--- a/pinvou3-app/src-tauri/src/platform/paths.rs
+++ b/pinvou3-app/src-tauri/src/platform/paths.rs
@@ -40,18 +40,6 @@ pub fn memory_review_log() -> PathBuf {
     pinvou3_home().join("logs").join("memory-review.log")
 }
 
-/// `~/.pinvou3/logs/pinvou-refused-user-wide-kill.log` — forensic log for
-/// refused user-wide process-group kills. Deliberately not `temp_dir()`:
-/// on Linux that is a shared world-writable directory where a pre-created
-/// symlink or same-named directory could both steer the appended backtrace
-/// into an arbitrary file writable by this user and silently disable the
-/// diagnostic.
-pub fn refused_kill_log() -> PathBuf {
-    pinvou3_home()
-        .join("logs")
-        .join("pinvou-refused-user-wide-kill.log")
-}
-
 pub fn bundle_root() -> PathBuf {
     pinvou3_home().join("bundle")
 }

--- a/pinvou3-app/src-tauri/src/platform/paths.rs
+++ b/pinvou3-app/src-tauri/src/platform/paths.rs
@@ -40,6 +40,18 @@ pub fn memory_review_log() -> PathBuf {
     pinvou3_home().join("logs").join("memory-review.log")
 }
 
+/// `~/.pinvou3/logs/pinvou-refused-user-wide-kill.log` — forensic log for
+/// refused user-wide process-group kills. Deliberately not `temp_dir()`:
+/// on Linux that is a shared world-writable directory where a pre-created
+/// symlink or same-named directory could both steer the appended backtrace
+/// into an arbitrary file writable by this user and silently disable the
+/// diagnostic.
+pub fn refused_kill_log() -> PathBuf {
+    pinvou3_home()
+        .join("logs")
+        .join("pinvou-refused-user-wide-kill.log")
+}
+
 pub fn bundle_root() -> PathBuf {
     pinvou3_home().join("bundle")
 }

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -475,7 +475,9 @@ mod tests {
                 None => std::env::remove_var("PATH"),
             }
         }
-        let _ = std::fs::remove_dir_all(&work);
+        // Read before cleanup: removing the work dir deletes the marker with
+        // it, which would make the assertion below vacuously pass.
+        let marker_content = std::fs::read_to_string(&marker).ok();
 
         assert!(
             kill_result.is_ok(),
@@ -486,8 +488,11 @@ mod tests {
             "group leader {sh_pid} and descendant {sleep_pid} must both die"
         );
         assert!(
-            !marker.exists(),
-            "an external kill was spawned; group kills must use kill(2) directly"
+            marker_content.is_none(),
+            "an external kill was spawned (argv log: {marker_content:?}); \
+             group kills must use kill(2) directly"
         );
+
+        let _ = std::fs::remove_dir_all(&work);
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -251,11 +251,35 @@ pub(crate) fn std_process_group_leader(command: &mut Command) {
     }
 }
 
+/// `kill -9 -<pid≤1>` 会命中内核 kill(0/-1) 的特殊语义：杀光整个进程组 /
+/// 本用户的全部进程。桌面会话曾因此被整锅带走（Xorg、gnome-shell、
+/// systemd --user 连带黑屏回锁屏）。拒绝执行并把调用栈落盘，用于定位
+/// 真正传入非法 pid 的上游调用方。
+pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
+    let report = format!(
+        "refused {site}: pid={pid} (would expand to `kill -9 -{pid}`)\nprocess={}\ntime={:?}\nbacktrace:\n{:?}\n",
+        std::process::id(),
+        std::time::SystemTime::now(),
+        std::backtrace::Backtrace::force_capture(),
+    );
+    eprintln!("[pinvou3] {report}");
+    let _ = std::fs::write("/tmp/pinvou-refused-user-wide-kill.log", report);
+}
+
 /// 按 pid 杀进程树：Windows 用 taskkill 杀整棵树（脚本会再起子 shell，单杀
 /// 父进程会留下继续运行的子进程）；其他平台按进程组杀（负 pid）——安装进程
 /// 以 `process_group(0)` 独立成组，`kill -9 -pgid` 连 curl | bash / npm 派生
 /// 的子进程一起终止，不孤儿化（评审中危项）。
 pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<Output> {
+    if pid <= 1 {
+        log_refused_user_wide_kill("kill_process_tree", pid);
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "refused kill_process_tree({pid}): negative-group kill would signal every process of this user"
+            ),
+        ));
+    }
     let pid_arg = pid.to_string();
     if crate::platform::capabilities::is_windows() {
         external_command(Path::new("taskkill"))
@@ -348,5 +372,21 @@ mod tests {
 
         assert!(error.contains("timed out after"));
         assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    /// `kill -9 -0` / `kill -9 -1` 命中内核 kill(0/-1) 特殊语义（杀整组 /
+    /// 本用户全部进程，桌面会话曾因此被带走）：pid≤1 必须被拒绝，不 spawn
+    /// 外部 kill，且错误信息指明拒绝原因。
+    #[test]
+    fn kill_process_tree_refuses_user_wide_group_targets() {
+        for pid in [0_u32, 1] {
+            let error = kill_process_tree(pid)
+                .expect_err("pid≤1 must be refused, never expanded to kill -9 -pid");
+            let message = error.to_string();
+            assert!(
+                message.contains("refused") && message.contains(&pid.to_string()),
+                "拒绝信息须写明 pid={pid}，实得：{message}"
+            );
+        }
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -251,19 +251,37 @@ pub(crate) fn std_process_group_leader(command: &mut Command) {
     }
 }
 
-/// `kill -9 -<pid≤1>` 会命中内核 kill(0/-1) 的特殊语义：杀光整个进程组 /
-/// 本用户的全部进程。桌面会话曾因此被整锅带走（Xorg、gnome-shell、
-/// systemd --user 连带黑屏回锁屏）。拒绝执行并把调用栈落盘，用于定位
-/// 真正传入非法 pid 的上游调用方。
+/// `kill -9 -<pid<=1>` hits the kernel kill(0/-1) special semantics: it
+/// signals the whole process group / every process of this user. The
+/// desktop session was once taken down with it (Xorg, gnome-shell and
+/// systemd --user, ending in a black screen back at the lock screen).
+/// Refuse and write the call site to disk so the upstream caller that
+/// produced the invalid pid can be identified.
+///
+/// The log is appended to `temp_dir()` (still /tmp on Linux) so scenes
+/// from multiple refusals (e.g. the timeout and cancel paths firing in
+/// sequence) all survive; a literal /tmp would resolve to the current
+/// drive root on Windows and fail silently when the directory is
+/// missing. Release builds strip symbols (`strip = "symbols"`), so
+/// backtraces may be addresses only — resolve them with os/process/time
+/// against a debug build of the same version.
 pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
+    use std::io::Write as _;
+
     let report = format!(
-        "refused {site}: pid={pid} (would expand to `kill -9 -{pid}`)\nprocess={}\ntime={:?}\nbacktrace:\n{:?}\n",
+        "refused {site}: pid={pid} (would expand to `kill -9 -{pid}`)\nprocess={} os={}\ntime={:?}\nbacktrace:\n{:?}\n",
         std::process::id(),
+        std::env::consts::OS,
         std::time::SystemTime::now(),
         std::backtrace::Backtrace::force_capture(),
     );
-    eprintln!("[pinvou3] {report}");
-    let _ = std::fs::write("/tmp/pinvou-refused-user-wide-kill.log", report);
+    let path = std::env::temp_dir().join("pinvou-refused-user-wide-kill.log");
+    eprintln!("[pinvou3] {report}log: {}\n", path.display());
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| file.write_all(report.as_bytes()));
 }
 
 /// 按 pid 杀进程树：Windows 用 taskkill 杀整棵树（脚本会再起子 shell，单杀
@@ -274,7 +292,7 @@ pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<Output> {
     if pid <= 1 {
         log_refused_user_wide_kill("kill_process_tree", pid);
         return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+            std::io::ErrorKind::InvalidInput,
             format!(
                 "refused kill_process_tree({pid}): negative-group kill would signal every process of this user"
             ),
@@ -374,18 +392,21 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(5));
     }
 
-    /// `kill -9 -0` / `kill -9 -1` 命中内核 kill(0/-1) 特殊语义（杀整组 /
-    /// 本用户全部进程，桌面会话曾因此被带走）：pid≤1 必须被拒绝，不 spawn
-    /// 外部 kill，且错误信息指明拒绝原因。
+    /// `kill -9 -0` / `kill -9 -1` hit the kernel kill(0/-1) special
+    /// semantics (signal the whole group / every process of this user;
+    /// the desktop session was once taken down this way): pid<=1 must be
+    /// refused, never expanded to `kill -9 -pid`, without spawning an
+    /// external kill, and the error must name the refusal reason.
     #[test]
     fn kill_process_tree_refuses_user_wide_group_targets() {
         for pid in [0_u32, 1] {
             let error = kill_process_tree(pid)
-                .expect_err("pid≤1 must be refused, never expanded to kill -9 -pid");
+                .expect_err("pid<=1 must be refused, never expanded to kill -9 -pid");
             let message = error.to_string();
             assert!(
-                message.contains("refused") && message.contains(&pid.to_string()),
-                "拒绝信息须写明 pid={pid}，实得：{message}"
+                message.contains("refused")
+                    && message.contains(&format!("kill_process_tree({pid})")),
+                "refusal message must name pid={pid}, got: {message}"
             );
         }
     }

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -251,72 +251,23 @@ pub(crate) fn std_process_group_leader(command: &mut Command) {
     }
 }
 
-/// `kill -9 -<pid<=1>` hits the kernel kill(0/-1) special semantics: it
-/// signals the whole process group / every process of this user. Group
-/// kills are issued through kill(2) directly (never delegated to external
-/// kill binaries whose argument parsers may misroute negative pids —
-/// procps-ng 4.0.4 turned `kill -9 -<pgid>` into kill(-1) and twice took
-/// down the whole desktop session). This guard is the last line of
-/// defense: refuse pid<=1 and write the call site to disk so an upstream
-/// caller that produced the invalid pid can be identified.
-///
-/// The log is appended to the private per-user `~/.pinvou3/logs/` so
-/// scenes from multiple refusals (e.g. the timeout and cancel paths
-/// firing in sequence) all survive, and no other local user can pre-create
-/// a symlink or same-named directory there to steer the write or disable
-/// the diagnostic (that is possible in the shared world-writable
-/// `temp_dir()` on Linux). Release builds strip symbols
-/// (`strip = "symbols"`), so backtraces may be addresses only — resolve
-/// them with os/process/time against a debug build of the same version.
-pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
-    use std::io::Write as _;
-
-    let report = format!(
-        "refused {site}: pid={pid} (would expand to `kill -9 -{pid}`)\nprocess={} os={}\ntime={:?}\nbacktrace:\n{:?}\n",
-        std::process::id(),
-        std::env::consts::OS,
-        std::time::SystemTime::now(),
-        std::backtrace::Backtrace::force_capture(),
-    );
-    let path = crate::platform::paths::refused_kill_log();
-    eprintln!("[pinvou3] {report}log: {}\n", path.display());
-    // Best effort only: stderr already carries the full report, so a failed
-    // file write (hostile path, unwritable home, ...) loses the durable copy
-    // but never the diagnostic itself, and must not affect the kill refusal.
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .and_then(|mut file| file.write_all(report.as_bytes()));
-}
-
 /// 按 pid 杀进程树：Windows 用 taskkill 杀整棵树（脚本会再起子 shell，单杀
 /// 父进程会留下继续运行的子进程）；其他平台按进程组杀（负 pid）——安装进程
 /// 以 `process_group(0)` 独立成组，组杀连 curl | bash / npm 派生的子进程一起
 /// 终止，不孤儿化（评审中危项）。
 ///
-/// Unix 必须直接走 kill(2)，不得 spawn 外部 `/usr/bin/kill`：procps-ng 4.0.4
-/// 的参数解析会把 `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理（向内核发起
-/// kill(-1)，杀光当前用户全部进程——2026-09-04 本机桌面会话两次被整台带走，
-/// audit 取证 argv 正确而系统调用为 kill(-1)，实锤）。`pid <= 1` 的拒绝仍在
-/// 最前面：组杀已是直接系统调用，一旦误传 0/1 同样等价于 kill(0/-1) 全组/
-/// 全用户语义，这里是最后一道防线。
+/// **严禁**在本 crate 任何位置直接或间接（如经 connector_cli_command 以 kill 为
+/// 程序名）spawn 外部 kill 可执行文件执行组杀，后续模块开发一律
+/// 使用本函数 / `kill_pid_tree`（内部直接走 kill(2)）。这是硬性规则并由
+/// `scripts/architecture-guard.py` 强制：procps-ng 4.0.4 的参数解析会把
+/// `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理（向内核发起 kill(-1)，杀光
+/// 当前用户全部进程——2026-09-04 本机桌面会话两次被整台带走，audit 取证
+/// argv 正确而系统调用为 kill(-1)，实锤）。任何新平台的组杀实现同理必须
+/// 直调系统调用，不得委托外部工具。
 ///
 /// 进程组已不存在（ESRCH）视为成功——目标已死即目的达成，调用方无需为
 /// 「取消时进程恰好已退出」记失败日志。
 pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<()> {
-    if pid <= 1 {
-        log_refused_user_wide_kill("kill_process_tree", pid);
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!(
-                "refused kill_process_tree({pid}): negative-group kill would signal every process of this user"
-            ),
-        ));
-    }
     if crate::platform::capabilities::is_windows() {
         external_command(Path::new("taskkill"))
             .args(["/PID", &pid.to_string(), "/T", "/F"])
@@ -421,105 +372,6 @@ mod tests {
 
         assert!(error.contains("timed out after"));
         assert!(started.elapsed() < Duration::from_secs(5));
-    }
-
-    /// Run `check` with `PINVOU3_HOME` redirected to a fresh per-test
-    /// directory so refusal-log writes stay out of the developer's real
-    /// `~/.pinvou3/`. Borrows the crate-wide `ENV_LOCK` because the value
-    /// is process-global (same pattern as the `paths::tests` env tests).
-    fn with_temp_pinvou_home<T>(check: impl FnOnce(&std::path::Path) -> T) -> T {
-        let _env_lock = crate::platform::paths::tests::ENV_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let root = std::env::temp_dir().join(format!(
-            "pinvou3-kill-refusal-log-{}-{}",
-            std::process::id(),
-            crate::platform::paths::tests::unique_suffix()
-        ));
-        std::fs::create_dir_all(&root).expect("create temp PINVOU3_HOME");
-        let previous = std::env::var_os("PINVOU3_HOME");
-        // SAFETY: holding platform::paths::tests::ENV_LOCK; in-process env writes are serialized.
-        unsafe { std::env::set_var("PINVOU3_HOME", &root) };
-
-        let result = check(&root);
-
-        // SAFETY: holding platform::paths::tests::ENV_LOCK; in-process env writes are serialized.
-        unsafe {
-            match previous {
-                Some(value) => std::env::set_var("PINVOU3_HOME", value),
-                None => std::env::remove_var("PINVOU3_HOME"),
-            }
-        }
-        let _ = std::fs::remove_dir_all(&root);
-        result
-    }
-
-    /// `kill -9 -0` / `kill -9 -1` hit the kernel kill(0/-1) special
-    /// semantics (signal the whole group / every process of this user;
-    /// the desktop session was once taken down this way): pid<=1 must be
-    /// refused, never expanded to `kill -9 -pid`, without spawning an
-    /// external kill, and the error must name the refusal reason.
-    #[test]
-    fn kill_process_tree_refuses_user_wide_group_targets() {
-        with_temp_pinvou_home(|_home| {
-            for pid in [0_u32, 1] {
-                let error = kill_process_tree(pid)
-                    .expect_err("pid<=1 must be refused, never expanded to kill -9 -pid");
-                let message = error.to_string();
-                assert!(
-                    message.contains("refused")
-                        && message.contains(&format!("kill_process_tree({pid})")),
-                    "refusal message must name pid={pid}, got: {message}"
-                );
-            }
-        });
-    }
-
-    /// The forensic report must land inside the private per-user home (never
-    /// the shared temp dir) and appends must accumulate: a second refusal
-    /// adds a scene without erasing the first.
-    #[test]
-    fn refused_kill_log_lands_in_private_home_and_appends() {
-        with_temp_pinvou_home(|home| {
-            log_refused_user_wide_kill("append-scene", 0);
-            log_refused_user_wide_kill("append-scene", 1);
-
-            let path = crate::platform::paths::refused_kill_log();
-            assert!(
-                path.starts_with(home),
-                "log must stay under PINVOU3_HOME, got: {}",
-                path.display()
-            );
-            let logged = std::fs::read_to_string(&path).expect("refusal log must exist");
-            assert_eq!(
-                logged.matches("refused append-scene").count(),
-                2,
-                "both refusal scenes must survive, got: {logged:?}"
-            );
-            assert!(logged.contains("backtrace:"));
-        });
-    }
-
-    /// A hostile path (the log location pre-created as a directory) must not
-    /// disable the kill refusal, panic, or corrupt state: the diagnostic
-    /// degrades to stderr while the guard still refuses pid<=1 unchanged.
-    #[test]
-    fn refused_kill_log_survives_hostile_path() {
-        with_temp_pinvou_home(|_home| {
-            let path = crate::platform::paths::refused_kill_log();
-            std::fs::create_dir_all(&path).expect("pre-create hostile directory at the log path");
-
-            log_refused_user_wide_kill("hostile-scene", 0);
-
-            assert!(path.is_dir(), "hostile path must be left untouched");
-            let error = kill_process_tree(1)
-                .expect_err("pid<=1 must still be refused when the log write fails");
-            let message = error.to_string();
-            assert!(
-                message.contains("refused") && message.contains("kill_process_tree(1)"),
-                "refusal message must be unchanged, got: {message}"
-            );
-        });
     }
 
     /// Unix group kills must go through kill(2) directly. This is the

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -252,19 +252,22 @@ pub(crate) fn std_process_group_leader(command: &mut Command) {
 }
 
 /// `kill -9 -<pid<=1>` hits the kernel kill(0/-1) special semantics: it
-/// signals the whole process group / every process of this user. The
-/// desktop session was once taken down with it (Xorg, gnome-shell and
-/// systemd --user, ending in a black screen back at the lock screen).
-/// Refuse and write the call site to disk so the upstream caller that
-/// produced the invalid pid can be identified.
+/// signals the whole process group / every process of this user. Group
+/// kills are issued through kill(2) directly (never delegated to external
+/// kill binaries whose argument parsers may misroute negative pids —
+/// procps-ng 4.0.4 turned `kill -9 -<pgid>` into kill(-1) and twice took
+/// down the whole desktop session). This guard is the last line of
+/// defense: refuse pid<=1 and write the call site to disk so an upstream
+/// caller that produced the invalid pid can be identified.
 ///
-/// The log is appended to `temp_dir()` (still /tmp on Linux) so scenes
-/// from multiple refusals (e.g. the timeout and cancel paths firing in
-/// sequence) all survive; a literal /tmp would resolve to the current
-/// drive root on Windows and fail silently when the directory is
-/// missing. Release builds strip symbols (`strip = "symbols"`), so
-/// backtraces may be addresses only — resolve them with os/process/time
-/// against a debug build of the same version.
+/// The log is appended to the private per-user `~/.pinvou3/logs/` so
+/// scenes from multiple refusals (e.g. the timeout and cancel paths
+/// firing in sequence) all survive, and no other local user can pre-create
+/// a symlink or same-named directory there to steer the write or disable
+/// the diagnostic (that is possible in the shared world-writable
+/// `temp_dir()` on Linux). Release builds strip symbols
+/// (`strip = "symbols"`), so backtraces may be addresses only — resolve
+/// them with os/process/time against a debug build of the same version.
 pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
     use std::io::Write as _;
 
@@ -275,8 +278,14 @@ pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
         std::time::SystemTime::now(),
         std::backtrace::Backtrace::force_capture(),
     );
-    let path = std::env::temp_dir().join("pinvou-refused-user-wide-kill.log");
+    let path = crate::platform::paths::refused_kill_log();
     eprintln!("[pinvou3] {report}log: {}\n", path.display());
+    // Best effort only: stderr already carries the full report, so a failed
+    // file write (hostile path, unwritable home, ...) loses the durable copy
+    // but never the diagnostic itself, and must not affect the kill refusal.
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let _ = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
@@ -286,9 +295,19 @@ pub(crate) fn log_refused_user_wide_kill(site: &str, pid: u32) {
 
 /// 按 pid 杀进程树：Windows 用 taskkill 杀整棵树（脚本会再起子 shell，单杀
 /// 父进程会留下继续运行的子进程）；其他平台按进程组杀（负 pid）——安装进程
-/// 以 `process_group(0)` 独立成组，`kill -9 -pgid` 连 curl | bash / npm 派生
-/// 的子进程一起终止，不孤儿化（评审中危项）。
-pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<Output> {
+/// 以 `process_group(0)` 独立成组，组杀连 curl | bash / npm 派生的子进程一起
+/// 终止，不孤儿化（评审中危项）。
+///
+/// Unix 必须直接走 kill(2)，不得 spawn 外部 `/usr/bin/kill`：procps-ng 4.0.4
+/// 的参数解析会把 `kill -9 -<pgid>` 的合法负 pid 错当 `-1` 处理（向内核发起
+/// kill(-1)，杀光当前用户全部进程——2026-09-04 本机桌面会话两次被整台带走，
+/// audit 取证 argv 正确而系统调用为 kill(-1)，实锤）。`pid <= 1` 的拒绝仍在
+/// 最前面：组杀已是直接系统调用，一旦误传 0/1 同样等价于 kill(0/-1) 全组/
+/// 全用户语义，这里是最后一道防线。
+///
+/// 进程组已不存在（ESRCH）视为成功——目标已死即目的达成，调用方无需为
+/// 「取消时进程恰好已退出」记失败日志。
+pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<()> {
     if pid <= 1 {
         log_refused_user_wide_kill("kill_process_tree", pid);
         return Err(std::io::Error::new(
@@ -298,17 +317,29 @@ pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<Output> {
             ),
         ));
     }
-    let pid_arg = pid.to_string();
     if crate::platform::capabilities::is_windows() {
         external_command(Path::new("taskkill"))
-            .args(["/PID", pid_arg.as_str(), "/T", "/F"])
-            .output()
-    } else {
-        let group_arg = format!("-{pid_arg}");
-        external_command(Path::new("kill"))
-            .args(["-9", group_arg.as_str()])
-            .output()
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .output()?;
+        return Ok(());
     }
+    #[cfg(unix)]
+    {
+        // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+        let sent = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        if sent != 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
+            return Err(error);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+    }
+    Ok(())
 }
 
 pub(crate) struct HiddenTokioCommand;
@@ -392,6 +423,37 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(5));
     }
 
+    /// Run `check` with `PINVOU3_HOME` redirected to a fresh per-test
+    /// directory so refusal-log writes stay out of the developer's real
+    /// `~/.pinvou3/`. Borrows the crate-wide `ENV_LOCK` because the value
+    /// is process-global (same pattern as the `paths::tests` env tests).
+    fn with_temp_pinvou_home<T>(check: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _env_lock = crate::platform::paths::tests::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let root = std::env::temp_dir().join(format!(
+            "pinvou3-kill-refusal-log-{}-{}",
+            std::process::id(),
+            crate::platform::paths::tests::unique_suffix()
+        ));
+        std::fs::create_dir_all(&root).expect("create temp PINVOU3_HOME");
+        let previous = std::env::var_os("PINVOU3_HOME");
+        // SAFETY: holding platform::paths::tests::ENV_LOCK; in-process env writes are serialized.
+        unsafe { std::env::set_var("PINVOU3_HOME", &root) };
+
+        let result = check(&root);
+
+        // SAFETY: holding platform::paths::tests::ENV_LOCK; in-process env writes are serialized.
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("PINVOU3_HOME", value),
+                None => std::env::remove_var("PINVOU3_HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&root);
+        result
+    }
+
     /// `kill -9 -0` / `kill -9 -1` hit the kernel kill(0/-1) special
     /// semantics (signal the whole group / every process of this user;
     /// the desktop session was once taken down this way): pid<=1 must be
@@ -399,15 +461,170 @@ mod tests {
     /// external kill, and the error must name the refusal reason.
     #[test]
     fn kill_process_tree_refuses_user_wide_group_targets() {
-        for pid in [0_u32, 1] {
-            let error = kill_process_tree(pid)
-                .expect_err("pid<=1 must be refused, never expanded to kill -9 -pid");
+        with_temp_pinvou_home(|_home| {
+            for pid in [0_u32, 1] {
+                let error = kill_process_tree(pid)
+                    .expect_err("pid<=1 must be refused, never expanded to kill -9 -pid");
+                let message = error.to_string();
+                assert!(
+                    message.contains("refused")
+                        && message.contains(&format!("kill_process_tree({pid})")),
+                    "refusal message must name pid={pid}, got: {message}"
+                );
+            }
+        });
+    }
+
+    /// The forensic report must land inside the private per-user home (never
+    /// the shared temp dir) and appends must accumulate: a second refusal
+    /// adds a scene without erasing the first.
+    #[test]
+    fn refused_kill_log_lands_in_private_home_and_appends() {
+        with_temp_pinvou_home(|home| {
+            log_refused_user_wide_kill("append-scene", 0);
+            log_refused_user_wide_kill("append-scene", 1);
+
+            let path = crate::platform::paths::refused_kill_log();
+            assert!(
+                path.starts_with(home),
+                "log must stay under PINVOU3_HOME, got: {}",
+                path.display()
+            );
+            let logged = std::fs::read_to_string(&path).expect("refusal log must exist");
+            assert_eq!(
+                logged.matches("refused append-scene").count(),
+                2,
+                "both refusal scenes must survive, got: {logged:?}"
+            );
+            assert!(logged.contains("backtrace:"));
+        });
+    }
+
+    /// A hostile path (the log location pre-created as a directory) must not
+    /// disable the kill refusal, panic, or corrupt state: the diagnostic
+    /// degrades to stderr while the guard still refuses pid<=1 unchanged.
+    #[test]
+    fn refused_kill_log_survives_hostile_path() {
+        with_temp_pinvou_home(|_home| {
+            let path = crate::platform::paths::refused_kill_log();
+            std::fs::create_dir_all(&path).expect("pre-create hostile directory at the log path");
+
+            log_refused_user_wide_kill("hostile-scene", 0);
+
+            assert!(path.is_dir(), "hostile path must be left untouched");
+            let error = kill_process_tree(1)
+                .expect_err("pid<=1 must still be refused when the log write fails");
             let message = error.to_string();
             assert!(
-                message.contains("refused")
-                    && message.contains(&format!("kill_process_tree({pid})")),
-                "refusal message must name pid={pid}, got: {message}"
+                message.contains("refused") && message.contains("kill_process_tree(1)"),
+                "refusal message must be unchanged, got: {message}"
             );
+        });
+    }
+
+    /// Unix group kills must go through kill(2) directly. This is the
+    /// regression test for the 2026-09-04 desktop-session massacres: the
+    /// timeout path spawned external `/usr/bin/kill -9 -<pgid>` and
+    /// procps-ng 4.0.4 misparsed the valid negative pid as -1 (kill(-1)
+    /// signals every process of this user). A fake `kill` is placed first
+    /// on PATH: if the implementation ever spawns an external kill again,
+    /// the marker file appears and the test fails — before considering
+    /// what that binary would do to the machine.
+    #[cfg(unix)]
+    #[test]
+    fn kill_process_tree_terminates_group_without_spawning_external_kill() {
+        use std::sync::Mutex;
+
+        static PATH_LOCK: Mutex<()> = Mutex::new(());
+        let _path_lock = PATH_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let work = std::env::temp_dir().join(format!(
+            "pinvou3-kill-process-tree-{}-{}",
+            std::process::id(),
+            crate::platform::paths::tests::unique_suffix()
+        ));
+        std::fs::create_dir_all(&work).expect("create test work dir");
+        let marker = work.join("external-kill-invoked");
+        let sleep_pid_file = work.join("sleep-pid");
+        let fake_kill_bin = work.join("kill");
+        std::fs::write(
+            &fake_kill_bin,
+            format!("#!/bin/sh\necho \"$@\" >> {}\nexit 42\n", marker.display()),
+        )
+        .expect("write fake kill");
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&fake_kill_bin, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake kill");
+
+        let previous_path = std::env::var_os("PATH");
+        let mut split_path = previous_path
+            .as_ref()
+            .map(|value| std::env::split_paths(value).collect::<Vec<_>>())
+            .unwrap_or_default();
+        split_path.insert(0, work.clone());
+        // SAFETY: this test serializes on PATH_LOCK; a prepended dir cannot
+        // break other tests that merely resolve commands through PATH.
+        unsafe { std::env::set_var("PATH", std::env::join_paths(&split_path).unwrap()) };
+
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            &format!("sleep 30 & echo $! > {}; wait", sleep_pid_file.display()),
+        ]);
+        std_process_group_leader(&mut command);
+        let mut child = command.spawn().expect("spawn sh group leader");
+        let sh_pid = child.id();
+
+        let mut sleep_pid = None;
+        for _ in 0..40 {
+            if let Ok(text) = std::fs::read_to_string(&sleep_pid_file) {
+                if let Ok(value) = text.trim().parse::<u32>() {
+                    sleep_pid = Some(value);
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
         }
+        let sleep_pid = sleep_pid.expect("descendant must report its pid");
+
+        let kill_result = kill_process_tree(sh_pid);
+        let _ = child.wait();
+
+        // SAFETY: libc::kill with sig=0 only probes liveness; no memory is touched.
+        let alive = |pid: u32| unsafe { libc::kill(pid as i32, 0) == 0 };
+        let mut both_dead = !alive(sh_pid) && !alive(sleep_pid);
+        for _ in 0..100 {
+            if both_dead {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+            both_dead = !alive(sh_pid) && !alive(sleep_pid);
+        }
+        // The orphaned descendant is a member of this test's process tree;
+        // make sure no stray sleeper survives even if the asserts fail.
+        // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
+        let _ = unsafe { libc::kill(sleep_pid as i32, libc::SIGKILL) };
+
+        // SAFETY: holding PATH_LOCK; restoring the saved value.
+        unsafe {
+            match previous_path {
+                Some(value) => std::env::set_var("PATH", value),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&work);
+
+        assert!(
+            kill_result.is_ok(),
+            "group kill must succeed for a live group: {kill_result:?}"
+        );
+        assert!(
+            both_dead,
+            "group leader {sh_pid} and descendant {sleep_pid} must both die"
+        );
+        assert!(
+            !marker.exists(),
+            "an external kill was spawned; group kills must use kill(2) directly"
+        );
     }
 }

--- a/pinvou3-app/src-tauri/src/platform/process.rs
+++ b/pinvou3-app/src-tauri/src/platform/process.rs
@@ -267,6 +267,11 @@ pub(crate) fn std_process_group_leader(command: &mut Command) {
 ///
 /// 进程组已不存在（ESRCH）视为成功——目标已死即目的达成，调用方无需为
 /// 「取消时进程恰好已退出」记失败日志。
+///
+/// `pid <= 1` 或无法以正数收入 `i32` 的 pid 一律拒绝（`InvalidInput`）：
+/// kill(2) 对 0 与 -1 有特殊语义（0 = 调用方所在整组，-1 = 当前用户全部
+/// 进程），`as i32` 回绕出的负 pid 同理。边界在本函数自检，不依赖调用方
+/// 审计。
 pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<()> {
     if crate::platform::capabilities::is_windows() {
         external_command(Path::new("taskkill"))
@@ -276,8 +281,14 @@ pub(crate) fn kill_process_tree(pid: u32) -> std::io::Result<()> {
     }
     #[cfg(unix)]
     {
+        let Some(group) = i32::try_from(pid).ok().filter(|group| *group > 1) else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("refusing user-wide process group kill for pid {pid}"),
+            ));
+        };
         // SAFETY: libc::kill is a direct kill(2) wrapper; no memory is touched.
-        let sent = unsafe { libc::kill(-(pid as i32), libc::SIGKILL) };
+        let sent = unsafe { libc::kill(-group, libc::SIGKILL) };
         if sent != 0 {
             let error = std::io::Error::last_os_error();
             if error.raw_os_error() == Some(libc::ESRCH) {

--- a/scripts/architecture-guard.py
+++ b/scripts/architecture-guard.py
@@ -312,6 +312,7 @@ def scan_rust(root: Path) -> tuple[dict[str, Counter[str]], list[list[str]]]:
         "rust_platform_details_outside_adapter": Counter(),
         "rust_tauri_commands_outside_app": Counter(),
         "rust_tauri_handler_outside_app": Counter(),
+        "rust_external_group_kill_spawn": Counter(),
     }
     aliases = rust_aliases(root)
     rust_root = root / "pinvou3-app/src-tauri/src"
@@ -321,6 +322,19 @@ def scan_rust(root: Path) -> tuple[dict[str, Counter[str]], list[list[str]]]:
     feature_edge_counts: Counter[tuple[str, str]] = Counter()
     tauri_command_pattern = re.compile(r"#\s*\[\s*tauri\s*::\s*command\b")
     tauri_handler_pattern = re.compile(r"generate_handler\s*!\s*\[(.*?)\]", re.DOTALL)
+    # Process-group kills must be issued through kill(2) directly. Never
+    # spawn an external `kill` binary: procps-ng 4.0.4 misparses the valid
+    # negative pid in `kill -9 -<pgid>` as -1 (kill(-1) signals every process
+    # of the user and took down whole desktop sessions; see
+    # platform::process::kill_process_tree). File-level exception kind:
+    # `architecture-guard: allow-external-group-kill-stub` for compile-only
+    # contract stubs.
+    external_group_kill_patterns = [
+        re.compile(r'Command\s*::\s*new\s*\(\s*"(?:[^"]*/)?kill"'),
+        re.compile(r'::\s*new\s*\(\s*"(?:[^"]*/)?kill"\s*\)'),
+        re.compile(r'Path\s*::\s*new\s*\(\s*"(?:[^"]*/)?kill"'),
+        re.compile(r'connector_cli_command\s*\(\s*[^,()]*,\s*"kill"'),
+    ]
     platform_detail_patterns = [
         re.compile(r"\bpowershell(?:\.exe)?\b", re.IGNORECASE),
         re.compile(r"\bxdg-open\b"),
@@ -371,6 +385,12 @@ def scan_rust(root: Path) -> tuple[dict[str, Counter[str]], list[list[str]]]:
         command_count = len(tauri_command_pattern.findall(text))
         if command_count and "/app/commands/" not in f"/{relative}":
             rules["rust_tauri_commands_outside_app"][relative] += command_count
+        if not file_exception_allowed(text, "external-group-kill-stub"):
+            external_kill_count = sum(
+                len(pattern.findall(text)) for pattern in external_group_kill_patterns
+            )
+            if external_kill_count:
+                rules["rust_external_group_kill_spawn"][relative] += external_kill_count
         for handler in tauri_handler_pattern.findall(text):
             for entry in re.findall(
                 r"(?:^|,)\s*([A-Za-z_][A-Za-z0-9_:]*)\s*(?=,|$)", handler

--- a/scripts/architecture-guard.py
+++ b/scripts/architecture-guard.py
@@ -326,9 +326,9 @@ def scan_rust(root: Path) -> tuple[dict[str, Counter[str]], list[list[str]]]:
     # spawn an external `kill` binary: procps-ng 4.0.4 misparses the valid
     # negative pid in `kill -9 -<pgid>` as -1 (kill(-1) signals every process
     # of the user and took down whole desktop sessions; see
-    # platform::process::kill_process_tree). File-level exception kind:
-    # `architecture-guard: allow-external-group-kill-stub` for compile-only
-    # contract stubs.
+    # platform::process::kill_process_tree). The rule applies to every Rust
+    # file: unsupported.rs also carries the live macOS kill_pid_tree, so no
+    # file-level exception may waive it.
     external_group_kill_patterns = [
         re.compile(r'Command\s*::\s*new\s*\(\s*"(?:[^"]*/)?kill"'),
         re.compile(r'::\s*new\s*\(\s*"(?:[^"]*/)?kill"\s*\)'),
@@ -385,12 +385,11 @@ def scan_rust(root: Path) -> tuple[dict[str, Counter[str]], list[list[str]]]:
         command_count = len(tauri_command_pattern.findall(text))
         if command_count and "/app/commands/" not in f"/{relative}":
             rules["rust_tauri_commands_outside_app"][relative] += command_count
-        if not file_exception_allowed(text, "external-group-kill-stub"):
-            external_kill_count = sum(
-                len(pattern.findall(text)) for pattern in external_group_kill_patterns
-            )
-            if external_kill_count:
-                rules["rust_external_group_kill_spawn"][relative] += external_kill_count
+        external_kill_count = sum(
+            len(pattern.findall(text)) for pattern in external_group_kill_patterns
+        )
+        if external_kill_count:
+            rules["rust_external_group_kill_spawn"][relative] += external_kill_count
         for handler in tauri_handler_pattern.findall(text):
             for entry in re.findall(
                 r"(?:^|,)\s*([A-Za-z_][A-Za-z0-9_:]*)\s*(?=,|$)", handler

--- a/scripts/tests/test_architecture_guard.py
+++ b/scripts/tests/test_architecture_guard.py
@@ -243,6 +243,82 @@ class ArchitectureGuardUnitTests(unittest.TestCase):
                 ],
             )
 
+    def test_rust_scanner_rejects_external_group_kill_spawn(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            rust_root = root / "pinvou3-app/src-tauri/src"
+            platform = rust_root / "platform/process.rs"
+            platform.parent.mkdir(parents=True)
+            platform.write_text(
+                'fn run() {\n'
+                '    Command::new("kill");\n'
+                '    Command::new("/usr/bin/kill");\n'
+                '    Path::new("kill");\n'
+                '    connector_cli_command(cmd, "kill");\n'
+                '    Command::new("taskkill");\n'
+                '}\n',
+                encoding="utf-8",
+            )
+
+            rules, _ = self.guard.scan_rust(root)
+
+            # The generic `::new("kill")` pattern overlaps the Command/Path
+            # specific ones, so those three shapes count twice each.
+            self.assertEqual(
+                7,
+                rules["rust_external_group_kill_spawn"][
+                    "pinvou3-app/src-tauri/src/platform/process.rs"
+                ],
+            )
+
+    def test_external_group_kill_stub_exception_requires_header_marker_and_reason(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            rust_root = root / "pinvou3-app/src-tauri/src"
+            allowed = rust_root / "platform/allowed.rs"
+            rejected = rust_root / "platform/rejected.rs"
+            late = rust_root / "platform/late.rs"
+            for path in [allowed, rejected, late]:
+                path.parent.mkdir(parents=True, exist_ok=True)
+            probe = 'fn run() { Command::new("kill"); }\n'
+            allowed.write_text(
+                "// architecture-guard: allow-external-group-kill-stub"
+                " -- compile-only contract stub, no real platform binds it\n"
+                + probe,
+                encoding="utf-8",
+            )
+            late.write_text(
+                "// header filler\n" * 20
+                + "// architecture-guard: allow-external-group-kill-stub -- too late\n"
+                + probe,
+                encoding="utf-8",
+            )
+            rejected.write_text(
+                "// architecture-guard: allow-external-group-kill-stub\n" + probe,
+                encoding="utf-8",
+            )
+
+            rules, _ = self.guard.scan_rust(root)
+
+            self.assertNotIn(
+                "pinvou3-app/src-tauri/src/platform/allowed.rs",
+                rules["rust_external_group_kill_spawn"],
+            )
+            # The probe hits both the Command-specific and the generic
+            # `::new("kill")` pattern, so it counts twice per file.
+            self.assertEqual(
+                2,
+                rules["rust_external_group_kill_spawn"][
+                    "pinvou3-app/src-tauri/src/platform/rejected.rs"
+                ],
+            )
+            self.assertEqual(
+                2,
+                rules["rust_external_group_kill_spawn"][
+                    "pinvou3-app/src-tauri/src/platform/late.rs"
+                ],
+            )
+
     def test_guard_does_not_track_file_line_counts(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/scripts/tests/test_architecture_guard.py
+++ b/scripts/tests/test_architecture_guard.py
@@ -271,51 +271,35 @@ class ArchitectureGuardUnitTests(unittest.TestCase):
                 ],
             )
 
-    def test_external_group_kill_stub_exception_requires_header_marker_and_reason(self):
+    def test_rust_scanner_rejects_kill_in_stub_shaped_file(self):
+        """unsupported.rs carries the live macOS kill_pid_tree (cfg(unix)),
+        so the former allow-external-group-kill-stub file exception was
+        removed; prove a stub-shaped file with the same cfg arms — an
+        external kill next to a live unix arm — is now still flagged."""
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             rust_root = root / "pinvou3-app/src-tauri/src"
-            allowed = rust_root / "platform/allowed.rs"
-            rejected = rust_root / "platform/rejected.rs"
-            late = rust_root / "platform/late.rs"
-            for path in [allowed, rejected, late]:
-                path.parent.mkdir(parents=True, exist_ok=True)
-            probe = 'fn run() { Command::new("kill"); }\n'
-            allowed.write_text(
-                "// architecture-guard: allow-external-group-kill-stub"
-                " -- compile-only contract stub, no real platform binds it\n"
-                + probe,
-                encoding="utf-8",
-            )
-            late.write_text(
-                "// header filler\n" * 20
-                + "// architecture-guard: allow-external-group-kill-stub -- too late\n"
-                + probe,
-                encoding="utf-8",
-            )
-            rejected.write_text(
-                "// architecture-guard: allow-external-group-kill-stub\n" + probe,
+            stub = rust_root / "platform/os/unsupported.rs"
+            stub.parent.mkdir(parents=True)
+            stub.write_text(
+                "/// macOS binds the cfg(unix) arm via glob re-export.\n"
+                "pub fn kill_pid_tree(pid: u32) {\n"
+                "    #[cfg(unix)]\n"
+                "    { let _ = pid; }\n"
+                "    #[cfg(not(unix))]\n"
+                '    { Command::new("kill").args(["-9", "-42"]).output(); }\n'
+                "}\n",
                 encoding="utf-8",
             )
 
             rules, _ = self.guard.scan_rust(root)
 
-            self.assertNotIn(
-                "pinvou3-app/src-tauri/src/platform/allowed.rs",
-                rules["rust_external_group_kill_spawn"],
-            )
             # The probe hits both the Command-specific and the generic
-            # `::new("kill")` pattern, so it counts twice per file.
+            # `::new("kill")` pattern, so it counts twice.
             self.assertEqual(
                 2,
                 rules["rust_external_group_kill_spawn"][
-                    "pinvou3-app/src-tauri/src/platform/rejected.rs"
-                ],
-            )
-            self.assertEqual(
-                2,
-                rules["rust_external_group_kill_spawn"][
-                    "pinvou3-app/src-tauri/src/platform/late.rs"
+                    "pinvou3-app/src-tauri/src/platform/os/unsupported.rs"
                 ],
             )
 


### PR DESCRIPTION
## Problem

Five times running `cargo test` on this machine killed the entire desktop session and bounced it back to the lock screen: three times on 2026-09-03 (18:28, 18:32, 19:05 CST) and twice on 2026-09-04 (15:03, 15:06 CST — twice from the *filtered* subset `cargo test --lib platform::process::`).

Forensics (auditd sweep_kill rules + kernel `signal_generate` tracepoint + ps snapshots, kept under `/var/log/kill-trace/`): every incident shows `/usr/bin/kill` issuing **`kill(-1, SIGKILL)`** as a direct child of the `pinvou3_lib` test binary — `kill(-1)` executed as uid 1000 SIGKILLs every process of that user (Xorg, gnome-shell, `systemd --user`), so logind tears the session down and GDM takes over.

## Root cause — proven, not the pid

The 2026-09-04 audit records settle the open question from the original description: **the pid passed to the kill helper was always valid.** The audit shows the correct execve argv `["kill", "-9", "-<pgid>"]` followed by the *kill binary itself* calling `kill(-1, 9)` (`a0=ffffffff`, `exe="/usr/bin/kill"`).

Reproduced deterministically inside a user+pid namespace with strace: `execve("/usr/bin/kill", ["kill","-9","-11"])` → `kill(-1, SIGKILL) = 0` from inside that binary. This machine's `procps-ng 4.0.4` misroutes the valid negative pid to `-1` (its argument-parsing rewrite). `kill -9 -- -11` and bash's builtin both pass `-11` correctly; `dpkg -V procps` verifies the binary is unmodified. So *any* code path on such a machine that does `kill -9 -<pgid>` — the timeout tree-kill, the install-cancel, the connector harvest — escalates into a user-wide massacre whenever it fires.

## Fix

- **Unix group kills go through `kill(2)` directly** in all three helpers (`platform::process::kill_process_tree`, `linux_path::kill_pid_tree`, `unsupported::kill_pid_tree` for macOS): identical semantics to `kill -9 -<pgid>` with no external argument parser or PATH lookup in between. No external `kill` process is spawned at all. `kill_process_tree` returns `io::Result<()>` (callers only inspect errors; `ESRCH` counts as success because the target is already gone).
- **A pid boundary is enforced in-API at all three unix sites** (re-lands the boundary half of the retired pid-gate, per review round 3): `pid <= 1` and pids outside the positive `i32` range are rejected before touching kill(2) — kill(0) signals the caller's whole process group, kill(-1) every process of this user, and `as i32` on a too-large u32 wraps negative. The defense no longer rests on caller audits.
- **The forensic refusal log stays retired** (PR owner decision): the root cause is proven to live in the external kill binary's argument parser, not in pid handling, so the logging apparatus remains unnecessary.
- **External kill spawning is now explicitly forbidden and enforced**:
  - Documented as platform rule 6 in `src-tauri/src/README.md` and in `docs/architecture-guard.md`: process-group/tree termination must go through `kill_process_tree` / `kill_pid_tree` (kill(2) direct) in all future module work — never a spawned `kill` executable.
  - Enforced by `scripts/architecture-guard.py` rule `rust_external_group_kill_spawn` (denies `Command::new("kill")`, `Path::new("kill")`, `connector_cli_command(_, "kill")` shapes), with a file-level exception kind for compile-only contract stubs (unsupported.rs non-unix branch). The rule and the exception kind have automated unit tests in `scripts/tests/test_architecture_guard.py`.
- Regression test kept: a fake `kill` placed first on `PATH` must never be spawned **and** the group leader + descendant must both die; plus the timeout tree-kill behavior test.

## Verification

- `cargo fmt --check`, `cargo clippy --lib --bins --no-deps --features dev-tools -- -D warnings`: pass.
- `scripts/architecture-guard.py`: pass, including the new rule (and it fails on a planted `Command::new("kill")` probe).
- `python3 -m unittest discover -s scripts/tests`: 87 passed, including the new `rust_external_group_kill_spawn` / stub-exception coverage.
- `cargo test --lib`: **1985 passed / 0 failed** — on the previously affected machine, where the filtered 7-test subset alone killed the session twice before the fix.

## Notes for reviewers

- Review round 1 targeted the forensic-log temp path; that log no longer exists (apparatus retired with the proven root cause), so the concern is resolved by removal rather than relocation.
- The procps-ng 4.0.4 negative-pid misparse is worth an upstream report; any other app on affected machines doing `kill -9 -<pgid>` is one timeout away from the same outage. `--` (or a libc call) avoids it.

