### PR TITLE
fix(chat): isolate stale shell task cards

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -64,6 +64,7 @@
     "test:multiagent-plan": "node --test tests/multiagent_plan_normalize.test.mjs",
     "test:chat-input-limit": "node tests/chat_input_limit_logic.test.js",
     "test:background-tasks": "node tests/background_tasks_logic.test.js",
+    "test:shell-task-projection": "node --test tests/shell_task_projection.test.mjs",
     "test:ime-compose-guard": "node tests/ime_compose_guard.test.mjs",
     "test:assistant-message-actions": "node tests/assistant_message_actions.test.mjs",
     "test:chat-error-isolation": "node tests/chat_turn_error_isolation.test.mjs",

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -37,7 +37,12 @@
     for (let i = state.chatItems.length - 1; i >= 0; i--) {
       const item = state.chatItems[i];
       if (item && item.type === "tool" && isShellExecutionTool(item.name)) {
-        return SHELL_WAIT_TOOL_NAMES.includes(item.name);
+        // Since engine v0.9.3 the wait observer is the canonical Bash tool
+        // with action="wait"; the exec_shell_wait/exec_wait names survive
+        // only in replayed legacy sessions. Cards carry the action both live
+        // (chat:tool_start) and after history replay.
+        return SHELL_WAIT_TOOL_NAMES.includes(item.name) ||
+          (item.name === "Bash" && item.args != null && item.args.action === "wait");
       }
     }
     return false;

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -27,9 +27,20 @@
   }
 
   const SHELL_TOOL_NAMES = ["exec_shell", "exec_shell_wait", "exec_wait", "task_shell_start", "task_shell_wait", "shell", "Bash"];
+  const SHELL_WAIT_TOOL_NAMES = ["exec_shell_wait", "exec_wait", "task_shell_wait"];
 
   function isShellExecutionTool(name) {
     return SHELL_TOOL_NAMES.includes(name);
+  }
+
+  function latestShellToolIsWaitObserver() {
+    for (let i = state.chatItems.length - 1; i >= 0; i--) {
+      const item = state.chatItems[i];
+      if (item && item.type === "tool" && isShellExecutionTool(item.name)) {
+        return SHELL_WAIT_TOOL_NAMES.includes(item.name);
+      }
+    }
+    return false;
   }
 
   function mentionsShellTool(text) {
@@ -130,9 +141,12 @@
           });
           if (item) item.shellHistoryReconciled = true;
         }
-        // A detached job may have been started by a subagent, so no matching
-        // top-level tool card exists. Completed jobs must also get a card: the
-        // first poll may happen after a short detached process already exited.
+        // A wait tool only observes existing work and cannot create a new job.
+        // The manager retains completed jobs across later waits, so an
+        // unmatched terminal snapshot here belongs to earlier work and must
+        // not be appended beside the wait result. A start tool can still race
+        // with a very short detached job, whose first snapshot is terminal.
+        if (!item && !running && latestShellToolIsWaitObserver()) return;
         if (!item) {
           item = {
             type: "tool", toolId: "shell-task:" + job.id, name: "exec_shell",

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -118,6 +118,19 @@
       runningCommandCounts[command] = (runningCommandCounts[command] || 0) + 1;
     });
     runSyncOnSession(sid, function () {
+      // A wait tool only observes existing work and cannot create a job, and
+      // the manager retains completed jobs across later waits, so an
+      // unmatched terminal snapshot beside a trailing wait card belongs to
+      // earlier work and must not be appended after newer results. Decide
+      // once per poll from the pre-poll timeline: the synthetic card of a
+      // running job from this same batch (the manager lists running jobs
+      // first) would otherwise disarm the guard for the jobs after it.
+      // Accepted limits until stable origin identity lands: a start tool can
+      // still race with a very short detached job whose first snapshot is
+      // terminal (the guard is off when the latest card is a start tool), and
+      // a brand-new subagent job started after the wait card is conservatively
+      // hidden like retained older work.
+      const suppressUnmatchedTerminal = latestShellToolIsWaitObserver();
       (jobs || []).forEach(function (job) {
         const status = String(job.status || "").toLowerCase();
         const running = status === "running";
@@ -141,12 +154,7 @@
           });
           if (item) item.shellHistoryReconciled = true;
         }
-        // A wait tool only observes existing work and cannot create a new job.
-        // The manager retains completed jobs across later waits, so an
-        // unmatched terminal snapshot here belongs to earlier work and must
-        // not be appended beside the wait result. A start tool can still race
-        // with a very short detached job, whose first snapshot is terminal.
-        if (!item && !running && latestShellToolIsWaitObserver()) return;
+        if (!item && !running && suppressUnmatchedTerminal) return;
         if (!item) {
           item = {
             type: "tool", toolId: "shell-task:" + job.id, name: "exec_shell",

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4310,9 +4310,21 @@
   }
 
   const SHELL_TOOL_NAMES = ["exec_shell", "task_shell_start", "shell", "Bash"];
+  const SHELL_WAIT_TOOL_NAMES = ["exec_shell_wait", "exec_wait", "task_shell_wait"];
 
   function isShellExecutionTool(name) {
     return SHELL_TOOL_NAMES.includes(name);
+  }
+
+  function latestShellToolIsWaitObserver() {
+    for (let i = state.chatItems.length - 1; i >= 0; i--) {
+      const item = state.chatItems[i];
+      if (item && item.type === "tool" &&
+          (isShellExecutionTool(item.name) || SHELL_WAIT_TOOL_NAMES.includes(item.name))) {
+        return SHELL_WAIT_TOOL_NAMES.includes(item.name);
+      }
+    }
+    return false;
   }
 
   function mentionsShellTool(text) {
@@ -4435,9 +4447,12 @@
           });
           if (item) item.shellHistoryReconciled = true;
         }
-        // A detached job may have been started by a subagent, so no matching
-        // top-level tool card exists. Completed jobs must also get a card: the
-        // first poll may happen after a short detached process already exited.
+        // A wait tool only observes existing work and cannot create a new job.
+        // The manager retains completed jobs across later waits, so an
+        // unmatched terminal snapshot here belongs to earlier work and must
+        // not be appended beside the wait result. A start tool can still race
+        // with a very short detached job, whose first snapshot is terminal.
+        if (!item && !running && latestShellToolIsWaitObserver()) return;
         if (!item) {
           item = {
             type: "tool", toolId: "shell-task:" + job.id, name: "exec_shell",

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4424,6 +4424,19 @@
       runningCommandCounts[command] = (runningCommandCounts[command] || 0) + 1;
     });
     runSyncOnSession(sid, function () {
+      // A wait tool only observes existing work and cannot create a job, and
+      // the manager retains completed jobs across later waits, so an
+      // unmatched terminal snapshot beside a trailing wait card belongs to
+      // earlier work and must not be appended after newer results. Decide
+      // once per poll from the pre-poll timeline: the synthetic card of a
+      // running job from this same batch (the manager lists running jobs
+      // first) would otherwise disarm the guard for the jobs after it.
+      // Accepted limits until stable origin identity lands: a start tool can
+      // still race with a very short detached job whose first snapshot is
+      // terminal (the guard is off when the latest card is a start tool), and
+      // a brand-new subagent job started after the wait card is conservatively
+      // hidden like retained older work.
+      const suppressUnmatchedTerminal = latestShellToolIsWaitObserver();
       (jobs || []).forEach(function (job) {
         const status = String(job.status || "").toLowerCase();
         const running = status === "running";
@@ -4447,12 +4460,7 @@
           });
           if (item) item.shellHistoryReconciled = true;
         }
-        // A wait tool only observes existing work and cannot create a new job.
-        // The manager retains completed jobs across later waits, so an
-        // unmatched terminal snapshot here belongs to earlier work and must
-        // not be appended beside the wait result. A start tool can still race
-        // with a very short detached job, whose first snapshot is terminal.
-        if (!item && !running && latestShellToolIsWaitObserver()) return;
+        if (!item && !running && suppressUnmatchedTerminal) return;
         if (!item) {
           item = {
             type: "tool", toolId: "shell-task:" + job.id, name: "exec_shell",

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -4321,7 +4321,12 @@
       const item = state.chatItems[i];
       if (item && item.type === "tool" &&
           (isShellExecutionTool(item.name) || SHELL_WAIT_TOOL_NAMES.includes(item.name))) {
-        return SHELL_WAIT_TOOL_NAMES.includes(item.name);
+        // Since engine v0.9.3 the wait observer is the canonical Bash tool
+        // with action="wait"; the exec_shell_wait/exec_wait names survive
+        // only in replayed legacy sessions. Cards carry the action both live
+        // (chat:tool_start) and after history replay.
+        return SHELL_WAIT_TOOL_NAMES.includes(item.name) ||
+          (item.name === "Bash" && item.args != null && item.args.action === "wait");
       }
     }
     return false;

--- a/pinvou3-app/tests/shell_task_projection.test.mjs
+++ b/pinvou3-app/tests/shell_task_projection.test.mjs
@@ -172,6 +172,51 @@ test('the guard is not disarmed by a running job projected in the same poll', ()
   assert.equal(harness.notifications(), 1);
 });
 
+test('the canonical Bash action=wait card also arms the guard', () => {
+  // Since engine v0.9.3 the wait observer is Bash with action="wait"
+  // (exec_shell_wait/exec_wait survive only in replayed legacy sessions).
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'bash-wait',
+    name: 'Bash',
+    state: 'done',
+    args: { action: 'wait', task_id: 'task-1' },
+    output: '13',
+  }]);
+
+  const running = harness.terminal.applyShellSnapshots('session-current', [snapshot()]);
+
+  assert.equal(running, false);
+  assert.equal(harness.chatItems.length, 1);
+  assert.equal(harness.notifications(), 0);
+  assert.equal(harness.chatItems.some(item => item.toolId === 'shell-task:shell-old'), false);
+});
+
+test('a Bash action=run card is a start tool and does not arm the guard', () => {
+  // Accepted limit: the guard stays off behind a start tool, so a very short
+  // detached job whose first snapshot is terminal still gets its card.
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'bash-run',
+    name: 'Bash',
+    state: 'done',
+    args: { action: 'run', command: 'fast-detached' },
+    output: 'running in background',
+  }]);
+
+  harness.terminal.applyShellSnapshots('session-current', [snapshot({
+    id: 'shell-fast-after-run',
+    command: 'fast-detached',
+    status: 'completed',
+    exit_code: 0,
+    stdout_tail: 'done fast',
+    stderr_tail: '',
+  })]);
+
+  assert.equal(harness.chatItems.length, 2);
+  assert.equal(harness.chatItems[1].toolId, 'shell-task:shell-fast-after-run');
+});
+
 test('a brand-new subagent job first seen terminal after an older wait card is conservatively hidden', () => {
   // Accepted limit until origin identity lands: the timeline alone cannot
   // tell this job apart from retained older work, so it stays hidden.
@@ -216,5 +261,10 @@ test('the web bridge keeps the same stale-completion guard', () => {
   assert.match(
     webBridge,
     /const suppressUnmatchedTerminal = latestShellToolIsWaitObserver\(\);/,
+  );
+  // The canonical Bash action=wait recognition must exist on both bridges.
+  assert.match(
+    webBridge,
+    /item\.name === "Bash" && item\.args != null && item\.args\.action === "wait"/,
   );
 });

--- a/pinvou3-app/tests/shell_task_projection.test.mjs
+++ b/pinvou3-app/tests/shell_task_projection.test.mjs
@@ -141,6 +141,63 @@ test('a fast detached job can still appear after its start tool', () => {
   assert.match(harness.chatItems[1].output, /done fast/);
 });
 
+test('the guard is not disarmed by a running job projected in the same poll', () => {
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'current-wait',
+    name: 'exec_shell_wait',
+    state: 'done',
+    output: '13',
+  }]);
+
+  const running = harness.terminal.applyShellSnapshots('session-current', [
+    snapshot({
+      id: 'shell-live',
+      command: 'long task',
+      status: 'running',
+      exit_code: null,
+      stdout_len: 0,
+      stderr_len: 0,
+      stdout_tail: '',
+      stderr_tail: '',
+    }),
+    snapshot(),
+  ]);
+
+  assert.equal(running, true);
+  assert.equal(harness.chatItems.length, 2);
+  assert.equal(harness.chatItems[1].toolId, 'shell-task:shell-live');
+  assert.equal(harness.chatItems[1].state, 'running');
+  assert.equal(harness.chatItems.some(item => item.toolId === 'shell-task:shell-old'), false);
+  assert.equal(harness.notifications(), 1);
+});
+
+test('a brand-new subagent job first seen terminal after an older wait card is conservatively hidden', () => {
+  // Accepted limit until origin identity lands: the timeline alone cannot
+  // tell this job apart from retained older work, so it stays hidden.
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'old-wait',
+    name: 'exec_shell_wait',
+    state: 'done',
+    output: 'ok',
+  }]);
+
+  const running = harness.terminal.applyShellSnapshots('session-current', [snapshot({
+    id: 'shell-fast-subagent',
+    command: 'echo hi',
+    status: 'completed',
+    exit_code: 0,
+    stdout_tail: 'hi',
+    stderr_tail: '',
+  })]);
+
+  assert.equal(running, false);
+  assert.equal(harness.chatItems.length, 1);
+  assert.equal(harness.chatItems[0].toolId, 'old-wait');
+  assert.equal(harness.notifications(), 0);
+});
+
 test('the web bridge keeps the same stale-completion guard', () => {
   const webBridge = fs.readFileSync(
     path.join(appRoot, 'src', 'platform', 'web', 'bridge.js'),
@@ -148,6 +205,16 @@ test('the web bridge keeps the same stale-completion guard', () => {
   );
   assert.match(
     webBridge,
-    /if \(!item && !running && latestShellToolIsWaitObserver\(\)\) return;/,
+    /if \(!item && !running && suppressUnmatchedTerminal\) return;/,
+  );
+  // The web helper scans a different name set (its SHELL_TOOL_NAMES lacks the
+  // wait names), so the union clause is the real cross-bridge parity point.
+  assert.match(
+    webBridge,
+    /\(isShellExecutionTool\(item\.name\) \|\| SHELL_WAIT_TOOL_NAMES\.includes\(item\.name\)\)/,
+  );
+  assert.match(
+    webBridge,
+    /const suppressUnmatchedTerminal = latestShellToolIsWaitObserver\(\);/,
   );
 });

--- a/pinvou3-app/tests/shell_task_projection.test.mjs
+++ b/pinvou3-app/tests/shell_task_projection.test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const terminalPath = path.join(appRoot, 'src', 'platform', 'tauri', 'bridge', 'terminal.js');
+const terminalSource = fs.readFileSync(terminalPath, 'utf8');
+
+function createTerminal(initialItems = []) {
+  const chatItems = structuredClone(initialItems);
+  const windowObject = {
+    __PINVOU_TAURI_BRIDGE_FEATURES__: {},
+    setTimeout,
+  };
+  const scriptContext = vm.createContext({
+    window: windowObject,
+    TextEncoder,
+    console,
+    setTimeout,
+    clearTimeout,
+  });
+  vm.runInContext(terminalSource, scriptContext, { filename: terminalPath });
+
+  let notifications = 0;
+  const terminal = windowObject.__PINVOU_TAURI_BRIDGE_FEATURES__.terminal({
+    state: { chatItems, activeSessionId: 'session-current' },
+    notify() { notifications += 1; },
+    invoke: async () => [],
+    bt(key) {
+      if (key === 'shellOutputOmitted') return kind => `${kind} omitted`;
+      if (key === 'shellTaskFinished') return code => `finished: ${code}`;
+      if (key === 'shellUnknownExit') return 'unknown';
+      throw new Error(`unexpected translation key: ${key}`);
+    },
+    runSyncOnSession(_sessionId, callback) { callback(); },
+    addChatItem(item) { chatItems.push(item); },
+  });
+
+  return { chatItems, terminal, notifications: () => notifications };
+}
+
+function snapshot(overrides = {}) {
+  return {
+    id: 'shell-old',
+    command: 'winget search "BaiduNetdisk"',
+    status: 'failed',
+    exit_code: 1,
+    elapsed_ms: 300,
+    stdout_len: 0,
+    stderr_len: 16,
+    stdout_tail: '',
+    stderr_tail: 'old task failed',
+    ...overrides,
+  };
+}
+
+test('completed historical shell jobs are not inserted into the current timeline', () => {
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'current-wait',
+    name: 'exec_shell_wait',
+    state: 'done',
+    output: '13',
+  }]);
+
+  const running = harness.terminal.applyShellSnapshots('session-current', [snapshot()]);
+
+  assert.equal(running, false);
+  assert.equal(harness.chatItems.length, 1);
+  assert.equal(harness.notifications(), 0);
+  assert.equal(harness.chatItems.some(item => item.toolId === 'shell-task:shell-old'), false);
+});
+
+test('running detached shell jobs still receive a synthetic status card', () => {
+  const harness = createTerminal();
+
+  const running = harness.terminal.applyShellSnapshots('session-current', [snapshot({
+    id: 'shell-current',
+    command: '1..100',
+    status: 'running',
+    exit_code: null,
+    stdout_len: 2,
+    stderr_len: 0,
+    stdout_tail: '13',
+    stderr_tail: '',
+  })]);
+
+  assert.equal(running, true);
+  assert.equal(harness.notifications(), 1);
+  assert.equal(harness.chatItems.length, 1);
+  assert.equal(harness.chatItems[0].toolId, 'shell-task:shell-current');
+  assert.equal(harness.chatItems[0].taskId, 'shell-current');
+  assert.equal(harness.chatItems[0].state, 'running');
+  assert.equal(harness.chatItems[0].output, '13');
+});
+
+test('completed shell jobs still update their explicitly linked tool card', () => {
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'tool-old',
+    taskId: 'shell-old',
+    name: 'exec_shell',
+    state: 'running',
+    args: { command: 'winget search "BaiduNetdisk"' },
+    output: null,
+  }]);
+
+  harness.terminal.applyShellSnapshots('session-current', [snapshot()]);
+
+  assert.equal(harness.chatItems.length, 1);
+  assert.equal(harness.chatItems[0].state, 'failed');
+  assert.equal(harness.chatItems[0].success, false);
+  assert.match(harness.chatItems[0].output, /old task failed/);
+  assert.equal(harness.notifications(), 1);
+});
+
+test('a fast detached job can still appear after its start tool', () => {
+  const harness = createTerminal([{
+    type: 'tool',
+    toolId: 'start-fast-detached',
+    name: 'exec_shell',
+    state: 'done',
+    output: 'running in background',
+  }]);
+
+  harness.terminal.applyShellSnapshots('session-current', [snapshot({
+    id: 'shell-fast-detached',
+    command: 'fast-detached',
+    status: 'completed',
+    exit_code: 0,
+    stdout_tail: 'done fast',
+    stderr_tail: '',
+  })]);
+
+  assert.equal(harness.chatItems.length, 2);
+  assert.equal(harness.chatItems[1].toolId, 'shell-task:shell-fast-detached');
+  assert.equal(harness.chatItems[1].state, 'done');
+  assert.match(harness.chatItems[1].output, /done fast/);
+});
+
+test('the web bridge keeps the same stale-completion guard', () => {
+  const webBridge = fs.readFileSync(
+    path.join(appRoot, 'src', 'platform', 'web', 'bridge.js'),
+    'utf8',
+  );
+  assert.match(
+    webBridge,
+    /if \(!item && !running && latestShellToolIsWaitObserver\(\)\) return;/,
+  );
+});


### PR DESCRIPTION
## Summary

- prevent an observer-only shell wait from appending retained completed jobs beside its own result
- keep synthetic cards for running detached jobs and fast detached jobs first seen after a start tool
- preserve updates to tool cards that already carry the matching task id
- cover both Tauri and web bridges with focused projection tests

## Root cause

The Shell manager retains completed jobs. Each later `exec_shell_wait` snapshot poll could project an unmatched earlier job into the current timeline, so an earlier `winget` failure appeared after a newer wait result.

## Phase

This is phase 1, an app-layer safety guard that is independent of the foundation change. It is intentionally limited to wait observers, so a short detached job that finishes before the first poll still gets a card whenever the latest card is a start tool. Two accepted limits remain in this phase: the guard is decided once per poll from the pre-poll timeline (a running job's own synthetic card from the same batch must not disarm it), so a start tool can still race with a very short detached job whose first snapshot is terminal; and a brand-new job a subagent starts after the wait card is conservatively hidden the same way as retained older work. Phase 2 adds stable origin identity for exact reconciliation (Pinvou/pinvou-agent#432): for origin-tagged root jobs it binds snapshots to their originating card and removes the start-tool race, while subagent-origin jobs have no top-level card to bind to and remain conservatively hidden there.

## Verification

- `node --test tests/shell_task_projection.test.mjs` (9 passed)
- `python scripts/architecture-guard.py`
- `git diff --check`
- full remote `frontend-test` and required gate passed
