### PR TITLE
perf: reduce memory churn and hot-path re-renders

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -337,6 +337,11 @@ pub async fn read_artifact_image_b64(path: String) -> Result<String, String> {
     if !p.is_file() {
         return Err(format!("图片不存在: {path}"));
     }
+    // 先验大小再整读：超过上限的文件整读进内存纯属浪费，提前按同一错误
+    // 形态拒绝（与下方读后校验保持一致，防两查之间文件被写大的极端情况）。
+    if std::fs::metadata(&p).map(|meta| meta.len()).unwrap_or(0) > 25_000_000 {
+        return Err("图片过大(>25MB),请用外部打开".into());
+    }
     let bytes = std::fs::read(&p).map_err(|e| format!("读取失败: {e}"))?;
     if bytes.len() > 25_000_000 {
         return Err("图片过大(>25MB),请用外部打开".into());

--- a/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/artifacts.rs
@@ -337,8 +337,10 @@ pub async fn read_artifact_image_b64(path: String) -> Result<String, String> {
     if !p.is_file() {
         return Err(format!("图片不存在: {path}"));
     }
-    // 先验大小再整读：超过上限的文件整读进内存纯属浪费，提前按同一错误
-    // 形态拒绝（与下方读后校验保持一致，防两查之间文件被写大的极端情况）。
+    // Check the size before reading the whole file: reading an oversized
+    // file into memory is pure waste, so reject up front with the same
+    // error shape as the post-read check below (which still guards the
+    // edge case of the file growing between the two checks).
     if std::fs::metadata(&p).map(|meta| meta.len()).unwrap_or(0) > 25_000_000 {
         return Err("图片过大(>25MB),请用外部打开".into());
     }

--- a/pinvou3-app/src-tauri/src/app/commands/codex.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/codex.rs
@@ -588,12 +588,13 @@ pub async fn cancel_codex_acp(
 }
 
 #[tauri::command]
-pub fn get_codex_acp_timeline(
+pub async fn get_codex_acp_timeline(
     session_id: String,
     acp_pool: State<'_, AcpPool>,
 ) -> Result<Vec<AcpEventEnvelope>, String> {
     acp_pool
         .timeline(&session_id)
+        .await
         .map_err(|error| format!("读取 Codex ACP timeline 失败: {error:#}"))
 }
 

--- a/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/remote_control.rs
@@ -1098,14 +1098,14 @@ pub struct WebAcpTimelinePage {
 /// Return one bounded page of the authoritative ACP timeline after projecting
 /// out desktop-only adapter metadata and credential-bearing diagnostic fields.
 #[tauri::command]
-pub fn web_access_get_codex_acp_timeline(
+pub async fn web_access_get_codex_acp_timeline(
     session_id: String,
     after_seq: Option<u64>,
     after_cursor: Option<u64>,
     limit: Option<usize>,
     acp_pool: State<'_, AcpPool>,
 ) -> Result<WebAcpTimelinePage, String> {
-    let outcome = (|| {
+    let outcome = (|| async {
         let limit = limit.unwrap_or(DEFAULT_WEB_ACP_TIMELINE_PAGE_EVENTS);
         if limit == 0 || limit > MAX_WEB_ACP_TIMELINE_PAGE_EVENTS {
             return Err(format!(
@@ -1121,6 +1121,7 @@ pub fn web_access_get_codex_acp_timeline(
                 MAX_WEB_ACP_TIMELINE_PAGE_BYTES,
                 MAX_WEB_ACP_TIMELINE_EVENT_BYTES,
             )
+            .await
             .map_err(|error| format!("{error:#}"))?;
         Ok(WebAcpTimelinePage {
             next_after_seq: page.events.last().map(|event| event.seq),
@@ -1129,7 +1130,7 @@ pub fn web_access_get_codex_acp_timeline(
             events: page.events,
         })
     })();
-    web_acp_result(WebAcpOperation::Timeline, outcome)
+    web_acp_result(WebAcpOperation::Timeline, outcome.await)
 }
 
 fn project_acp_pending_permission_for_web(

--- a/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
@@ -65,8 +65,15 @@ pub(crate) fn spawn_event_forwarder(
         let mut turn_tracker = TurnCompletionTracker::default();
         let mut scheduled_engine_total_tokens = 0_u64;
         let mut scheduled_persistence_error: Option<String> = None;
-        let mut latest_chat_engine_state: Option<ChatEngineState> = None;
+        // 快照用 Arc 共享:SessionUpdated 事件携带的全量 transcript 不再为留存
+        // 终态快照而整份深拷贝,TurnComplete 处也只克隆 Arc。
+        let mut latest_chat_engine_state: Option<Arc<ChatEngineState>> = None;
         let mut chat_persistence_error: Option<String> = None;
+        // 最近一次成功落盘快照的 transcript revision 缓存:仅在“最新快照已成功
+        // 落盘且此后无新快照”时为 Some。终态用它判定终态落盘与最后一次
+        // per-message 落盘内容完全相同,从而跳过重复写盘并复用 revision(见
+        // TurnComplete 臂);任何新快照、落盘失败或哈希失败都会清空它。
+        let mut last_persisted_chat_revision: Option<String> = None;
         let mut active_transcript_seen = false;
         // A typed preflight rejection completes the admitted lifecycle without
         // changing engine history. Preserve that distinction through
@@ -459,23 +466,31 @@ pub(crate) fn spawn_event_forwarder(
                         let (messages, matched_active_rule) =
                             turn_lifecycle.sanitize_messages(messages);
                         active_transcript_seen |= matched_active_rule;
-                        let state = ChatEngineState {
+                        let state = Arc::new(ChatEngineState {
                             messages,
                             system_prompt,
                             model,
                             workspace,
-                        };
-                        latest_chat_engine_state = Some(state.clone());
+                        });
+                        // 落盘前先失效 revision 缓存:此刻最新内容尚未落盘,
+                        // 旧缓存不能被终态臂误读为“最新快照已持久”。
+                        last_persisted_chat_revision = None;
+                        latest_chat_engine_state = Some(Arc::clone(&state));
                         let store_for_save = store.clone();
                         let session_for_save = session_id.clone();
                         match tokio::task::spawn_blocking(move || {
-                            store_for_save.persist_chat_engine_state(&session_for_save, state)
+                            store_for_save.persist_chat_engine_state(&session_for_save, &state)
                         })
                         .await
                         {
                             Ok(Ok(saved)) => {
                                 chat_persistence_error = None;
-                                if let Ok(revision) = transcript_revision(&saved.messages) {
+                                // revision 对本次落盘内容只计算一次,同时缓存给
+                                // 终态臂复用(Err 时缓存为 None,终态退回原落盘
+                                // 路径),不再对相同内容二次哈希。
+                                let revision = transcript_revision(&saved.messages).ok();
+                                last_persisted_chat_revision = revision.clone();
+                                if let Some(revision) = revision {
                                     emit_transcript_committed(
                                         &app,
                                         &session_id,
@@ -801,14 +816,36 @@ pub(crate) fn spawn_event_forwarder(
                             // and the optimistic admission fallback.
                             None
                         } else if active_transcript_seen {
-                            latest_chat_engine_state.clone().map(|state| {
-                                let store_for_save = store.clone();
-                                let session_for_save = session_id.clone();
-                                tokio::task::spawn_blocking(move || {
-                                    store_for_save
-                                        .persist_chat_engine_state(&session_for_save, state)
-                                })
-                            })
+                            // 终态快照与最后一次 SessionUpdated 落盘共用同一份
+                            // Arc,内容不可能再变化;revision 缓存命中说明同内容
+                            // 已成功落盘,此时再 load→serialize→write 一次是纯
+                            // 重复。跳过写盘,用缓存 revision 复发 terminal_fallback
+                            // 事件(载荷与原实现完全一致,事件序列不变);缓存
+                            // 未命中(最近一次落盘/哈希失败)时保留原终态落盘
+                            // 重试,失败照旧转化为 Failed 终态。
+                            match last_persisted_chat_revision.take() {
+                                Some(revision) => {
+                                    let message_count = latest_chat_engine_state
+                                        .as_ref()
+                                        .map_or(0, |state| state.messages.len());
+                                    emit_transcript_committed(
+                                        &app,
+                                        &session_id,
+                                        revision,
+                                        "terminal_fallback",
+                                        message_count,
+                                    );
+                                    None
+                                }
+                                None => latest_chat_engine_state.clone().map(|state| {
+                                    let store_for_save = store.clone();
+                                    let session_for_save = session_id.clone();
+                                    tokio::task::spawn_blocking(move || {
+                                        store_for_save
+                                            .persist_chat_engine_state(&session_for_save, &state)
+                                    })
+                                }),
+                            }
                         } else {
                             turn_lifecycle.active_transcript_fallback().map(|fallback| {
                                 let store_for_save = store.clone();
@@ -865,6 +902,9 @@ pub(crate) fn spawn_event_forwarder(
                     // rejection repersist a stale snapshot.
                     active_transcript_seen = false;
                     latest_chat_engine_state = None;
+                    // revision 缓存与快照同属本轮所有权窗口,一并失效,防止
+                    // 跨 turn 误判“最新快照已持久”。
+                    last_persisted_chat_revision = None;
                     // Keep the shell scope cancellable throughout persistence.
                     // Final cleanup runs before terminal admission is claimed;
                     // Engine reclaim can therefore still win an await race and

--- a/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/forwarder.rs
@@ -65,14 +65,18 @@ pub(crate) fn spawn_event_forwarder(
         let mut turn_tracker = TurnCompletionTracker::default();
         let mut scheduled_engine_total_tokens = 0_u64;
         let mut scheduled_persistence_error: Option<String> = None;
-        // 快照用 Arc 共享:SessionUpdated 事件携带的全量 transcript 不再为留存
-        // 终态快照而整份深拷贝,TurnComplete 处也只克隆 Arc。
+        // The snapshot is Arc-shared: the full transcript carried by the
+        // SessionUpdated event is no longer deep-copied just to retain the
+        // terminal snapshot; TurnComplete only clones the Arc.
         let mut latest_chat_engine_state: Option<Arc<ChatEngineState>> = None;
         let mut chat_persistence_error: Option<String> = None;
-        // 最近一次成功落盘快照的 transcript revision 缓存:仅在“最新快照已成功
-        // 落盘且此后无新快照”时为 Some。终态用它判定终态落盘与最后一次
-        // per-message 落盘内容完全相同,从而跳过重复写盘并复用 revision(见
-        // TurnComplete 臂);任何新快照、落盘失败或哈希失败都会清空它。
+        // Transcript revision cache of the last successfully persisted
+        // snapshot: Some only while "the latest snapshot persisted cleanly
+        // and no newer snapshot has arrived since". The terminal arm uses it
+        // to detect that the terminal persist would write content identical
+        // to the last per-message persist, skip the duplicate write, and
+        // reuse the revision (see the TurnComplete arm); any newer snapshot,
+        // persist failure, or hash failure clears it.
         let mut last_persisted_chat_revision: Option<String> = None;
         let mut active_transcript_seen = false;
         // A typed preflight rejection completes the admitted lifecycle without
@@ -472,8 +476,10 @@ pub(crate) fn spawn_event_forwarder(
                             model,
                             workspace,
                         });
-                        // 落盘前先失效 revision 缓存:此刻最新内容尚未落盘,
-                        // 旧缓存不能被终态臂误读为“最新快照已持久”。
+                        // Invalidate the revision cache before persisting:
+                        // the latest content is not durable yet, and the
+                        // stale cache must not let the terminal arm mistake
+                        // it for "the latest snapshot is already persisted".
                         last_persisted_chat_revision = None;
                         latest_chat_engine_state = Some(Arc::clone(&state));
                         let store_for_save = store.clone();
@@ -485,9 +491,12 @@ pub(crate) fn spawn_event_forwarder(
                         {
                             Ok(Ok(saved)) => {
                                 chat_persistence_error = None;
-                                // revision 对本次落盘内容只计算一次,同时缓存给
-                                // 终态臂复用(Err 时缓存为 None,终态退回原落盘
-                                // 路径),不再对相同内容二次哈希。
+                                // The revision is computed once for this
+                                // persist and cached for the terminal arm to
+                                // reuse (on Err the cache stays None and the
+                                // terminal arm falls back to the original
+                                // persist path), so identical content is not
+                                // hashed a second time.
                                 let revision = transcript_revision(&saved.messages).ok();
                                 last_persisted_chat_revision = revision.clone();
                                 if let Some(revision) = revision {
@@ -816,13 +825,18 @@ pub(crate) fn spawn_event_forwarder(
                             // and the optimistic admission fallback.
                             None
                         } else if active_transcript_seen {
-                            // 终态快照与最后一次 SessionUpdated 落盘共用同一份
-                            // Arc,内容不可能再变化;revision 缓存命中说明同内容
-                            // 已成功落盘,此时再 load→serialize→write 一次是纯
-                            // 重复。跳过写盘,用缓存 revision 复发 terminal_fallback
-                            // 事件(载荷与原实现完全一致,事件序列不变);缓存
-                            // 未命中(最近一次落盘/哈希失败)时保留原终态落盘
-                            // 重试,失败照旧转化为 Failed 终态。
+                            // The terminal snapshot shares one Arc with the
+                            // last SessionUpdated persist, so its content can
+                            // no longer change; a revision-cache hit means
+                            // this exact content already persisted cleanly and
+                            // another load→serialize→write would be pure
+                            // duplication. Skip the write and re-emit the
+                            // terminal_fallback event with the cached revision
+                            // (payload identical to the original path, event
+                            // sequence unchanged); on a cache miss (the last
+                            // persist/hash failed) keep the original terminal
+                            // persist retry, still mapping a failure to the
+                            // Failed terminal state.
                             match last_persisted_chat_revision.take() {
                                 Some(revision) => {
                                     let message_count = latest_chat_engine_state
@@ -902,8 +916,10 @@ pub(crate) fn spawn_event_forwarder(
                     // rejection repersist a stale snapshot.
                     active_transcript_seen = false;
                     latest_chat_engine_state = None;
-                    // revision 缓存与快照同属本轮所有权窗口,一并失效,防止
-                    // 跨 turn 误判“最新快照已持久”。
+                    // The revision cache belongs to the same turn's
+                    // ownership window as the snapshot; clear it together so
+                    // a later turn cannot misread "the latest snapshot is
+                    // already persisted".
                     last_persisted_chat_revision = None;
                     // Keep the shell scope cancellable throughout persistence.
                     // Final cleanup runs before terminal admission is claimed;

--- a/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
@@ -73,17 +73,23 @@ impl StreamMirror {
         };
         let emitted_tail = stable.get(self.skip..)?;
         let delta = emitted_tail.strip_prefix(self.text.as_str())?;
-        self.text.push_str(delta);
-        if self.text.len() > EMITTED_TAIL_KEEP_BYTES {
-            // Drop already-emitted head bytes so the mirror stays bounded;
-            // `skip` advances with them to keep `text` aligned with
-            // `stable[self.skip..]`. Trim only at char boundaries.
-            let mut trim = self.text.len() - EMITTED_TAIL_KEEP_BYTES;
-            while !self.text.is_char_boundary(trim) {
+        if emitted_tail.len() <= EMITTED_TAIL_KEEP_BYTES {
+            self.text.push_str(delta);
+        } else {
+            // `text + delta == emitted_tail`, so the bounded mirror is the
+            // last keep-window bytes of `emitted_tail`. Rebuild from that
+            // suffix instead of push+drain: `drain` shortens the string
+            // without releasing capacity, so one large observation would
+            // keep a whole-delta allocation resident for the job's
+            // lifetime. `skip` advances with the dropped head to keep
+            // `text` aligned with `stable[self.skip..]`, cutting only at
+            // char boundaries.
+            let mut trim = emitted_tail.len() - EMITTED_TAIL_KEEP_BYTES;
+            while !emitted_tail.is_char_boundary(trim) {
                 trim += 1;
             }
             self.skip += trim;
-            self.text.drain(..trim);
+            self.text = String::from(&emitted_tail[trim..]);
         }
         Some(delta.to_string())
     }
@@ -686,6 +692,41 @@ mod tests {
             ]
         );
         assert!(!state.tools.contains_key("tool-1"));
+    }
+
+    #[test]
+    fn large_burst_trims_without_retaining_the_whole_allocation() {
+        let mut mirror = StreamMirror::default();
+        // A first observation after substantial output accumulation: the
+        // burst crosses the keep window with a multibyte code point
+        // straddling the trim cut, so the trim must advance to the next
+        // char boundary.
+        let burst = format!(
+            "{}中{}",
+            "x".repeat(EMITTED_TAIL_KEEP_BYTES),
+            "y".repeat(EMITTED_TAIL_KEEP_BYTES - 2)
+        );
+        assert_eq!(mirror.delta(&burst, true).as_deref(), Some(burst.as_str()));
+        // The mirror keeps only the bounded suffix and, unlike push+drain,
+        // does not retain the whole-burst capacity afterwards.
+        assert_eq!(mirror.text, "y".repeat(EMITTED_TAIL_KEEP_BYTES - 2));
+        assert_eq!(mirror.skip, EMITTED_TAIL_KEEP_BYTES + 3);
+        assert!(mirror.text.capacity() <= EMITTED_TAIL_KEEP_BYTES);
+
+        // Progress after the burst still reaches the display while the
+        // job keeps running, and retained capacity stays bounded.
+        let progressed = format!("{burst}still alive\n");
+        assert_eq!(
+            mirror.delta(&progressed, true).as_deref(),
+            Some("still alive\n")
+        );
+        assert!(mirror.text.capacity() <= EMITTED_TAIL_KEEP_BYTES);
+
+        // Completion emits the remainder, still without growing the
+        // retained allocation.
+        let completed = format!("{progressed}done\n");
+        assert_eq!(mirror.delta(&completed, false).as_deref(), Some("done\n"));
+        assert!(mirror.text.capacity() <= EMITTED_TAIL_KEEP_BYTES);
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
@@ -279,7 +279,9 @@ impl MonitorState {
             // 镜像超限的兜底：不再增长镜像、也不再逐 tick 做全量前缀增量
             // （strip_prefix 是 O(总输出)，短路后本 tick 代价归零）。前端实时
             // 展示自身有尾部截断；终态 BackgroundFinished 仍走权威 tail，
-            // 最终落到聊天的输出不受影响。
+            // 最终落到聊天的输出不受影响。注意这是软上限：跨限那一 tick 的
+            // 整块 delta 仍会先入镜像（判定在追加前做），实际峰值 ≈ cap +
+            // 单个轮询周期的增量。
             let mirror_over_cap = tool
                 .emitted_stdout
                 .len()

--- a/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
@@ -16,7 +16,16 @@ use parking_lot::Mutex;
 use serde_json::{Value, json};
 use tauri::{AppHandle, Emitter};
 
-const POLL_INTERVAL: Duration = Duration::from_millis(80);
+// 轮询间隔是上游缺游标 API 下的部分缓解：每 tick 底座 `inspect_job` 都会整
+// 克隆+解码全部输出（根治需要 CodeWhale 提供游标式读取，此处改不动），拉长
+// 周期直接摊薄该常数；配合 `observe_jobs` 的字节长度短路与镜像上限兜底。
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// 单个任务已回显镜像（emitted_stdout+emitted_stderr）的累计上限。镜像只为
+/// 前缀增量计算服务，超限后停止增长并停发增量（见 `reconcile`）：实时展示
+/// 由前端自身尾部截断兜住，终态 BackgroundFinished 仍携带权威 tail，聊天里
+/// 的最终输出不受影响。上游提供游标 API 后应移除此兜底。
+const EMITTED_MIRROR_CAP_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Clone)]
 pub(crate) struct ShellOutputMonitor {
@@ -38,6 +47,9 @@ struct MonitorState {
     tools: HashMap<String, TrackedTool>,
     claimed_tasks: HashSet<String>,
     next_order: u64,
+    /// task_id -> 上一轮观察到的累计输出字节数（快照 stdout_len+stderr_len）。
+    /// 字节数没变且仍在运行时跳过 `inspect_job` 的整克隆+解码（短路面）。
+    last_output_bytes: HashMap<String, usize>,
 }
 
 #[derive(Debug)]
@@ -129,7 +141,9 @@ impl ShellOutputMonitor {
     pub(crate) fn tool_completed(&self, tool_id: &str, background_task_id: Option<&str>) {
         let mut state = self.state.lock();
         let Some(task_id) = background_task_id else {
-            state.tools.remove(tool_id);
+            if let Some(task_id) = state.tools.remove(tool_id).and_then(|tool| tool.task_id) {
+                state.last_output_bytes.remove(&task_id);
+            }
             return;
         };
         state.claimed_tasks.insert(task_id.to_string());
@@ -192,8 +206,27 @@ fn observe_jobs(
         .collect::<Vec<_>>();
     Ok(tracked
         .into_iter()
-        .filter_map(|task_id| manager.inspect_job(&task_id).ok())
-        .map(ObservedJob::from)
+        .filter_map(|task_id| {
+            // `inspect_job` 每次都整克隆+解码全部输出（上游缺游标 API）。
+            // `list_jobs` 快照自带累计字节数且本调用内已 poll 过：仍在运行
+            // 且总字节数没变时，解码结果必与上一轮相同、增量必为空，直接
+            // 跳过本次整读。终态不短路，收口事件照常发出。
+            if let Some(snapshot) = snapshots.iter().find(|job| job.id == task_id) {
+                let total = snapshot.stdout_len.saturating_add(snapshot.stderr_len);
+                if snapshot.status == ShellStatus::Running
+                    && state.last_output_bytes.get(&task_id) == Some(&total)
+                {
+                    return None;
+                }
+            }
+            let detail = manager.inspect_job(&task_id).ok()?;
+            let total = detail
+                .snapshot
+                .stdout_len
+                .saturating_add(detail.snapshot.stderr_len);
+            state.last_output_bytes.insert(task_id, total);
+            Some(ObservedJob::from(detail))
+        })
         .collect())
 }
 
@@ -243,32 +276,43 @@ impl MonitorState {
                 continue;
             };
 
-            if let Some(delta) = appended_stable_delta(
-                &tool.emitted_stdout,
-                &job.stdout,
-                job.status == ShellStatus::Running,
-            ) {
-                tool.emitted_stdout.push_str(&delta);
-                if !delta.is_empty() {
-                    emissions.push(MonitorEmission::Delta {
-                        tool_id: tool_id.clone(),
-                        stream: "stdout",
-                        content: delta,
-                    });
+            // 镜像超限的兜底：不再增长镜像、也不再逐 tick 做全量前缀增量
+            // （strip_prefix 是 O(总输出)，短路后本 tick 代价归零）。前端实时
+            // 展示自身有尾部截断；终态 BackgroundFinished 仍走权威 tail，
+            // 最终落到聊天的输出不受影响。
+            let mirror_over_cap = tool
+                .emitted_stdout
+                .len()
+                .saturating_add(tool.emitted_stderr.len())
+                > EMITTED_MIRROR_CAP_BYTES;
+            if !mirror_over_cap {
+                if let Some(delta) = appended_stable_delta(
+                    &tool.emitted_stdout,
+                    &job.stdout,
+                    job.status == ShellStatus::Running,
+                ) {
+                    tool.emitted_stdout.push_str(&delta);
+                    if !delta.is_empty() {
+                        emissions.push(MonitorEmission::Delta {
+                            tool_id: tool_id.clone(),
+                            stream: "stdout",
+                            content: delta,
+                        });
+                    }
                 }
-            }
-            if let Some(delta) = appended_stable_delta(
-                &tool.emitted_stderr,
-                &job.stderr,
-                job.status == ShellStatus::Running,
-            ) {
-                tool.emitted_stderr.push_str(&delta);
-                if !delta.is_empty() {
-                    emissions.push(MonitorEmission::Delta {
-                        tool_id: tool_id.clone(),
-                        stream: "stderr",
-                        content: delta,
-                    });
+                if let Some(delta) = appended_stable_delta(
+                    &tool.emitted_stderr,
+                    &job.stderr,
+                    job.status == ShellStatus::Running,
+                ) {
+                    tool.emitted_stderr.push_str(&delta);
+                    if !delta.is_empty() {
+                        emissions.push(MonitorEmission::Delta {
+                            tool_id: tool_id.clone(),
+                            stream: "stderr",
+                            content: delta,
+                        });
+                    }
                 }
             }
 
@@ -285,7 +329,9 @@ impl MonitorState {
             }
         }
         for tool_id in finished {
-            self.tools.remove(&tool_id);
+            if let Some(task_id) = self.tools.remove(&tool_id).and_then(|tool| tool.task_id) {
+                self.last_output_bytes.remove(&task_id);
+            }
         }
         emissions
     }
@@ -370,6 +416,7 @@ fn emit_owner_reclaimed(app: &AppHandle, session_id: &str, state: &mut MonitorSt
         })
         .collect::<Vec<_>>();
     state.tools.clear();
+    state.last_output_bytes.clear();
     for (tool_id, task_id) in background {
         emit_shell_task_status(
             app,
@@ -545,6 +592,50 @@ mod tests {
             snapshot("new", "same", ShellStatus::Running),
         ]);
         assert_eq!(state.tools["tool-1"].task_id.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn oversized_mirror_stops_deltas_but_completion_still_fires() {
+        let mut state = MonitorState::default();
+        state.tools.insert(
+            "tool-1".to_string(),
+            TrackedTool {
+                command: "build".to_string(),
+                order: 0,
+                task_id: Some("job-1".to_string()),
+                emitted_stdout: "x".repeat(EMITTED_MIRROR_CAP_BYTES + 1),
+                emitted_stderr: String::new(),
+                keep_after_tool_end: true,
+            },
+        );
+        // 镜像超限：运行中的新输出不再产生增量，镜像也不再被撑大。
+        assert!(
+            state
+                .reconcile(vec![observed("job-1", ShellStatus::Running, "more\n")])
+                .is_empty()
+        );
+        assert_eq!(
+            state.tools["tool-1"].emitted_stdout.len(),
+            EMITTED_MIRROR_CAP_BYTES + 1
+        );
+        // 终态收口不受兜底影响：BackgroundFinished 仍带权威 tail。
+        let emissions = state.reconcile(vec![observed(
+            "job-1",
+            ShellStatus::Completed,
+            "more\ndone\n",
+        )]);
+        assert_eq!(
+            emissions,
+            vec![MonitorEmission::BackgroundFinished {
+                tool_id: "tool-1".to_string(),
+                task_id: "job-1".to_string(),
+                status: ShellStatus::Completed,
+                exit_code: Some(0),
+                stdout_tail: "more\ndone\n".to_string(),
+                stderr_tail: String::new(),
+            }]
+        );
+        assert!(!state.tools.contains_key("tool-1"));
     }
 
     #[test]

--- a/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/shell_output.rs
@@ -16,16 +16,21 @@ use parking_lot::Mutex;
 use serde_json::{Value, json};
 use tauri::{AppHandle, Emitter};
 
-// 轮询间隔是上游缺游标 API 下的部分缓解：每 tick 底座 `inspect_job` 都会整
-// 克隆+解码全部输出（根治需要 CodeWhale 提供游标式读取，此处改不动），拉长
-// 周期直接摊薄该常数；配合 `observe_jobs` 的字节长度短路与镜像上限兜底。
+// The poll interval partially mitigates the engine's missing cursor API:
+// every tick `inspect_job` clones and decodes a job's entire output (a real
+// fix needs a cursor read in CodeWhale, which cannot change here), so a
+// longer period amortizes that constant cost. Paired with the byte-length
+// short-circuit in `observe_jobs` and the bounded emission mirror below.
 const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
-/// 单个任务已回显镜像（emitted_stdout+emitted_stderr）的累计上限。镜像只为
-/// 前缀增量计算服务，超限后停止增长并停发增量（见 `reconcile`）：实时展示
-/// 由前端自身尾部截断兜住，终态 BackgroundFinished 仍携带权威 tail，聊天里
-/// 的最终输出不受影响。上游提供游标 API 后应移除此兜底。
-const EMITTED_MIRROR_CAP_BYTES: usize = 8 * 1024 * 1024;
+/// Tail of already-emitted output kept per tracked stream. The tail acts as
+/// the reconciliation cursor: delta computation runs against the last
+/// `EMITTED_TAIL_KEEP_BYTES` bytes of emitted text plus the byte offset
+/// where that tail starts inside the job's full output buffer, so memory
+/// and per-tick compare costs stay bounded while live deltas keep flowing
+/// for arbitrarily verbose jobs. A cursor read API upstream remains the
+/// real fix for the per-tick full clone+decode.
+const EMITTED_TAIL_KEEP_BYTES: usize = 64 * 1024;
 
 #[derive(Clone)]
 pub(crate) struct ShellOutputMonitor {
@@ -37,9 +42,51 @@ struct TrackedTool {
     command: String,
     order: u64,
     task_id: Option<String>,
-    emitted_stdout: String,
-    emitted_stderr: String,
+    stdout: StreamMirror,
+    stderr: StreamMirror,
     keep_after_tool_end: bool,
+}
+
+/// Bounded tail of one stream's already-emitted text plus the byte offset
+/// where that tail starts inside the job's full output buffer.
+#[derive(Debug, Default)]
+struct StreamMirror {
+    /// Bytes of the full stream output before `text` begins.
+    skip: usize,
+    /// Already-emitted tail, at most `EMITTED_TAIL_KEEP_BYTES` bytes.
+    text: String,
+}
+
+impl StreamMirror {
+    /// Return the not-yet-emitted suffix of `current`, or `None` when
+    /// `current` does not extend the already-emitted text (hold the mirror
+    /// and retry on the next snapshot). While `running`, a trailing U+FFFD
+    /// is held back so a code point split across reader chunks is emitted
+    /// exactly once (`inspect_job` lossily decodes the whole buffer every
+    /// observation, so an incomplete trailing code point shows up as a
+    /// temporary replacement character).
+    fn delta(&mut self, current: &str, running: bool) -> Option<String> {
+        let stable = if running {
+            current.trim_end_matches('\u{fffd}')
+        } else {
+            current
+        };
+        let emitted_tail = stable.get(self.skip..)?;
+        let delta = emitted_tail.strip_prefix(self.text.as_str())?;
+        self.text.push_str(delta);
+        if self.text.len() > EMITTED_TAIL_KEEP_BYTES {
+            // Drop already-emitted head bytes so the mirror stays bounded;
+            // `skip` advances with them to keep `text` aligned with
+            // `stable[self.skip..]`. Trim only at char boundaries.
+            let mut trim = self.text.len() - EMITTED_TAIL_KEEP_BYTES;
+            while !self.text.is_char_boundary(trim) {
+                trim += 1;
+            }
+            self.skip += trim;
+            self.text.drain(..trim);
+        }
+        Some(delta.to_string())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -47,8 +94,11 @@ struct MonitorState {
     tools: HashMap<String, TrackedTool>,
     claimed_tasks: HashSet<String>,
     next_order: u64,
-    /// task_id -> 上一轮观察到的累计输出字节数（快照 stdout_len+stderr_len）。
-    /// 字节数没变且仍在运行时跳过 `inspect_job` 的整克隆+解码（短路面）。
+    /// task_id -> cumulative output bytes (snapshot stdout_len+stderr_len)
+    /// observed last round. While a job is running and the byte count is
+    /// unchanged, the decoded output must equal the previous round and the
+    /// delta must be empty, so the full clone+decode in `inspect_job` is
+    /// skipped entirely.
     last_output_bytes: HashMap<String, usize>,
 }
 
@@ -128,8 +178,8 @@ impl ShellOutputMonitor {
                 command: command.to_string(),
                 order,
                 task_id: None,
-                emitted_stdout: String::new(),
-                emitted_stderr: String::new(),
+                stdout: StreamMirror::default(),
+                stderr: StreamMirror::default(),
                 keep_after_tool_end: false,
             },
         );
@@ -207,10 +257,14 @@ fn observe_jobs(
     Ok(tracked
         .into_iter()
         .filter_map(|task_id| {
-            // `inspect_job` 每次都整克隆+解码全部输出（上游缺游标 API）。
-            // `list_jobs` 快照自带累计字节数且本调用内已 poll 过：仍在运行
-            // 且总字节数没变时，解码结果必与上一轮相同、增量必为空，直接
-            // 跳过本次整读。终态不短路，收口事件照常发出。
+            // `inspect_job` clones and decodes a job's entire output on every
+            // call (the engine has no cursor API). `list_jobs` snapshots
+            // carry cumulative byte counts and were already polled within
+            // this call: while a job is running and its total byte count is
+            // unchanged, the decoded output must equal the previous round
+            // and the delta must be empty, so skip the full read. Terminal
+            // snapshots are never short-circuited so the closing event is
+            // always emitted.
             if let Some(snapshot) = snapshots.iter().find(|job| job.id == task_id) {
                 let total = snapshot.stdout_len.saturating_add(snapshot.stderr_len);
                 if snapshot.status == ShellStatus::Running
@@ -276,45 +330,28 @@ impl MonitorState {
                 continue;
             };
 
-            // 镜像超限的兜底：不再增长镜像、也不再逐 tick 做全量前缀增量
-            // （strip_prefix 是 O(总输出)，短路后本 tick 代价归零）。前端实时
-            // 展示自身有尾部截断；终态 BackgroundFinished 仍走权威 tail，
-            // 最终落到聊天的输出不受影响。注意这是软上限：跨限那一 tick 的
-            // 整块 delta 仍会先入镜像（判定在追加前做），实际峰值 ≈ cap +
-            // 单个轮询周期的增量。
-            let mirror_over_cap = tool
-                .emitted_stdout
-                .len()
-                .saturating_add(tool.emitted_stderr.len())
-                > EMITTED_MIRROR_CAP_BYTES;
-            if !mirror_over_cap {
-                if let Some(delta) = appended_stable_delta(
-                    &tool.emitted_stdout,
-                    &job.stdout,
-                    job.status == ShellStatus::Running,
-                ) {
-                    tool.emitted_stdout.push_str(&delta);
-                    if !delta.is_empty() {
-                        emissions.push(MonitorEmission::Delta {
-                            tool_id: tool_id.clone(),
-                            stream: "stdout",
-                            content: delta,
-                        });
-                    }
+            if let Some(delta) = tool
+                .stdout
+                .delta(&job.stdout, job.status == ShellStatus::Running)
+            {
+                if !delta.is_empty() {
+                    emissions.push(MonitorEmission::Delta {
+                        tool_id: tool_id.clone(),
+                        stream: "stdout",
+                        content: delta,
+                    });
                 }
-                if let Some(delta) = appended_stable_delta(
-                    &tool.emitted_stderr,
-                    &job.stderr,
-                    job.status == ShellStatus::Running,
-                ) {
-                    tool.emitted_stderr.push_str(&delta);
-                    if !delta.is_empty() {
-                        emissions.push(MonitorEmission::Delta {
-                            tool_id: tool_id.clone(),
-                            stream: "stderr",
-                            content: delta,
-                        });
-                    }
+            }
+            if let Some(delta) = tool
+                .stderr
+                .delta(&job.stderr, job.status == ShellStatus::Running)
+            {
+                if !delta.is_empty() {
+                    emissions.push(MonitorEmission::Delta {
+                        tool_id: tool_id.clone(),
+                        stream: "stderr",
+                        content: delta,
+                    });
                 }
             }
 
@@ -354,20 +391,6 @@ impl From<ShellJobDetail> for ObservedJob {
             stderr_tail: detail.snapshot.stderr_tail,
         }
     }
-}
-
-/// `inspect_job` converts the complete byte buffer on every observation.  An
-/// incomplete UTF-8 code point can therefore appear temporarily as a trailing
-/// replacement character.  Hold that final marker until the next snapshot so
-/// a Chinese character split across reader chunks is emitted exactly once.
-fn appended_stable_delta(previous: &str, current: &str, running: bool) -> Option<String> {
-    let mut stable = current;
-    if running {
-        stable = stable.trim_end_matches('\u{fffd}');
-    }
-    stable
-        .strip_prefix(previous)
-        .map(std::string::ToString::to_string)
 }
 
 fn emit_monitor_event(app: &AppHandle, session_id: &str, emission: MonitorEmission) {
@@ -518,8 +541,8 @@ mod tests {
                 command: "cargo check".to_string(),
                 order: 0,
                 task_id: None,
-                emitted_stdout: String::new(),
-                emitted_stderr: String::new(),
+                stdout: StreamMirror::default(),
+                stderr: StreamMirror::default(),
                 keep_after_tool_end: false,
             },
         );
@@ -550,11 +573,9 @@ mod tests {
 
     #[test]
     fn holds_incomplete_utf8_replacement_until_a_stable_snapshot() {
-        assert_eq!(
-            appended_stable_delta("", "中\u{fffd}", true),
-            Some("中".into())
-        );
-        assert_eq!(appended_stable_delta("中", "中文", true), Some("文".into()));
+        let mut mirror = StreamMirror::default();
+        assert_eq!(mirror.delta("中\u{fffd}", true).as_deref(), Some("中"));
+        assert_eq!(mirror.delta("中文", true).as_deref(), Some("文"));
     }
 
     #[test]
@@ -581,8 +602,8 @@ mod tests {
                 command: "same".to_string(),
                 order: 0,
                 task_id: None,
-                emitted_stdout: String::new(),
-                emitted_stderr: String::new(),
+                stdout: StreamMirror::default(),
+                stderr: StreamMirror::default(),
                 keep_after_tool_end: false,
             },
         );
@@ -597,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn oversized_mirror_stops_deltas_but_completion_still_fires() {
+    fn bounded_mirror_keeps_streaming_after_the_window_overflows() {
         let mut state = MonitorState::default();
         state.tools.insert(
             "tool-1".to_string(),
@@ -605,37 +626,64 @@ mod tests {
                 command: "build".to_string(),
                 order: 0,
                 task_id: Some("job-1".to_string()),
-                emitted_stdout: "x".repeat(EMITTED_MIRROR_CAP_BYTES + 1),
-                emitted_stderr: String::new(),
+                stdout: StreamMirror::default(),
+                stderr: StreamMirror::default(),
                 keep_after_tool_end: true,
             },
         );
-        // 镜像超限：运行中的新输出不再产生增量，镜像也不再被撑大。
-        assert!(
-            state
-                .reconcile(vec![observed("job-1", ShellStatus::Running, "more\n")])
-                .is_empty()
-        );
+        // The first observation coalesces the whole backlog into one delta;
+        // the mirror then trims to the keep window.
+        let backlog = "x".repeat(EMITTED_TAIL_KEEP_BYTES + 4096);
         assert_eq!(
-            state.tools["tool-1"].emitted_stdout.len(),
-            EMITTED_MIRROR_CAP_BYTES + 1
-        );
-        // 终态收口不受兜底影响：BackgroundFinished 仍带权威 tail。
-        let emissions = state.reconcile(vec![observed(
-            "job-1",
-            ShellStatus::Completed,
-            "more\ndone\n",
-        )]);
-        assert_eq!(
-            emissions,
-            vec![MonitorEmission::BackgroundFinished {
+            state.reconcile(vec![observed("job-1", ShellStatus::Running, &backlog)]),
+            vec![MonitorEmission::Delta {
                 tool_id: "tool-1".to_string(),
-                task_id: "job-1".to_string(),
-                status: ShellStatus::Completed,
-                exit_code: Some(0),
-                stdout_tail: "more\ndone\n".to_string(),
-                stderr_tail: String::new(),
+                stream: "stdout",
+                content: backlog.clone(),
             }]
+        );
+        assert_eq!(state.tools["tool-1"].stdout.skip, 4096);
+        assert_eq!(
+            state.tools["tool-1"].stdout.text.len(),
+            EMITTED_TAIL_KEEP_BYTES
+        );
+
+        // Progress appended after the window overflowed still reaches the
+        // display while the job keeps running.
+        let progressed = backlog + "still alive\n";
+        assert_eq!(
+            state.reconcile(vec![observed("job-1", ShellStatus::Running, &progressed)]),
+            vec![MonitorEmission::Delta {
+                tool_id: "tool-1".to_string(),
+                stream: "stdout",
+                content: "still alive\n".to_string(),
+            }]
+        );
+        assert_eq!(
+            state.tools["tool-1"].stdout.text.len(),
+            EMITTED_TAIL_KEEP_BYTES
+        );
+
+        // The terminal snapshot still fires the closing event with the
+        // authoritative tails.
+        let completed = progressed + "done\n";
+        assert_eq!(
+            state.reconcile(vec![observed("job-1", ShellStatus::Completed, &completed)]),
+            vec![
+                MonitorEmission::Delta {
+                    tool_id: "tool-1".to_string(),
+                    stream: "stdout",
+                    content: "done\n".to_string(),
+                },
+                MonitorEmission::BackgroundFinished {
+                    tool_id: "tool-1".to_string(),
+                    task_id: "job-1".to_string(),
+                    status: ShellStatus::Completed,
+                    exit_code: Some(0),
+                    stdout_tail: completed.clone(),
+                    stderr_tail: String::new(),
+                }
+            ]
         );
         assert!(!state.tools.contains_key("tool-1"));
     }
@@ -649,8 +697,11 @@ mod tests {
                 command: "build".to_string(),
                 order: 0,
                 task_id: Some("job-1".to_string()),
-                emitted_stdout: "building\n".to_string(),
-                emitted_stderr: String::new(),
+                stdout: StreamMirror {
+                    skip: 0,
+                    text: "building\n".to_string(),
+                },
+                stderr: StreamMirror::default(),
                 keep_after_tool_end: true,
             },
         );

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -27,6 +27,14 @@ const HOST_PATH_REDACTION: &str = "[host path omitted]";
 /// Upper bound for waiting on a missing predecessor sequence before ordered
 /// Web delivery skips the gap and keeps the session pipeline responsive.
 const WEB_DELIVERY_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Buffered append window for the cached timeline handle. Between the
+/// synchronous turn-boundary flushes below, the BufWriter reaches the OS at
+/// least once per full window, so streamed chunk bytes never linger unbounded.
+const TIMELINE_APPEND_BUFFER_BYTES: usize = 64 * 1024;
+/// Tail window parsed for the resume sequence when a session reopens;
+/// journals larger than it skip everything before the window
+/// (see `load_timeline_last_seq`).
+const TIMELINE_TAIL_BYTES: u64 = 256 * 1024;
 
 /// Codex ACP 页面唯一消费的事件合同。
 ///
@@ -685,6 +693,7 @@ pub struct EventBridge {
     event_order: Arc<Mutex<()>>,
     web_delivery: OrderedWebDelivery,
     tools: Arc<Mutex<HashMap<String, ToolCall>>>,
+    timeline_writer: Arc<Mutex<TimelineWriter>>,
 }
 
 #[derive(Clone)]
@@ -738,10 +747,11 @@ impl OrderedWebDelivery {
 
 impl EventBridge {
     pub fn new(app: AppHandle, pinvou_session_id: String) -> Self {
-        let last_seq = load_timeline(&pinvou_session_id)
-            .ok()
-            .and_then(|events| events.last().map(|event| event.seq))
-            .unwrap_or(0);
+        // Session reopen only needs the resume point; reading the journal tail
+        // instead of parsing the whole file keeps reopen cheap for long
+        // sessions, with a full-scan fallback when the tail is inconclusive.
+        let last_seq = load_timeline_last_seq(&pinvou_session_id).unwrap_or(0);
+        let timeline_writer = Arc::new(Mutex::new(TimelineWriter::new(&pinvou_session_id)));
         Self {
             app,
             pinvou_session_id,
@@ -751,6 +761,7 @@ impl EventBridge {
             event_order: Arc::new(Mutex::new(())),
             web_delivery: OrderedWebDelivery::new(last_seq),
             tools: Arc::new(Mutex::new(HashMap::new())),
+            timeline_writer,
         }
     }
 
@@ -799,6 +810,12 @@ impl EventBridge {
     /// 本方法只处理当前 timeline 已存在的孤儿回合。正常的同进程活跃回合仍由
     /// `prompt()` 返回后调用 `finish_turn()` 收口。
     pub fn interrupt_orphaned_turns(&self, reason: &str) -> usize {
+        // Orphan detection must pair turn_started/turn_completed events that
+        // can live arbitrarily far apart, so this scan is inherently over the
+        // full journal. Flush this bridge's append buffer first so the scan
+        // reads the current on-disk state (turn boundaries are already
+        // flushed synchronously; this only covers buffered chunk events).
+        let _ = self.timeline_writer.lock().flush();
         let events = match load_timeline(&self.pinvou_session_id) {
             Ok(events) => events,
             Err(error) => {
@@ -955,7 +972,15 @@ impl EventBridge {
                     data,
                 },
             };
-            if let Err(error) = append_timeline(&envelope) {
+            // Turn boundaries and terminal runtime errors are the journal's
+            // crash-recovery anchors: they flush synchronously so resume and
+            // orphan-turn recovery never depend on buffered chunk bytes.
+            // Everything else rides the TIMELINE_APPEND_BUFFER_BYTES window.
+            let flush_timeline = matches!(
+                event_type,
+                "turn_started" | "turn_completed" | "runtime_error"
+            );
+            if let Err(error) = self.append_timeline(&envelope, flush_timeline) {
                 eprintln!(
                     "[pinvou3-app] append Codex ACP timeline failed for {}: {error:#}",
                     self.pinvou_session_id
@@ -1006,6 +1031,11 @@ impl EventBridge {
                 None => {}
             });
         envelope
+    }
+
+    /// Append one envelope to the session journal through the cached handle.
+    fn append_timeline(&self, event: &AcpEventEnvelope, flush_after: bool) -> Result<()> {
+        self.timeline_writer.lock().append(event, flush_after)
     }
 }
 
@@ -1091,21 +1121,100 @@ pub fn patch_acp_state(session_id: &str, patch: Value) -> Result<()> {
     persist_acp_state(session_id, state)
 }
 
-fn append_timeline(event: &AcpEventEnvelope) -> Result<()> {
-    let path = timeline_path(&event.session_id)?;
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("创建 ACP timeline 目录 {} 失败", parent.display()))?;
+/// Cached append handle for one session's ACP timeline journal.
+///
+/// `EventBridge` is the single writer for its session's journal and every
+/// clone shares the same `Arc<Mutex<TimelineWriter>>`, so the open file is
+/// kept across envelopes instead of paying an open/write/flush syscall trio
+/// per streamed token. Readers are unaffected: lines are still appended as
+/// whole newline-terminated JSON lines. Dropping the last bridge clone flushes
+/// the remaining buffer best-effort (BufWriter Drop ignores errors and never
+/// panics).
+struct TimelineWriter {
+    session_id: String,
+    writer: Option<BufWriter<File>>,
+}
+
+impl TimelineWriter {
+    fn new(session_id: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            writer: None,
+        }
     }
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .with_context(|| format!("打开 ACP timeline {} 失败", path.display()))?;
-    serde_json::to_writer(&mut file, event)?;
-    file.write_all(b"\n")?;
-    file.flush()?;
-    Ok(())
+
+    fn append(&mut self, event: &AcpEventEnvelope, flush_after: bool) -> Result<()> {
+        // Serialize first: a write failure then can only leave a torn line,
+        // never a half-serialized event mixed into the retry below.
+        let mut line = serde_json::to_vec(event)?;
+        line.push(b'\n');
+        if let Err(error) = self.write_line(&line, flush_after) {
+            // The cached handle may be stale (the journal was removed or
+            // replaced externally, or the descriptor broke): reopen once and
+            // retry. A partially written line is skipped by readers as
+            // malformed, the same way a crash mid-append is recovered.
+            self.writer = None;
+            self.open()?;
+            self.write_line(&line, flush_after)
+                .with_context(|| format!("重试写入 ACP timeline 失败: {error}"))?;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        match self.writer.as_mut() {
+            Some(writer) => Ok(writer.flush()?),
+            None => Ok(()),
+        }
+    }
+
+    fn write_line(&mut self, line: &[u8], flush_after: bool) -> Result<()> {
+        {
+            let writer = self.writer_mut()?;
+            writer.write_all(line)?;
+            if flush_after {
+                writer.flush()?;
+            }
+        }
+        if flush_after && !self.journal_exists() {
+            // POSIX appends into an externally removed file keep succeeding
+            // into the unlinked inode without an error, so only the rare
+            // flush points pay one existence check to re-anchor durability.
+            // Reopening recreates the file; the just-flushed line stays lost
+            // with the deleted journal instead of being duplicated.
+            self.writer = None;
+            self.open()?;
+        }
+        Ok(())
+    }
+
+    fn writer_mut(&mut self) -> Result<&mut BufWriter<File>> {
+        if self.writer.is_none() {
+            self.open()?;
+        }
+        self.writer.as_mut().context("ACP timeline 写入句柄不可用")
+    }
+
+    fn journal_exists(&self) -> bool {
+        timeline_path(&self.session_id).is_ok_and(|path| path.exists())
+    }
+
+    fn open(&mut self) -> Result<()> {
+        // Directory creation and open stay out of the per-envelope hot path;
+        // they only run on first use and on reopen after a failure.
+        let path = timeline_path(&self.session_id)?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("创建 ACP timeline 目录 {} 失败", parent.display()))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("打开 ACP timeline {} 失败", path.display()))?;
+        self.writer = Some(BufWriter::with_capacity(TIMELINE_APPEND_BUFFER_BYTES, file));
+        Ok(())
+    }
 }
 
 pub fn load_timeline(session_id: &str) -> Result<Vec<AcpEventEnvelope>> {
@@ -1131,6 +1240,70 @@ pub fn load_timeline(session_id: &str) -> Result<Vec<AcpEventEnvelope>> {
         }
     }
     Ok(events)
+}
+
+/// Resolve the newest durable sequence by parsing only the journal tail.
+///
+/// Session reopen (`EventBridge::new`) only needs the resume point, which
+/// always lives in the last complete line: sequence allocation and journal
+/// appends happen under the bridge's ordering lock. Small files, unreadable
+/// files, and tails without one complete parseable line fall back to the
+/// authoritative full `load_timeline` scan.
+fn load_timeline_last_seq(session_id: &str) -> Option<u64> {
+    let path = match timeline_path(session_id) {
+        Ok(path) => path,
+        Err(_) => return None,
+    };
+    match load_timeline_last_seq_from_path(&path) {
+        Ok(Some(seq)) => Some(seq),
+        _ => load_timeline(session_id)
+            .ok()
+            .and_then(|events| events.last().map(|event| event.seq)),
+    }
+}
+
+fn load_timeline_last_seq_from_path(path: &Path) -> Result<Option<u64>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let file = fs::File::open(path)
+        .with_context(|| format!("读取 ACP timeline {} 失败", path.display()))?;
+    let file_len = file.metadata()?.len();
+    if file_len == 0 {
+        return Ok(None);
+    }
+    let from_tail = file_len > TIMELINE_TAIL_BYTES;
+    let mut reader = BufReader::new(file);
+    if from_tail {
+        reader
+            .seek(SeekFrom::Start(file_len - TIMELINE_TAIL_BYTES))
+            .with_context(|| format!("跳转 ACP timeline {} 失败", path.display()))?;
+        // The window may open mid-line; skip to the next line boundary so
+        // parsing starts at a whole event (one earlier line changes nothing:
+        // the maximum seq sits at the end).
+        let mut skipped = Vec::new();
+        reader.read_until(b'\n', &mut skipped)?;
+    }
+    let mut last_seq: Option<u64> = None;
+    loop {
+        let mut line = Vec::new();
+        if reader.read_until(b'\n', &mut line)? == 0 {
+            break;
+        }
+        if line.last() != Some(&b'\n') {
+            // A trailing fragment is an in-flight or crash-truncated append;
+            // the event never completed durably, so it must not be resumed.
+            break;
+        }
+        let Ok(event) = serde_json::from_slice::<AcpEventEnvelope>(&line) else {
+            continue;
+        };
+        last_seq = Some(match last_seq {
+            Some(current) => current.max(event.seq),
+            None => event.seq,
+        });
+    }
+    Ok(last_seq)
 }
 
 #[derive(Debug)]
@@ -1213,7 +1386,8 @@ fn load_web_timeline_page_from_path(
         }
         line_number += 1;
         let line_end = reader.stream_position()?;
-        // append_timeline writes JSON and the newline separately. A concurrent
+        // The journal writer may still be mid-line: an event larger than the
+        // append buffer reaches the file in several writes. A concurrent
         // reader can briefly observe the final JSON fragment; never advance a
         // durable cursor past that incomplete event.
         if !line.ends_with('\n') {
@@ -1886,6 +2060,91 @@ mod tests {
         assert!(
             orphaned_turn_ids(&events).is_empty(),
             "re-running recovery after terminal events must be a no-op"
+        );
+    }
+
+    #[test]
+    fn timeline_tail_reader_returns_the_last_complete_sequence() {
+        let timeline = TempTimeline::create(&[
+            event(1, Some("turn-1"), "turn_started"),
+            event(2, Some("turn-1"), "turn_completed"),
+        ]);
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            Some(2)
+        );
+
+        // A trailing fragment without a newline (in-flight buffered write or a
+        // crash mid-append) must not be mistaken for a durable resume point.
+        let serialized = serde_json::to_vec(&message_event(3, "in-flight")).unwrap();
+        timeline.append(&serialized[..serialized.len() / 2]);
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            Some(2)
+        );
+
+        timeline.append(&serialized[serialized.len() / 2..]);
+        timeline.append(b"\n");
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn timeline_tail_reader_skips_malformed_complete_lines() {
+        let timeline = TempTimeline::create(&[event(1, None, "turn_started")]);
+        timeline.append(b"{not json}\n");
+        timeline.append(&serde_json::to_vec(&event(7, None, "runtime_error")).unwrap());
+        timeline.append(b"\n");
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn timeline_tail_reader_reports_empty_and_missing_journals() {
+        let empty = TempTimeline::create(&[]);
+        assert_eq!(
+            load_timeline_last_seq_from_path(empty.path()).unwrap(),
+            None
+        );
+        let missing = Path::new("/nonexistent/pinvou-acp-tail-case.jsonl");
+        assert_eq!(load_timeline_last_seq_from_path(missing).unwrap(), None);
+    }
+
+    #[test]
+    fn timeline_tail_reader_parses_only_the_window_and_still_finds_the_end() {
+        // The first line alone exceeds the tail window, so the reader must
+        // seek into its middle, skip the cut line, and still return the newest
+        // sequence from the events after it.
+        let oversized = message_event(1, &"x".repeat(TIMELINE_TAIL_BYTES as usize + 1024));
+        let timeline = TempTimeline::create(&[oversized]);
+        for seq in 2..=6_u64 {
+            let chunk = event(seq, Some("turn-1"), "agent_message_chunk");
+            timeline.append(&serde_json::to_vec(&chunk).unwrap());
+            timeline.append(b"\n");
+        }
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn timeline_tail_reader_falls_back_when_the_window_holds_no_complete_line() {
+        // A single line longer than the tail window with no trailing newline:
+        // the window contains no complete line, so the reader must report no
+        // resume point (the caller falls back to the full scan) instead of
+        // guessing from the fragment.
+        let oversized = message_event(1, &"x".repeat(TIMELINE_TAIL_BYTES as usize + 1024));
+        let serialized = serde_json::to_vec(&oversized).unwrap();
+        let timeline = TempTimeline::create(&[]);
+        timeline.append(&serialized[..serialized.len() - 1]);
+        assert_eq!(
+            load_timeline_last_seq_from_path(timeline.path()).unwrap(),
+            None
         );
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -976,6 +976,7 @@ impl EventBridge {
             // crash-recovery anchors: they flush synchronously so resume and
             // orphan-turn recovery never depend on buffered chunk bytes.
             // Everything else rides the TIMELINE_APPEND_BUFFER_BYTES window.
+            // runtime_error is a defensive anchor: no emitter exists today.
             let flush_timeline = matches!(
                 event_type,
                 "turn_started" | "turn_completed" | "runtime_error"
@@ -998,6 +999,10 @@ impl EventBridge {
                 _ => None,
             };
             if let Some(status) = last_status {
+                // state.lastSeq is a best-effort cursor: it is written outside
+                // the journal flush set, so after a crash it may point past the
+                // durable journal tail. No reader consumes it for resume today;
+                // if one ever does, these event types must join the flush set.
                 if let Err(error) = patch_acp_state(
                     &self.pinvou_session_id,
                     json!({ "lastStatus": status, "lastSeq": envelope.seq }),
@@ -1036,6 +1041,15 @@ impl EventBridge {
     /// Append one envelope to the session journal through the cached handle.
     fn append_timeline(&self, event: &AcpEventEnvelope, flush_after: bool) -> Result<()> {
         self.timeline_writer.lock().append(event, flush_after)
+    }
+
+    /// Best-effort flush of the append buffer so journal readers outside the
+    /// emit path (`AcpPool::timeline` / `AcpPool::web_timeline_page`) never
+    /// observe a pre-buffer view of an active turn. Turn boundaries already
+    /// flush synchronously; this only drains the buffered chunk window.
+    /// Failures are swallowed: the reader falls back to whatever is durable.
+    pub fn flush_journal(&self) {
+        let _ = self.timeline_writer.lock().flush();
     }
 }
 
@@ -1149,10 +1163,13 @@ impl TimelineWriter {
         let mut line = serde_json::to_vec(event)?;
         line.push(b'\n');
         if let Err(error) = self.write_line(&line, flush_after) {
-            // The cached handle may be stale (the journal was removed or
-            // replaced externally, or the descriptor broke): reopen once and
-            // retry. A partially written line is skipped by readers as
-            // malformed, the same way a crash mid-append is recovered.
+            // The cached handle may be stale (the journal file was removed
+            // externally, or the descriptor broke): reopen once and retry.
+            // Note this only covers error-producing breakage; rename-style
+            // rotation keeps the old handle silently appending to the unlinked
+            // inode until the next flush-point existence check re-anchors it.
+            // A partially written line is skipped by readers as malformed,
+            // the same way a crash mid-append is recovered.
             self.writer = None;
             self.open()?;
             self.write_line(&line, flush_after)
@@ -2146,5 +2163,152 @@ mod tests {
             load_timeline_last_seq_from_path(timeline.path()).unwrap(),
             None
         );
+    }
+
+    /// Redirect the sessions root to a per-test directory so TimelineWriter's
+    /// `timeline_path` resolves inside a disposable sandbox. Holds the
+    /// crate-wide ENV_LOCK for the whole test (PINVOU3_HOME is process-wide)
+    /// and restores the previous value on drop.
+    struct TempSessionsRoot {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        root: PathBuf,
+        previous: Option<String>,
+    }
+
+    impl TempSessionsRoot {
+        fn new(tag: &str) -> Self {
+            let guard = crate::platform::paths::tests::ENV_LOCK
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let root = std::env::temp_dir().join(format!(
+                "pinvou3-acp-timeline-writer-{}-{tag}",
+                std::process::id(),
+            ));
+            fs::create_dir_all(&root).expect("create temporary sessions root");
+            let previous = std::env::var("PINVOU3_HOME").ok();
+            // SAFETY: this struct holds platform::paths::tests::ENV_LOCK; env writes are serialized in-process.
+            unsafe { std::env::set_var("PINVOU3_HOME", &root) };
+            Self {
+                _guard: guard,
+                root,
+                previous,
+            }
+        }
+    }
+
+    impl Drop for TempSessionsRoot {
+        fn drop(&mut self) {
+            // SAFETY: this struct holds platform::paths::tests::ENV_LOCK; env writes are serialized in-process.
+            match &self.previous {
+                Some(value) => unsafe { std::env::set_var("PINVOU3_HOME", value) },
+                None => unsafe { std::env::remove_var("PINVOU3_HOME") },
+            }
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn writer_event(seq: u64, event_type: &str) -> AcpEventEnvelope {
+        let mut envelope = event(seq, Some("turn-writer"), event_type);
+        envelope.session_id = "acp-writer-sandbox".into();
+        envelope
+    }
+
+    fn journal_len() -> u64 {
+        timeline_path("acp-writer-sandbox")
+            .expect("resolve sandbox journal path")
+            .metadata()
+            .map(|meta| meta.len())
+            .unwrap_or(0)
+    }
+
+    fn journal_lines() -> Vec<String> {
+        let path = timeline_path("acp-writer-sandbox").expect("resolve sandbox journal path");
+        if !path.exists() {
+            return Vec::new();
+        }
+        fs::read_to_string(path)
+            .expect("read sandbox journal")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn timeline_writer_buffers_chunks_until_an_explicit_flush() {
+        let _root = TempSessionsRoot::new("buffer");
+        let mut writer = TimelineWriter::new("acp-writer-sandbox");
+
+        // A buffered chunk append opens the journal lazily but must not put
+        // any bytes on disk: the 64KB window is far from full.
+        writer
+            .append(&writer_event(1, "agent_message_chunk"), false)
+            .expect("append buffered chunk");
+        assert_eq!(journal_len(), 0);
+        assert!(journal_lines().is_empty());
+
+        // An explicit flush (turn boundary / reader entry) drains the whole
+        // buffer, including the earlier chunk line.
+        writer.flush().expect("flush journal buffer");
+        let lines = journal_lines();
+        assert_eq!(lines.len(), 1);
+        let persisted: AcpEventEnvelope = serde_json::from_str(&lines[0]).unwrap();
+        assert_eq!(persisted.seq, 1);
+    }
+
+    #[test]
+    fn timeline_writer_flush_after_persists_buffered_and_current_lines() {
+        let _root = TempSessionsRoot::new("flush-after");
+        let mut writer = TimelineWriter::new("acp-writer-sandbox");
+
+        writer
+            .append(&writer_event(1, "agent_message_chunk"), false)
+            .expect("append buffered chunk");
+        writer
+            .append(&writer_event(2, "turn_started"), true)
+            .expect("append boundary event");
+
+        let lines = journal_lines();
+        assert_eq!(lines.len(), 2, "boundary flush drains earlier chunks too");
+        let first: AcpEventEnvelope = serde_json::from_str(&lines[0]).unwrap();
+        let second: AcpEventEnvelope = serde_json::from_str(&lines[1]).unwrap();
+        assert_eq!(first.seq, 1);
+        assert_eq!(second.event.event_type, "turn_started");
+    }
+
+    #[test]
+    fn timeline_writer_reanchors_when_the_journal_is_removed_externally() {
+        let _root = TempSessionsRoot::new("reanchor");
+        let mut writer = TimelineWriter::new("acp-writer-sandbox");
+
+        writer
+            .append(&writer_event(1, "turn_started"), true)
+            .expect("append first boundary");
+        let journal = timeline_path("acp-writer-sandbox").expect("resolve journal path");
+        fs::remove_file(&journal).expect("remove the journal externally");
+
+        // The flush-point existence check re-anchors onto a fresh file; the
+        // line written into the unlinked inode stays lost (documented
+        // trade-off), and the recreated journal starts empty.
+        writer
+            .append(&writer_event(2, "turn_completed"), true)
+            .expect("append after external removal");
+        assert!(journal.exists(), "flush point must recreate the journal");
+        assert!(
+            journal_lines().is_empty(),
+            "the line lost with the removed inode must not be duplicated"
+        );
+
+        // The re-anchored handle keeps appending normally afterwards.
+        writer
+            .append(&writer_event(3, "agent_message_chunk"), false)
+            .expect("append buffered after re-anchor");
+        writer
+            .append(&writer_event(4, "turn_started"), true)
+            .expect("append boundary after re-anchor");
+        let seqs: Vec<u64> = journal_lines()
+            .iter()
+            .map(|line| serde_json::from_str::<AcpEventEnvelope>(line).unwrap().seq)
+            .collect();
+        assert_eq!(seqs, vec![3, 4]);
     }
 }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -1209,7 +1209,9 @@ impl TimelineWriter {
         if self.writer.is_none() {
             self.open()?;
         }
-        self.writer.as_mut().context("ACP timeline writer handle unavailable")
+        self.writer
+            .as_mut()
+            .context("ACP timeline writer handle unavailable")
     }
 
     fn journal_exists(&self) -> bool {
@@ -1221,8 +1223,12 @@ impl TimelineWriter {
         // they only run on first use and on reopen after a failure.
         let path = timeline_path(&self.session_id)?;
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create ACP timeline directory {}", parent.display()))?;
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create ACP timeline directory {}",
+                    parent.display()
+                )
+            })?;
         }
         let file = OpenOptions::new()
             .create(true)

--- a/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/events.rs
@@ -1173,7 +1173,7 @@ impl TimelineWriter {
             self.writer = None;
             self.open()?;
             self.write_line(&line, flush_after)
-                .with_context(|| format!("重试写入 ACP timeline 失败: {error}"))?;
+                .with_context(|| format!("failed to retry the ACP timeline write: {error}"))?;
         }
         Ok(())
     }
@@ -1209,7 +1209,7 @@ impl TimelineWriter {
         if self.writer.is_none() {
             self.open()?;
         }
-        self.writer.as_mut().context("ACP timeline 写入句柄不可用")
+        self.writer.as_mut().context("ACP timeline writer handle unavailable")
     }
 
     fn journal_exists(&self) -> bool {
@@ -1222,13 +1222,13 @@ impl TimelineWriter {
         let path = timeline_path(&self.session_id)?;
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)
-                .with_context(|| format!("创建 ACP timeline 目录 {} 失败", parent.display()))?;
+                .with_context(|| format!("failed to create ACP timeline directory {}", parent.display()))?;
         }
         let file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&path)
-            .with_context(|| format!("打开 ACP timeline {} 失败", path.display()))?;
+            .with_context(|| format!("failed to open ACP timeline {}", path.display()))?;
         self.writer = Some(BufWriter::with_capacity(TIMELINE_APPEND_BUFFER_BYTES, file));
         Ok(())
     }
@@ -1284,7 +1284,7 @@ fn load_timeline_last_seq_from_path(path: &Path) -> Result<Option<u64>> {
         return Ok(None);
     }
     let file = fs::File::open(path)
-        .with_context(|| format!("读取 ACP timeline {} 失败", path.display()))?;
+        .with_context(|| format!("failed to open ACP timeline {}", path.display()))?;
     let file_len = file.metadata()?.len();
     if file_len == 0 {
         return Ok(None);
@@ -1294,7 +1294,7 @@ fn load_timeline_last_seq_from_path(path: &Path) -> Result<Option<u64>> {
     if from_tail {
         reader
             .seek(SeekFrom::Start(file_len - TIMELINE_TAIL_BYTES))
-            .with_context(|| format!("跳转 ACP timeline {} 失败", path.display()))?;
+            .with_context(|| format!("failed to seek in ACP timeline {}", path.display()))?;
         // The window may open mid-line; skip to the next line boundary so
         // parsing starts at a whole event (one earlier line changes nothing:
         // the maximum seq sits at the end).

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -3278,14 +3278,15 @@ impl AcpPool {
         result
     }
 
-    pub fn timeline(&self, session_id: &str) -> Result<Vec<AcpEventEnvelope>> {
+    pub async fn timeline(&self, session_id: &str) -> Result<Vec<AcpEventEnvelope>> {
         if !self.is_acp(session_id) {
             bail!("当前会话不是 ACP 会话");
         }
+        self.flush_session_journal(session_id).await;
         load_timeline(session_id)
     }
 
-    pub(crate) fn web_timeline_page(
+    pub(crate) async fn web_timeline_page(
         &self,
         session_id: &str,
         after_seq: u64,
@@ -3297,6 +3298,7 @@ impl AcpPool {
         if !self.is_acp(session_id) {
             bail!("当前会话不是 ACP 会话");
         }
+        self.flush_session_journal(session_id).await;
         load_web_timeline_page(
             session_id,
             after_seq,
@@ -3305,6 +3307,22 @@ impl AcpPool {
             max_page_bytes,
             max_event_bytes,
         )
+    }
+
+    // 读盘前 best-effort 排空该会话 journal 的缓冲窗：turn 边界之外，活跃 turn 的
+    // chunk 事件最多可在 BufWriter 内滞留 64KB；不先 flush，重连重放/时间线读取会
+    // 短暂看到滞后于内存投影的视图。锁内只克隆 bridge（Arc），flush 在锁外进行。
+    // 会话不在运行时（仅存历史 journal）时无需 flush，盘上即全部持久状态。
+    async fn flush_session_journal(&self, session_id: &str) {
+        let bridge = self
+            .sessions
+            .lock()
+            .await
+            .get(session_id)
+            .map(|session| session.bridge.clone());
+        if let Some(bridge) = bridge {
+            bridge.flush_journal();
+        }
     }
 
     pub async fn pending_permissions_for(

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -3088,6 +3088,12 @@ impl AcpPool {
     pub async fn evict(&self, session_id: &str) {
         self.cancel_pending_permissions(session_id).await;
         self.cancel_pending_elicitations(session_id).await;
+        // 辅助索引映射此前只增不删：真正删除的会话条目会永久滞留。这里随
+        // 回收一并移除是安全的——`is_acp_metadata` 在 list() 时会按持久化
+        // 元数据（agents 索引或 `* (ACP)` model 字符串）按需重建该条目，启动
+        // 时也会按会话元数据整体重建。存活的会话（升级重启、模型探针）下一轮 list()
+        // 即自愈；空闲回收走 `evict_if_idle`，不经过本路径、映射原样保留。
+        self.acp_metadata_backends.write().remove(session_id);
         if let Some(runtime) = self.sessions.lock().await.remove(session_id) {
             runtime.shutdown().await;
         }

--- a/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/codex_acp/mod.rs
@@ -3088,11 +3088,14 @@ impl AcpPool {
     pub async fn evict(&self, session_id: &str) {
         self.cancel_pending_permissions(session_id).await;
         self.cancel_pending_elicitations(session_id).await;
-        // 辅助索引映射此前只增不删：真正删除的会话条目会永久滞留。这里随
-        // 回收一并移除是安全的——`is_acp_metadata` 在 list() 时会按持久化
-        // 元数据（agents 索引或 `* (ACP)` model 字符串）按需重建该条目，启动
-        // 时也会按会话元数据整体重建。存活的会话（升级重启、模型探针）下一轮 list()
-        // 即自愈；空闲回收走 `evict_if_idle`，不经过本路径、映射原样保留。
+        // The helper index map previously only grew: entries of truly
+        // deleted sessions were retained forever. Removing them together
+        // with the eviction is safe — `is_acp_metadata` rebuilds the entry
+        // on demand from persisted metadata during list() (the agents index
+        // or the `* (ACP)` model string), and startup rebuilds the whole map
+        // from session metadata. Surviving sessions (upgrade restarts, model
+        // probes) self-heal on the next list(); idle eviction goes through
+        // `evict_if_idle`, never through this path, so its map entries stay.
         self.acp_metadata_backends.write().remove(session_id);
         if let Some(runtime) = self.sessions.lock().await.remove(session_id) {
             runtime.shutdown().await;
@@ -3309,10 +3312,14 @@ impl AcpPool {
         )
     }
 
-    // 读盘前 best-effort 排空该会话 journal 的缓冲窗：turn 边界之外，活跃 turn 的
-    // chunk 事件最多可在 BufWriter 内滞留 64KB；不先 flush，重连重放/时间线读取会
-    // 短暂看到滞后于内存投影的视图。锁内只克隆 bridge（Arc），flush 在锁外进行。
-    // 会话不在运行时（仅存历史 journal）时无需 flush，盘上即全部持久状态。
+    // Best-effort drain of the session journal's buffer window before
+    // reading from disk: outside turn boundaries, up to 64KB of an active
+    // turn's chunk events can sit in the BufWriter; without a flush first,
+    // reconnect replays / timeline reads would briefly observe a view
+    // lagging behind the in-memory projection. Only the bridge (Arc) is
+    // cloned under the lock; the flush happens outside it. A session not in
+    // the runtime (historical journal only) needs no flush — everything
+    // already lives on disk.
     async fn flush_session_journal(&self, session_id: &str) {
         let bridge = self
             .sessions

--- a/pinvou3-app/src-tauri/src/features/deliverables.rs
+++ b/pinvou3-app/src-tauri/src/features/deliverables.rs
@@ -4,24 +4,28 @@
 //! `app::commands::artifacts`，本模块只根据会话磁盘真相装配交付物索引。
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+use std::time::SystemTime;
 
 /// 「产出物」跨会话索引:遍历 `~/.pinvou3/sessions/*.json`,把每个会话跟踪的
 /// artifacts 汇成一张扁平表(供「产出物」一级入口用)。只走磁盘真相:
 /// 文件已被删则跳过;mtime/size 现取 fs。
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct DvSessionView {
     metadata: DvMeta,
     #[serde(default)]
     artifacts: Vec<DvArtifact>,
 }
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct DvMeta {
     #[serde(default)]
     id: String,
     #[serde(default)]
     title: String,
 }
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct DvArtifact {
     storage_path: std::path::PathBuf,
     #[serde(default)]
@@ -46,6 +50,19 @@ const DELIVERABLE_EXTS: &[&str] = &[
     "jpeg", "svg", "gif", "webp", "zip",
 ];
 
+/// 会话 JSON 解析缓存的条目上限。单条只含 metadata+artifacts，量级很小；
+/// 满员逐出一条（哈希表任意序），不整表清空，避免清单刷新时的缓存雪崩。
+const DV_VIEW_CACHE_LIMIT: usize = 512;
+
+/// 按 (mtime, len) 缓存每个会话 JSON 解析出的索引视图（metadata+artifacts）。
+/// 会话文件每回合整体重写、mtime 必变，缓存只对未变化的文件省去重复整读
+/// +解析——正是「产出物」列表高频刷新时的常见情形。视图的其余派生数据
+/// （产物文件的 mtime/size 现取 fs、扩展名过滤、排序）每次调用都重新计算，
+/// 解析是纯读取、无副作用，缓存值可安全复用。
+static DV_VIEW_CACHE: OnceLock<
+    Mutex<HashMap<PathBuf, ((Option<SystemTime>, u64), DvSessionView)>>,
+> = OnceLock::new();
+
 fn deliverable_category(ext: &str) -> &'static str {
     match ext {
         "html" | "htm" | "mhtml" | "mht" => "web",
@@ -68,14 +85,48 @@ pub(crate) fn list_deliverable_index_impl() -> Vec<DeliverableItem> {
 
     for entry in entries.flatten() {
         let file = entry.path();
-        if !file.is_file() || file.extension().and_then(|s| s.to_str()) != Some("json") {
+        if file.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
-        let Ok(raw) = std::fs::read_to_string(&file) else {
+        let Ok(meta) = std::fs::metadata(&file) else {
             continue;
         };
-        let Ok(view) = serde_json::from_str::<DvSessionView>(&raw) else {
+        if !meta.is_file() {
             continue;
+        }
+        let stamp = (meta.modified().ok(), meta.len());
+        let cache = DV_VIEW_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+        let cached = {
+            let guard = cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard
+                .get(&file)
+                .filter(|(cached_stamp, _)| *cached_stamp == stamp)
+                .map(|(_, view)| view.clone())
+        };
+        let view = match cached {
+            Some(view) => view,
+            None => {
+                let Ok(raw) = std::fs::read_to_string(&file) else {
+                    continue;
+                };
+                let Ok(view) = serde_json::from_str::<DvSessionView>(&raw) else {
+                    continue;
+                };
+                let mut guard = cache
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                // 满员只逐出一条（理由见 DV_VIEW_CACHE_LIMIT），签名不匹配的
+                // 条目靠 (mtime, len) 自然失效。
+                if guard.len() >= DV_VIEW_CACHE_LIMIT && !guard.contains_key(&file) {
+                    if let Some(evicted) = guard.keys().next().cloned() {
+                        guard.remove(&evicted);
+                    }
+                }
+                guard.insert(file.clone(), (stamp, view.clone()));
+                view
+            }
         };
 
         for art in view.artifacts {

--- a/pinvou3-app/src-tauri/src/features/deliverables.rs
+++ b/pinvou3-app/src-tauri/src/features/deliverables.rs
@@ -50,15 +50,20 @@ const DELIVERABLE_EXTS: &[&str] = &[
     "jpeg", "svg", "gif", "webp", "zip",
 ];
 
-/// 会话 JSON 解析缓存的条目上限。单条只含 metadata+artifacts，量级很小；
-/// 满员逐出一条（哈希表任意序），不整表清空，避免清单刷新时的缓存雪崩。
+/// Entry limit of the session JSON parse cache. One entry holds only
+/// metadata+artifacts and is tiny; when full, a single entry is evicted (in
+/// hash-map order) instead of clearing the whole table, avoiding a cache
+/// avalanche on inventory refreshes.
 const DV_VIEW_CACHE_LIMIT: usize = 512;
 
-/// 按 (mtime, len) 缓存每个会话 JSON 解析出的索引视图（metadata+artifacts）。
-/// 会话文件每回合整体重写、mtime 必变，缓存只对未变化的文件省去重复整读
-/// +解析——正是「产出物」列表高频刷新时的常见情形。视图的其余派生数据
-/// （产物文件的 mtime/size 现取 fs、扩展名过滤、排序）每次调用都重新计算，
-/// 解析是纯读取、无副作用，缓存值可安全复用。
+/// Cache of the index view (metadata+artifacts) parsed out of each session
+/// JSON, keyed by (mtime, len). Session files are rewritten whole every
+/// turn, so the mtime always changes; the cache only saves the redundant
+/// full read+parse of unchanged files — exactly the common case during
+/// high-frequency "deliverables" list refreshes. The view's remaining
+/// derived data (artifact file mtime/size read live from the fs, extension
+/// filtering, sorting) is recomputed on every call. Parsing is a pure read
+/// with no side effects, so the cached value is safe to reuse.
 static DV_VIEW_CACHE: OnceLock<
     Mutex<HashMap<PathBuf, ((Option<SystemTime>, u64), DvSessionView)>>,
 > = OnceLock::new();
@@ -117,8 +122,9 @@ pub(crate) fn list_deliverable_index_impl() -> Vec<DeliverableItem> {
                 let mut guard = cache
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
-                // 满员只逐出一条（理由见 DV_VIEW_CACHE_LIMIT），签名不匹配的
-                // 条目靠 (mtime, len) 自然失效。
+                // When full, evict a single entry (rationale in
+                // DV_VIEW_CACHE_LIMIT); entries with mismatched signatures
+                // expire naturally via (mtime, len).
                 if guard.len() >= DV_VIEW_CACHE_LIMIT && !guard.contains_key(&file) {
                     if let Some(evicted) = guard.keys().next().cloned() {
                         guard.remove(&evicted);

--- a/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
@@ -15,16 +15,24 @@
 //! 不在 workspace/artifacts 子目录下的事件(如 `sessions/<id>.json` session 元数据本身)忽略。
 //!
 //! Debouncing：notify 后端(inotify)对单个文件写入可能 fire 多次事件
-//! (Create + 多次 Modify(Data) + 最后 Modify(Metadata))。watcher 端不 debounce,
-//! 由前端按 path 去重(trackArtifact 已经处理重复 path)。
+//! (Create + 多次 Modify(Data) + 最后 Modify(Metadata))。产物事件(artifact:disk)
+//! watcher 端不 debounce,由前端按 path 去重(trackArtifact 已经处理重复 path)。
+//! 例外：顶层 `sched-*.json` 在一次定时运行里随每条消息整体重写,成片事件只
+//! 应换来一次刷新,因此按 path 做 400ms 尾沿去抖(scheduled_task:run_updated
+//! 只驱动前端刷新,payload 的 event 字段无消费者,延迟发射不损语义)。
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
+use std::time::{Duration, Instant};
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::json;
 use tauri::{AppHandle, Emitter};
+
+/// 顶层 `sched-*.json` 事件的尾沿去抖窗口：最后一次事件后静默满窗口才发射。
+const SCHED_DEBOUNCE: Duration = Duration::from_millis(400);
 
 /// 启动后台 watcher 线程。spawn 后 return,watcher 自己跑直到 app 退出。
 pub fn spawn(app: AppHandle, sessions_root: PathBuf) {
@@ -55,16 +63,55 @@ pub fn spawn(app: AppHandle, sessions_root: PathBuf) {
         }
         eprintln!("[file_watcher] watching {}", sessions_root.display());
 
-        for result in rx {
-            match result {
-                Ok(event) => handle_event(&app, &event, &sessions_root),
-                Err(e) => eprintln!("[file_watcher] event error: {e}"),
+        // sched-*.json 的待发射表：session_id -> (路径, 最后一次事件时刻)。
+        // 主循环在等下一条事件与等最早到期之间 recv_timeout，到期的先发射。
+        let mut pending_sched: HashMap<String, (PathBuf, Instant)> = HashMap::new();
+        loop {
+            let now = Instant::now();
+            let due: Vec<String> = pending_sched
+                .iter()
+                .filter(|(_, (_, at))| now.duration_since(*at) >= SCHED_DEBOUNCE)
+                .map(|(id, _)| id.clone())
+                .collect();
+            for id in due {
+                if let Some((path, _)) = pending_sched.remove(&id) {
+                    emit_scheduled_run_updated(&app, &id, path.exists());
+                }
+            }
+            let deadline = pending_sched
+                .values()
+                .map(|(_, at)| *at + SCHED_DEBOUNCE)
+                .min();
+            let event = match deadline {
+                Some(deadline) => {
+                    match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+                        Ok(result) => Some(result),
+                        Err(mpsc::RecvTimeoutError::Timeout) => None,
+                        Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+                None => match rx.recv() {
+                    Ok(result) => Some(result),
+                    Err(_) => break,
+                },
+            };
+            match event {
+                Some(Ok(event)) => {
+                    handle_event(&app, &event, &sessions_root, &mut pending_sched);
+                }
+                Some(Err(e)) => eprintln!("[file_watcher] event error: {e}"),
+                None => continue,
             }
         }
     });
 }
 
-fn handle_event(app: &AppHandle, ev: &Event, root: &Path) {
+fn handle_event(
+    app: &AppHandle,
+    ev: &Event,
+    root: &Path,
+    pending_sched: &mut HashMap<String, (PathBuf, Instant)>,
+) {
     // 只处理这几类事件:
     // - Create        → 新文件
     // - Modify(Data)  → 文件写入
@@ -79,16 +126,9 @@ fn handle_event(app: &AppHandle, ev: &Event, root: &Path) {
     }
     for path in &ev.paths {
         if let Some(session_id) = scheduled_session_id(path, root) {
-            let payload = json!({
-                "sessionId": session_id,
-                "event": if path.exists() { "upsert" } else { "removed" },
-            });
-            let _ = app.emit("scheduled_task:run_updated", payload.clone());
-            crate::platform::app_events::forward_app_event(
-                app,
-                "scheduled_task:run_updated",
-                payload,
-            );
+            // 只登记、不立即发射：由主循环尾沿去抖后统一发出；event 语义
+            // （upsert/removed）延迟到发射时刻按 path 存在性现判。
+            pending_sched.insert(session_id, (path.clone(), Instant::now()));
             continue;
         }
         let Some((session_id, rel)) = parse_session_relative(path, root) else {
@@ -138,6 +178,17 @@ fn handle_event(app: &AppHandle, ev: &Event, root: &Path) {
     }
 }
 
+/// 发射一次定时运行刷新事件。`exists` 在发射时刻按 path 现判，保留原有
+/// upsert/removed 语义（当前前端两个监听方都只据此触发刷新、不读 event）。
+fn emit_scheduled_run_updated(app: &AppHandle, session_id: &str, exists: bool) {
+    let payload = json!({
+        "sessionId": session_id,
+        "event": if exists { "upsert" } else { "removed" },
+    });
+    let _ = app.emit("scheduled_task:run_updated", payload.clone());
+    crate::platform::app_events::forward_app_event(app, "scheduled_task:run_updated", payload);
+}
+
 /// Match only the top-level persisted JSON for a scheduled conversation.
 /// Sidecars and workspace files are deliberately excluded.
 fn scheduled_session_id(path: &Path, root: &Path) -> Option<String> {
@@ -170,6 +221,11 @@ fn should_skip(basename: &str) -> bool {
         return true;
     }
     if basename.ends_with(".tmp") || basename.ends_with(".bak") {
+        return true;
+    }
+    // 工作流内部审计流水（assistant/audit.rs，逐条 TokenUsage 追加），纯基础
+    // 设施、前端零消费；不跳过会随每次子代理事件刷一遍产物面板。
+    if basename == "workflow_audit.jsonl" {
         return true;
     }
     false
@@ -217,6 +273,7 @@ mod tests {
         assert!(should_skip(".hidden")); // 通用 dot file
         assert!(should_skip(".bashrc.swp")); // vim swap
         assert!(should_skip("draft.tmp"));
+        assert!(should_skip("workflow_audit.jsonl")); // 工作流内部审计流水
         assert!(!should_skip("report.docx"));
         assert!(!should_skip("人类文档.docx")); // 正常中文文件名
         assert!(!should_skip("plan.md"));

--- a/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
+++ b/pinvou3-app/src-tauri/src/features/files/file_watcher.rs
@@ -15,11 +15,15 @@
 //! 不在 workspace/artifacts 子目录下的事件(如 `sessions/<id>.json` session 元数据本身)忽略。
 //!
 //! Debouncing：notify 后端(inotify)对单个文件写入可能 fire 多次事件
-//! (Create + 多次 Modify(Data) + 最后 Modify(Metadata))。产物事件(artifact:disk)
-//! watcher 端不 debounce,由前端按 path 去重(trackArtifact 已经处理重复 path)。
-//! 例外：顶层 `sched-*.json` 在一次定时运行里随每条消息整体重写,成片事件只
-//! 应换来一次刷新,因此按 path 做 400ms 尾沿去抖(scheduled_task:run_updated
-//! 只驱动前端刷新,payload 的 event 字段无消费者,延迟发射不损语义)。
+//! (Create + several Modify(Data) + a final Modify(Metadata)). Artifact
+//! events (artifact:disk) are not debounced watcher-side; the frontend
+//! deduplicates by path (trackArtifact already handles repeated paths).
+//! Exception: top-level `sched-*.json` files are rewritten whole with every
+//! message of a scheduled run, and that burst of events should produce a
+//! single refresh, so they get a 400ms trailing-edge debounce per path
+//! (scheduled_task:run_updated only drives a frontend refresh and no
+//! consumer reads the payload's event field, so emitting late keeps the
+//! semantics intact).
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -31,7 +35,8 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::json;
 use tauri::{AppHandle, Emitter};
 
-/// 顶层 `sched-*.json` 事件的尾沿去抖窗口：最后一次事件后静默满窗口才发射。
+/// Trailing-edge debounce window for top-level `sched-*.json` events: emit
+/// once the stream has stayed quiet for a full window after the last event.
 const SCHED_DEBOUNCE: Duration = Duration::from_millis(400);
 
 /// 启动后台 watcher 线程。spawn 后 return,watcher 自己跑直到 app 退出。
@@ -63,8 +68,10 @@ pub fn spawn(app: AppHandle, sessions_root: PathBuf) {
         }
         eprintln!("[file_watcher] watching {}", sessions_root.display());
 
-        // sched-*.json 的待发射表：session_id -> (路径, 最后一次事件时刻)。
-        // 主循环在等下一条事件与等最早到期之间 recv_timeout，到期的先发射。
+        // Pending emission table for sched-*.json: session_id -> (path, time
+        // of the last event). The main loop recv_timeouts between waiting for
+        // the next event and waiting for the earliest deadline; due entries
+        // are emitted first.
         let mut pending_sched: HashMap<String, (PathBuf, Instant)> = HashMap::new();
         loop {
             let now = Instant::now();
@@ -126,8 +133,10 @@ fn handle_event(
     }
     for path in &ev.paths {
         if let Some(session_id) = scheduled_session_id(path, root) {
-            // 只登记、不立即发射：由主循环尾沿去抖后统一发出；event 语义
-            // （upsert/removed）延迟到发射时刻按 path 存在性现判。
+            // Record only, do not emit immediately: the main loop emits
+            // after the trailing-edge debounce; the event semantics
+            // (upsert/removed) are decided at emit time from the path's
+            // existence.
             pending_sched.insert(session_id, (path.clone(), Instant::now()));
             continue;
         }
@@ -178,8 +187,10 @@ fn handle_event(
     }
 }
 
-/// 发射一次定时运行刷新事件。`exists` 在发射时刻按 path 现判，保留原有
-/// upsert/removed 语义（当前前端两个监听方都只据此触发刷新、不读 event）。
+/// Emit one scheduled-run refresh event. `exists` is determined at emit time
+/// from the path, preserving the original upsert/removed semantics (both
+/// current frontend listeners only trigger a refresh from it and never read
+/// the event field).
 fn emit_scheduled_run_updated(app: &AppHandle, session_id: &str, exists: bool) {
     let payload = json!({
         "sessionId": session_id,
@@ -223,8 +234,10 @@ fn should_skip(basename: &str) -> bool {
     if basename.ends_with(".tmp") || basename.ends_with(".bak") {
         return true;
     }
-    // 工作流内部审计流水（assistant/audit.rs，逐条 TokenUsage 追加），纯基础
-    // 设施、前端零消费；不跳过会随每次子代理事件刷一遍产物面板。
+    // The workflow-internal audit journal (assistant/audit.rs, one
+    // TokenUsage appended per entry) is pure infrastructure with zero
+    // frontend consumers; without the skip, every subagent event would
+    // refresh the artifact panel.
     if basename == "workflow_audit.jsonl" {
         return true;
     }
@@ -273,7 +286,7 @@ mod tests {
         assert!(should_skip(".hidden")); // 通用 dot file
         assert!(should_skip(".bashrc.swp")); // vim swap
         assert!(should_skip("draft.tmp"));
-        assert!(should_skip("workflow_audit.jsonl")); // 工作流内部审计流水
+        assert!(should_skip("workflow_audit.jsonl")); // workflow-internal audit journal
         assert!(!should_skip("report.docx"));
         assert!(!should_skip("人类文档.docx")); // 正常中文文件名
         assert!(!should_skip("plan.md"));

--- a/pinvou3-app/src-tauri/src/features/multiagent/transcripts.rs
+++ b/pinvou3-app/src-tauri/src/features/multiagent/transcripts.rs
@@ -138,8 +138,13 @@ fn transcript_is_blocked(path: &Path) -> bool {
     let mut guard = cache
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // 满员只逐出一条而不是整表清空：burst 式失效会让清单轮询在下一轮把全部
+    // transcript 重新整读一遍（缓存雪崩）。哈希表无序，逐出任意一条即可收敛。
     if guard.len() >= BLOCKED_CACHE_LIMIT && !guard.contains_key(path) {
-        guard.clear();
+        if let Some((evicted, _)) = guard.iter().next() {
+            let evicted = evicted.clone();
+            guard.remove(&evicted);
+        }
     }
     guard.insert(path.to_path_buf(), (stamp, blocked));
     blocked

--- a/pinvou3-app/src-tauri/src/features/multiagent/transcripts.rs
+++ b/pinvou3-app/src-tauri/src/features/multiagent/transcripts.rs
@@ -138,8 +138,10 @@ fn transcript_is_blocked(path: &Path) -> bool {
     let mut guard = cache
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // 满员只逐出一条而不是整表清空：burst 式失效会让清单轮询在下一轮把全部
-    // transcript 重新整读一遍（缓存雪崩）。哈希表无序，逐出任意一条即可收敛。
+    // When full, evict a single entry instead of clearing the whole table:
+    // burst-style invalidation would make the next inventory poll re-read
+    // every transcript from scratch (a cache avalanche). Hash maps are
+    // unordered, so evicting any one entry converges.
     if guard.len() >= BLOCKED_CACHE_LIMIT && !guard.contains_key(path) {
         if let Some((evicted, _)) = guard.iter().next() {
             let evicted = evicted.clone();

--- a/pinvou3-app/src-tauri/src/features/sessions/store.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/store.rs
@@ -635,10 +635,16 @@ impl SessionStore {
         *self.active.write() = id;
     }
 
+    /// Persist one authoritative engine snapshot for an ordinary chat session.
+    ///
+    /// Takes `state` by reference so event-forwarder callers can keep the
+    /// snapshot alive in an `Arc` for the terminal path without a second deep
+    /// copy; the transcript clone into the durable record happens here, once
+    /// per persist.
     pub fn persist_chat_engine_state(
         &self,
         id: &str,
-        state: ChatEngineState,
+        state: &ChatEngineState,
     ) -> Result<SavedSession> {
         let _mutation = self.scheduled_mutation.lock();
         if self.scheduled_profiles.read().contains_key(id) {
@@ -652,9 +658,9 @@ impl SessionStore {
             .with_context(|| format!("load chat session {id} for engine persistence"))?;
         session.metadata.updated_at = Utc::now();
         session.metadata.message_count = state.messages.len();
-        session.metadata.model = state.model;
-        session.metadata.workspace = state.workspace;
-        session.messages = state.messages;
+        session.metadata.model = state.model.clone();
+        session.metadata.workspace = state.workspace.clone();
+        session.messages = state.messages.clone();
         session.system_prompt = persisted_system_prompt(state.system_prompt.as_ref());
 
         self.persist_then_reconcile_with(

--- a/pinvou3-app/src-tauri/src/features/sessions/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/tests.rs
@@ -372,7 +372,7 @@ fn ordinary_session_updated_snapshot_is_persisted_authoritatively() {
     let saved = store
         .persist_chat_engine_state(
             &session.metadata.id,
-            chat_engine_state(authoritative.clone()),
+            &chat_engine_state(authoritative.clone()),
         )
         .expect("persist ordinary SessionUpdated");
 
@@ -3682,7 +3682,7 @@ fn truncate_reports_compaction_summary_residue_in_system_prompt() {
         "前文摘要：Conversation Summary (Auto-Generated)\n……".to_string(),
     ));
     store
-        .persist_chat_engine_state(&with_marker.metadata.id, state)
+        .persist_chat_engine_state(&with_marker.metadata.id, &state)
         .expect("persist with marker");
     store
         .update_messages(&without_marker.metadata.id, messages())

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -1530,6 +1530,9 @@ const NAV_PREFETCH = {
         .filter(chat => chat.pinned)
         .sort((a, b) => String(b.pinnedAt || b.updatedAt).localeCompare(String(a.pinnedAt || a.updatedAt))), [chatHistory]);
       const bridgeScheduledTaskRecentRuns = bs && bs.scheduledTaskRecentRuns;
+      // bridge.available is deliberately not a dependency: the flag is assigned
+      // once when the bridge script installs window.TauriBridge and never
+      // reassigned, so the preview branch below cannot go stale afterwards.
       const scheduledRunShortcuts = useMemo(() => (bridgeScheduledTaskRecentRuns && bridgeScheduledTaskRecentRuns.length)
         ? bridgeScheduledTaskRecentRuns
         : (bridge.available ? [] : PREVIEW_SCHEDULED_RUN_SHORTCUTS.map(run => ({ ...run, taskName: t[run.taskNameKey] || run.taskNameKey }))), [bridgeScheduledTaskRecentRuns, t]);

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -156,12 +156,16 @@ function workspaceDisplayName(path) {
   return parts[parts.length - 1] || String(path || '');
 }
 
-// RecentItem memo 化后的逐项回调缓存:侧栏任务项(item)由 useMemo 派生、底层数据
-// 不变时引用稳定,以 item 为键缓存 onPickUp/定时运行 onSelect 闭包,使 RecentItem
-// 的 props 在无关重渲染(本地 UI 状态、纯聊天流式 token)中保持全等而跳过整行重渲。
-// 闭包捕获的 handler 均为 useCallback 稳定引用,且其依赖(t 等)变化时 item 一定会
-// 随之重建(派生 memo 以同一批状态为依赖),因此缓存不会提供过期闭包;旧 item 键由
-// GC 连同闭包一并回收。
+// Per-item callback cache behind the RecentItem memo: sidebar task items
+// (item) are derived by useMemo and keep stable references while the
+// underlying data is unchanged, so caching the onPickUp / scheduled-run
+// onSelect closures keyed by item keeps RecentItem props shallow-equal
+// across unrelated re-renders (local UI state, pure chat streaming tokens)
+// and skips the row re-render. Every captured handler is a stable useCallback
+// reference, and whenever a dependency (t etc.) changes the item is rebuilt
+// too (the derived memo depends on the same state), so the cache can never
+// hand out a stale closure; old item keys are garbage-collected along with
+// their closures.
 function cachedItemCallback(cache, item, build) {
   let fn = cache.get(item);
   if (!fn) {
@@ -173,7 +177,8 @@ function cachedItemCallback(cache, item, build) {
 const sidebarPickUpCallbacks = new WeakMap();
 const sidebarScheduledSelectCallbacks = new WeakMap();
 
-// 侧栏主导航的静态图标元素:模块级常量保持元素引用稳定,NavItem memo 才能命中。
+// Static icon elements for the sidebar main nav: module-level constants keep
+// the element references stable so the NavItem memo can hit.
 const NAV_ICON_NEW_CHAT = <Edit2 size={18} />;
 const NAV_ICON_SEARCH = <Search size={18} />;
 const NAV_ICON_SCHEDULED = <Clock size={18} />;
@@ -184,7 +189,8 @@ const NAV_ICON_CARD_POOL = <Layers size={18} />;
 const NAV_ICON_KNOWLEDGE = <BookOpen size={18} />;
 const NAV_ICON_CURRENT_CHAT = <MessageSquare size={18} />;
 
-// 悬停/聚焦预取回调(prefetchView 为模块函数):常量引用,供 NavItem memo 比较。
+// Hover/focus prefetch callbacks (prefetchView is a module function):
+// constant references for the NavItem memo comparison.
 const NAV_PREFETCH = {
   scheduled: () => prefetchView('scheduled'),
   knowledge: () => prefetchView('knowledge'),
@@ -204,8 +210,10 @@ const NAV_PREFETCH = {
         window.__PINVOU_STARTUP__.mark('react:app_render_start');
       }
       const bs = useBridgeState(APP_BRIDGE_STATE_DOMAINS);
-      // latest-ref mirror:稳定 useCallback(如 navigateFromScheduledRun)在事件触发时
-      // 读取最新桥接快照,避免依赖 bs 而使回调身份逐 notify 变化、击穿 memo。
+      // latest-ref mirror: stable useCallbacks (e.g. navigateFromScheduledRun)
+      // read the latest bridge snapshot when the event fires instead of
+      // depending on bs, which would change the callback identity on every
+      // notify and defeat the memo.
       const bsRef = useRef(bs);
       bsRef.current = bs;
       useLayoutEffect(() => {
@@ -1169,8 +1177,10 @@ const NAV_PREFETCH = {
       // dragAvatar = 被拎起的标签副本(跟随光标的 DOM 元素);null=没在拖。原生只判落点,视觉全在这。
       const [dragAvatar, setDragAvatar] = useState(null); // {key,label,dx,dy,w,h,x,y}
       const dragOffsetRef = useRef({ dx: 0, dy: 0 });
-      // useCallback 稳定引用:RecentItem/NavItem 的逐项 onPickUp 闭包缓存(见 renderSidebarTaskItem)
-      // 依赖此引用跨渲染不变,memo 才不会被每次渲染的新回调击穿。
+      // Stable useCallback: the per-item onPickUp closure caches of
+      // RecentItem/NavItem (see renderSidebarTaskItem) rely on this reference
+      // staying constant across renders so fresh callbacks per render cannot
+      // defeat the memo.
       const beginTearOff = useCallback((kind, id, label, info) => {
         const inv = isTauriAvailable() ? invokeTauri : null;
         if (!inv || !info) return;
@@ -1203,7 +1213,8 @@ const NAV_PREFETCH = {
       // 原生拖拽结束(松手/取消)→ 收起 avatar。
       useEffect(() => {
         if (!isTauriAvailable()) return;
-        // 卸载晚于 listen() resolve 时直接 unlisten,避免泄漏(与 browser:activated 同口径)。
+        // If unmount happens after listen() resolves, unlisten immediately
+        // to avoid a leak (same policy as browser:activated).
         let disposed = false;
         let un;
         tauriEvents.listen('detach:drag-ended', () => setDragAvatar(null)).then(f => {
@@ -1466,15 +1477,21 @@ const NAV_PREFETCH = {
       // 语言已即时写盘+切 UI,但 LLM 的 locale_tag 要重启 engine 才生效 → 偏离启动语言就提示。
       const languageNeedsRestart = !!bootedLanguageRef.current && language !== bootedLanguageRef.current;
 
-      // 定时运行状态文案(依赖当前语言词典);定义在派生 useMemo 之前,供下方 memo 依赖。
+      // Scheduled-run status copy (depends on the current language
+      // dictionary); defined before the derived useMemos below so they can
+      // depend on it.
       const scheduledRunLabel = useCallback((value) => {
         return (t.uiScheduled.runStatus[value] || value || t.uiScheduled.unknown);
       }, [t]);
 
-      // App 每个 bridge notify 都整体重渲染(含与侧栏无关的本地 UI 状态变化)。
-      // 下方 O(sessions) 派生全部按真实数据切片做 useMemo:bridge 订阅快照是持久化
-      // 投影,未变化的切片引用不变(如纯聊天流式 token 只动 chat 域,sessions 域
-      // 引用保持),这些 memo 命中后侧栏派生与 RecentItem memo 才能真正跳过重算。
+      // App re-renders in full on every bridge notify (including local UI
+      // state changes unrelated to the sidebar). Every O(sessions) derivation
+      // below is a useMemo over the real data slices: bridge subscription
+      // snapshots are persistent projections whose unchanged slices keep
+      // their references (pure chat streaming tokens only touch the chat
+      // domain and keep the sessions domain identical), so these memos are
+      // what let the sidebar derivations and the RecentItem memo actually
+      // skip recomputation.
 
       // Build chat history from sessions
       const bridgeSessions = bs && bs.sessions;
@@ -1488,7 +1505,9 @@ const NAV_PREFETCH = {
             : sessionTitlePresentation(s.title, s.title_attachment_names);
           return {
             id: s.id,
-            // 后端默认标题是三语哨兵之一(见 isDefaultChatTitle;bridge 以此判断是否自动改名)——显示层映射成当前语言
+            // The backend default title is one of the trilingual sentinels
+            // (see isDefaultChatTitle; the bridge uses it to decide whether to
+            // auto-rename) — map it to the current language at the display layer
             title: sessionTitlePlainText(titlePresentation),
             titleContent: titlePresentation.attachments.length
               ? <SessionAttachmentTitle presentation={titlePresentation} />
@@ -1497,7 +1516,7 @@ const NAV_PREFETCH = {
             updatedAt: s.updated_at || s.created_at || '',
             pinned: !!s.pinned,
             pinnedAt: s.pinned_at || '',
-            working: !!sessionBusy[s.id], // 多 session 并发:该 session 是否正在后台生成
+            working: !!sessionBusy[s.id], // concurrent sessions: is this session generating in the background
             leadingIcon: <PinvouLogo className="h-[18px] w-[18px]" />,
             testId: 'regular-sidebar-item',
             menuTestId: 'regular-sidebar-menu',
@@ -1799,8 +1818,9 @@ const NAV_PREFETCH = {
         ...scheduledRunHistory.map(chat => ({ ...chat, taskKind: 'scheduled' })),
         ...codexHistory,
       ], [pinnedHistory, regularHistory, scheduledRunHistory, scheduledRunBySessionId, codexHistory, decorateScheduledRunChat]);
-      // latest-ref mirror:handleArchiveSession(稳定 useCallback)在调用时读取最新
-      // 任务列表取会话标题,避免为取值而让回调身份逐渲染变化。
+      // latest-ref mirror: handleArchiveSession (a stable useCallback) reads
+      // the latest task list for the session title at call time, instead of
+      // changing the callback identity per render just to read a value.
       const allSidebarTasksRef = useRef(allSidebarTasks);
       allSidebarTasksRef.current = allSidebarTasks;
       const sidebarTaskHistory = useMemo(() => allSidebarTasks
@@ -1915,8 +1935,9 @@ const NAV_PREFETCH = {
         }
       }, []);
 
-      // useCallback 稳定引用:侧栏 NavItem memo 依赖此回调身份。bs 经 latest-ref
-      // 读取——点击时取到的就是最近一次渲染的快照,与闭包捕获语义一致。
+      // Stable useCallback: the sidebar NavItem memo depends on this callback
+      // identity. bs is read through a latest-ref — a click sees the most
+      // recently rendered snapshot, matching closure-capture semantics.
       const navigateFromScheduledRun = useCallback(async (nextView, beforeNavigate) => {
         const bs = bsRef.current;
         const context = browserSurfaceTransitionContextRef.current;
@@ -1951,8 +1972,9 @@ const NAV_PREFETCH = {
         return navigateFromScheduledRun('settings');
       }
 
-      // useCallback 稳定引用:LazySearchView/RecentItem memo 依赖这些回调身份,
-      // 逐渲染重建会让 memo 失效(依赖取值即真实语义依赖)。
+      // Stable useCallbacks: the LazySearchView/RecentItem memos depend on
+      // these callback identities; rebuilding them per render would defeat
+      // the memo (the dependencies are the real semantic dependencies).
       const handleOpenScheduledRunShortcut = useCallback(async (run) => {
         if (!run || !run.sessionId) return;
         // A scheduled-run session is a normal chat: both the fallback and the
@@ -1986,7 +2008,8 @@ const NAV_PREFETCH = {
         });
       }, [t, closeMobileSidebar, runBrowserUiTransition, setCurrentView]);
 
-      // useCallback 稳定引用:侧栏「新对话」NavItems memo 依赖其身份(包装于 handleNavNewChat)。
+      // Stable useCallback: the sidebar "new chat" NavItems memo depends on
+      // its identity (wrapped in handleNavNewChat).
       const handleNewChat = useCallback((installedToolId, forceMode) => {
         // 类型守卫:installedToolId 必须是字符串 toolId。侧边栏按钮 onClick={() => handleNewChat()}
         // 本不传参,但若哪天有调用点写成 onClick={handleNewChat},React 会把事件对象当首参塞进来——
@@ -2100,7 +2123,8 @@ const NAV_PREFETCH = {
         setSearchOverlayOpen(false);
       }
 
-      // useCallback 稳定引用:RecentItem memo 的 onSelect(codex 分支)直接传本回调。
+      // Stable useCallback: passed directly as the RecentItem memo's onSelect
+      // (codex branch).
       const handleSwitchCodexSession = useCallback((id) => {
         setCodeModeOn(true);
         updateActiveCodexSession(id);
@@ -2347,8 +2371,9 @@ const NAV_PREFETCH = {
         };
       }, []);
 
-      // 以下四个会话操作回调均为 useCallback 稳定引用:RecentItem/搜索管理页的
-      // memo 依赖其身份,依赖数组即真实读取的状态。
+      // The four session-action callbacks below are all stable useCallbacks:
+      // the RecentItem/search management memos depend on their identities and
+      // their dependency arrays list exactly the state they read.
       const handleDeleteSession = useCallback(async (id) => {
         const isCodexSession = codexSessions.some(session => session.id === id);
         if (bridge.available) await bridge.sessions.deleteSession(id);
@@ -2370,14 +2395,17 @@ const NAV_PREFETCH = {
         if (isCodexSession) await refreshCodexSessions().catch(() => {});
       }, [codexSessions, refreshCodexSessions]);
 
-      // 归档确认需要会话标题:经 latest-ref 读最新任务列表,回调本身保持稳定,
-      // 避免 RecentItem memo 因该 prop 每渲染失效。
+      // The archive confirmation needs the session title: read through a
+      // latest-ref so the callback itself stays stable and the RecentItem
+      // memo is not defeated by this prop on every render.
       const handleArchiveSession = useCallback((id) => {
         const chat = (allSidebarTasksRef.current || []).find(c => c.id === id);
         setArchiveConfirm(chat || { id, title: t.newChat });
       }, [t]);
 
-      // 「打开会话文件夹」: RecentItem 与对话管理页共用;bridge 为模块单例,依赖恒稳定。
+      // "Open session folder": shared by RecentItem and the conversation
+      // management page; the bridge is a module singleton, so its dependency
+      // is constant.
       const handleRevealSessionFolder = useCallback((id) => {
         if (bridge.artifacts.revealSessionFolder) bridge.artifacts.revealSessionFolder(id);
       }, []);
@@ -2694,9 +2722,11 @@ const NAV_PREFETCH = {
         );
       };
 
-      // 侧栏主导航回调集合(稳定引用):NavItem memo 化后 onClick/onPickUp 必须引用
-      // 稳定,否则 memo 永远失效。导航经 navigateFromScheduledRun(内部读 bsRef),
-      // 撕离闭包仅依赖 beginTearOff(稳定)与当前语言词典 t。
+      // Sidebar main nav callback set (stable references): with NavItem
+      // memoized, onClick/onPickUp must be reference-stable or the memo never
+      // hits. Navigation goes through navigateFromScheduledRun (reads bsRef
+      // internally); the tear-off closure depends only on beginTearOff
+      // (stable) and the current language dictionary t.
       const navNavigateHandlers = useMemo(() => ({
         scheduled: () => navigateFromScheduledRun('scheduled'),
         outputs: () => navigateFromScheduledRun('outputs'),

--- a/pinvou3-app/src/app/main.jsx
+++ b/pinvou3-app/src/app/main.jsx
@@ -1,4 +1,4 @@
-import { lazy, startTransition as scheduleViewTransition, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { lazy, startTransition as scheduleViewTransition, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import '../styles/base.css';
@@ -156,6 +156,43 @@ function workspaceDisplayName(path) {
   return parts[parts.length - 1] || String(path || '');
 }
 
+// RecentItem memo 化后的逐项回调缓存:侧栏任务项(item)由 useMemo 派生、底层数据
+// 不变时引用稳定,以 item 为键缓存 onPickUp/定时运行 onSelect 闭包,使 RecentItem
+// 的 props 在无关重渲染(本地 UI 状态、纯聊天流式 token)中保持全等而跳过整行重渲。
+// 闭包捕获的 handler 均为 useCallback 稳定引用,且其依赖(t 等)变化时 item 一定会
+// 随之重建(派生 memo 以同一批状态为依赖),因此缓存不会提供过期闭包;旧 item 键由
+// GC 连同闭包一并回收。
+function cachedItemCallback(cache, item, build) {
+  let fn = cache.get(item);
+  if (!fn) {
+    fn = build(item);
+    cache.set(item, fn);
+  }
+  return fn;
+}
+const sidebarPickUpCallbacks = new WeakMap();
+const sidebarScheduledSelectCallbacks = new WeakMap();
+
+// 侧栏主导航的静态图标元素:模块级常量保持元素引用稳定,NavItem memo 才能命中。
+const NAV_ICON_NEW_CHAT = <Edit2 size={18} />;
+const NAV_ICON_SEARCH = <Search size={18} />;
+const NAV_ICON_SCHEDULED = <Clock size={18} />;
+const NAV_ICON_OUTPUTS = <Package size={18} />;
+const NAV_ICON_MONITOR = <BarChart2 size={18} />;
+const NAV_ICON_TOOL_STORE = <Puzzle size={18} />;
+const NAV_ICON_CARD_POOL = <Layers size={18} />;
+const NAV_ICON_KNOWLEDGE = <BookOpen size={18} />;
+const NAV_ICON_CURRENT_CHAT = <MessageSquare size={18} />;
+
+// 悬停/聚焦预取回调(prefetchView 为模块函数):常量引用,供 NavItem memo 比较。
+const NAV_PREFETCH = {
+  scheduled: () => prefetchView('scheduled'),
+  knowledge: () => prefetchView('knowledge'),
+  monitor: () => prefetchView('monitor'),
+  toolStore: () => prefetchView('toolStore'),
+  cardpool: () => prefetchView('cardpool'),
+};
+
     // App root component: aggregates bridge state, routing, and all sidebar/overlay UI. Size and complexity are historical
     // evolution; splitting requires a dedicated refactor task (involving a hundred-plus closure handlers and test contracts);
     // only lint fixes here, no behavior change.
@@ -167,6 +204,10 @@ function workspaceDisplayName(path) {
         window.__PINVOU_STARTUP__.mark('react:app_render_start');
       }
       const bs = useBridgeState(APP_BRIDGE_STATE_DOMAINS);
+      // latest-ref mirror:稳定 useCallback(如 navigateFromScheduledRun)在事件触发时
+      // 读取最新桥接快照,避免依赖 bs 而使回调身份逐 notify 变化、击穿 memo。
+      const bsRef = useRef(bs);
+      bsRef.current = bs;
       useLayoutEffect(() => {
         window.__PINVOU_STARTUP__.mark('react:first_commit');
         window.__PINVOU_STARTUP__.flush();
@@ -1128,7 +1169,9 @@ function workspaceDisplayName(path) {
       // dragAvatar = 被拎起的标签副本(跟随光标的 DOM 元素);null=没在拖。原生只判落点,视觉全在这。
       const [dragAvatar, setDragAvatar] = useState(null); // {key,label,dx,dy,w,h,x,y}
       const dragOffsetRef = useRef({ dx: 0, dy: 0 });
-      const beginTearOff = (kind, id, label, info) => {
+      // useCallback 稳定引用:RecentItem/NavItem 的逐项 onPickUp 闭包缓存(见 renderSidebarTaskItem)
+      // 依赖此引用跨渲染不变,memo 才不会被每次渲染的新回调击穿。
+      const beginTearOff = useCallback((kind, id, label, info) => {
         const inv = isTauriAvailable() ? invokeTauri : null;
         if (!inv || !info) return;
         inv('begin_detach_drag', { kind, id: id == null ? null : id });
@@ -1138,7 +1181,7 @@ function workspaceDisplayName(path) {
           w: info.w, h: info.h, x: info.startX - info.dx, y: info.startY - info.dy,
         });
         if (window.getSelection) { const s = window.getSelection(); if (s && s.removeAllRanges) s.removeAllRanges(); }
-      };
+      }, []);
       // 拖拽中:光标移动 → 更新 avatar 位置(光标 - 抓取偏移,相对位置锁定);禁选 + 抓手光标。
       const dragAvatarActive = !!dragAvatar;
       useEffect(() => {
@@ -1160,9 +1203,14 @@ function workspaceDisplayName(path) {
       // 原生拖拽结束(松手/取消)→ 收起 avatar。
       useEffect(() => {
         if (!isTauriAvailable()) return;
+        // 卸载晚于 listen() resolve 时直接 unlisten,避免泄漏(与 browser:activated 同口径)。
+        let disposed = false;
         let un;
-        tauriEvents.listen('detach:drag-ended', () => setDragAvatar(null)).then(f => { un = f; });
-        return () => { if (un) un(); };
+        tauriEvents.listen('detach:drag-ended', () => setDragAvatar(null)).then(f => {
+          if (disposed) f();
+          else un = f;
+        });
+        return () => { disposed = true; if (un) un(); };
       }, []);
 
       // 兜底 zh:词典 chunk 装载失败时按 zh 渲染而非白屏(与 PetWindow/ReaderApp 同口径)。
@@ -1418,31 +1466,45 @@ function workspaceDisplayName(path) {
       // 语言已即时写盘+切 UI,但 LLM 的 locale_tag 要重启 engine 才生效 → 偏离启动语言就提示。
       const languageNeedsRestart = !!bootedLanguageRef.current && language !== bootedLanguageRef.current;
 
+      // 定时运行状态文案(依赖当前语言词典);定义在派生 useMemo 之前,供下方 memo 依赖。
+      const scheduledRunLabel = useCallback((value) => {
+        return (t.uiScheduled.runStatus[value] || value || t.uiScheduled.unknown);
+      }, [t]);
+
+      // App 每个 bridge notify 都整体重渲染(含与侧栏无关的本地 UI 状态变化)。
+      // 下方 O(sessions) 派生全部按真实数据切片做 useMemo:bridge 订阅快照是持久化
+      // 投影,未变化的切片引用不变(如纯聊天流式 token 只动 chat 域,sessions 域
+      // 引用保持),这些 memo 命中后侧栏派生与 RecentItem memo 才能真正跳过重算。
+
       // Build chat history from sessions
-      const sessionBusy = (bs && bs.sessionBusy) || {};
-      const chatHistory = bs && bs.sessions ? bs.sessions.map(s => {
-        const isPlaceholder = !s.title || isDefaultChatTitle(s.title);
-        const titlePresentation = isPlaceholder
-          ? { text: t.newChat, attachments: [] }
-          : sessionTitlePresentation(s.title, s.title_attachment_names);
-        return {
-          id: s.id,
-          // 后端默认标题是三语哨兵之一(见 isDefaultChatTitle;bridge 以此判断是否自动改名)——显示层映射成当前语言
-          title: sessionTitlePlainText(titlePresentation),
-          titleContent: titlePresentation.attachments.length
-            ? <SessionAttachmentTitle presentation={titlePresentation} />
-            : null,
-          date: formatSessionDate(s.updated_at || s.created_at, language),
-          updatedAt: s.updated_at || s.created_at || '',
-          pinned: !!s.pinned,
-          pinnedAt: s.pinned_at || '',
-          working: !!sessionBusy[s.id], // 多 session 并发:该 session 是否正在后台生成
-          leadingIcon: <PinvouLogo className="h-[18px] w-[18px]" />,
-          testId: 'regular-sidebar-item',
-          menuTestId: 'regular-sidebar-menu',
-        };
-      }) : [];
-      const codexHistory = codexSessions.map(session => ({
+      const bridgeSessions = bs && bs.sessions;
+      const bridgeSessionBusy = bs && bs.sessionBusy;
+      const chatHistory = useMemo(() => {
+        const sessionBusy = bridgeSessionBusy || {};
+        return bridgeSessions ? bridgeSessions.map(s => {
+          const isPlaceholder = !s.title || isDefaultChatTitle(s.title);
+          const titlePresentation = isPlaceholder
+            ? { text: t.newChat, attachments: [] }
+            : sessionTitlePresentation(s.title, s.title_attachment_names);
+          return {
+            id: s.id,
+            // 后端默认标题是三语哨兵之一(见 isDefaultChatTitle;bridge 以此判断是否自动改名)——显示层映射成当前语言
+            title: sessionTitlePlainText(titlePresentation),
+            titleContent: titlePresentation.attachments.length
+              ? <SessionAttachmentTitle presentation={titlePresentation} />
+              : null,
+            date: formatSessionDate(s.updated_at || s.created_at, language),
+            updatedAt: s.updated_at || s.created_at || '',
+            pinned: !!s.pinned,
+            pinnedAt: s.pinned_at || '',
+            working: !!sessionBusy[s.id], // 多 session 并发:该 session 是否正在后台生成
+            leadingIcon: <PinvouLogo className="h-[18px] w-[18px]" />,
+            testId: 'regular-sidebar-item',
+            menuTestId: 'regular-sidebar-menu',
+          };
+        }) : [];
+      }, [bridgeSessions, bridgeSessionBusy, t, language]);
+      const codexHistory = useMemo(() => codexSessions.map(session => ({
         id: session.id,
         title: (!session.title || isDefaultChatTitle(session.title))
           ? t.newChat
@@ -1463,26 +1525,30 @@ function workspaceDisplayName(path) {
         testId: 'codex-sidebar-item',
         menuTestId: 'codex-sidebar-menu',
         codexSession: session,
-      }));
-      const pinnedChatHistory = chatHistory
+      })), [codexSessions, codexBusyBySession, codexWaitingInputBySession, t, language]);
+      const pinnedChatHistory = useMemo(() => chatHistory
         .filter(chat => chat.pinned)
-        .sort((a, b) => String(b.pinnedAt || b.updatedAt).localeCompare(String(a.pinnedAt || a.updatedAt)));
-      const scheduledRunShortcuts = (bs && bs.scheduledTaskRecentRuns && bs.scheduledTaskRecentRuns.length)
-        ? bs.scheduledTaskRecentRuns
-        : (bridge.available ? [] : PREVIEW_SCHEDULED_RUN_SHORTCUTS.map(run => ({ ...run, taskName: t[run.taskNameKey] || run.taskNameKey })));
-      const scheduledRunSessionIds = new Set(
+        .sort((a, b) => String(b.pinnedAt || b.updatedAt).localeCompare(String(a.pinnedAt || a.updatedAt))), [chatHistory]);
+      const bridgeScheduledTaskRecentRuns = bs && bs.scheduledTaskRecentRuns;
+      const scheduledRunShortcuts = useMemo(() => (bridgeScheduledTaskRecentRuns && bridgeScheduledTaskRecentRuns.length)
+        ? bridgeScheduledTaskRecentRuns
+        : (bridge.available ? [] : PREVIEW_SCHEDULED_RUN_SHORTCUTS.map(run => ({ ...run, taskName: t[run.taskNameKey] || run.taskNameKey }))), [bridgeScheduledTaskRecentRuns, t]);
+      const scheduledRunSessionIds = useMemo(() => new Set(
         scheduledRunShortcuts
           .map(run => run && run.sessionId)
           .filter(Boolean)
-      );
-      const scheduledRunBySessionId = Object.create(null);
-      scheduledRunShortcuts.forEach(run => {
-        if (run && run.sessionId) scheduledRunBySessionId[run.sessionId] = run;
-      });
-      const regularHistory = chatHistory
+      ), [scheduledRunShortcuts]);
+      const scheduledRunBySessionId = useMemo(() => {
+        const byId = Object.create(null);
+        scheduledRunShortcuts.forEach(run => {
+          if (run && run.sessionId) byId[run.sessionId] = run;
+        });
+        return byId;
+      }, [scheduledRunShortcuts]);
+      const regularHistory = useMemo(() => chatHistory
         .filter(chat => !chat.pinned && !scheduledRunSessionIds.has(chat.id))
-        .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
-      const scheduledRunItems = scheduledRunShortcuts
+        .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt))), [chatHistory, scheduledRunSessionIds]);
+      const scheduledRunItems = useMemo(() => scheduledRunShortcuts
         .filter(run => run && run.sessionId)
         .map(run => {
           // 定时运行会话不进 bs.sessions(list_sessions 隔离 sched-*),标题/置顶
@@ -1513,12 +1579,12 @@ function workspaceDisplayName(path) {
             menuTestId: 'scheduled-run-sidebar-menu',
             scheduledRun: run,
           };
-        });
-      const scheduledRunHistory = scheduledRunItems.filter(chat => !chat.pinned);
-      const pinnedHistory = [...pinnedChatHistory, ...scheduledRunItems.filter(chat => chat.pinned)]
-        .sort((a, b) => String(b.pinnedAt || b.updatedAt).localeCompare(String(a.pinnedAt || a.updatedAt)));
+        }), [scheduledRunShortcuts, scheduledRunLabel, t, language, activeTheme]);
+      const scheduledRunHistory = useMemo(() => scheduledRunItems.filter(chat => !chat.pinned), [scheduledRunItems]);
+      const pinnedHistory = useMemo(() => [...pinnedChatHistory, ...scheduledRunItems.filter(chat => chat.pinned)]
+        .sort((a, b) => String(b.pinnedAt || b.updatedAt).localeCompare(String(a.pinnedAt || a.updatedAt))), [pinnedChatHistory, scheduledRunItems]);
 
-      function decorateScheduledRunChat(chat, run) {
+      const decorateScheduledRunChat = useCallback((chat, run) => {
         if (!run) return chat;
         const title = (!chat.title || isDefaultChatTitle(chat.title))
           ? (run.taskName || t.scheduledPlans)
@@ -1539,7 +1605,7 @@ function workspaceDisplayName(path) {
           menuTestId: 'scheduled-run-sidebar-menu',
           scheduledRun: run,
         });
-      }
+      }, [t, language, activeTheme, scheduledRunLabel]);
 
       const [justInstalledTool, setJustInstalledTool] = useState(null);
       const [taskListFilter, setTaskListFilter] = useState('all');
@@ -1720,7 +1786,7 @@ function workspaceDisplayName(path) {
         { id: 'pinned_first', label: t.sidebarTaskSortPinnedFirst },
         { id: 'recent', label: t.sidebarTaskSortRecent },
       ];
-      const allSidebarTasks = [
+      const allSidebarTasks = useMemo(() => [
         ...pinnedHistory.map((chat) => {
           const run = chat.scheduledRun || scheduledRunBySessionId[chat.id];
           const item = decorateScheduledRunChat(chat, run);
@@ -1729,8 +1795,12 @@ function workspaceDisplayName(path) {
         ...regularHistory.map(chat => ({ ...chat, taskKind: 'regular' })),
         ...scheduledRunHistory.map(chat => ({ ...chat, taskKind: 'scheduled' })),
         ...codexHistory,
-      ];
-      const sidebarTaskHistory = allSidebarTasks
+      ], [pinnedHistory, regularHistory, scheduledRunHistory, scheduledRunBySessionId, codexHistory, decorateScheduledRunChat]);
+      // latest-ref mirror:handleArchiveSession(稳定 useCallback)在调用时读取最新
+      // 任务列表取会话标题,避免为取值而让回调身份逐渲染变化。
+      const allSidebarTasksRef = useRef(allSidebarTasks);
+      allSidebarTasksRef.current = allSidebarTasks;
+      const sidebarTaskHistory = useMemo(() => allSidebarTasks
         .filter((chat) => {
           if (taskListFilter === 'pinned') return !!chat.pinned;
           if (taskListFilter === 'code') return chat.taskKind === 'codex';
@@ -1748,18 +1818,18 @@ function workspaceDisplayName(path) {
             ? (b.pinnedAt || b.updatedAt)
             : (b.updatedAt || b.pinnedAt);
           return String(bTime || '').localeCompare(String(aTime || ''));
-        });
+        }), [allSidebarTasks, taskListFilter, taskListSort]);
 
       // 任务列表按日期堆叠:今天默认展开、以往默认折叠;组内顺序沿用上面的筛选+排序结果,
       // 组间按日期倒序,无时间戳的落 'unknown' 组沉底。
       // 「置顶优先」排序下置顶项提升到所有日期组之上,否则旧会话会埋进默认折叠的以往分组,
       // 只剩置顶标志、没有置顶效果。
       const todayDateKey = localDateKey(Date.now());
-      const sidebarPinnedHoisted = taskListSort === 'pinned_first'
+      const sidebarPinnedHoisted = useMemo(() => (taskListSort === 'pinned_first'
         ? sidebarTaskHistory.filter(chat => !!chat.pinned)
-        : [];
-      const sidebarTaskGroups = [];
-      {
+        : []), [taskListSort, sidebarTaskHistory]);
+      const sidebarTaskGroups = useMemo(() => {
+        const groups = [];
         const byDate = new Map();
         sidebarTaskHistory.forEach(chat => {
           if (sidebarPinnedHoisted.length && chat.pinned) return;
@@ -1767,36 +1837,37 @@ function workspaceDisplayName(path) {
           if (!byDate.has(key)) byDate.set(key, []);
           byDate.get(key).push(chat);
         });
-        byDate.forEach((rows, key) => { sidebarTaskGroups.push({ key, rows }); });
-        sidebarTaskGroups.sort((a, b) => {
+        byDate.forEach((rows, key) => { groups.push({ key, rows }); });
+        groups.sort((a, b) => {
           if (a.key === 'unknown') return 1;
           if (b.key === 'unknown') return -1;
           return b.key.localeCompare(a.key);
         });
-      }
+        return groups;
+      }, [sidebarTaskHistory, sidebarPinnedHoisted]);
 
       // Code-style sidebar: lists only code sessions, grouped by folder (workspace);
       // groups and rows both sort by latest activity descending, temporary sessions merge
       // into one bottom group; with "pinned first", pinned code sessions hoist above the
       // folder groups.
-      const sidebarCodeTasks = sidebarCodeListActive
+      const sidebarCodeTasks = useMemo(() => (sidebarCodeListActive
         ? sidebarTaskHistory.filter(chat => chat.taskKind === 'codex')
-        : [];
-      const sidebarFolderPinned = taskListSort === 'pinned_first'
+        : []), [sidebarCodeListActive, sidebarTaskHistory]);
+      const sidebarFolderPinned = useMemo(() => (taskListSort === 'pinned_first'
         ? sidebarCodeTasks.filter(chat => !!chat.pinned)
-        : [];
-      const sidebarFolderGroups = sidebarCodeListActive
+        : []), [taskListSort, sidebarCodeTasks]);
+      const sidebarFolderGroups = useMemo(() => (sidebarCodeListActive
         ? groupSessionsByFolder(
             sidebarCodeTasks.filter(chat => !(sidebarFolderPinned.length && chat.pinned)))
-        : [];
+        : []), [sidebarCodeListActive, sidebarCodeTasks, sidebarFolderPinned]);
 
       // latest-ref mirror: the pet-snapshot broadcast effect only subscribes to bs.sessions/sessionBusy/language,
       // while snapshot contents (id/title/working) are read via refs to reduce effect resubscription.
-      petSnapshotRef.current = chatHistory.map(chat => ({
+      petSnapshotRef.current = useMemo(() => chatHistory.map(chat => ({
         id: chat.id,
         title: chat.title,
         working: chat.working,
-      }));
+      })), [chatHistory]);
       const petSessions = bs && bs.sessions;
       const petSessionBusy = bs && bs.sessionBusy;
       useEffect(() => {
@@ -1834,7 +1905,17 @@ function workspaceDisplayName(path) {
         };
       }, [petSessions, petSessionBusy, language]);
 
-      async function navigateFromScheduledRun(nextView, beforeNavigate) {
+      const closeMobileSidebar = useCallback(() => {
+        if (!isWeb || typeof window === 'undefined') return;
+        if (window.matchMedia && window.matchMedia('(max-width: 639px)').matches) {
+          setIsSidebarOpen(false);
+        }
+      }, []);
+
+      // useCallback 稳定引用:侧栏 NavItem memo 依赖此回调身份。bs 经 latest-ref
+      // 读取——点击时取到的就是最近一次渲染的快照,与闭包捕获语义一致。
+      const navigateFromScheduledRun = useCallback(async (nextView, beforeNavigate) => {
+        const bs = bsRef.current;
         const context = browserSurfaceTransitionContextRef.current;
         const keepsDesktopBrowserVisible = !context.compact && (
           nextView === 'chat'
@@ -1857,7 +1938,7 @@ function workspaceDisplayName(path) {
             ? 'workspace'
             : keepsDesktopBrowserVisible ? 'none' : 'visible',
         });
-      }
+      }, [closeMobileSidebar, runBrowserUiTransition, setCurrentView]);
 
       function openSettingsSection(section = 'general') {
         // 记录进入设置前的页面（代码页齿轮等深链入口），关闭设置时原路返回，
@@ -1867,18 +1948,9 @@ function workspaceDisplayName(path) {
         return navigateFromScheduledRun('settings');
       }
 
-      const closeMobileSidebar = useCallback(() => {
-        if (!isWeb || typeof window === 'undefined') return;
-        if (window.matchMedia && window.matchMedia('(max-width: 639px)').matches) {
-          setIsSidebarOpen(false);
-        }
-      }, []);
-
-      function scheduledRunLabel(value) {
-        return (t.uiScheduled.runStatus[value] || value || t.uiScheduled.unknown);
-      }
-
-      async function handleOpenScheduledRunShortcut(run) {
+      // useCallback 稳定引用:LazySearchView/RecentItem memo 依赖这些回调身份,
+      // 逐渲染重建会让 memo 失效(依赖取值即真实语义依赖)。
+      const handleOpenScheduledRunShortcut = useCallback(async (run) => {
         if (!run || !run.sessionId) return;
         // A scheduled-run session is a normal chat: both the fallback and the
         // successful-open branches land on the scheduled view, so each branch
@@ -1909,9 +1981,10 @@ function workspaceDisplayName(path) {
           serialize: true,
           sessionTarget: run.sessionId,
         });
-      }
+      }, [t, closeMobileSidebar, runBrowserUiTransition, setCurrentView]);
 
-      function handleNewChat(installedToolId, forceMode) {
+      // useCallback 稳定引用:侧栏「新对话」NavItems memo 依赖其身份(包装于 handleNavNewChat)。
+      const handleNewChat = useCallback((installedToolId, forceMode) => {
         // 类型守卫:installedToolId 必须是字符串 toolId。侧边栏按钮 onClick={() => handleNewChat()}
         // 本不传参,但若哪天有调用点写成 onClick={handleNewChat},React 会把事件对象当首参塞进来——
         // 那是 truthy 的 SyntheticEvent,会被当成 toolId 置进 welcomeToolId → ToolWelcomeCard 查不到
@@ -1957,7 +2030,7 @@ function workspaceDisplayName(path) {
           serialize: true,
           sessionTarget: null,
         });
-      }
+      }, [codeModeOn, codexAcpSupported, closeMobileSidebar, runBrowserUiTransition, updateActiveCodexSession, setCurrentView]);
 
       function handleSwitchHomeMode(mode) {
         if (mode === 'code' && codexAcpSupported) {
@@ -2024,12 +2097,13 @@ function workspaceDisplayName(path) {
         setSearchOverlayOpen(false);
       }
 
-      function handleSwitchCodexSession(id) {
+      // useCallback 稳定引用:RecentItem memo 的 onSelect(codex 分支)直接传本回调。
+      const handleSwitchCodexSession = useCallback((id) => {
         setCodeModeOn(true);
         updateActiveCodexSession(id);
         setCurrentView('codex');
         closeMobileSidebar();
-      }
+      }, [updateActiveCodexSession, closeMobileSidebar, setCurrentView]);
 
       // 用户在主窗口里亲眼看着完成的会话，公仔的活动卡属于冗余提醒——
       // 完成瞬间若该会话正处于前台聊天视图且窗口有焦点，直接标记已读，
@@ -2270,31 +2344,40 @@ function workspaceDisplayName(path) {
         };
       }, []);
 
-      async function handleDeleteSession(id) {
+      // 以下四个会话操作回调均为 useCallback 稳定引用:RecentItem/搜索管理页的
+      // memo 依赖其身份,依赖数组即真实读取的状态。
+      const handleDeleteSession = useCallback(async (id) => {
         const isCodexSession = codexSessions.some(session => session.id === id);
         if (bridge.available) await bridge.sessions.deleteSession(id);
         if (isCodexSession) {
           if (activeCodexId === id) updateActiveCodexSession(null);
           await refreshCodexSessions().catch(() => {});
         }
-      }
+      }, [codexSessions, activeCodexId, updateActiveCodexSession, refreshCodexSessions]);
 
-      async function handleRenameSession(id, title) {
+      const handleRenameSession = useCallback(async (id, title) => {
         const isCodexSession = codexSessions.some(session => session.id === id);
         if (bridge.available) await bridge.sessions.renameSession(id, title);
         if (isCodexSession) await refreshCodexSessions().catch(() => {});
-      }
+      }, [codexSessions, refreshCodexSessions]);
 
-      async function handleToggleSessionPinned(id, pinned) {
+      const handleToggleSessionPinned = useCallback(async (id, pinned) => {
         const isCodexSession = codexSessions.some(session => session.id === id);
         if (bridge.available) await bridge.sessions.toggleSessionPinned(id, pinned);
         if (isCodexSession) await refreshCodexSessions().catch(() => {});
-      }
+      }, [codexSessions, refreshCodexSessions]);
 
-      function handleArchiveSession(id) {
-        const chat = allSidebarTasks.find(c => c.id === id);
+      // 归档确认需要会话标题:经 latest-ref 读最新任务列表,回调本身保持稳定,
+      // 避免 RecentItem memo 因该 prop 每渲染失效。
+      const handleArchiveSession = useCallback((id) => {
+        const chat = (allSidebarTasksRef.current || []).find(c => c.id === id);
         setArchiveConfirm(chat || { id, title: t.newChat });
-      }
+      }, [t]);
+
+      // 「打开会话文件夹」: RecentItem 与对话管理页共用;bridge 为模块单例,依赖恒稳定。
+      const handleRevealSessionFolder = useCallback((id) => {
+        if (bridge.artifacts.revealSessionFolder) bridge.artifacts.revealSessionFolder(id);
+      }, []);
 
       async function confirmArchiveSession() {
         const id = archiveConfirm && archiveConfirm.id;
@@ -2592,20 +2675,46 @@ function workspaceDisplayName(path) {
             onSelect={chat.taskKind === 'codex'
               ? handleSwitchCodexSession
               : chat.scheduledRun
-                ? () => handleOpenScheduledRunShortcut(chat.scheduledRun)
+                ? cachedItemCallback(sidebarScheduledSelectCallbacks, chat, (c) => () => handleOpenScheduledRunShortcut(c.scheduledRun))
                 : handleSwitchSession}
             onRename={handleRenameSession}
             onDelete={handleDeleteSession}
             onTogglePinned={handleToggleSessionPinned}
-            onOpenFolder={can('externalSystemOpen') ? ((id) => bridge.artifacts.revealSessionFolder && bridge.artifacts.revealSessionFolder(id)) : undefined}
+            onOpenFolder={can('externalSystemOpen') ? handleRevealSessionFolder : undefined}
             onArchive={handleArchiveSession}
             dragKind={detachKind}
             dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === `${detachKind}:${chat.id}`}
-            onPickUp={canDetachWindows ? ((geom) => beginTearOff(detachKind, chat.id, chat.title, geom)) : undefined}
+            onPickUp={canDetachWindows
+              ? cachedItemCallback(sidebarPickUpCallbacks, chat, (c) => (geom) => beginTearOff(detachKind, c.id, c.title, geom))
+              : undefined}
           />
         );
       };
 
+      // 侧栏主导航回调集合(稳定引用):NavItem memo 化后 onClick/onPickUp 必须引用
+      // 稳定,否则 memo 永远失效。导航经 navigateFromScheduledRun(内部读 bsRef),
+      // 撕离闭包仅依赖 beginTearOff(稳定)与当前语言词典 t。
+      const navNavigateHandlers = useMemo(() => ({
+        scheduled: () => navigateFromScheduledRun('scheduled'),
+        outputs: () => navigateFromScheduledRun('outputs'),
+        monitor: () => navigateFromScheduledRun('monitor', () => {
+          const liveBridge = window.TauriBridge || bridge;
+          if (liveBridge?.monitor && typeof liveBridge.monitor.startMonitorPolling === 'function') liveBridge.monitor.startMonitorPolling();
+        }),
+        toolStore: () => navigateFromScheduledRun('toolStore'),
+        cardpool: () => navigateFromScheduledRun('cardpool', () => setPoolMyOnly(false)),
+        knowledge: () => navigateFromScheduledRun('knowledge'),
+        chat: () => navigateFromScheduledRun('chat'),
+      }), [navigateFromScheduledRun]);
+      const navPickUpHandlers = useMemo(() => ({
+        outputs: (geom) => beginTearOff('outputs', undefined, t.outputs, geom),
+        monitor: (geom) => beginTearOff('monitor', undefined, t.monitor, geom),
+        toolstore: (geom) => beginTearOff('toolstore', undefined, t.toolStore, geom),
+        cardpool: (geom) => beginTearOff('cardpool', undefined, t.cardPool, geom),
+        knowledge: (geom) => beginTearOff('knowledge', undefined, t.knowledge, geom),
+      }), [t, beginTearOff]);
+      const openSearchOverlay = useCallback(() => setSearchOverlayOpen(true), []);
+      const handleNavNewChat = useCallback(() => { handleNewChat(); }, [handleNewChat]);
       const apiKeyGateOpen = shouldShowApiKeyGate(bs, currentView, bridge.available);
       const vllmSetupModalOpen = !!(
         can('localModelSetup')
@@ -2864,20 +2973,20 @@ function workspaceDisplayName(path) {
                 the bottom after expanding. */}
             <div data-testid="sidebar-primary-nav" className={`shrink-0 flex flex-col gap-0.5 mt-1.5 max-sm:gap-0 max-sm:mt-1 ${isSidebarOpen ? 'px-3' : 'px-2 items-center'}`}>
               <NavItem
-                icon={<Edit2 size={18} />} label={t.newChat}
+                icon={NAV_ICON_NEW_CHAT} label={t.newChat}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onClick={() => handleNewChat()}
+                onClick={handleNavNewChat}
               />
               {/* On the compact shell search is only reachable from the nav, so it must
                   stay pinned even when collapsed */}
               {(!isSidebarOpen || isCompactShell) && (
                 <NavItem
-                  icon={<Search size={18} />} label={t.searchChats}
+                  icon={NAV_ICON_SEARCH} label={t.searchChats}
                   active={searchOverlayOpen}
                   theme={activeTheme}
                   isSidebarOpen={isSidebarOpen}
-                  onClick={() => setSearchOverlayOpen(true)}
+                  onClick={openSearchOverlay}
                 />
               )}
               {codeStyleActive && isSidebarOpen && !codeNavExpanded ? (
@@ -2895,74 +3004,69 @@ function workspaceDisplayName(path) {
               <>
               {SCHEDULED_TASKS_ENTRY_ENABLED && (
                 <NavItem
-                  icon={<Clock size={18} />} label={t.scheduledPlans}
+                  icon={NAV_ICON_SCHEDULED} label={t.scheduledPlans}
                   active={currentView === 'scheduled'}
                   unread={!!(bs && ((bs.scheduledTasks || []).some(task => task.hasUnreadRuns) || (bs.scheduledTaskRecentRuns || []).some(run => run && run.unread)))}
                   theme={activeTheme}
                   t={t}
                   isSidebarOpen={isSidebarOpen}
-                  onClick={() => navigateFromScheduledRun('scheduled')}
-                  onPointerEnter={() => prefetchView('scheduled')} onFocus={() => prefetchView('scheduled')}
+                  onClick={navNavigateHandlers.scheduled}
+                  onPointerEnter={NAV_PREFETCH.scheduled} onFocus={NAV_PREFETCH.scheduled}
                 />
               )}
               <NavItem
-                icon={<Package size={18} />} label={t.outputs}
+                icon={NAV_ICON_OUTPUTS} label={t.outputs}
                 active={currentView === 'outputs'}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onClick={() => navigateFromScheduledRun('outputs')}
-                onPointerEnter={() => prefetchView('knowledge')} onFocus={() => prefetchView('knowledge')}
-                dragKind={canDetachWindows ? 'outputs' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'outputs:'} onPickUp={canDetachWindows ? (geom) => beginTearOff('outputs', undefined, t.outputs, geom) : undefined}
+                onClick={navNavigateHandlers.outputs}
+                onPointerEnter={NAV_PREFETCH.knowledge} onFocus={NAV_PREFETCH.knowledge}
+                dragKind={canDetachWindows ? 'outputs' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'outputs:'} onPickUp={canDetachWindows ? navPickUpHandlers.outputs : undefined}
               />
               <NavItem
-                icon={<BarChart2 size={18} />} label={t.monitor}
+                icon={NAV_ICON_MONITOR} label={t.monitor}
                 active={currentView === 'monitor'}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onPointerEnter={() => prefetchView('monitor')} onFocus={() => prefetchView('monitor')}
-                onClick={() => {
-                  navigateFromScheduledRun('monitor', () => {
-                    const liveBridge = window.TauriBridge || bridge;
-                    if (liveBridge?.monitor && typeof liveBridge.monitor.startMonitorPolling === 'function') liveBridge.monitor.startMonitorPolling();
-                  });
-                }}
-                dragKind={canDetachWindows ? 'monitor' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'monitor:'} onPickUp={canDetachWindows ? (geom) => beginTearOff('monitor', undefined, t.monitor, geom) : undefined}
+                onPointerEnter={NAV_PREFETCH.monitor} onFocus={NAV_PREFETCH.monitor}
+                onClick={navNavigateHandlers.monitor}
+                dragKind={canDetachWindows ? 'monitor' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'monitor:'} onPickUp={canDetachWindows ? navPickUpHandlers.monitor : undefined}
               />
               <NavItem
-                icon={<Puzzle size={18} />} label={t.toolStore}
+                icon={NAV_ICON_TOOL_STORE} label={t.toolStore}
                 active={currentView === 'toolStore'}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onClick={() => navigateFromScheduledRun('toolStore')}
-                onPointerEnter={() => prefetchView('toolStore')} onFocus={() => prefetchView('toolStore')}
-                dragKind={canDetachWindows ? 'toolstore' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'toolstore:'} onPickUp={canDetachWindows ? (geom) => beginTearOff('toolstore', undefined, t.toolStore, geom) : undefined}
+                onClick={navNavigateHandlers.toolStore}
+                onPointerEnter={NAV_PREFETCH.toolStore} onFocus={NAV_PREFETCH.toolStore}
+                dragKind={canDetachWindows ? 'toolstore' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'toolstore:'} onPickUp={canDetachWindows ? navPickUpHandlers.toolstore : undefined}
               />
               <NavItem
-                icon={<Layers size={18} />} label={t.cardPool}
+                icon={NAV_ICON_CARD_POOL} label={t.cardPool}
                 active={currentView === 'cardpool'}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onClick={() => navigateFromScheduledRun('cardpool', () => setPoolMyOnly(false))}
-                onPointerEnter={() => prefetchView('cardpool')} onFocus={() => prefetchView('cardpool')}
-                dragKind={canDetachWindows ? 'cardpool' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'cardpool:'} onPickUp={canDetachWindows ? (geom) => beginTearOff('cardpool', undefined, t.cardPool, geom) : undefined}
+                onClick={navNavigateHandlers.cardpool}
+                onPointerEnter={NAV_PREFETCH.cardpool} onFocus={NAV_PREFETCH.cardpool}
+                dragKind={canDetachWindows ? 'cardpool' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'cardpool:'} onPickUp={canDetachWindows ? navPickUpHandlers.cardpool : undefined}
               />
               <NavItem
-                icon={<BookOpen size={18} />} label={t.knowledge}
+                icon={NAV_ICON_KNOWLEDGE} label={t.knowledge}
                 active={currentView === 'knowledge'}
                 theme={activeTheme}
                 isSidebarOpen={isSidebarOpen}
-                onClick={() => navigateFromScheduledRun('knowledge')}
-                onPointerEnter={() => prefetchView('knowledge')} onFocus={() => prefetchView('knowledge')}
-                dragKind={canDetachWindows ? 'knowledge' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'knowledge:'} onPickUp={canDetachWindows ? (geom) => beginTearOff('knowledge', undefined, t.knowledge, geom) : undefined}
+                onClick={navNavigateHandlers.knowledge}
+                onPointerEnter={NAV_PREFETCH.knowledge} onFocus={NAV_PREFETCH.knowledge}
+                dragKind={canDetachWindows ? 'knowledge' : undefined} dragging={canDetachWindows && !!dragAvatar && dragAvatar.key === 'knowledge:'} onPickUp={canDetachWindows ? navPickUpHandlers.knowledge : undefined}
               />
               {/* 收起态专属:展开态近期列表的高亮项就是回会话入口,不重复渲染 */}
               {!isSidebarOpen && (
                 <NavItem
-                  icon={<MessageSquare size={18} />} label={t.currentChat}
+                  icon={NAV_ICON_CURRENT_CHAT} label={t.currentChat}
                   active={currentView === 'chat'}
                   theme={activeTheme}
                   isSidebarOpen={isSidebarOpen}
-                  onClick={() => navigateFromScheduledRun('chat')}
+                  onClick={navNavigateHandlers.chat}
                 />
               )}
               {codeStyleActive && isSidebarOpen && codeNavExpanded && (
@@ -3422,7 +3526,7 @@ function workspaceDisplayName(path) {
                 onRename={handleRenameSession}
                 onDelete={handleDeleteSession}
                 onTogglePinned={handleToggleSessionPinned}
-                onOpenFolder={can('externalSystemOpen') ? ((id) => bridge.artifacts.revealSessionFolder && bridge.artifacts.revealSessionFolder(id)) : undefined}
+                onOpenFolder={can('externalSystemOpen') ? handleRevealSessionFolder : undefined}
                 onArchive={handleArchiveSession}
                 onArchiveMany={handleBatchArchiveSessions}
                 onDeleteMany={handleBatchDeleteSessions}

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -1,10 +1,13 @@
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Archive, Check, Edit2, FolderOpen, MoreHorizontal, PinIcon, PinOffIcon, Sparkles, Trash2, X } from '../icons.jsx';
 import { useLongPressDrag } from '../../hooks/useLongPressDrag.js';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
 
-const NavItem = ({ icon, label, active, unread = false, isSidebarOpen = true, onClick, dragKind, dragging, onPickUp, nativeButton = false, t, onPointerEnter, onFocus }) => {
+    // NavItem memo 化:主导航在 App 每次 bridge notify(含后台流式 token)都会重渲,
+    // props 引用稳定(见 main.jsx 的 NAV_ICON_*/NAV_PREFETCH/navNavigateHandlers)时
+    // 整个导航项可跳过重渲。
+    const NavItem = memo(function NavItem({ icon, label, active, unread = false, isSidebarOpen = true, onClick, dragKind, dragging, onPickUp, nativeButton = false, t, onPointerEnter, onFocus }) {
       const drag = useLongPressDrag(dragKind, onPickUp);
       const dragProps = dragKind ? drag.handlers : {};
       const clickH = dragKind ? drag.guardClick(onClick) : onClick;
@@ -35,7 +38,7 @@ const NavItem = ({ icon, label, active, unread = false, isSidebarOpen = true, on
           {isSidebarOpen && <span className="whitespace-nowrap">{label}</span>}
         </Root>
       );
-    };
+    });
 
     const ArchiveConfirmDialog = ({ theme, t, onCancel, onConfirm }) => {
       const isDark = theme === 'dark';
@@ -205,7 +208,10 @@ const NavItem = ({ icon, label, active, unread = false, isSidebarOpen = true, on
         color: isDark ? '#fff' : '#1F1F1F',
       };
     };
-    const RecentItem = ({ chat, active, personaTarget, theme, t, onSelect, onRename, onDelete, onTogglePinned, onOpenFolder, onArchive, dragKind = 'session', dragging, onPickUp }) => {
+    // RecentItem memo 化:O(sessions) 的侧栏列表是 token 速率重渲的主要成本。
+    // props 需引用稳定——chat 由父级 useMemo 派生,回调由父级 useCallback/逐项
+    // 闭包缓存提供(见 main.jsx renderSidebarTaskItem);默认浅比较即可正确跳过。
+    const RecentItem = memo(function RecentItem({ chat, active, personaTarget, theme, t, onSelect, onRename, onDelete, onTogglePinned, onOpenFolder, onArchive, dragKind = 'session', dragging, onPickUp }) {
       const isDark = theme === 'dark';
       const [editing, setEditing] = useState(false);
       const [confirming, setConfirming] = useState(false);
@@ -392,6 +398,6 @@ const NavItem = ({ icon, label, active, unread = false, isSidebarOpen = true, on
           {menu}
         </div>
       );
-    };
+    });
 
 export { NavItem, ArchiveConfirmDialog, ArchivedDeleteConfirmDialog, ArchiveToast, RecentItem };

--- a/pinvou3-app/src/components/layout/NavigationComponents.jsx
+++ b/pinvou3-app/src/components/layout/NavigationComponents.jsx
@@ -4,9 +4,10 @@ import { Archive, Check, Edit2, FolderOpen, MoreHorizontal, PinIcon, PinOffIcon,
 import { useLongPressDrag } from '../../hooks/useLongPressDrag.js';
 import { isImeComposing } from '../../shared/ime-guard.mjs';
 
-    // NavItem memo 化:主导航在 App 每次 bridge notify(含后台流式 token)都会重渲,
-    // props 引用稳定(见 main.jsx 的 NAV_ICON_*/NAV_PREFETCH/navNavigateHandlers)时
-    // 整个导航项可跳过重渲。
+    // NavItem memoization: the main nav re-renders on every App bridge
+    // notify (including background streaming tokens); when the props are
+    // reference stable (see NAV_ICON_*/NAV_PREFETCH/navNavigateHandlers in
+    // main.jsx) the whole nav item can skip the re-render.
     const NavItem = memo(function NavItem({ icon, label, active, unread = false, isSidebarOpen = true, onClick, dragKind, dragging, onPickUp, nativeButton = false, t, onPointerEnter, onFocus }) {
       const drag = useLongPressDrag(dragKind, onPickUp);
       const dragProps = dragKind ? drag.handlers : {};
@@ -208,9 +209,11 @@ import { isImeComposing } from '../../shared/ime-guard.mjs';
         color: isDark ? '#fff' : '#1F1F1F',
       };
     };
-    // RecentItem memo 化:O(sessions) 的侧栏列表是 token 速率重渲的主要成本。
-    // props 需引用稳定——chat 由父级 useMemo 派生,回调由父级 useCallback/逐项
-    // 闭包缓存提供(见 main.jsx renderSidebarTaskItem);默认浅比较即可正确跳过。
+    // RecentItem memoization: the O(sessions) sidebar list is the dominant
+    // token-rate re-render cost. Props must be reference stable — chat is
+    // derived by the parent's useMemo and callbacks come from the parent's
+    // useCallback / per-item closure cache (see renderSidebarTaskItem in
+    // main.jsx); the default shallow compare then skips correctly.
     const RecentItem = memo(function RecentItem({ chat, active, personaTarget, theme, t, onSelect, onRename, onDelete, onTogglePinned, onOpenFolder, onArchive, dragKind = 'session', dragging, onPickUp }) {
       const isDark = theme === 'dark';
       const [editing, setEditing] = useState(false);

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -220,11 +220,15 @@ function renderLegacyMarkdownCached(item, syntaxVersion) {
   return html;
 }
 
-// 与 legacyMarkdownCache 同思路:ChatBubble 输入框每个按键、流式每个 delta、秒级 tick
-// 都会全量重渲,而 assistant 气泡每渲染要跑三轮 pre/code 正则解析(persona 草稿、定时
-// 任务草稿、card-question 追问)+流式折叠。整条链是
-// (html, streaming, allowScheduledTaskDraft, streamingDraftLabel) 的纯函数,按 item 键控
-// 缓存、四元组未变直接复用;流式期间 item 随 delta 换新引用,缓存自然失效,行为不变。
+// Same idea as legacyMarkdownCache: every composer keystroke, streaming
+// delta, and clock tick re-renders the full view, and each render of an
+// assistant bubble ran three rounds of pre/code regex parsing (persona
+// draft, scheduled-task draft, card-question follow-up) plus the streaming
+// fold. The whole chain is a pure function of
+// (html, streaming, allowScheduledTaskDraft, streamingDraftLabel), cached
+// per item and reused while the tuple is unchanged; while streaming, the
+// item gets a new reference per delta so the cache invalidates naturally —
+// behavior unchanged.
 const assistantParseCache = new WeakMap();
 function parseAssistantBubblesCached(item, html, streaming, allowScheduledTaskDraft, streamingDraftLabel) {
   const cached = assistantParseCache.get(item);
@@ -243,8 +247,9 @@ function parseAssistantBubblesCached(item, html, streaming, allowScheduledTaskDr
   return parsed;
 }
 
-// 记忆状态映射表只依赖当前语言词典 t(字典表为模块单例),按 t 缓存,
-// 避免每个气泡每次渲染都重建同一张表。
+// The memory status label map depends only on the current language
+// dictionary t (a module singleton); caching per t avoids rebuilding the
+// same map on every render of every bubble.
 const memoryStatusLabelsCache = new WeakMap();
 function getMemoryStatusLabels(t) {
   let labels = memoryStatusLabelsCache.get(t);
@@ -3288,8 +3293,10 @@ const UserBubble = ({ item, sessionId, _theme, editable, t, conversationVariant 
           ? renderLegacyMarkdownCached(item, syntaxVersion)
           : (item.html || '');
         const streamingDraftLabel = /scheduled-task-draft/.test(html) ? t.uiChatExtra.draftingScheduled : (t && t.cpDesigning);
-        // 三轮解析链纯函数化并按 item 缓存(见 parseAssistantBubblesCached):
-        // memo 击穿(流式 delta/syntaxVersion bump)时也只重算真正变化的气泡。
+        // The three-pass parse chain is a pure function cached per item (see
+        // parseAssistantBubblesCached): even when the memo is defeated
+        // (streaming delta / syntaxVersion bump) only bubbles that actually
+        // changed reparse.
         const { pd, cq } = parseAssistantBubblesCached(item, html, !!item.streaming, allowScheduledTaskDraft, streamingDraftLabel);
         const assistantCopyAvailable = !item.streaming
           && [item.text, item.html].some(value => String(value || '').trim());
@@ -3507,10 +3514,14 @@ const UserBubble = ({ item, sessionId, _theme, editable, t, conversationVariant 
 
       return null;
     });
-    // ChatBubble memo 化:inputText 挂在 ChatView 顶层,每个按键都整视图重渲;legacy
-    // 气泡列表 O(n),memo 后未变化的气泡只剩 prop 浅比较。调用点回调均为稳定引用
-    // (setInputText/sendChatMessage/onOpenEditor),item 由 bridge 会话数据保持引用稳定;
-    // syntaxVersion 订阅在组件内部,memo 不会阻断懒语言注册后的重渲染。
+    // ChatBubble memoization: inputText lives at the ChatView top level, so
+    // every keystroke re-renders the whole view; the legacy bubble list is
+    // O(n), and after memoization unchanged bubbles only pay a shallow prop
+    // compare. Callbacks at call sites are stable references
+    // (setInputText/sendChatMessage/onOpenEditor) and items keep stable
+    // references from the bridge session data; the syntaxVersion subscription
+    // lives inside the component, so the memo cannot block the re-render
+    // after lazy language registration.
 
     // ==========================================
     // Artifact Card — present_artifact 成品卡（点击打开预览）

--- a/pinvou3-app/src/features/chat/ChatView.jsx
+++ b/pinvou3-app/src/features/chat/ChatView.jsx
@@ -220,6 +220,52 @@ function renderLegacyMarkdownCached(item, syntaxVersion) {
   return html;
 }
 
+// 与 legacyMarkdownCache 同思路:ChatBubble 输入框每个按键、流式每个 delta、秒级 tick
+// 都会全量重渲,而 assistant 气泡每渲染要跑三轮 pre/code 正则解析(persona 草稿、定时
+// 任务草稿、card-question 追问)+流式折叠。整条链是
+// (html, streaming, allowScheduledTaskDraft, streamingDraftLabel) 的纯函数,按 item 键控
+// 缓存、四元组未变直接复用;流式期间 item 随 delta 换新引用,缓存自然失效,行为不变。
+const assistantParseCache = new WeakMap();
+function parseAssistantBubblesCached(item, html, streaming, allowScheduledTaskDraft, streamingDraftLabel) {
+  const cached = assistantParseCache.get(item);
+  if (cached
+    && cached.html === html
+    && cached.streaming === streaming
+    && cached.allowScheduledTaskDraft === allowScheduledTaskDraft
+    && cached.streamingDraftLabel === streamingDraftLabel) {
+    return cached.parsed;
+  }
+  const pd = streaming ? { draft: null, html: hideStreamingDraft(html, streamingDraftLabel) } : parsePersonaDraft(html);
+  const sd = (streaming || !allowScheduledTaskDraft) ? { draft: null, html: pd.html } : parseScheduledTaskDraft(pd.html);
+  const cq = streaming ? { q: null, html: sd.html } : parseCardQuestion(sd.html);
+  const parsed = { pd, sd, cq };
+  assistantParseCache.set(item, { html, streaming, allowScheduledTaskDraft, streamingDraftLabel, parsed });
+  return parsed;
+}
+
+// 记忆状态映射表只依赖当前语言词典 t(字典表为模块单例),按 t 缓存,
+// 避免每个气泡每次渲染都重建同一张表。
+const memoryStatusLabelsCache = new WeakMap();
+function getMemoryStatusLabels(t) {
+  let labels = memoryStatusLabelsCache.get(t);
+  if (!labels) {
+    const chatCopy = t.uiChat;
+    const chatViewCopy = t.uiChatView;
+    labels = {
+      '已忽略': chatCopy.ignoreOnce,
+      '不再提示': chatCopy.neverAsk,
+      '已记住': chatViewCopy.memStatusRemembered,
+      '已归档': chatViewCopy.memStatusArchived,
+      '已删除': chatViewCopy.memStatusDeleted,
+      '记忆已更新': chatCopy.memoryUpdated,
+      '记忆已归档': chatViewCopy.memStatusArchivedNotice,
+      '记忆已删除': chatViewCopy.memStatusDeletedNotice,
+    };
+    memoryStatusLabelsCache.set(t, labels);
+  }
+  return labels;
+}
+
 function localizeSceneTabs(items, copy) {
   return items.map(item => ({
     ...item,
@@ -2262,7 +2308,7 @@ const ToolWelcomeCard = ({ toolId, _theme, t, onSend }) => {
                   .slice(-2)
                   .map((item) => (
                     <div key={item.id} className="pointer-events-auto w-full flex justify-end">
-                      <ChatBubble item={item} sessionId={activeSessionId} theme={theme} t={t} onPrefill={(txt) => setInputText(txt)} onSend={sendChatMessage} editable={false} onOpenEditor={onOpenEditor} isLatestArtifact={false} />
+                      <ChatBubble item={item} sessionId={activeSessionId} theme={theme} t={t} onPrefill={setInputText} onSend={sendChatMessage} editable={false} onOpenEditor={onOpenEditor} isLatestArtifact={false} />
                     </div>
                 ))}
               </div>
@@ -3202,20 +3248,10 @@ const UserBubble = ({ item, sessionId, _theme, editable, t, conversationVariant 
     }
 
     // eslint-disable-next-line sonarjs/cognitive-complexity -- legacy bubble dispatches rendering by message type; split refactor tracked separately
-    const ChatBubble = ({ item, sessionId, theme, onPrefill, onSend, editable, onOpenEditor, t, isLatestArtifact, allowScheduledTaskDraft, conversationVariant, showAssistantActions = true }) => {
+    const ChatBubble = React.memo(function ChatBubble({ item, sessionId, theme, onPrefill, onSend, editable, onOpenEditor, t, isLatestArtifact, allowScheduledTaskDraft, conversationVariant, showAssistantActions = true }) {
       const chatCopy = t.uiChat;
-      const chatViewCopy = t.uiChatView;
       // 后端持久化的记忆状态值是固定中文数据，仅在 UI 边界映射为当前语言；未识别值原样透传
-      const memoryStatusLabels = {
-        '已忽略': chatCopy.ignoreOnce,
-        '不再提示': chatCopy.neverAsk,
-        '已记住': chatViewCopy.memStatusRemembered,
-        '已归档': chatViewCopy.memStatusArchived,
-        '已删除': chatViewCopy.memStatusDeleted,
-        '记忆已更新': chatCopy.memoryUpdated,
-        '记忆已归档': chatViewCopy.memStatusArchivedNotice,
-        '记忆已删除': chatViewCopy.memStatusDeletedNotice,
-      };
+      const memoryStatusLabels = getMemoryStatusLabels(t);
       const localizedMemoryStatus = (label) => memoryStatusLabels[label] || label;
       const assistantSelectionHostRef = useRef(null);
       const assistantSelectionTargetRef = useRef(null);
@@ -3252,9 +3288,9 @@ const UserBubble = ({ item, sessionId, _theme, editable, t, conversationVariant 
           ? renderLegacyMarkdownCached(item, syntaxVersion)
           : (item.html || '');
         const streamingDraftLabel = /scheduled-task-draft/.test(html) ? t.uiChatExtra.draftingScheduled : (t && t.cpDesigning);
-        const pd = item.streaming ? { draft: null, html: hideStreamingDraft(html, streamingDraftLabel) } : parsePersonaDraft(html);
-        const sd = (item.streaming || !allowScheduledTaskDraft) ? { draft: null, html: pd.html } : parseScheduledTaskDraft(pd.html);
-        const cq = item.streaming ? { q: null, html: sd.html } : parseCardQuestion(sd.html);
+        // 三轮解析链纯函数化并按 item 缓存(见 parseAssistantBubblesCached):
+        // memo 击穿(流式 delta/syntaxVersion bump)时也只重算真正变化的气泡。
+        const { pd, cq } = parseAssistantBubblesCached(item, html, !!item.streaming, allowScheduledTaskDraft, streamingDraftLabel);
         const assistantCopyAvailable = !item.streaming
           && [item.text, item.html].some(value => String(value || '').trim());
         // 草稿是否已存入(按名字在已加载的卡池里找同名自制卡 → 派生"已存入",免单独持久化)
@@ -3470,7 +3506,11 @@ const UserBubble = ({ item, sessionId, _theme, editable, t, conversationVariant 
       }
 
       return null;
-    };
+    });
+    // ChatBubble memo 化:inputText 挂在 ChatView 顶层,每个按键都整视图重渲;legacy
+    // 气泡列表 O(n),memo 后未变化的气泡只剩 prop 浅比较。调用点回调均为稳定引用
+    // (setInputText/sendChatMessage/onOpenEditor),item 由 bridge 会话数据保持引用稳定;
+    // syntaxVersion 订阅在组件内部,memo 不会阻断懒语言注册后的重渲染。
 
     // ==========================================
     // Artifact Card — present_artifact 成品卡（点击打开预览）

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -426,9 +426,11 @@ function CodexComposerConfigSelect({
   );
 }
 
-// 秒级时钟曾挂在 CodexAcpView 顶层 state(busy 时每秒重渲整个 4000+ 行视图),
-// 现按 ChatView 的 LiveConversationActivityIndicator 同款模式下沉:只有真正在显示
-// "已耗时" 的运行中指示器自己持有时钟,每秒只重渲这一小块子树。
+// The 1Hz clock used to live in CodexAcpView top-level state (re-rendering
+// the whole 4000+ line view every second while busy); it now sinks down with
+// the same pattern as ChatView's LiveConversationActivityIndicator: only the
+// running indicator that actually shows "elapsed" owns a clock, so each tick
+// re-renders just that small subtree.
 function LiveConversationActivityIndicator({ turn, onRequestAttention, className, copy }) {
   const running = !!turn && turn.status === 'running';
   const now = useConversationSecondClock(running);
@@ -2524,11 +2526,16 @@ export function CodexAcpView({
 
   // 原生（品悟）会话的 engine 事件：按 session 推进对应 lane，仅当前会话 bump 渲染；
   // turn 边界顺手刷新会话列表（标题/时间戳），与 acp:event 的 turn_completed 处理对齐。
-  // 注意:nativeLaneTick 是全视图共用的版本号——lane 是可变 ref 对象,除时间线投影外,
-  // 记忆弹层/底栏控件(直接读 lane 字段)与自动滚动 effect(2786 附近)都依赖此 bump。
-  // 把"每个 token 全视图重渲"收敛到单 lane 订阅组件,需要把 visibleTurns 及其全部
-  // 回调(respond/renderNativeItem/pendingByTool/rewind 系列等)沉到子组件,契约面太宽,
-  // 风险不匹配本项;时间线本身已有 ConversationTurn 深比较兜底,未变 turn 不重渲。
+  // Note: nativeLaneTick is a view-wide version counter — lane is a mutable
+  // ref object, and beyond the timeline projection, the memory popover /
+  // bottom-bar controls (reading lane fields directly) and the auto-scroll
+  // effect (near line 2786) all rely on this bump. Confining "re-render the
+  // whole view per token" to a per-lane subscription component would require
+  // sinking visibleTurns and all of its callbacks (respond/renderNativeItem/
+  // pendingByTool/the rewind family etc.) into a child — a contract surface
+  // too wide for the risk this item justifies; the timeline already has the
+  // ConversationTurn deep compare as a backstop, so unchanged turns do not
+  // re-render.
   useEffect(() => {
     let disposed = false;
     let unlisteners = [];

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -2529,7 +2529,7 @@ export function CodexAcpView({
   // Note: nativeLaneTick is a view-wide version counter — lane is a mutable
   // ref object, and beyond the timeline projection, the memory popover /
   // bottom-bar controls (reading lane fields directly) and the auto-scroll
-  // effect (near line 2786) all rely on this bump. Confining "re-render the
+  // effect below all rely on this bump. Confining "re-render the
   // whole view per token" to a per-lane subscription component would require
   // sinking visibleTurns and all of its callbacks (respond/renderNativeItem/
   // pendingByTool/the rewind family etc.) into a child — a contract surface

--- a/pinvou3-app/src/features/codex/CodexAcpView.jsx
+++ b/pinvou3-app/src/features/codex/CodexAcpView.jsx
@@ -426,6 +426,23 @@ function CodexComposerConfigSelect({
   );
 }
 
+// 秒级时钟曾挂在 CodexAcpView 顶层 state(busy 时每秒重渲整个 4000+ 行视图),
+// 现按 ChatView 的 LiveConversationActivityIndicator 同款模式下沉:只有真正在显示
+// "已耗时" 的运行中指示器自己持有时钟,每秒只重渲这一小块子树。
+function LiveConversationActivityIndicator({ turn, onRequestAttention, className, copy }) {
+  const running = !!turn && turn.status === 'running';
+  const now = useConversationSecondClock(running);
+  return (
+    <ConversationActivityIndicator
+      turn={turn}
+      now={now}
+      onRequestAttention={onRequestAttention}
+      className={className}
+      copy={copy}
+    />
+  );
+}
+
 function ElicitationCard({ elicitation, pending, onRespond, responding, copy, conversationCopy }) {
   const request = elicitation.request || {};
   const schema = request.requestedSchema || {};
@@ -1143,9 +1160,9 @@ export function CodexAcpView({
   const busy = isNativeAgent
     ? Boolean(activeNativeLane && activeNativeLane.busy)
     : projection.turns.some(turn => turn.status === 'running');
-  // Per-second clock shared with ChatView: on busy activation the baseline is synced before the
-  // interval starts; no timer while inactive; cleared on unmount (consolidates the old top ticker).
-  const now = useConversationSecondClock(busy);
+  // The per-second clock lives in the display subtrees (ConversationTurnView's internal
+  // useConversationSecondClock, LiveConversationActivityIndicator below), so busy no longer
+  // re-renders the whole view at 1Hz; no top-level `now` is passed down.
   // 「回退到第 N 轮」入口（仅原生代码车道）：checkpoint 列表 + turn 边界对齐。
   // 回退编排（rewind_to_turn）由 confirmRewind 发起；成功后走既有 loadSession
   // 重载（磁盘对话已截断、engine 已被后端回收重注水）。refreshKey 含 busy 边沿：
@@ -2507,6 +2524,11 @@ export function CodexAcpView({
 
   // 原生（品悟）会话的 engine 事件：按 session 推进对应 lane，仅当前会话 bump 渲染；
   // turn 边界顺手刷新会话列表（标题/时间戳），与 acp:event 的 turn_completed 处理对齐。
+  // 注意:nativeLaneTick 是全视图共用的版本号——lane 是可变 ref 对象,除时间线投影外,
+  // 记忆弹层/底栏控件(直接读 lane 字段)与自动滚动 effect(2786 附近)都依赖此 bump。
+  // 把"每个 token 全视图重渲"收敛到单 lane 订阅组件,需要把 visibleTurns 及其全部
+  // 回调(respond/renderNativeItem/pendingByTool/rewind 系列等)沉到子组件,契约面太宽,
+  // 风险不匹配本项;时间线本身已有 ConversationTurn 深比较兜底,未变 turn 不重渲。
   useEffect(() => {
     let disposed = false;
     let unlisteners = [];
@@ -3556,7 +3578,6 @@ export function CodexAcpView({
                     )}
                     <ConversationTurn
                       turn={turn}
-                      now={now}
                       copy={t.uiConversation}
                       pendingByTool={pendingByTool}
                       onRespond={respond}
@@ -3686,9 +3707,8 @@ export function CodexAcpView({
                 onApplyAndSend={() => nativeVoice.applyVoiceEditPreview({ send: true })}
                 onCancel={nativeVoice.cancelVoiceEditPreview}
               />
-              <ConversationActivityIndicator
+              <LiveConversationActivityIndicator
                 turn={activeConversationTurn}
-                now={now}
                 onRequestAttention={scrollConversationToBottom}
                 className="mb-0.5"
                 copy={t.uiConversation}

--- a/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
+++ b/pinvou3-app/src/features/conversation/ConversationTimeline.jsx
@@ -824,7 +824,7 @@ function ConversationTurnView({
   const c = conversationCopy(copy);
   const running = turn.status === 'running';
   // The per-second tick is scoped to the running turn itself: the parent may still pass a ticking `now`
-  // (CodexAcpView keeps its original behavior via `now || tickNow` prop precedence); when omitted, an
+  // (`now || tickNow` precedence keeps an external ticker working); when omitted or 0, an
   // internal clock drives elapsed time, re-rendering only this one turn subtree per second.
   const tickNow = useConversationSecondClock(running);
   const effectiveNow = now || tickNow;

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -514,10 +514,14 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
         { key: 'ppt', label: t.kbOutCatPpt, color: '#e0773a', icon: PresentationIcon },
       ];
       const outCatMeta = (k) => OUTPUT_CATS.find((c) => c.key === k) || OUTPUT_CATS[0];
+      const outputsDisposedRef = useRef(false);
       const refreshOutputs = useCallback(async () => {
         const list = bridge && bridge.artifacts.listDeliverableIndex
           ? await bridge.artifacts.listDeliverableIndex().catch(() => [])
           : await inv('list_deliverable_index').catch(() => []);
+        // 卸载清理已释放大表：unmount 前发起的在途请求 resolve 后不得把索引
+        // 回写进模块级缓存，否则抵消清理意图（unmount 后 setOutputs 是 no-op，无害）。
+        if (outputsDisposedRef.current) return;
         const nextList = list || [];
         const nextSig = outputListSig(nextList);
         if (nextSig !== outputsSigRef.current) {
@@ -545,8 +549,9 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
       // 视图按需条件渲染,卸载后模块级缓存会存活整个窗口周期:产出物索引是
       // 无上限大表,卸载时释放;轻量字段(stats/embedInfo/scan 游标等)保留。
       // 重挂载由 sub='output' 的既有 refreshOutputs() 路径重拉;outputsLoaded
-      // 归位让骨架屏接管,避免闪现「空状态」。
+      // 归位让骨架屏接管,避免闪现「空状态」。disposed 标志拦下在途回写。
       useEffect(() => () => {
+        outputsDisposedRef.current = true;
         kbCache.outputs = [];
         kbCache.outputsLoaded = false;
       }, []);

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -43,6 +43,11 @@ import { useOutsidePointerClose } from '../../components/ComposerPopover.jsx';
  */
 
 const kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], allDocs: [], embedInfo: null, model: null, outputs: [], outputsLoaded: false };
+// 全量文档表(kb_documents limit:0)无上限,模块级缓存只保留有界切片:
+// 重挂载先秒显前若干条,完整数据由 loadColls() 挂载后重拉覆盖,
+// 避免整表在视图卸载后仍常驻整个窗口生命周期。
+const KB_ALL_DOCS_CACHE_CAP = 2000;
+const capCachedAllDocs = (docs) => (docs.length > KB_ALL_DOCS_CACHE_CAP ? docs.slice(0, KB_ALL_DOCS_CACHE_CAP) : docs);
 
 const MODEL_PROGRESS_RADIUS = 31;
 const MODEL_PROGRESS_CIRCUMFERENCE = 2 * Math.PI * MODEL_PROGRESS_RADIUS;
@@ -537,6 +542,14 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
       // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous setState in this effect is intentional: mirrors into local state right after reading the backend snapshot, avoiding first-frame flicker
         if (sub === 'output') refreshOutputs();
       }, [sub, outputArtifactKey, refreshOutputs]);
+      // 视图按需条件渲染,卸载后模块级缓存会存活整个窗口周期:产出物索引是
+      // 无上限大表,卸载时释放;轻量字段(stats/embedInfo/scan 游标等)保留。
+      // 重挂载由 sub='output' 的既有 refreshOutputs() 路径重拉;outputsLoaded
+      // 归位让骨架屏接管,避免闪现「空状态」。
+      useEffect(() => () => {
+        kbCache.outputs = [];
+        kbCache.outputsLoaded = false;
+      }, []);
       const filteredOutputs = React.useMemo(() => {
         const q = outQuery.trim().toLowerCase();
         return outputs.filter((o) => {
@@ -741,7 +754,7 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
           setActiveColl((current) => (current ? c.find((item) => item.id === current.id) || null : null));
           kbCache.colls = c;
         } catch { /* silently degrade */ }
-        try { const d = await inv('kb_documents', { collectionId: 0, limit: 0 }) || []; setAllDocs(d); kbCache.allDocs = d; } catch { /* silently degrade */ }
+        try { const d = await inv('kb_documents', { collectionId: 0, limit: 0 }) || []; setAllDocs(d); kbCache.allDocs = capCachedAllDocs(d); } catch { /* silently degrade */ }
         try { const ei = await inv('kb_embed_info'); setEmbedInfo(ei); kbCache.embedInfo = ei; } catch { /* silently degrade */ }
         try { const m = await inv('kb_model_status'); setKbModel(m); kbCache.model = m; } catch { /* silently degrade */ }
         try { replaceIndexState(await inv('kb_index_status')); } catch { /* silently degrade */ }
@@ -915,7 +928,7 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
         setDocs((current) => current.filter((item) => item.id !== document.id));
         setAllDocs((current) => {
           const next = current.filter((item) => item.id !== document.id);
-          kbCache.allDocs = next;
+          kbCache.allDocs = capCachedAllDocs(next);
           return next;
         });
         // Optimistic collection-count update (docCount/chunkCount/totalBytes all lowered on delete, clamped >= 0) consolidated into shared.

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -43,9 +43,11 @@ import { useOutsidePointerClose } from '../../components/ComposerPopover.jsx';
  */
 
 const kbCache = { scan: null, stats: null, types: [], loaded: false, colls: [], allDocs: [], embedInfo: null, model: null, outputs: [], outputsLoaded: false };
-// 全量文档表(kb_documents limit:0)无上限,模块级缓存只保留有界切片:
-// 重挂载先秒显前若干条,完整数据由 loadColls() 挂载后重拉覆盖,
-// 避免整表在视图卸载后仍常驻整个窗口生命周期。
+// The full document table (kb_documents limit:0) is unbounded, so the
+// module-level cache keeps only a bounded slice: a remount instantly shows
+// the first rows and loadColls() re-fetches the complete data after mount,
+// so the whole table no longer stays resident for the window's lifetime
+// after the view unmounts.
 const KB_ALL_DOCS_CACHE_CAP = 2000;
 const capCachedAllDocs = (docs) => (docs.length > KB_ALL_DOCS_CACHE_CAP ? docs.slice(0, KB_ALL_DOCS_CACHE_CAP) : docs);
 
@@ -519,8 +521,10 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
         const list = bridge && bridge.artifacts.listDeliverableIndex
           ? await bridge.artifacts.listDeliverableIndex().catch(() => [])
           : await inv('list_deliverable_index').catch(() => []);
-        // 卸载清理已释放大表：unmount 前发起的在途请求 resolve 后不得把索引
-        // 回写进模块级缓存，否则抵消清理意图（unmount 后 setOutputs 是 no-op，无害）。
+        // Unmount cleanup already released the big table: an in-flight
+        // request started before unmount must not write the index back into
+        // the module-level cache once it resolves, or it would undo the
+        // cleanup (setOutputs after unmount is a no-op and harmless).
         if (outputsDisposedRef.current) return;
         const nextList = list || [];
         const nextSig = outputListSig(nextList);
@@ -546,10 +550,13 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
       // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous setState in this effect is intentional: mirrors into local state right after reading the backend snapshot, avoiding first-frame flicker
         if (sub === 'output') refreshOutputs();
       }, [sub, outputArtifactKey, refreshOutputs]);
-      // 视图按需条件渲染,卸载后模块级缓存会存活整个窗口周期:产出物索引是
-      // 无上限大表,卸载时释放;轻量字段(stats/embedInfo/scan 游标等)保留。
-      // 重挂载由 sub='output' 的既有 refreshOutputs() 路径重拉;outputsLoaded
-      // 归位让骨架屏接管,避免闪现「空状态」。disposed 标志拦下在途回写。
+      // The view renders conditionally on demand and module-level caches
+      // survive the whole window lifetime after unmount: the deliverables
+      // index is an unbounded table, released on unmount; lightweight fields
+      // (stats/embedInfo/scan cursors etc.) are kept. A remount re-fetches
+      // via the existing sub='output' refreshOutputs() path; resetting
+      // outputsLoaded hands control to the skeleton and avoids flashing the
+      // "empty state". The disposed flag blocks late writebacks.
       useEffect(() => () => {
         outputsDisposedRef.current = true;
         kbCache.outputs = [];

--- a/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
+++ b/pinvou3-app/src/features/knowledge/KnowledgeView.jsx
@@ -537,7 +537,6 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
         kbCache.outputsLoaded = true;
       // eslint-disable-next-line react-hooks/exhaustive-deps -- dependency list manually reviewed: this effect only needs the listed deps; completing it would cause duplicate requests or polling loops
       }, []);
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous setState in this effect is intentional: mirrors into local state right after reading the backend snapshot, avoiding first-frame flicker
       useEffect(() => { if (sub === 'output') refreshOutputs(); }, [sub, refreshOutputs]);
       useEffect(() => {
         if (sub !== 'output') return;
@@ -547,7 +546,6 @@ const OutputLivePreview = ({ o, onOpen, outPreviewCache, runQueuedPreview, remem
       }, [sub, refreshOutputs]);
       const outputArtifactKey = ((bs && bs.artifacts) || []).map((a) => `${a.path || ''}:${a.basename || ''}`).join('|');
       useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- synchronous setState in this effect is intentional: mirrors into local state right after reading the backend snapshot, avoiding first-frame flicker
         if (sub === 'output') refreshOutputs();
       }, [sub, outputArtifactKey, refreshOutputs]);
       // The view renders conditionally on demand and module-level caches

--- a/pinvou3-app/src/features/monitor/MonitorView.jsx
+++ b/pinvou3-app/src/features/monitor/MonitorView.jsx
@@ -233,7 +233,6 @@ const MONITOR_CLOCK_LOCALE = { zh: 'zh-CN', en: 'en-US', ja: 'ja-JP' };
         };
       }, []);
 
-      const updatedAt = fmt ? fmt.updatedAt : loadingValue;
       const gpuName = fmt ? fmt.gpuName : loadingValue;
       const gpuAvailable = fmt ? fmt.gpuAvailable : false;
       const gpuHasVram = fmt ? fmt.gpuHasVram : false;
@@ -323,8 +322,12 @@ const MONITOR_CLOCK_LOCALE = { zh: 'zh-CN', en: 'en-US', ja: 'ja-JP' };
           Object.assign(getMonitorHistoryStore(), next);
           return next;
         });
+      // The bridge suppresses notify for display-equal snapshots (memory-footprint
+      // gate), so fmt.updatedAt can freeze while polling continues; the local 1s
+      // page clock keeps the ring history advancing at the polling cadence
+      // instead (same one-sample-per-second behavior as an ungated poll).
       // eslint-disable-next-line react-hooks/exhaustive-deps -- fmt mirrors the polling object and the sampled values are already in deps; adding fmt would re-sample on every poll object change
-      }, [vllmMaxLen, vllmQueue, vllmTtft, vllmTps, vllmKv, clearOverride, updatedAt]);
+      }, [vllmMaxLen, vllmQueue, vllmTtft, vllmTps, vllmKv, clearOverride, clockNow]);
       const handleModelClearStart = () => {
         setIsModelClearing(true);
         if (modelClearTimerRef.current) clearTimeout(modelClearTimerRef.current);

--- a/pinvou3-app/src/features/settings/ProvidersSection.jsx
+++ b/pinvou3-app/src/features/settings/ProvidersSection.jsx
@@ -305,6 +305,7 @@ export function ProvidersSection({ t }) {
   // 为输出最新一行，80ms 限流）。只消费当前标签页 Agent 的事件，避免切页串扰。
   useEffect(() => {
     if (!isTauriAvailable()) return;
+    let disposed = false;
     let unlisten = null;
     tauriEvents
       .listen('acp:install-progress', event => {
@@ -318,9 +319,12 @@ export function ProvidersSection({ t }) {
         }
       })
       .then(fn => {
+        // 注册是异步的：卸载后才 resolve 时必须立刻反注册，否则监听泄漏。
+        if (disposed) { fn(); return; }
         unlisten = fn;
       });
     return () => {
+      disposed = true;
       if (unlisten) unlisten();
     };
   }, []);

--- a/pinvou3-app/src/features/settings/ProvidersSection.jsx
+++ b/pinvou3-app/src/features/settings/ProvidersSection.jsx
@@ -319,7 +319,8 @@ export function ProvidersSection({ t }) {
         }
       })
       .then(fn => {
-        // 注册是异步的：卸载后才 resolve 时必须立刻反注册，否则监听泄漏。
+        // Registration is async: if it resolves after unmount, unregister
+        // immediately or the listener leaks.
         if (disposed) { fn(); return; }
         unlisten = fn;
       });

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1237,27 +1237,37 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
       useEffect(() => {
         const ev = isTauriAvailable() ? tauriEvents : null;
         if (!ev) return;
+        let disposed = false;
         const unlisten = [];
-        ev.listen('wecom:qr', (e) => {
+        // 注册是异步的:卸载后才 resolve 的监听必须立刻反注册,
+        // 否则 push 进数组也无人消费,监听泄漏。
+        const track = (p) => p.then((u) => {
+          if (disposed) { try { u(); } catch { /* silent: listeners may already be stale at unmount */ } return; }
+          unlisten.push(u);
+        });
+        track(ev.listen('wecom:qr', (e) => {
           const p = e.payload || {};
           // 二维码到了 → 清掉一直显示的"正在生成…"loading,再弹出二维码弹窗。
           setAlert(a => ({ ...a, visible: false, loading: false }));
           setWecomQr({ qr: p.qr_data_url, url: p.url, phase: p.phase });
-        }).then(u => { unlisten.push(u); });
-        ev.listen('wecom:connected', () => {
+        }));
+        track(ev.listen('wecom:connected', () => {
           setWecomQr(null); setBusyId(null);
           // 连上 → 按规则写技能(默认启用),企微技能即刻对模型可见;连接态经 readiness 重取。
           invokeTauri('wecom_apply_skills').catch(() => {});
           loadBackendState();
           setAlert({ visible: true, loading: false, title: storeCopy.connectedTool(storeCopy.toolNames.wecom), subtitle: '', isInstall: true, isError: false, toolId: 'wecom' });
           notifyComposerToolsChanged();
-        }).then(u => { unlisten.push(u); });
-        ev.listen('wecom:error', (e) => {
+        }));
+        track(ev.listen('wecom:error', (e) => {
           const p = e.payload || {};
           setWecomQr(null); setBusyId(null);
           setAlert({ visible: true, loading: false, title: storeCopy.connectFailed(storeCopy.toolNames.wecom), subtitle: String(p.message || '').slice(0, 240), isError: true });
-        }).then(u => { unlisten.push(u); });
-        return () => { unlisten.forEach(u => { try { u(); } catch { /* silent: listeners may already be stale at unmount */ } }); };
+        }));
+        return () => {
+          disposed = true;
+          unlisten.forEach(u => { try { u(); } catch { /* silent: listeners may already be stale at unmount */ } });
+        };
       // eslint-disable-next-line react-hooks/exhaustive-deps -- subscription mounts/unmounts only with externalAuthAvailable; the copy snapshot is read on demand by the callback, so resubscribing is unnecessary
       }, [externalAuthAvailable]);
 

--- a/pinvou3-app/src/features/tools/ToolStoreView.jsx
+++ b/pinvou3-app/src/features/tools/ToolStoreView.jsx
@@ -1239,8 +1239,9 @@ const withUiTimeout = (promise, timeoutMs, fallbackResult) => {
         if (!ev) return;
         let disposed = false;
         const unlisten = [];
-        // 注册是异步的:卸载后才 resolve 的监听必须立刻反注册,
-        // 否则 push 进数组也无人消费,监听泄漏。
+        // Registration is async: a listener resolving after unmount must be
+        // unregistered immediately — nobody consumes the array entries and
+        // the listener leaks.
         const track = (p) => p.then((u) => {
           if (disposed) { try { u(); } catch { /* silent: listeners may already be stale at unmount */ } return; }
           unlisten.push(u);

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1080,10 +1080,13 @@
       if (id && typeof chatFeature.purgeSteerState === "function") {
         chatFeature.purgeSteerState(id);
       }
-      // 流式 markdown 渲染的尾沿定时器按 sid 记在 chat-events 内部表里；缓冲
-      // 被逐出/删除时一并取消，避免定时器在缓冲重建后再触发（虽然回调内有
-      // currentStreamId 守卫，但清掉才不留下跨生命周期的悬挂 timer）。
-      // chatEventsFeature 在本文件更下方初始化；purge 只在运行期发生，无 TDZ 问题。
+      // The streaming markdown render trailing-edge timers are recorded per
+      // sid in a chat-events internal table; cancel them when the buffer is
+      // evicted/deleted so a timer cannot fire after the buffer is rebuilt
+      // (the callback has a currentStreamId guard, but clearing the entry is
+      // what avoids leaving a dangling timer across lifecycles).
+      // chatEventsFeature is initialized further down this file; purge only
+      // happens at runtime, so there is no TDZ concern.
       if (id && chatEventsFeature && typeof chatEventsFeature.cancelStreamRenderTimers === "function") {
         chatEventsFeature.cancelStreamRenderTimers(id);
       }
@@ -2001,8 +2004,10 @@
               updateToolItem(c.tool_use_id, contentForCard, !c.is_error);
             }
           }
-          // 回填即删：meta 只服务于这一次 tool_result 还原（迟到的重复 tool_end
-          // 会被 toolCallAlreadyFinished 早退），残留会让历史 args 常驻会话缓冲。
+          // Delete after backfill: the meta serves exactly this one
+          // tool_result restoration (a late duplicate tool_end exits early
+          // via toolCallAlreadyFinished); leftovers would keep historical
+          // args resident in the session buffer.
           delete toolMeta[c.tool_use_id];
         }
         continue;
@@ -2031,9 +2036,12 @@
             addChatItem({ type: "assistant", text: textBuf, html: renderMarkdown(textBuf), time: "", streaming: false });
             textBuf = "";
           }
-          // 只为仍有 tool_result 待回填的历史 tool_use 重建 meta（上方回填循环
-          // 消费后立即删除）；无结果的中断轮残留没有任何消费者，不再插入。
-          // live hydration(keepLiveToolMeta) 例外：在途工具的 tool_end 事件仍需读 meta。
+          // Rebuild meta only for historical tool_use entries that still
+          // have a tool_result pending backfill (the backfill loop above
+          // deletes them right after consuming); leftovers from interrupted
+          // turns with no result have no consumer and are no longer inserted.
+          // live hydration exception (keepLiveToolMeta): the tool_end event
+          // of an in-flight tool still needs the meta.
           if (resultById[b.id] || (opts && opts.keepLiveToolMeta)) {
             toolMeta[b.id] = { name: b.name, args: b.input };
           }

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -1080,6 +1080,13 @@
       if (id && typeof chatFeature.purgeSteerState === "function") {
         chatFeature.purgeSteerState(id);
       }
+      // 流式 markdown 渲染的尾沿定时器按 sid 记在 chat-events 内部表里；缓冲
+      // 被逐出/删除时一并取消，避免定时器在缓冲重建后再触发（虽然回调内有
+      // currentStreamId 守卫，但清掉才不留下跨生命周期的悬挂 timer）。
+      // chatEventsFeature 在本文件更下方初始化；purge 只在运行期发生，无 TDZ 问题。
+      if (id && chatEventsFeature && typeof chatEventsFeature.cancelStreamRenderTimers === "function") {
+        chatEventsFeature.cancelStreamRenderTimers(id);
+      }
     },
     runSyncOnSession, persistMessagesFor,
     resetPendingAssistant: function (...args) { return resetPendingAssistant(...args); },
@@ -1877,15 +1884,13 @@
   function rerenderFromMessages(opts) {
     state.chatItems = [];
     itemIdSeq = 0;
-    // Replay re-adds every historical tool_use's metadata (including
-    // write/patch's large args) to toolMeta for tool_result backfill and
-    // never deletes after backfill — the residue resides in the buffer
-    // with the working set, and memory is bounded by the 32-entry
-    // all-session LRU cap. Durable replay clears first (when not live
-    // hydrating), reclaiming only orphan entries left by interrupted
-    // turns (the live event path itself stays insert/delete balanced);
-    // the replay then rebuilds the needed entries for the historical
-    // tool_uses inside messages.
+    // Replay rebuilds toolMeta only for historical tool_uses that still have a
+    // matching tool_result to backfill (write/patch's large args otherwise
+    // duplicate the whole transcript inside the 32-entry all-session LRU).
+    // Durable replay clears first (when not live hydrating), reclaiming only
+    // orphan entries left by interrupted turns (the live event path itself
+    // stays insert/delete balanced); entries are deleted again right after
+    // their tool_result backfill lookup — nothing reads them afterwards.
     if (!(opts && opts.keepLiveToolMeta)) toolMeta = {};
     // 卡牌事件按 pos 插回原位(pos=事件发生时的 messages 数)。让重载历史不割裂。
     const pe = Array.isArray(state.personaEvents) ? state.personaEvents : [];
@@ -1996,6 +2001,9 @@
               updateToolItem(c.tool_use_id, contentForCard, !c.is_error);
             }
           }
+          // 回填即删：meta 只服务于这一次 tool_result 还原（迟到的重复 tool_end
+          // 会被 toolCallAlreadyFinished 早退），残留会让历史 args 常驻会话缓冲。
+          delete toolMeta[c.tool_use_id];
         }
         continue;
       }
@@ -2023,7 +2031,12 @@
             addChatItem({ type: "assistant", text: textBuf, html: renderMarkdown(textBuf), time: "", streaming: false });
             textBuf = "";
           }
-          toolMeta[b.id] = { name: b.name, args: b.input };
+          // 只为仍有 tool_result 待回填的历史 tool_use 重建 meta（上方回填循环
+          // 消费后立即删除）；无结果的中断轮残留没有任何消费者，不再插入。
+          // live hydration(keepLiveToolMeta) 例外：在途工具的 tool_end 事件仍需读 meta。
+          if (resultById[b.id] || (opts && opts.keepLiveToolMeta)) {
+            toolMeta[b.id] = { name: b.name, args: b.input };
+          }
           // request_user_input → 还原只读选择卡（问题来自 input，选项高亮来自 result）
           if (b.name === "request_user_input") {
             const qs = (b.input && b.input.questions) || [];
@@ -2172,7 +2185,7 @@
     return invoke("cancel_shell_task", { sessionId, taskId });
   }
 
-  installBridgeFeature("chat-events", {
+  const chatEventsFeature = installBridgeFeature("chat-events", {
     state, listen, invoke, turnUsageDirty,
     sessionStates, renderMarkdown, bt,
     notify, onSessionEvent, runSyncOnSession,

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -236,12 +236,16 @@
       context.pendingAssistantText = "";
       context.pendingAssistantBlocks = [];
     }
-    // chat:done 终态清扫：删除没有配对 tool_result 的 toolMeta 条目。forwarder
-    // 对同一 session 顺序投递邮箱事件，done 之后本 turn 不会再有 chat:tool_end
-    // （下一轮工具用全新 id），interrupt/error 轮的在途条目（args 可达数十 KB）
-    // 永远等不到消费者，只会随会话缓冲常驻。必须在 preserveInterruptedAssistant
-    // Presentation / flushAssistantMessageToHistory 之后调用：那时 pendingAssistant
-    // Blocks 已清空或全部入史，state.messages 即最终口径，按 tool_result 配对判定。
+    // chat:done terminal sweep: delete toolMeta entries that never got a
+    // paired tool_result. The forwarder delivers mailbox events for a session
+    // in order, and after done this turn sees no more chat:tool_end (the next
+    // turn's tools use fresh ids), so in-flight entries from interrupted /
+    // errored turns (args can reach tens of KB) would never find a consumer
+    // and would stay resident in the session buffer. Must run after
+    // preserveInterruptedAssistantPresentation /
+    // flushAssistantMessageToHistory: by then pendingAssistant Blocks are
+    // cleared or archived, state.messages is the final authority, and the
+    // tool_result pairing can be decided.
     function sweepUnpairedToolMeta() {
       const meta = context.toolMeta;
       const ids = Object.keys(meta || {});
@@ -358,8 +362,10 @@
               break;
             }
           }
-          // 流节流不变量：flush 必须先于流状态复位。此时旧流气泡已随上面的
-          // splice 删除，flush 无渲染目标，只负责取消该会话的尾沿定时器。
+          // Stream throttle invariant: the flush must precede the stream
+          // state reset. The old streaming bubble was already removed by the
+          // splice above, so the flush has no render target and only cancels
+          // the session's trailing-edge timer.
           flushPendingStreamRender();
           resetPendingAssistant();
         }
@@ -367,7 +373,7 @@
       }
       state.busy = true;
       if (!state.thinking.active) startThinking();
-      flushPendingStreamRender(); // 新 turn 复位流状态前，旧流气泡先出最终 html
+      flushPendingStreamRender(); // the old streaming bubble gets its final html before the new turn resets stream state
       context.currentStreamText = "";
       context.currentStreamId = 0;
     });
@@ -595,18 +601,24 @@
     }
   }
 
-  // ── 流式 markdown 渲染节流 ────────────────────────────────────────
-  // Rust 每个引擎 delta 都发一个 chat:delta（forwarder 无合帧），此前每个 delta
-  // 都对【全部累计文本】做一次 marked+DOMPurify+hljs 全量重解析 → 长回复 O(n²)。
-  // 流式期间改为 ~180ms 尾沿重渲一次（尾沿定时器保证最后一个 delta 之后仍会渲染，
-  // 不丢尾帧）；首个 delta（气泡新建或 html 尚空）仍立即渲染。
-  // 不变量：所有终结/迁移该流式气泡的路径（chat:done/error/interrupt、
-  // chat:tool_start、chat:tool_end、转 reasoning、新 user message 复位、会话缓冲清除）必须先
-  // flushPendingStreamRender 同步出最终 html —— 否则尾沿定时器会在气泡终结后才
-  // 触发，用过期快照覆盖权威文本。定时器按 session 隔离：active 与后台会话可能
-  // 同时流式，共用一个定时器会渲染错工作集。
+  // ── Streaming markdown render throttle ────────────────────────────
+  // Rust emits one chat:delta per engine delta (the forwarder does not
+  // coalesce), and every delta used to reparse the ENTIRE accumulated text
+  // with marked+DOMPurify+hljs → O(n²) over a long reply. While streaming,
+  // re-render once per ~180ms trailing edge instead (the trailing-edge timer
+  // guarantees a render after the last delta, so the tail frame is never
+  // lost); the first delta (new bubble or still-empty html) still renders
+  // immediately.
+  // Invariant: every path that terminates or migrates the streaming bubble
+  // (chat:done/error/interrupt, chat:tool_start, chat:tool_end, switching to
+  // reasoning, a new user message reset, session buffer eviction) must call
+  // flushPendingStreamRender first to synchronously produce the final html —
+  // otherwise the trailing-edge timer fires after the bubble terminated and
+  // overwrites authoritative text with a stale snapshot. Timers are isolated
+  // per session: active and background sessions can stream simultaneously,
+  // and a shared timer would render the wrong working set.
   const STREAM_RENDER_THROTTLE_MS = 180;
-  const streamRenderTimers = Object.create(null); // sid → 尾沿重渲定时器
+  const streamRenderTimers = Object.create(null); // sid → trailing-edge render timer
 
   function renderStreamItemHtml() {
     const item = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
@@ -616,38 +628,44 @@
     return true;
   }
 
-  // 只允许在 onSessionEvent/runSyncOnSession 的同步体内调用：此时
-  // state.activeSessionId 已被路由为事件所属 session，才能作为定时器表 key
-  // 与工作集一一对应。
+  // Only callable inside the synchronous body of
+  // onSessionEvent/runSyncOnSession: state.activeSessionId has been routed
+  // to the event's session there, making it a valid timer-table key that
+  // maps one-to-one onto the working set.
   function flushPendingStreamRender() {
     const sid = state.activeSessionId;
     if (sid && streamRenderTimers[sid]) {
       clearTimeout(streamRenderTimers[sid]);
       delete streamRenderTimers[sid];
     }
-    // 流文本为空时不出渲染：保住「空流泡（optimistic 空 html）被终结路径移除」
-    // 的既有行为，也不给空气泡伪造 html。
+    // Do not render while the stream text is empty: preserves the existing
+    // behavior where an empty streaming bubble (optimistic empty html) is
+    // removed by terminal paths, and avoids fabricating html for an empty
+    // bubble.
     if (!context.currentStreamId || !context.currentStreamText) return false;
     return renderStreamItemHtml();
   }
 
   function scheduleStreamRender(sid) {
-    // 无 sid 或宿主没有定时器（部分测试沙箱）时退回逐 delta 渲染的旧行为。
+    // Without a sid, or when the host has no timers (some test sandboxes),
+    // fall back to the old render-per-delta behavior.
     if (!sid || typeof setTimeout !== "function") {
       if (context.currentStreamId && context.currentStreamText) renderStreamItemHtml();
       return;
     }
-    if (streamRenderTimers[sid]) return; // 已有待渲尾沿：本次 delta 只攒文本
+    if (streamRenderTimers[sid]) return; // a trailing edge is already pending: this delta only accumulates text
     streamRenderTimers[sid] = setTimeout(function () {
       delete streamRenderTimers[sid];
       let rendered = false;
-      // 定时器在事件循环空闲点触发，必须重新进入该 session 的工作集再渲染；
-      // 流已终结（currentStreamId 复位）说明终态路径已同步 flush，直接跳过。
+      // The timer fires at an event-loop idle point, so it must re-enter the
+      // session's working set before rendering; a terminated stream
+      // (currentStreamId reset) means a terminal path already flushed
+      // synchronously — skip.
       runSyncOnSession(sid, function () {
         if (!context.currentStreamId || !context.currentStreamText) return;
         rendered = renderStreamItemHtml();
       });
-      if (rendered) notify(); // 后台会话在 runSyncOnSession 内被 suppress，补一次
+      if (rendered) notify(); // background sessions are suppressed inside runSyncOnSession; notify once more
     }, STREAM_RENDER_THROTTLE_MS);
   }
 
@@ -736,7 +754,9 @@
     const item = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
     if (item) {
       item.text = context.currentStreamText;
-      // 气泡首个 delta（html 尚空）立即渲染；后续只攒文本，html 交给节流尾沿
+      // The bubble's first delta (html still empty) renders immediately;
+      // later deltas only accumulate text and leave the html to the
+      // throttle's trailing edge
       if (!item.html) item.html = renderMarkdown(context.currentStreamText);
       item.streaming = true;
     } else {
@@ -777,7 +797,7 @@
     context.pendingAssistantBlocks.push({ type: "tool_use", id: p.id, name: p.name, input: p.args || {} });
 
     // Finalize current streaming bubble
-    flushPendingStreamRender(); // 工具卡接管前同步出最终 html，并取消待渲尾沿
+    flushPendingStreamRender(); // synchronously produce the final html before the tool card takes over, and cancel the pending trailing edge
     const streamItem = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
     if (streamItem) {
       streamItem.streaming = false;
@@ -1096,7 +1116,9 @@
       if (typeof shellMessages.showShellCleanupFailure === "function") {
         shellMessages.showShellCleanupFailure(e.payload, state, addSystemItem);
       }
-      // 终态先同步出流式气泡的最终 html（含 interrupted 保留展示），并取消待渲尾沿
+      // Terminal states synchronously flush the streaming bubble's final
+      // html first (including the interrupted retention display) and cancel
+      // the pending trailing edge
       flushPendingStreamRender();
       const terminalStatus = String(e.payload && e.payload.status || "").toLowerCase();
       const interrupted = ["interrupted", "cancelled", "canceled"].includes(terminalStatus);
@@ -1541,7 +1563,8 @@
       latestTimelineCompletion,
       authoritativeTimelineMissesKnownCompletion,
       refreshAuthoritativeTurnTimeline,
-      // 会话缓冲清除（evict/delete）时由 bridge.js 调用，取消该 sid 的待渲尾沿
+      // Called from bridge.js on session buffer eviction/deletion to cancel
+      // the pending trailing edge for that sid
       cancelStreamRenderTimers,
     };
   };

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -358,6 +358,9 @@
               break;
             }
           }
+          // 流节流不变量：flush 必须先于流状态复位。此时旧流气泡已随上面的
+          // splice 删除，flush 无渲染目标，只负责取消该会话的尾沿定时器。
+          flushPendingStreamRender();
           resetPendingAssistant();
         }
         addChatItem({ type: "user", text: content, time: timeStr() });

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -598,7 +598,7 @@
   // 流式期间改为 ~180ms 尾沿重渲一次（尾沿定时器保证最后一个 delta 之后仍会渲染，
   // 不丢尾帧）；首个 delta（气泡新建或 html 尚空）仍立即渲染。
   // 不变量：所有终结/迁移该流式气泡的路径（chat:done/error/interrupt、
-  // chat:tool_start、转 reasoning、新 user message 复位、会话缓冲清除）必须先
+  // chat:tool_start、chat:tool_end、转 reasoning、新 user message 复位、会话缓冲清除）必须先
   // flushPendingStreamRender 同步出最终 html —— 否则尾沿定时器会在气泡终结后才
   // 触发，用过期快照覆盖权威文本。定时器按 session 隔离：active 与后台会话可能
   // 同时流式，共用一个定时器会渲染错工作集。
@@ -848,6 +848,7 @@
     if (meta && ["bash", "exec_shell", "Bash"].includes(meta.name) && backgroundTaskId) {
       markBackgroundToolItem(p.id, p.session_id, backgroundTaskId, p.output);
       delete context.toolMeta[p.id];
+      flushPendingStreamRender(); // terminal path: emit final html before the reset
       context.currentStreamText = ""; context.currentStreamId = 0;
       notify();
       return;
@@ -860,6 +861,7 @@
         { resolved: true, cardState: p.success ? "submitted" : "cancelled" }
       );
       delete context.toolMeta[p.id];
+      flushPendingStreamRender(); // terminal path: emit final html before the reset
       context.currentStreamText = ""; context.currentStreamId = 0;
       notify();
       return;
@@ -888,6 +890,7 @@
         // 不走 write_file 的工具(如 make_pptx)→ 卡有、面板无」。trackArtifact 已去重。
         if (presentedPath) trackArtifact(presentedPath);
         delete context.toolMeta[p.id];
+        flushPendingStreamRender(); // terminal path: emit final html before the reset
         context.currentStreamText = ""; context.currentStreamId = 0;
         notify();
         // Card identity and panel presentation are separate concerns: updating an
@@ -910,6 +913,7 @@
         output: p.output, success: false, state: "done",
       });
       delete context.toolMeta[p.id];
+      flushPendingStreamRender(); // terminal path: emit final html before the reset
       context.currentStreamText = ""; context.currentStreamId = 0;
       notify();
       return;
@@ -993,6 +997,7 @@
       }
 
     delete context.toolMeta[p.id];
+    flushPendingStreamRender(); // terminal path: emit final html before the reset
     context.currentStreamText = "";
     context.currentStreamId = 0;
     notify();

--- a/pinvou3-app/src/platform/tauri/bridge/chat-events.js
+++ b/pinvou3-app/src/platform/tauri/bridge/chat-events.js
@@ -236,6 +236,31 @@
       context.pendingAssistantText = "";
       context.pendingAssistantBlocks = [];
     }
+    // chat:done 终态清扫：删除没有配对 tool_result 的 toolMeta 条目。forwarder
+    // 对同一 session 顺序投递邮箱事件，done 之后本 turn 不会再有 chat:tool_end
+    // （下一轮工具用全新 id），interrupt/error 轮的在途条目（args 可达数十 KB）
+    // 永远等不到消费者，只会随会话缓冲常驻。必须在 preserveInterruptedAssistant
+    // Presentation / flushAssistantMessageToHistory 之后调用：那时 pendingAssistant
+    // Blocks 已清空或全部入史，state.messages 即最终口径，按 tool_result 配对判定。
+    function sweepUnpairedToolMeta() {
+      const meta = context.toolMeta;
+      const ids = Object.keys(meta || {});
+      if (!ids.length) return;
+      const paired = Object.create(null);
+      for (let i = 0; i < state.messages.length; i++) {
+        const blocks = state.messages[i] && state.messages[i].content;
+        if (!Array.isArray(blocks)) continue;
+        for (let j = 0; j < blocks.length; j++) {
+          const block = blocks[j];
+          if (block && block.type === "tool_result" && block.tool_use_id) {
+            paired[block.tool_use_id] = true;
+          }
+        }
+      }
+      ids.forEach(function (id) {
+        if (!paired[id]) delete meta[id];
+      });
+    }
     const markTurnDirtyArtifact = context.markTurnDirtyArtifact;
     const trackArtifact = context.trackArtifact;
     const untrackArtifact = context.untrackArtifact;
@@ -339,6 +364,7 @@
       }
       state.busy = true;
       if (!state.thinking.active) startThinking();
+      flushPendingStreamRender(); // 新 turn 复位流状态前，旧流气泡先出最终 html
       context.currentStreamText = "";
       context.currentStreamId = 0;
     });
@@ -566,7 +592,70 @@
     }
   }
 
+  // ── 流式 markdown 渲染节流 ────────────────────────────────────────
+  // Rust 每个引擎 delta 都发一个 chat:delta（forwarder 无合帧），此前每个 delta
+  // 都对【全部累计文本】做一次 marked+DOMPurify+hljs 全量重解析 → 长回复 O(n²)。
+  // 流式期间改为 ~180ms 尾沿重渲一次（尾沿定时器保证最后一个 delta 之后仍会渲染，
+  // 不丢尾帧）；首个 delta（气泡新建或 html 尚空）仍立即渲染。
+  // 不变量：所有终结/迁移该流式气泡的路径（chat:done/error/interrupt、
+  // chat:tool_start、转 reasoning、新 user message 复位、会话缓冲清除）必须先
+  // flushPendingStreamRender 同步出最终 html —— 否则尾沿定时器会在气泡终结后才
+  // 触发，用过期快照覆盖权威文本。定时器按 session 隔离：active 与后台会话可能
+  // 同时流式，共用一个定时器会渲染错工作集。
+  const STREAM_RENDER_THROTTLE_MS = 180;
+  const streamRenderTimers = Object.create(null); // sid → 尾沿重渲定时器
+
+  function renderStreamItemHtml() {
+    const item = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
+    if (!item) return false;
+    item.text = context.currentStreamText;
+    item.html = renderMarkdown(context.currentStreamText);
+    return true;
+  }
+
+  // 只允许在 onSessionEvent/runSyncOnSession 的同步体内调用：此时
+  // state.activeSessionId 已被路由为事件所属 session，才能作为定时器表 key
+  // 与工作集一一对应。
+  function flushPendingStreamRender() {
+    const sid = state.activeSessionId;
+    if (sid && streamRenderTimers[sid]) {
+      clearTimeout(streamRenderTimers[sid]);
+      delete streamRenderTimers[sid];
+    }
+    // 流文本为空时不出渲染：保住「空流泡（optimistic 空 html）被终结路径移除」
+    // 的既有行为，也不给空气泡伪造 html。
+    if (!context.currentStreamId || !context.currentStreamText) return false;
+    return renderStreamItemHtml();
+  }
+
+  function scheduleStreamRender(sid) {
+    // 无 sid 或宿主没有定时器（部分测试沙箱）时退回逐 delta 渲染的旧行为。
+    if (!sid || typeof setTimeout !== "function") {
+      if (context.currentStreamId && context.currentStreamText) renderStreamItemHtml();
+      return;
+    }
+    if (streamRenderTimers[sid]) return; // 已有待渲尾沿：本次 delta 只攒文本
+    streamRenderTimers[sid] = setTimeout(function () {
+      delete streamRenderTimers[sid];
+      let rendered = false;
+      // 定时器在事件循环空闲点触发，必须重新进入该 session 的工作集再渲染；
+      // 流已终结（currentStreamId 复位）说明终态路径已同步 flush，直接跳过。
+      runSyncOnSession(sid, function () {
+        if (!context.currentStreamId || !context.currentStreamText) return;
+        rendered = renderStreamItemHtml();
+      });
+      if (rendered) notify(); // 后台会话在 runSyncOnSession 内被 suppress，补一次
+    }, STREAM_RENDER_THROTTLE_MS);
+  }
+
+  function cancelStreamRenderTimers(purgedSid) {
+    if (!purgedSid || !streamRenderTimers[purgedSid]) return;
+    clearTimeout(streamRenderTimers[purgedSid]);
+    delete streamRenderTimers[purgedSid];
+  }
+
   function finalizeAssistantStreamBeforeReasoning() {
+    flushPendingStreamRender();
     flushPendingTextBlock();
     const item = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
     if (item) {
@@ -644,7 +733,8 @@
     const item = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
     if (item) {
       item.text = context.currentStreamText;
-      item.html = renderMarkdown(context.currentStreamText);
+      // 气泡首个 delta（html 尚空）立即渲染；后续只攒文本，html 交给节流尾沿
+      if (!item.html) item.html = renderMarkdown(context.currentStreamText);
       item.streaming = true;
     } else {
       // New bubble needed (after tool card)
@@ -658,6 +748,7 @@
         streaming: true,
       });
     }
+    scheduleStreamRender(e.payload && e.payload.session_id || state.activeSessionId);
     notify();
   }); });
 
@@ -683,6 +774,7 @@
     context.pendingAssistantBlocks.push({ type: "tool_use", id: p.id, name: p.name, input: p.args || {} });
 
     // Finalize current streaming bubble
+    flushPendingStreamRender(); // 工具卡接管前同步出最终 html，并取消待渲尾沿
     const streamItem = state.chatItems.find(function (it) { return it.id === context.currentStreamId; });
     if (streamItem) {
       streamItem.streaming = false;
@@ -996,10 +1088,13 @@
       if (typeof shellMessages.showShellCleanupFailure === "function") {
         shellMessages.showShellCleanupFailure(e.payload, state, addSystemItem);
       }
+      // 终态先同步出流式气泡的最终 html（含 interrupted 保留展示），并取消待渲尾沿
+      flushPendingStreamRender();
       const terminalStatus = String(e.payload && e.payload.status || "").toLowerCase();
       const interrupted = ["interrupted", "cancelled", "canceled"].includes(terminalStatus);
       if (interrupted) preserveInterruptedAssistantPresentation();
       else flushAssistantMessageToHistory();
+      sweepUnpairedToolMeta();
       // Refresh artifacts written in this turn in place when already presented.
       // Add only the first card for artifacts the model did not present, and
       // skip artifacts already presented in this turn or changed repeatedly.
@@ -1438,6 +1533,8 @@
       latestTimelineCompletion,
       authoritativeTimelineMissesKnownCompletion,
       refreshAuthoritativeTurnTimeline,
+      // 会话缓冲清除（evict/delete）时由 bridge.js 调用，取消该 sid 的待渲尾沿
+      cancelStreamRenderTimers,
     };
   };
 })();

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -129,12 +129,52 @@
     return { running, waiting };
   }
 
+  // MonitorView 只消费 state.monitor._fmt（含 vllmRaw 一层嵌套），浅等即显示
+  // 等价。轮询每秒跑一次，快照显示等价时不再赋值 + notify，避免监控页开着时
+  // 每秒一次的全量 App 重渲染。数值有天然抖动（cpu/gpu 百分比等），比较给
+  // 0.5 容差（宁可多发一次，也不许卡住不发）；计数经 toFixed/round 后多为
+  // 字符串，按精确比较。updatedAt 是轮询 tick 标记（无 UI 渲染，仅作采样
+  // 触发器），必须排除，否则每秒都「有变化」；页面时钟由 MonitorView 本地
+  // 1s 计时器驱动，不依赖它。
+  function monitorFmtEqual(prev, next) {
+    if (prev === next) return true;
+    if (!prev || !next) return false;
+    const numEq = function (a, b) {
+      if (a === b) return true;
+      return typeof a === "number" && typeof b === "number"
+        && Number.isFinite(a) && Number.isFinite(b)
+        && Math.abs(a - b) <= 0.5;
+    };
+    const keys = Object.keys(next);
+    if (keys.length !== Object.keys(prev).length) return false;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (key === "updatedAt") continue;
+      const a = prev[key];
+      const b = next[key];
+      if (a && b && typeof a === "object" && typeof b === "object") {
+        const inner = Object.keys(b);
+        if (inner.length !== Object.keys(a).length) return false;
+        let same = true;
+        for (let j = 0; j < inner.length; j++) {
+          if (!numEq(a[inner[j]], b[inner[j]])) { same = false; break; }
+        }
+        if (!same) return false;
+        continue;
+      }
+      if (!numEq(a, b)) return false;
+    }
+    return true;
+  }
+
   // eslint-disable-next-line sonarjs/cognitive-complexity -- legacy bridge; refactor tracked separately
   async function pollMonitor() {
     if (monitorPollInFlight) return;
     monitorPollInFlight = true;
     try {
       const snap = await invoke("get_monitor_snapshot");
+      // 上一轮出错 → 本轮必须通知一次,让「读取失败」横幅切换回正常面板。
+      const hadMonitorError = !!state.monitorError;
       state.monitorError = null;
       // GPU util sliding window
       if (snap.gpu) {
@@ -249,8 +289,12 @@
         maxModelLen = snap.vllm.max_model_len;
         state.tokens.max = maxModelLen;
       }
-      state.monitor = snap;
-      notify();
+      // 显示等价的快照不覆盖 state.monitor、不 notify（首帧或上一轮出错时必须发）。
+      const prevFmt = state.monitor && state.monitor._fmt;
+      if (hadMonitorError || !prevFmt || !monitorFmtEqual(prevFmt, snap._fmt)) {
+        state.monitor = snap;
+        notify();
+      }
     } catch (e) {
       state.monitorError = e && e.message ? e.message : String(e || "monitor poll failed");
       console.warn("monitor poll failed", e);

--- a/pinvou3-app/src/platform/tauri/bridge/monitor.js
+++ b/pinvou3-app/src/platform/tauri/bridge/monitor.js
@@ -129,13 +129,17 @@
     return { running, waiting };
   }
 
-  // MonitorView 只消费 state.monitor._fmt（含 vllmRaw 一层嵌套），浅等即显示
-  // 等价。轮询每秒跑一次，快照显示等价时不再赋值 + notify，避免监控页开着时
-  // 每秒一次的全量 App 重渲染。数值有天然抖动（cpu/gpu 百分比等），比较给
-  // 0.5 容差（宁可多发一次，也不许卡住不发）；计数经 toFixed/round 后多为
-  // 字符串，按精确比较。updatedAt 是轮询 tick 标记（无 UI 渲染，仅作采样
-  // 触发器），必须排除，否则每秒都「有变化」；页面时钟由 MonitorView 本地
-  // 1s 计时器驱动，不依赖它。
+  // MonitorView only consumes state.monitor._fmt (plus one level of vllmRaw
+  // nesting), so shallow equality means display equivalence. The poll runs
+  // once per second; when a snapshot is display-equivalent, skip the
+  // assignment + notify to avoid a full App re-render every second while the
+  // monitor page is open. Numeric values jitter naturally (cpu/gpu
+  // percentages etc.), so comparisons allow a 0.5 tolerance (prefer one
+  // extra notify over ever getting stuck); counters are mostly strings after
+  // toFixed/round and compare exactly. updatedAt is a poll-tick marker (never
+  // rendered, only a sampling trigger) and must be excluded, otherwise every
+  // second counts as "changed"; the page clock is driven by MonitorView's
+  // local 1s timer and does not depend on it.
   function monitorFmtEqual(prev, next) {
     if (prev === next) return true;
     if (!prev || !next) return false;
@@ -173,7 +177,8 @@
     monitorPollInFlight = true;
     try {
       const snap = await invoke("get_monitor_snapshot");
-      // 上一轮出错 → 本轮必须通知一次,让「读取失败」横幅切换回正常面板。
+      // The previous round errored → this round must notify once so the
+      // "read failed" banner switches back to the normal panel.
       const hadMonitorError = !!state.monitorError;
       state.monitorError = null;
       // GPU util sliding window
@@ -289,7 +294,8 @@
         maxModelLen = snap.vllm.max_model_len;
         state.tokens.max = maxModelLen;
       }
-      // 显示等价的快照不覆盖 state.monitor、不 notify（首帧或上一轮出错时必须发）。
+      // Display-equivalent snapshots neither overwrite state.monitor nor
+      // notify (must send on the first frame or after an errored round).
       const prevFmt = state.monitor && state.monitor._fmt;
       if (hadMonitorError || !prevFmt || !monitorFmtEqual(prevFmt, snap._fmt)) {
         state.monitor = snap;

--- a/pinvou3-app/src/platform/tauri/bridge/terminal.js
+++ b/pinvou3-app/src/platform/tauri/bridge/terminal.js
@@ -258,6 +258,10 @@
     for (let i = 0; i < state.chatItems.length; i++) {
       const item = state.chatItems[i];
       if (item.type !== "tool" || item.toolId !== toolId) continue;
+      // chat:shell_task_status can repeat for an already finalized task;
+      // re-merging would append the tails a second time, so leave items in a
+      // terminal state untouched.
+      if (item.state === "done" || item.state === "failed") return true;
       const status = payload.status || "Failed";
       const success = status === "Completed";
       item.success = success;
@@ -449,10 +453,16 @@
     );
   }
 
+  // Live and background shell output are display-only; completion replaces
+  // the tail with the normal full result. Both paths must share one cap so a
+  // verbose process cannot grow renderer memory without bound.
+  const MAX_LIVE_OUTPUT_CHARS = 128 * 1024;
+
   function reconcileBackgroundTerminalOutput(previous, payload) {
     let output = String(previous == null ? "" : previous);
     output = mergeTerminalTail(output, normalizeTerminalTail(payload.stdout_tail, ""));
     output = mergeTerminalTail(output, normalizeTerminalTail(payload.stderr_tail, "[STDERR] "));
+    if (output.length > MAX_LIVE_OUTPUT_CHARS) output = "…\n" + output.slice(-MAX_LIVE_OUTPUT_CHARS);
     return output;
   }
 
@@ -473,8 +483,7 @@
       );
       // A verbose long-running process must not grow renderer memory without
       // bound. Completion replaces this tail with the normal full result.
-      const maxLiveChars = 128 * 1024;
-      if (output.length > maxLiveChars) output = "…\n" + output.slice(-maxLiveChars);
+      if (output.length > MAX_LIVE_OUTPUT_CHARS) output = "…\n" + output.slice(-MAX_LIVE_OUTPUT_CHARS);
       item.output = output;
       item.liveOutput = true;
       return true;

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -109,8 +109,13 @@ const expectedProtocolHashes = {
   // v0.9.12 rereview fix that persists toolName/reason/risk with each
   // ToolGateDecision so history replay retains the structured audit detail.
   // Recomputed again when the shell background-task projection learned the
-  // canonical v0.9.12 `bash` name while retaining legacy replay aliases.
-  chat: '908516b590b380becfc66db8bf9d147547193b95f5d809e3fddb7d4170c7391d',
+  // canonical v0.9.12 `bash` name while retaining legacy replay aliases. And
+  // again for the streaming markdown render throttle: the chat:delta /
+  // chat:tool_start / chat:done listener bodies gained the trailing-edge
+  // render flush/schedule plus the unpaired-toolMeta terminal sweep — no new
+  // invoke or listen entries, only body-internal edits, so this is a
+  // capture-text refresh.
+  chat: '1f036190b5f21a9da231d01f57c4b1209bff78c91d87d8398fdca3767e427520',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',
   knowledge: '9105a42c6b69f04d0bc28b6a72e0746648110a44823891ded3261cdcbc99766b',

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -114,8 +114,11 @@ const expectedProtocolHashes = {
   // chat:tool_start / chat:done listener bodies gained the trailing-edge
   // render flush/schedule plus the unpaired-toolMeta terminal sweep — no new
   // invoke or listen entries, only body-internal edits, so this is a
-  // capture-text refresh.
-  chat: '1f036190b5f21a9da231d01f57c4b1209bff78c91d87d8398fdca3767e427520',
+  // capture-text refresh. Recomputed again for the chat:tool_end listener
+  // bodies emitting the final stream html via flushPendingStreamRender
+  // before resetting the stream state (same throttle invariant, still no new
+  // invoke or listen entries).
+  chat: '66184c9e4bafb1227cdbcec9d2dc91f77f026cf6cb3a841352b1d5154d62ed19',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',
   knowledge: '9105a42c6b69f04d0bc28b6a72e0746648110a44823891ded3261cdcbc99766b',

--- a/pinvou3-app/tests/bridge_domain_protocol.test.mjs
+++ b/pinvou3-app/tests/bridge_domain_protocol.test.mjs
@@ -117,8 +117,11 @@ const expectedProtocolHashes = {
   // capture-text refresh. Recomputed again for the chat:tool_end listener
   // bodies emitting the final stream html via flushPendingStreamRender
   // before resetting the stream state (same throttle invariant, still no new
-  // invoke or listen entries).
-  chat: '66184c9e4bafb1227cdbcec9d2dc91f77f026cf6cb3a841352b1d5154d62ed19',
+  // invoke or listen entries). Recomputed again for the review-follow-up
+  // comment translations inside the captured listener bodies (same
+  // capture-text refresh; the comment-stripped signature list is
+  // byte-identical to the previous state).
+  chat: 'd9b18bcde6f40b5ff1644c1bccc388b70632a9f49444de44524c24b39830959c',
   dependencies: '2cb185d38dabeb35f48773457c182e1c35951b210f5d0fc853b074eb2eb68626',
   interaction: '3f275b9c4fc77ebf42a56df1c84d638ca5f1f8a3b80612efebeddf1a39f14efd',
   knowledge: '9105a42c6b69f04d0bc28b6a72e0746648110a44823891ded3261cdcbc99766b',

--- a/pinvou3-app/tests/code_mode_exit_contract.test.mjs
+++ b/pinvou3-app/tests/code_mode_exit_contract.test.mjs
@@ -47,7 +47,7 @@ assertClearBefore(
 // fails the user is still on the active code session, and an entry-side clear
 // would leave it behind the standard sidebar.
 {
-  const head = windowFrom('async function handleOpenScheduledRunShortcut(run)', 700);
+  const head = windowFrom('const handleOpenScheduledRunShortcut = useCallback(async (run) => {', 700);
   const fallbackAt = head.indexOf('if (!bridge.available || !bridge.scheduled.openScheduledRunChat)');
   assert.ok(fallbackAt > -1, 'handleOpenScheduledRunShortcut: fallback branch marker not found');
   assert.ok(

--- a/pinvou3-app/tests/conditional_platform_scripts.test.mjs
+++ b/pinvou3-app/tests/conditional_platform_scripts.test.mjs
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  desktopPlatformMarkerScript,
+  transformIndexHtmlForPlatform,
+} from '../vite.config.mjs';
+import { localClassicScriptPaths } from '../scripts/vite-runtime-assets.mjs';
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sourceIndex = fs.readFileSync(path.join(appRoot, 'src', 'index.html'), 'utf8');
+
+const DESKTOP_MARKER = 'window.PinvouPlatform = Object.freeze({ kind: "desktop", isWeb: false })';
+
+function classicScripts(html) {
+  return localClassicScriptPaths(html);
+}
+
+test('desktop transform drops web-only bridge scripts and keeps everything else in order', () => {
+  const source = classicScripts(sourceIndex);
+  const desktop = classicScripts(transformIndexHtmlForPlatform(false, sourceIndex));
+
+  assert.ok(
+    desktop.every((relative) => !relative.startsWith('platform/web/')),
+    `desktop index must not reference platform/web/ scripts: ${desktop.filter((relative) => relative.startsWith('platform/web/')).join(', ')}`,
+  );
+  assert.deepEqual(
+    desktop.filter((relative) => relative.startsWith('platform/tauri/')),
+    source.filter((relative) => relative.startsWith('platform/tauri/')),
+    'desktop transform must keep every tauri bridge tag in source order',
+  );
+  assert.deepEqual(
+    desktop.filter((relative) => !relative.startsWith('platform/')),
+    source.filter((relative) => !relative.startsWith('platform/')),
+    'desktop transform must keep shared/vendor tags in source order',
+  );
+
+  // Ordering pairs the web bridge contract test relies on, restricted to what
+  // the desktop build still loads.
+  const indexOf = (relative) => desktop.indexOf(relative);
+  assert.ok(indexOf('shared/bridge-messages.js') < indexOf('platform/tauri/bridge/chat-events.js'));
+  assert.ok(indexOf('shared/bridge-messages.js') < indexOf('platform/tauri/bridge.js'));
+  assert.ok(indexOf('shared/legacy-polyfills.js') < indexOf('vendor/tailwind.js'));
+  assert.ok(indexOf('platform/tauri/bridge.js') < desktop.length - 1);
+});
+
+test('desktop transform replaces bootstrap.js in place with the platform marker', () => {
+  const html = transformIndexHtmlForPlatform(false, sourceIndex);
+  const markerAt = html.indexOf(DESKTOP_MARKER);
+  assert.notEqual(markerAt, -1, 'desktop marker must be present');
+
+  const markerLine = html.split('\n').find((line) => line.includes(DESKTOP_MARKER));
+  assert.ok(markerLine.trim().startsWith('<script>'), 'marker must be an inline classic script');
+  assert.ok(
+    !/\bsrc=/u.test(markerLine),
+    'marker must not become a classic runtime script reference',
+  );
+
+  // The marker must sit exactly where bootstrap.js ran: after the contextmenu
+  // guard and before authority-sync diagnostics (which read PinvouPlatform at
+  // parse time) and the head timing script contract stays untouched.
+  const contextMenuAt = html.indexOf("document.addEventListener('contextmenu'");
+  const authoritySyncAt = html.indexOf('shared/authority-sync-diagnostics.js');
+  assert.ok(contextMenuAt !== -1 && authoritySyncAt !== -1);
+  assert.ok(contextMenuAt < markerAt && markerAt < authoritySyncAt);
+  assert.ok(html.includes('window.__PINVOU_STARTUP__ = { mark: mark, markAt: markAt, flush: flush, entries: entries }'), 'head timing script preserved');
+});
+
+test('desktop transform only touches platform script lines', () => {
+  const transformed = transformIndexHtmlForPlatform(false, sourceIndex);
+  const sourceLines = sourceIndex.split('\n');
+  const transformedLines = transformed.split('\n');
+  assert.equal(sourceLines.length, transformedLines.length, 'line count must be preserved');
+
+  let removed = 0;
+  let markerSeen = 0;
+  for (let i = 0; i < sourceLines.length; i += 1) {
+    if (transformedLines[i] === sourceLines[i]) continue;
+    const isWebScriptTag = /<script\b[^>]*%BASE_URL%platform\/web\//u.test(sourceLines[i]);
+    assert.ok(isWebScriptTag, `only platform/web script lines may change, line ${i + 1}: ${sourceLines[i]}`);
+    if (transformedLines[i] === '') removed += 1;
+    if (transformedLines[i].includes(DESKTOP_MARKER)) markerSeen += 1;
+  }
+  assert.equal(markerSeen, 1, 'exactly one desktop marker replaces bootstrap.js');
+  assert.equal(removed, 4, 'the four other web-only tags must be dropped');
+});
+
+test('web transform drops tauri-only bridge scripts and keeps the web transport in order', () => {
+  const source = classicScripts(sourceIndex);
+  const web = classicScripts(transformIndexHtmlForPlatform(true, sourceIndex));
+
+  assert.ok(
+    web.every((relative) => !relative.startsWith('platform/tauri/')),
+    `web index must not reference platform/tauri/ scripts: ${web.filter((relative) => relative.startsWith('platform/tauri/')).join(', ')}`,
+  );
+  assert.deepEqual(
+    web.filter((relative) => relative.startsWith('platform/web/')),
+    source.filter((relative) => relative.startsWith('platform/web/')),
+    'web transform must keep every web bridge tag in source order',
+  );
+  assert.deepEqual(
+    web.filter((relative) => !relative.startsWith('platform/')),
+    source.filter((relative) => !relative.startsWith('platform/')),
+    'web transform must keep shared/vendor tags in source order',
+  );
+
+  const indexOf = (relative) => web.indexOf(relative);
+  assert.ok(indexOf('shared/bridge-messages.js') < indexOf('platform/web/bridge.js'));
+  assert.ok(indexOf('shared/chunked-file-upload.js') < indexOf('platform/web/bridge.js'));
+  assert.ok(indexOf('platform/web/bridge/turn-terminal.js') < indexOf('platform/web/bridge.js'));
+  assert.ok(indexOf('platform/web/bridge.js') < indexOf('platform/web/bridge/domain-adapter.js'));
+  assert.ok(
+    !transformIndexHtmlForPlatform(true, sourceIndex).includes(DESKTOP_MARKER),
+    'web index must not inline the desktop platform marker',
+  );
+});
+
+test('both transforms preserve the module entry and startup plumbing', () => {
+  for (const webBuild of [false, true]) {
+    const html = transformIndexHtmlForPlatform(webBuild, sourceIndex);
+    assert.ok(
+      html.includes('<script type="module" src="/app/main.jsx"'),
+      `module entry untouched (webBuild=${webBuild})`,
+    );
+    assert.ok(
+      html.includes('window.__PINVOU_STARTUP__ = { mark: mark, markAt: markAt, flush: flush, entries: entries }'),
+      `head startup observers untouched (webBuild=${webBuild})`,
+    );
+    assert.ok(
+      html.includes("window.TauriBridge.init()"),
+      `bridge boot init untouched (webBuild=${webBuild})`,
+    );
+    assert.equal(
+      html,
+      transformIndexHtmlForPlatform(webBuild, html),
+      `transform must be idempotent (webBuild=${webBuild})`,
+    );
+  }
+});
+
+test('transform handles a rewritten non-root base (web relay base path)', () => {
+  // In the served/built html, `%BASE_URL%`/base rewriting has already replaced
+  // the placeholder with the deployment base (e.g. /pinvou3/remote/).
+  const based = sourceIndex.replaceAll('%BASE_URL%', '/pinvou3/remote/');
+  // localClassicScriptPaths keeps the deployment base prefix, so classify by
+  // the platform path segment instead of a leading `platform/`.
+  const segmentClass = (html) => {
+    const scripts = classicScripts(html).map((relative) => {
+      const at = relative.indexOf('/platform/');
+      return at >= 0 ? relative.slice(at + 1) : relative;
+    });
+    return {
+      web: scripts.filter((relative) => relative.startsWith('platform/web/')),
+      tauri: scripts.filter((relative) => relative.startsWith('platform/tauri/')),
+      all: scripts,
+    };
+  };
+  const web = segmentClass(transformIndexHtmlForPlatform(true, based));
+  const desktop = segmentClass(transformIndexHtmlForPlatform(false, based));
+
+  assert.deepEqual(web.tauri, [], 'web transform must classify tauri scripts under a non-root base');
+  assert.ok(web.all.includes('platform/web/bootstrap.js') && web.all.includes('platform/web/bridge.js'),
+    'web transform must keep the web transport under a non-root base');
+  assert.deepEqual(desktop.web, [], 'desktop transform must classify web scripts under a non-root base');
+  assert.equal(desktop.tauri.length, 19, 'desktop transform must keep all 19 tauri bridge tags under a non-root base');
+  assert.ok(transformIndexHtmlForPlatform(false, based).includes(DESKTOP_MARKER),
+    'desktop marker must also replace bootstrap.js under a non-root base');
+});
+
+test('desktop and web transforms together retain the full shared source manifest', () => {
+  const source = classicScripts(sourceIndex);
+  const desktop = classicScripts(transformIndexHtmlForPlatform(false, sourceIndex));
+  const web = classicScripts(transformIndexHtmlForPlatform(true, sourceIndex));
+  const union = [...new Set([...desktop, ...web])].sort(); // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic string order is the assertion's expectation
+  assert.deepEqual(union, [...new Set(source)].sort()); // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic string order is the assertion's expectation
+});
+
+test('marker export stays byte-stable for the dist contract test', () => {
+  assert.equal(desktopPlatformMarkerScript.includes(DESKTOP_MARKER), true);
+  assert.equal(desktopPlatformMarkerScript.startsWith('<script>'), true);
+  assert.equal(desktopPlatformMarkerScript.endsWith('</script>'), true);
+});

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -153,7 +153,7 @@ assert.ok(
   'ordinary session navigation must hide the native browser before publishing the chat route and loading the remote session'
 );
 assert.ok(
-  /async function navigateFromScheduledRun\(nextView[\s\S]{0,520}runBrowserUiTransition[\s\S]{0,260}await bridge\.scheduled\.exitScheduledRunChat\(\)[\s\S]{0,160}!exited \|\| !isCurrent\(\)[\s\S]{0,200}setCurrentView\(nextView\)[\s\S]{0,360}hideMode: bs && bs\.scheduledRunContext[\s\S]{0,80}'workspace'/.test(indexHtml),
+  /const navigateFromScheduledRun = useCallback\(async \(nextView[\s\S]{0,520}runBrowserUiTransition[\s\S]{0,260}await bridge\.scheduled\.exitScheduledRunChat\(\)[\s\S]{0,160}!exited \|\| !isCurrent\(\)[\s\S]{0,260}setCurrentView\(nextView\)[\s\S]{0,360}hideMode: bs && bs\.scheduledRunContext[\s\S]{0,80}'workspace'/.test(indexHtml),
   'leaving a scheduled run must hide the native browser before restoring its return session and publishing the next route'
 );
 assert.ok(
@@ -420,7 +420,7 @@ assert.ok(
     !/data-testid="scheduled-task-action-menu"/.test(indexHtml) &&
     !/data-testid="scheduled-detail-actions"/.test(indexHtml) &&
     /scheduledRunHistory\.map/.test(indexHtml) &&
-    /<RecentItem[\s\S]{0,900}chat=\{chat\}[\s\S]{0,900}handleOpenScheduledRunShortcut\(chat\.scheduledRun\)/.test(indexHtml) &&
+    /<RecentItem[\s\S]{0,900}chat=\{chat\}[\s\S]{0,900}handleOpenScheduledRunShortcut\(c\.scheduledRun\)/.test(indexHtml) &&
     /onContextMenu=\{openContextMenu\}/.test(indexHtml) &&
     /onTogglePinned && onTogglePinned\(chat\.id, !chat\.pinned\)/.test(indexHtml) &&
     /setConfirming\(true\)/.test(indexHtml) &&
@@ -1305,11 +1305,15 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   }
   await tick();
 
-  assert.strictEqual(updates, 1001, "stream boundaries and deltas should remain immediately observable");
-  assert.strictEqual(secondSubscriberUpdates, 1001,
+  // 节流契约（perf/memory-footprint-optimization）：每个 delta 仍立即 notify 一次
+  // （下限 1001 守住「流式边界与 delta 立即可观察」的原始回归方向）；在此之上，
+  // chat:delta 的流式 markdown 尾沿节流定时器（~180ms）可能在长流期间插入最多
+  // 数次额外的渲染快照（≤ 时长/180ms），属预期而非合并丢失。
+  assert.ok(updates >= 1001, "stream boundaries and deltas should remain immediately observable");
+  assert.ok(secondSubscriberUpdates >= 1001,
     "all subscribers should receive one immediate update per stream boundary and delta");
-  assert.strictEqual(snapshots.length, 1001, "the regression must retain every persistent snapshot");
-  assert.strictEqual(secondSubscriberSnapshots.length, 1001,
+  assert.ok(snapshots.length >= 1001, "the regression must retain every persistent snapshot");
+  assert.ok(secondSubscriberSnapshots.length >= 1001,
     "the second subscriber must retain every same-round snapshot for identity checks");
   assert.strictEqual(
     harness.getStructuredCloneCalls(),

--- a/pinvou3-app/tests/scheduled_tasks_unit.test.js
+++ b/pinvou3-app/tests/scheduled_tasks_unit.test.js
@@ -1305,10 +1305,13 @@ async function longSessionStreamingAvoidsPerDeltaDeepClone() {
   }
   await tick();
 
-  // 节流契约（perf/memory-footprint-optimization）：每个 delta 仍立即 notify 一次
-  // （下限 1001 守住「流式边界与 delta 立即可观察」的原始回归方向）；在此之上，
-  // chat:delta 的流式 markdown 尾沿节流定时器（~180ms）可能在长流期间插入最多
-  // 数次额外的渲染快照（≤ 时长/180ms），属预期而非合并丢失。
+  // Throttle contract (perf/memory-footprint-optimization): every delta
+  // still notifies immediately (the floor of 1001 preserves the original
+  // regression direction "streaming boundaries and deltas are immediately
+  // observable"); on top of that, the chat:delta streaming markdown
+  // trailing-edge throttle timer (~180ms) may insert a few extra render
+  // snapshots during a long stream (≤ duration/180ms) — expected, not
+  // dropped coalescing.
   assert.ok(updates >= 1001, "stream boundaries and deltas should remain immediately observable");
   assert.ok(secondSubscriberUpdates >= 1001,
     "all subscribers should receive one immediate update per stream boundary and delta");

--- a/pinvou3-app/tests/vite_static_assets_contract.test.mjs
+++ b/pinvou3-app/tests/vite_static_assets_contract.test.mjs
@@ -13,6 +13,7 @@ const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const sourceRoot = path.join(appRoot, 'src');
 const distRoot = path.join(appRoot, 'dist');
 const distIndexPath = path.join(distRoot, 'index.html');
+const webDistIndexPath = path.resolve(appRoot, '../remote-control-relay/web/dist/index.html');
 
 test('classic runtime script parser recognizes only real HTML attributes', () => {
   const html = `
@@ -89,9 +90,32 @@ test('Vite build contains every local classic runtime script referenced by index
   const sourceIndex = fs.readFileSync(path.join(sourceRoot, 'index.html'), 'utf8');
 
   const expected = localClassicScriptPaths(sourceIndex).sort(); // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic string order is the assertion's expectation
-  const built = localClassicScriptPaths(fs.readFileSync(distIndexPath, 'utf8')).sort(); // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic string order is the assertion's expectation
+  const distIndex = fs.readFileSync(distIndexPath, 'utf8');
+  const built = localClassicScriptPaths(distIndex).sort(); // eslint-disable-line unicorn/require-array-sort-compare -- lexicographic string order is the assertion's expectation
   assert.ok(expected.length > 0, 'index.html must retain classic runtime scripts');
-  assert.deepEqual(built, expected, 'built index classic runtime references changed');
+  // The conditional platform transform strips the other platform's bridge tags
+  // per mode, so the desktop index references a subset of the shared source
+  // list rather than an exact copy. New references must still come from the
+  // shared source manifest.
+  assert.deepEqual(
+    built.filter((relative) => !expected.includes(relative)),
+    [],
+    'built index introduced classic runtime references absent from source index',
+  );
+  assert.ok(
+    built.some((relative) => relative.startsWith('platform/tauri/')),
+    'desktop index must keep the tauri bridge scripts',
+  );
+  for (const prefix of ['platform/web/']) {
+    assert.ok(
+      built.every((relative) => !relative.startsWith(prefix)),
+      `desktop index must not reference ${prefix} scripts: ${built.filter((relative) => relative.startsWith(prefix)).join(', ')}`,
+    );
+  }
+  assert.ok(
+    distIndex.includes('window.PinvouPlatform = Object.freeze({ kind: "desktop", isWeb: false })'),
+    'desktop index must inline the desktop platform marker replacing bootstrap.js',
+  );
 
   for (const relative of expected) {
     const sourcePath = resolveContainedRuntimePath(sourceRoot, relative);
@@ -104,4 +128,31 @@ test('Vite build contains every local classic runtime script referenced by index
       `runtime build asset differs from source: ${relative}`,
     );
   }
+});
+
+test('web build index strips tauri-only bridge scripts', {
+  skip: fs.existsSync(webDistIndexPath) ? false : 'run npm run build:web to verify web artifacts',
+}, () => {
+  const sourceIndex = fs.readFileSync(path.join(sourceRoot, 'index.html'), 'utf8');
+  const expected = localClassicScriptPaths(sourceIndex);
+  const webIndex = fs.readFileSync(webDistIndexPath, 'utf8');
+  const built = localClassicScriptPaths(webIndex);
+
+  assert.deepEqual(
+    built.filter((relative) => !expected.includes(relative)),
+    [],
+    'web index introduced classic runtime references absent from source index',
+  );
+  assert.ok(
+    built.every((relative) => !relative.startsWith('platform/tauri/')),
+    `web index must not reference platform/tauri/ scripts: ${built.filter((relative) => relative.startsWith('platform/tauri/')).join(', ')}`,
+  );
+  for (const relative of ['platform/web/bootstrap.js', 'platform/web/bridge.js', 'shared/bridge-messages.js']) {
+    assert.ok(built.includes(relative), `web index must keep ${relative}`);
+  }
+  assert.equal(
+    webIndex.includes('window.PinvouPlatform = Object.freeze({ kind: "desktop", isWeb: false })'),
+    false,
+    'web index must not inline the desktop platform marker',
+  );
 });

--- a/pinvou3-app/tests/vite_static_assets_contract.test.mjs
+++ b/pinvou3-app/tests/vite_static_assets_contract.test.mjs
@@ -136,7 +136,17 @@ test('web build index strips tauri-only bridge scripts', {
   const sourceIndex = fs.readFileSync(path.join(sourceRoot, 'index.html'), 'utf8');
   const expected = localClassicScriptPaths(sourceIndex);
   const webIndex = fs.readFileSync(webDistIndexPath, 'utf8');
-  const built = localClassicScriptPaths(webIndex);
+  // build:web bakes the relay deployment base (vite.config.mjs
+  // normalizeWebBasePath: PINVOU_REMOTE_PUBLIC_BASE_PATH, default
+  // /pinvou3/remote) into every copied runtime URL; strip it so the built
+  // index compares against source-relative paths.
+  const webBase = String(process.env.PINVOU_REMOTE_PUBLIC_BASE_PATH || '/pinvou3/remote')
+    .replace(/^https?:\/\/[^/]+/iu, '')
+    .replace(/^\/+|\/+$/gu, '');
+  const built = localClassicScriptPaths(webIndex)
+    .map((relative) => (webBase && relative.startsWith(`${webBase}/`)
+      ? relative.slice(webBase.length + 1)
+      : relative));
 
   assert.deepEqual(
     built.filter((relative) => !expected.includes(relative)),

--- a/pinvou3-app/vite.config.mjs
+++ b/pinvou3-app/vite.config.mjs
@@ -34,6 +34,75 @@ export const staticRuntimeScripts = new Set([
 ]);
 export const staticRuntimeScriptPrefixes = ['platform/tauri/bridge/', 'platform/web/bridge/'];
 
+// Desktop marker injected in place of platform/web/bootstrap.js. It replicates
+// bootstrap.js's only desktop side effect (the `window.__TAURI__` branch at the
+// top of that file) verbatim: kind/isWeb without a capabilities map, so
+// shared/platform.js keeps merging in DEFAULT_DESKTOP_CAPABILITIES exactly as
+// before. Kept ES2021-clean and attribute-free so audit-compat and CSP stay
+// unaffected.
+export const desktopPlatformMarkerScript = '<script>'
+  + 'if (window.__TAURI__) { window.PinvouPlatform = Object.freeze({ kind: "desktop", isWeb: false }); }'
+  + '</script>';
+
+const scriptSrcLinePattern = /<script\b[^>]*?\ssrc=["']([^"']*)["'][^>]*>/u;
+
+// Resolve the runtime-relative path of a single-line classic `<script src>`
+// tag, or null for anything else (inline scripts, module entries, external
+// URLs). Mirrors localClassicScriptPaths normalization so both layers agree.
+function lineScriptRuntimePath(line) {
+  const match = scriptSrcLinePattern.exec(line);
+  if (!match) return null;
+  const src = match[1].trim();
+  if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/iu.test(src)) return null;
+  const withoutBase = src.replace(/^%BASE_URL%/u, '').replace(/^\/+/u, '');
+  const relative = withoutBase.split(/[?#]/u, 1)[0] || null;
+  // Build/dev base rewriting may prefix the deployment base (the web relay
+  // serves under e.g. /pinvou3/remote/), so the runtime-relative path starts
+  // at the platform segment, not at the leading slash.
+  const platformAt = relative.indexOf('/platform/');
+  return platformAt >= 0 ? relative.slice(platformAt + 1) : relative;
+}
+
+// The desktop and web builds ship one shared index.html; every window of both
+// products previously parsed BOTH platforms' bridge code (~0.5 MB per window
+// on the losing side) and each bridge returned immediately through its
+// platform guard. This pure transform keeps each build's own bridge tags in
+// their original order and drops the other platform's:
+//   - desktop (every mode except `web`, including the dev server): removes the
+//     five `platform/web/` tags, replacing bootstrap.js in place with the
+//     desktop marker above (its sole desktop side effect).
+//   - web (`--mode web`): removes the `platform/tauri/` fragment tags and
+//     platform/tauri/bridge.js. On web those scripts parse and no-op today:
+//     the fragments only fill `window.__PINVOU_TAURI_BRIDGE_FEATURES__`, whose
+//     sole reader (platform/tauri/bridge.js) returns before any side effect
+//     when PinvouPlatform.kind === "web" (set earlier by the retained
+//     platform/web/bootstrap.js).
+// Build-time `%BASE_URL%`/base rewriting runs before this hook in both the dev
+// and build HTML pipelines, and the path normalization above accepts both the
+// raw placeholder and a rewritten base. Tag order of everything retained is
+// untouched, so execution-order semantics are preserved on both sides.
+export function transformIndexHtmlForPlatform(webBuild, html) {
+  return html.split('\n').map((line) => {
+    const relative = lineScriptRuntimePath(line);
+    if (!relative) return line;
+    if (webBuild) {
+      return relative.startsWith('platform/tauri/') ? '' : line;
+    }
+    if (!relative.startsWith('platform/web/')) return line;
+    if (relative === 'platform/web/bootstrap.js') return desktopPlatformMarkerScript;
+    return '';
+  }).join('\n');
+}
+
+function conditionalPlatformScripts(webBuild) {
+  return {
+    name: 'pinvou-conditional-platform-scripts',
+    transformIndexHtml(html) {
+      return transformIndexHtmlForPlatform(webBuild, html);
+    },
+  };
+}
+
 // Verbatim-copied static assets referenced by string paths instead of ESM
 // imports (JSX `src="..."` literals, `resolveAppAssetUrl('...')`, CSS url(), or
 // dynamic prefixes like `file-icons/theme/${iconFile}` and
@@ -140,7 +209,7 @@ export default defineConfig(({ mode }) => {
     port: Number(process.env.PINVOU3_UI_DEV_PORT || 1420),
     strictPort: true,
   },
-  plugins: [react(), copyRuntimeAssets(), enforceAcpLazyChunk()],
+  plugins: [react(), copyRuntimeAssets(), enforceAcpLazyChunk(), conditionalPlatformScripts(webBuild)],
   build: {
     outDir: webBuild ? '../../remote-control-relay/web/dist' : '../dist',
     emptyOutDir: true,

--- a/remote-control-relay/test/web-ui.smoke.cjs
+++ b/remote-control-relay/test/web-ui.smoke.cjs
@@ -582,15 +582,18 @@ async function main() {
         && !Object.hasOwn(message, 'session_id')
         && !Object.hasOwn(message, 'room_id')
     )));
+  // The web build strips platform/tauri/ bridge scripts at build time
+  // (conditional platform scripts in vite.config.mjs), so the page must load
+  // the web bridge set and must not request any tauri-side script at all.
   const exactFixedAssets = [
     `${basePath}/platform/web/bootstrap.js`,
-    `${basePath}/platform/tauri/bridge.js`,
     `${basePath}/platform/web/access-policy.json`,
   ];
   record('extensionless SPA 深链仍连接固定 base WebSocket 并加载固定资源',
     browserWebSocketUrls.length >= 2
       && browserWebSocketUrls.every(url => url === wsUrl)
       && exactFixedAssets.every(target => relayHttpRequestTargets.includes(target))
+      && !relayHttpRequestTargets.some(target => target.includes('/platform/tauri/'))
       && !relayHttpRequestTargets.some(target => target.includes('/conversations/current/web-')),
     `${browserWebSocketUrls.join(', ')} | ${exactFixedAssets.join(', ')}`);
 


### PR DESCRIPTION
## Summary

A dedicated memory-footprint audit (10 parallel audit passes over the frontend bridges, React features, Rust backend, build output, and the CodeWhale submodule) found one architectural hot path plus a set of bounded-but-real waste points. This PR fixes 19 significant issues across the four audit areas: lazy loading/unloading, leaks and unbounded growth, cache effectiveness, and redundant rendering. Findings that need a product decision or upstream work are listed at the end.

The codebase's existing memory hygiene is strong (LRU/byte-capped rings, Weak registries, TTL patrols), so the fixes target the genuine outliers rather than blanket hardening.

## Changes

**Frontend streaming hot path (c4a90731, 84eaa948)**
- Stream markdown re-render is throttled to a 180ms trailing edge instead of re-parsing the entire accumulated text with marked+DOMPurify+hljs on every `chat:delta` (O(n²) per reply); every terminal/transition path flushes synchronously so final html is exact.
- `toolMeta` no longer keeps every historical tool call's args resident after replay backfill, and interrupted turns sweep orphaned entries.
- App-level O(sessions) sidebar derivations are memoized; sidebar rows and chat bubbles are `React.memo`'d with per-item parse caches, so background-session tokens and composer keystrokes stop re-running regex passes over all messages.
- Codex view ticks elapsed time in the smallest subtree instead of re-rendering the whole 4.3k-line view at 1Hz.
- Background shell tails share the 128KB live cap and become idempotent once finished; monitor polling notifies only when the displayed snapshot changes; the knowledge view caps its cached document table and drops output lists on unmount; three async Tauri listener registrations get disposed-guards.

**Startup payload (b55696be)**
- The shared `index.html` made every desktop window parse ~0.5MB of web-only bridge code (and the web build ~630KB of tauri-only code), all no-op through platform guards. A pure `transformIndexHtml` step now keeps each mode's own bridge tags in original order and drops the other platform's; desktop replaces web `bootstrap.js` with an inline marker replicating its only desktop side effect.
- Disclosed dev-workflow change: opening the desktop dev server in a plain browser (no `window.__TAURI__`) previously ran the full web bridge simulation; it now lands in the documented degraded browser-preview fallback of `platform/tauri/bridge.js`. `tauri dev` and `vite dev --mode web` are unaffected.

**Rust backend (bf8f99af, adc5351c, 1b2aeb48)**
- ACP timeline journal: shared per-session buffered writer instead of open+write+flush per streamed token (flush at turn boundaries / 64KB, reopen-on-error, drop flush); `last_seq` reads a 256KB tail window instead of parsing the whole file.
- Disclosed durability trade-off: neither side ever fsyncs, but a hard kill can now drop up to the 64KB buffered window of non-boundary chunk events, so crash resume can miss the tail of the in-flight assistant message. Turn boundaries, `runtime_error`, orphan recovery, and sequence resume stay synchronous and are unaffected.
- Session persistence: the forwarder no longer deep-copies the whole transcript per message (the snapshot is Arc-shared and the durable copy happens once inside the store), revision is computed once per persist, and the duplicate terminal re-persist of identical content is skipped. Per-message persist cadence (crash resilience) is unchanged.
- Shell monitor: 80ms→250ms poll, skips decode while a running job's output byte length is unchanged, and reconciles live deltas against a bounded 64KB-per-stream tail cursor (memory and per-tick compare costs stay bounded while live output keeps flowing for arbitrarily verbose jobs; final output still comes from authoritative terminal tails).
- Misc: evicted ACP metadata backends on session evict, single-entry eviction for the multiagent blocked cache, size-checked artifact image reads, mtime-keyed parse cache for the deliverables index, 400ms debounce for scheduled-run watcher events, watcher skip for the internal workflow audit journal.

## Review follow-ups (f2f605bfa..4c3bfe46e)

Independent re-audit against source confirmed the root causes above and found no correctness defects in the Rust changes; four follow-ups are included in this push:

- test(relay): the SPA deep-link smoke still asserted that the web page requests `platform/tauri/bridge.js`, which the build-time strip intentionally removes — this was the only red CI lane. The contract now expects the web asset set and forbids tauri-side script requests (verified locally: full `web-ui.smoke.cjs`, 32/32 journeys green).
- fix(monitor): the snapshot equality gate froze `fmt.updatedAt`, which stalled the sparkline ring history during display-steady workloads; sampling is now driven by the local 1s page clock, restoring the one-sample-per-second cadence.
- fix(chat): the five `chat:tool_end` reset sites now honor the stated throttle invariant (`flushPendingStreamRender` before resetting stream state) — a proven no-op with the current forwarder, hardened against engines that stream text between tool_start and tool_end; chat protocol hash refreshed.
- chore(ui): documented the `bridge.available` invariant that lets `scheduledRunShortcuts` omit it from its memo deps.

## Review round 2 follow-ups (rebase + 1bf39743..c5515398)

Rebased onto the latest `main` (the rebase auto-merged cleanly; all six overlapping files changed in disjoint regions, and the ChatBubble/memoization chain was re-verified against main's `subscriptionStateValue` structural projection, so main's new in-place shell-card mutations still surface as fresh item references). Both review findings were confirmed and fixed:

- **fix(shell): keep live output flowing past the mirror window (1bf39743).** The review correctly identified that once `emitted_stdout + emitted_stderr` crossed 8MB, `reconcile` stopped emitting all deltas for the rest of the job — freezing the live view of verbose long-running builds/servers that never finish. The hard stop is replaced by a bounded-tail reconciliation cursor: each stream keeps the last 64KB of already-emitted text plus the byte offset where that tail starts inside the job's full output buffer, so memory and per-tick compare costs stay bounded while live deltas keep flowing; the terminal `BackgroundFinished` snapshot still carries the authoritative tails. `oversized_mirror_stops_deltas_but_completion_still_fires` is replaced by `bounded_mirror_keeps_streaming_after_the_window_overflows`, which crosses the window, appends later progress, verifies it reaches the display before completion, and checks the closing event. A cursor read API upstream remains the real fix for the per-tick full clone+decode and is still listed under leftovers.
- **docs: translate PR-added comments/diagnostics to English (cc6a1e1d).** All PR-added implementation comments, docstrings, and error-context diagnostics across the touched Rust/JS files are now English. Deliberately unchanged: the artifacts image-size error (user-facing copy, reused verbatim from the same function's pre-existing message), backend protocol literals used as i18n mapping keys in ChatView, and multibyte test fixtures.
- **test(chat): refresh the chat protocol hash (c5515398).** The translations landed inside captured `invoke`/`listen` bodies, so the digest changed. Verified as a pure capture-text refresh: entry counts are unchanged and the comment-stripped signature list is byte-identical to the pre-translation state — no new invoke or listen entries.

## Verification

- `cargo fmt` / `check --all-targets` / `clippy` clean; `cargo test`: 1991 passed, 0 failed
- Frontend node suite: 528 passed, 0 failed (17 pre-existing skips); eslint + knip clean
- `scripts/architecture-guard.py` and `fork-guard.sh --fast` pass
- Production `build:ui` smoke: desktop dist contains zero `platform/web/` references and the desktop marker; dist-gated contract tests pass
- After the follow-up push: affected suites re-run green (bridge protocol hash, conditional platform scripts, scheduled tasks, code-mode exit, full `npm test`, eslint/knip), and the full relay `web-ui.smoke.cjs` passes locally against a fresh `build:web` (32/32 journeys, exit 0)
- After the rebase + review round 2: `cargo fmt --check`, `cargo check --lib --all-targets`, and the CI-equivalent `cargo clippy --lib --bins --tests --no-deps --features dev-tools` pass locally (the only clippy hits with the extra `-D warnings` variant are pre-existing `undocumented_unsafe_blocks` in Windows-only platform adapter files and the CodeWhale submodule — cfg-excluded on the Linux CI gate, none in PR-touched files); full `cargo test` remains blocked locally by the known codewhale-tui thin-LTO stack overflow and runs in CI (`rust-test` / `windows-rust-test`); frontend `test:node` 556 pass / 0 fail / 3 pre-existing skips; eslint 0 errors (2 unused-directive warnings verified pre-existing on the pre-translation tree); knip, `architecture-guard.py`, and `fork-guard.sh --fast` pass

## Leftovers (intentionally out of scope)

- Tailwind 404KB runtime JIT → precompiled CSS migration (pet window already has a static-CSS precedent); needs a full visual regression pass.
- CodeWhale upstream: full-transcript deep clones in emergency compaction / per-turn token estimate / tool-context snapshot / per-request paths, the unbounded shell job buffer (root fix needs a cursor API), and the root cause of `transcript_rules` linear growth (engine state holding raw prompts).
- `platform/web/bridge.js` mirrors of the throttle/toolMeta/monitor fixes (web deployment parity).
- Minor: trimming the unconditional idle prefetch, lazy-loading low-frequency bridge fragments, a byte budget for the browser RequestLedger, the browser host's idle 100ms `read_dir` fallback, and moving ~12MB of `include_dir` resources to bundle resources.





## Review round 3 / rebase onto 0.9.3 (59f60f1a)

Rebased onto `a14b38d1`; conflicts in `ChatView.jsx` / `CodexAcpView.jsx` / `MonitorView.jsx` resolved organically — main's #427 component consolidation kept, the PR's optimizations re-expressed on the new architecture (clock scoping via `ConversationTurnView`'s internal `useConversationSecondClock` + `LiveConversationActivityIndicator` for the composer indicator; monitor sampling deps on the shared `clockNow`; legacy-branch contentVisibility wrapper dropped as dead code). Two rebase-surfaced gaps fixed: orphaned `set-state-in-effect` directives in `KnowledgeView.jsx` removed (lint:ui now 0/0), and the PR-added dist-gated web index contract adapted to main's relay deployment base (`/pinvou3/remote`). Re-verified per area: node suite 552/0/15 (dist-gated contracts now execute), eslint 0/0, knip, exact CI clippy gates, targeted Rust suites (assistant 300 / monitor 37 / scheduled 50 / knowledge 64 / sessions 105), architecture + fork guards, desktop dist contract, fresh `build:web` + relay smoke 32/32. Details in the review reply.



## Review round 4 / rebase onto latest main (06ea2d4b)

Rewrote the two commit subjects that exceeded the 50-character description limit (`commit-message` was the only failing check): `chore(ui): adapt comments and lint directives after rebase` (47) and `test(web): strip relay base prefix in web index contract` (45); bodies and sign-offs unchanged, tree byte-identical. Also rebased onto the new `05099187` head (main's #428 design-lane merge + #459 custom model port) — zero textual conflicts; the PR's memoization/clock changes were re-checked against #428's composer simplification on the merged file (stable `ChatBubble` callback props intact). Re-verified: commit-message validation over the full range, node suite 552/0/15 against fresh dists, eslint 0/0, knip, `cargo fmt` + both CI clippy gates, targeted Rust suites (sessions 107 / monitor 37 / prefs 52), architecture + fork guards, fresh `build:ui`, `build:web` + relay smoke 32/32.



## Review round 5 / rebase onto v0.9.12 main (1c1a6567)

Rebased onto `9a92684d` (CodeWhale v0.9.12 upgrade); head is now `1c1a6567`. Two real conflict areas, both resolved organically and re-verified: `shell_output.rs` keeps main's `is_shell_execution_tool` v0.9.12 gate (lowercase `bash` + replay aliases) with the PR's StreamMirror/cursor rework merged around it, and the `chat` bridge protocol digest was recomputed at each conflicting replay step with main's and the PR's recompute reasons merged — structural check confirms 59 invoke/listen entries with identical name sets on both sides (capture-text-only shift). All prior review findings re-verified in the tree (bounded-tail cursor, capacity-bounded mirror rebuild, English comments, ≤50-char subjects). Re-verified: `cargo fmt`, CI clippy gate, targeted Rust suites (assistant 302 / sessions 118 / knowledge 78 / scheduled 51 / multiagent 24), node suite 553/0/15 against fresh dists, eslint, knip, both guards, relay smoke 32/32. Details in the review reply.
