### PR TITLE
build: allow unrs-resolver postinstall script

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -168,5 +168,8 @@
     "eslint-plugin-react": {
       "eslint": "$eslint"
     }
+  },
+  "allowScripts": {
+    "unrs-resolver@1.12.2": true
   }
 }


### PR DESCRIPTION
## What changed and why

npm 11 blocks dependency install scripts by default and emits an `npm install-scripts` warning for `unrs-resolver@1.12.2` (a transitive dependency pulled in by `eslint-plugin-import-x`) during `npm ci`. This adds an explicit project-level `allowScripts` entry in `pinvou3-app/package.json` so the package's `postinstall` script is approved for every contributor and CI run, instead of each developer getting a silently skipped script plus a warning.

The `postinstall` script (`node postinstall.js`) calls `checkAndPreparePackage(packageJson, true)` from the locked `napi-postinstall@0.3.4`. Approving it permits more than resolving/verifying an already installed binding; the full behavior is:

- **Normal path (binding present):** resolves the prebuilt native binding delivered through the platform-scoped optional dependencies. No subprocess, no network access.
- **Missing-binding path** (e.g. `--omit=optional`, damaged installation): spawns `npm install --loglevel=error --prefer-offline --no-audit --progress=false @unrs/resolver-binding-<platform>@1.12.2` in a temporary `npm-install/` directory inside the package, then moves the binding into place (`napi-postinstall/lib/index.js:64-134`).
- **Download fallback** (npm install fails, e.g. offline or controlled registry): resolves the registry via `npm config get registry`, downloads `https://registry.npmjs.org/@unrs/resolver-binding-<platform>/-/resolver-binding-<platform>-1.12.2.tgz` directly over HTTPS, extracts it, and writes the native binding next to the host package (`lib/index.js:137-141`). This path performs no integrity verification beyond HTTP 200.
- **Both fail:** postinstall throws `Failed to install package`, failing the install loudly.

So this approval permits subprocess (`npm`) and network (registry tarball download) fallback behavior, not only warning suppression.

## Affected areas, compatibility, and risks

- Development-only change in `pinvou3-app`; no runtime behavior change and no changes to dependencies or `package-lock.json`.
- The allowlist entry is pinned to `unrs-resolver@1.12.2`; if the dependency updates to a new version, the new version will need re-approval (npm fails closed, which is the intended safe default). The fallback install/download is likewise pinned to binding version `1.12.2` taken from the package's own metadata.
- Residual risk: the fallback paths (temp-dir `npm install` without the project lockfile, and the direct tarball download) do not verify integrity against `package-lock.json`. This is inherent to `napi-postinstall`, applies only when the platform binding is missing, and is disclosed here per the project convention on network access and external commands.
- Works without private services or credentials; no other platform is affected since the allowlist is package-level rather than platform-specific.

## Tests run

- `npm ci` with a clean `node_modules`: completes successfully with no skipped-install-script warning (Node 24, npm 11.19, Windows).
- `npm rebuild unrs-resolver`: postinstall executes under the new allowlist entry.
- `npm install-scripts ls`: reports no packages with unreviewed install scripts.
- `npm run build:ui`: passes after the clean reinstall.
- Deterministic missing-binding/offline validation against the actual locked `napi-postinstall@0.3.4`, with `child_process` and HTTP(S) intercepted (no real subprocess, package installation, filesystem mutation outside the temp sandbox, or network download):
  - Binding present: postinstall resolves with zero subprocess and zero network operations.
  - Binding missing: captured `npm install ... @unrs/resolver-binding-win32-x64-msvc@1.12.2` in the package's `npm-install` temp directory; no direct download attempted.
  - Binding missing + npm install failure: captured the fallback sequence — `npm config get registry`, then HTTPS GET of the pinned 1.12.2 platform tarball, with the extracted binding written next to the host package.
  - Offline (both paths fail): postinstall throws `Failed to install package`, failing loudly instead of silently skipping.

## Unverified scenarios

- Linux/macOS: npm reads the same `allowScripts` field and the fallback logic is platform-generic, but only the `win32-x64-msvc` binding resolution was exercised locally.
