### PR TITLE
fix(personas): clear deleted card selections

### DIFF
--- a/pinvou3-app/src-tauri/src/app/commands/personas.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/personas.rs
@@ -95,8 +95,21 @@ pub async fn update_persona(
 
 /// 删除自制卡。
 #[tauri::command]
-pub async fn delete_persona(persona_id: String) -> Result<(), String> {
-    crate::features::personas::delete_user_persona(&persona_id)
+pub async fn delete_persona(
+    persona_id: String,
+    app: AppHandle,
+    store: State<'_, SessionStore>,
+) -> Result<(), String> {
+    crate::features::personas::delete_user_persona(&persona_id)?;
+    for session_id in store.remove_persona_from_all(&persona_id) {
+        super::sessions::emit_session_event(
+            &app,
+            "session:persona_changed",
+            &session_id,
+            "unequipped",
+        );
+    }
+    Ok(())
 }
 
 /// 保存某 session 的卡牌加持/卸下事件时间线(sidecar,不进 messages)。

--- a/pinvou3-app/src-tauri/src/features/personas/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/personas/mod.rs
@@ -286,7 +286,11 @@ pub fn delete_user_persona(id: &str) -> Result<(), String> {
         return Err("只能删除自制卡".to_string());
     }
     let path = crate::platform::paths::user_personas_dir().join(format!("{id}.json"));
-    let _ = std::fs::remove_file(&path);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(format!("Failed to delete persona: {error}")),
+    }
     reload_user();
     Ok(())
 }
@@ -515,6 +519,18 @@ mod tests {
         // delete
         delete_user_persona(&sum.id).expect("delete");
         assert!(get(&sum.id).is_none(), "删后查不到");
+
+        // Missing files are idempotent; other filesystem failures must reach the UI.
+        delete_user_persona(&sum.id).expect("delete already missing card");
+        let blocked_path =
+            crate::platform::paths::user_personas_dir().join(format!("{}.json", sum.id));
+        std::fs::create_dir(&blocked_path).expect("create non-file deletion target");
+        let error = delete_user_persona(&sum.id).expect_err("directory is not a card file");
+        assert!(error.starts_with("Failed to delete persona:"));
+        assert!(
+            blocked_path.is_dir(),
+            "failed deletion must not remove the target"
+        );
 
         // cleanup
         match prev {

--- a/pinvou3-app/src-tauri/src/features/sessions/mode_state.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/mode_state.rs
@@ -474,6 +474,24 @@ impl SessionStore {
             .pending_persona_body = body;
     }
 
+    /// Clear a deleted persona and its one-shot body from every session that
+    /// still references it. Returning the affected IDs lets callers publish a
+    /// presentation update for each session after the atomic state change.
+    pub fn remove_persona_from_all(&self, persona_id: &str) -> Vec<String> {
+        let mut states = self.mode_states.write();
+        let mut changed = Vec::new();
+        for (session_id, state) in states.iter_mut() {
+            if state.active_persona.as_deref() != Some(persona_id) {
+                continue;
+            }
+            state.active_persona = None;
+            state.pending_persona_body = None;
+            changed.push(session_id.clone());
+        }
+        changed.sort();
+        changed
+    }
+
     pub fn set_mounted_collection(&self, id: &str, collection_id: Option<i64>) {
         let mounted = collection_id
             .filter(|collection_id| *collection_id > 0)

--- a/pinvou3-app/src-tauri/src/features/sessions/tests.rs
+++ b/pinvou3-app/src-tauri/src/features/sessions/tests.rs
@@ -2483,6 +2483,36 @@ fn pending_turn_injections_restore_on_drop_and_commit_only_after_submission() {
 }
 
 #[test]
+fn deleting_persona_clears_all_session_state_and_blocks_pending_restore() {
+    let (store, _g) = isolated_store();
+    for (session_id, persona_id, body) in [
+        ("session-a", "persona-a", "BODY A"),
+        ("session-b", "persona-a", "BODY B"),
+        ("session-c", "persona-b", "BODY C"),
+    ] {
+        store.set_active_persona(session_id, Some(persona_id.into()));
+        store.set_pending_persona_body(session_id, Some(body.into()));
+    }
+
+    let pending = store.take_pending_turn_injections("session-a");
+    assert_eq!(pending.persona_body(), Some("BODY A"));
+    assert_eq!(
+        store.remove_persona_from_all("persona-a"),
+        vec!["session-a".to_string(), "session-b".to_string()]
+    );
+    drop(pending);
+
+    for session_id in ["session-a", "session-b"] {
+        let state = store.mode_state(session_id);
+        assert!(state.active_persona.is_none());
+        assert!(state.pending_persona_body.is_none());
+    }
+    let untouched = store.mode_state("session-c");
+    assert_eq!(untouched.active_persona.as_deref(), Some("persona-b"));
+    assert_eq!(untouched.pending_persona_body.as_deref(), Some("BODY C"));
+}
+
+#[test]
 fn mounted_collections_are_ordered_deduplicated_and_legacy_compatible() {
     let (store, _g) = isolated_store();
     let sid = "s-multi-kb";

--- a/pinvou3-app/src/features/personas/Personas.jsx
+++ b/pinvou3-app/src/features/personas/Personas.jsx
@@ -153,7 +153,7 @@ import { deptLabelFor, personaText, DEPT_ORDER, ALL_DEPT, DEPT_OPTIONS, deptColo
               </div>
               {/* 删除(编辑态) */}
               {isEdit ? (
-                <button type="button" onClick={()=>{ if(confirmDel){ bridge.personas.deletePersona(init.id).then(()=>{ if(onDeleted) { onDeleted(init); } onClose(); }); } else { setConfirmDel(true); } }}
+                <button type="button" onClick={()=>{ if(confirmDel){ bridge.personas.deletePersona(init.id).then(()=>{ if(onDeleted) { onDeleted(init); } onClose(); }).catch(() => { setErr(t.cpToastDelFailed); }); } else { setConfirmDel(true); } }}
                   className="w-full rounded-[10px] py-3 text-[17px] transition-colors bg-[#fff] dark:bg-[#000]" style={{ color:'#FF3B30' }}>
                   {confirmDel ? t.cpDelThisConfirm : t.cpDeleteThis}
                 </button>

--- a/pinvou3-app/src/platform/tauri/bridge.js
+++ b/pinvou3-app/src/platform/tauri/bridge.js
@@ -2377,7 +2377,7 @@
   const resolveConversationAttachment = artifactsFeature.resolveConversationAttachment;
   const openConversationAttachment = artifactsFeature.openConversationAttachment;
   const revealConversationAttachment = artifactsFeature.revealConversationAttachment;
-  const personasFeature = installBridgeFeature("personas", { state, notify, invoke, listen, bt, isDefaultChatTitle, addSystemItem, addChatItem, timeStr, ensureSession, runOnSession, personaPlaceholderTitles });
+  const personasFeature = installBridgeFeature("personas", { state, sessionStates, notify, invoke, listen, bt, isDefaultChatTitle, addSystemItem, addChatItem, timeStr, ensureSession, runOnSession, personaPlaceholderTitles });
   const loadPersonas = personasFeature.loadPersonas;
   const getPersonas = personasFeature.getPersonas;
   const createPersona = personasFeature.createPersona;

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -9,6 +9,7 @@
   const registry = root.__PINVOU_TAURI_BRIDGE_FEATURES__ = root.__PINVOU_TAURI_BRIDGE_FEATURES__ || {};
   registry["personas"] = function (context) {
     const state = context.state;
+    const sessionStates = context.sessionStates;
     const notify = context.notify;
     const invoke = context.invoke;
     const bt = context.bt;
@@ -41,6 +42,7 @@
   // ── 用户自创卡 CRUD(写盘后刷新缓存) ──
   async function createPersona(input) {
     const sum = await invoke("create_persona", { input });
+    deletedPersonaIds.delete(sum.id);
     await refreshPersonas();
     return sum;
   }
@@ -53,6 +55,14 @@
   }
   async function deletePersona(personaId) {
     await invoke("delete_persona", { personaId });
+    // Invalidate live and cached selections only after deletion succeeds.
+    // Late reads/equip responses must not restore a card that no longer exists.
+    deletedPersonaIds.add(personaId);
+    if (state.activePersona && state.activePersona.id === personaId) state.activePersona = null;
+    Object.values(sessionStates).forEach(function (buffer) {
+      if (buffer.activePersona && buffer.activePersona.id === personaId) buffer.activePersona = null;
+    });
+    notify();
     await refreshPersonas();
   }
   // 给当前 session 加持一张专家面具。后端存 persona_id + 每 turn 注入人设;
@@ -90,6 +100,7 @@
     try {
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       const card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId });
+      if (deletedPersonaIds.has(personaId)) return null;
       lastEquippedSid = sid; // 成功加持的目标会话(即使已切走)：供紧随其后的引导卡定向(审计补充)
       if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
@@ -109,6 +120,7 @@
       // 同 session 换了一张不同的卡 → 先弹一条"已卸下旧专家",再弹新加持。
       // 旧专家在写点复核而非入口捕获：同会话快速连续换卡时,入口值可能已被
       // 上一次 equip 的权威写覆盖,陈旧值会播报错误的"已卸下"(二审补充)。
+      if (deletedPersonaIds.has(personaId)) return null;
       const prev = state.activePersona;
       if (prev && prev.id !== card.id) {
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
@@ -150,6 +162,7 @@
   //   与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
   // - lastEquippedSid 供 equip 后紧随的播报(如卡牌制造者引导卡)定向回
   //   发起会话——equip 的 await 窗口用户可能已切走。
+  const deletedPersonaIds = new Set();
   let personaSyncSeq = 0;
   let lastEquippedSid = null;
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
@@ -161,7 +174,7 @@
       // invoke 形状保持原样（协议指纹按文本计算）；发起瞬间 activeSessionId === sid。
       const persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
       if (sid !== state.activeSessionId || seq !== personaSyncSeq) return; // 已切走或被权威写/新 sync 作废
-      state.activePersona = persona;
+      state.activePersona = persona && !deletedPersonaIds.has(persona.id) ? persona : null;
     } catch { /* 旧 session 无加持,忽略 */ }
   }
   // 在【指定 session】追加卡牌制造者引导卡并落 sidecar(持久化,重载按 pos 插回)。

--- a/pinvou3-app/src/platform/tauri/bridge/personas.js
+++ b/pinvou3-app/src/platform/tauri/bridge/personas.js
@@ -49,6 +49,7 @@
   async function updatePersona(personaId, input) {
     const sum = await invoke("update_persona", { personaId, input });
     await refreshPersonas();
+    if (deletedPersonaIds.has(personaId)) return null;
     // 若改的正是当前 session 加持的卡, 同步挂件显示
     if (state.activePersona && state.activePersona.id === personaId) { state.activePersona = sum; notify(); }
     return sum;

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -3256,7 +3256,7 @@
     state.modeState = mode.ok && mode.value
       ? { mode: mode.value.mode || "yolo", multiAgent: !!mode.value.multi_agent }
       : { mode: "yolo", multiAgent: false };
-    state.activePersona = persona.ok ? (persona.value || null) : null;
+    state.activePersona = persona.ok && persona.value && !deletedPersonaIds.has(persona.value.id) ? persona.value : null;
     if (snapshot.ok && snapshot.value && Array.isArray(snapshot.value.collections)) {
       applyMountedCollections(snapshot.value);
     } else if (collections.ok && Array.isArray(collections.value)) {
@@ -8762,6 +8762,7 @@
   // ── 用户自创卡 CRUD(写盘后刷新缓存) ──
   async function createPersona(input) {
     const sum = await invoke("create_persona", { input });
+    deletedPersonaIds.delete(sum.id);
     await refreshPersonas();
     return sum;
   }
@@ -8774,6 +8775,14 @@
   }
   async function deletePersona(personaId) {
     await invoke("delete_persona", { personaId });
+    // Invalidate live and cached selections only after deletion succeeds.
+    // Late reads/equip responses must not restore a card that no longer exists.
+    deletedPersonaIds.add(personaId);
+    if (state.activePersona && state.activePersona.id === personaId) state.activePersona = null;
+    Object.values(sessionStates).forEach(function (buffer) {
+      if (buffer.activePersona && buffer.activePersona.id === personaId) buffer.activePersona = null;
+    });
+    notify();
     await refreshPersonas();
   }
   // 给当前 session 加持一张专家面具。后端存 persona_id + 每 turn 注入人设;
@@ -8811,6 +8820,7 @@
     const sid = state.activeSessionId;
     try {
       const card = await invoke("equip_persona", { sessionId: state.activeSessionId, personaId });
+      if (deletedPersonaIds.has(personaId)) return null;
       lastEquippedSid = sid; // 成功加持的目标会话(即使已切走)：供紧随其后的引导卡定向(与 tauri 对齐，审计补充)
       if (sid !== state.activeSessionId) return card; // 已切走：不写当前显示
       // 标题仍是默认占位(三语哨兵,见 isDefaultChatTitle)→ 用卡牌名命名(无论草稿态物化还是遗留空会话;
@@ -8830,6 +8840,7 @@
       // 同 session 换了一张不同的卡 → 先弹一条"已卸下旧专家",再弹新加持。
       // 旧专家在写点复核而非入口捕获：同会话快速连续换卡时,入口值可能已被
       // 上一次 equip 的权威写覆盖,陈旧值会播报错误的"已卸下"(与 tauri 对齐,二审补充)。
+      if (deletedPersonaIds.has(personaId)) return null;
       const prev = state.activePersona;
       if (prev && prev.id !== card.id) {
         addChatItem({ type: "system", text: bt("personaUnequipped") + personaName(prev), time: timeStr() });
@@ -8871,6 +8882,7 @@
   // 与 equip/unequip 权威写时递增,旧快照一律作废(审计补充)。
   // - lastEquippedSid 供 equip 后紧随的播报(如卡牌制造者引导卡)定向回
   //   发起会话——equip 的 await 窗口用户可能已切走。
+  const deletedPersonaIds = new Set();
   let personaSyncSeq = 0;
   let lastEquippedSid = null;
   // 切换/重载 session 后,从后端拉该 session 的加持状态还原挂件(backend 是真相)。
@@ -8881,7 +8893,7 @@
     try {
       const persona = await invoke("get_active_persona", { sessionId: state.activeSessionId }) || null;
       if (sid !== state.activeSessionId || seq !== personaSyncSeq) return; // 已切走或被权威写/新 sync 作废
-      state.activePersona = persona;
+      state.activePersona = persona && !deletedPersonaIds.has(persona.id) ? persona : null;
     } catch { /* 旧 session 无加持,忽略 */ }
   }
   // 在【指定 session】追加卡牌制造者引导卡并落 sidecar(持久化,重载按 pos 插回)。

--- a/pinvou3-app/src/platform/web/bridge.js
+++ b/pinvou3-app/src/platform/web/bridge.js
@@ -8769,6 +8769,7 @@
   async function updatePersona(personaId, input) {
     const sum = await invoke("update_persona", { personaId, input });
     await refreshPersonas();
+    if (deletedPersonaIds.has(personaId)) return null;
     // 若改的正是当前 session 加持的卡, 同步挂件显示
     if (state.activePersona && state.activePersona.id === personaId) { state.activePersona = sum; notify(); }
     return sum;

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -33,6 +33,7 @@ function loadFeature(fileName, state, contextOverrides) {
   const calls = { invoke: [] };
   const api = factory(Object.assign({
     state,
+    sessionStates: {},
     notify() { calls.notify = (calls.notify || 0) + 1; },
     bt(key) { return key; },
     addSystemItem(text) { state.chatItems.push({ type: 'system', text, id: 'sys-' + (state.chatItems.length + 1) }); },
@@ -325,4 +326,87 @@ test('equip 挂起期间 unequip 先完成：不重复播报入口捕获的旧�
   assert.equal(unequips.length, 1, '只播报一次卸下(陈旧入口 prev 会重复播报)');
   assert.equal(unequips[0].name, 'A专家');
   assert.equal(rt.state.activePersona.id, 'persona-x', '最后完成的 equip 为终态');
+});
+
+
+test('deletePersona clears matching live and cached selections after success', async () => {
+  const card = { id: 'user-a', name: 'Card A' };
+  const other = { id: 'user-b', name: 'Card B' };
+  const state = { activePersona: card, personaPool: {}, personaEvents: [{ kind: 'equip', card }] };
+  const sessionStates = { a: { activePersona: card }, b: { activePersona: other } };
+  const rt = loadFeature('personas.js', state, { sessionStates });
+  const deletion = rt.defer('delete_persona');
+  const refresh = rt.defer('list_personas');
+  const pending = rt.api.deletePersona(card.id);
+  assert.equal(state.activePersona, card, 'pending deletion must preserve selection');
+  deletion.resolve();
+  await new Promise(resolve => { setTimeout(resolve, 0); });
+  assert.equal(state.activePersona, null, 'clear before the list refresh completes');
+  assert.equal(sessionStates.a.activePersona, null);
+  assert.equal(sessionStates.b.activePersona, other);
+  assert.equal(state.personaEvents.length, 1, 'historical equip events are preserved');
+  refresh.resolve([other]);
+  await pending;
+});
+
+test('deletePersona failure preserves live and cached selections', async () => {
+  const card = { id: 'user-a' };
+  const state = { activePersona: card, personaPool: {} };
+  const sessionStates = { a: { activePersona: card } };
+  const rt = loadFeature('personas.js', state, { sessionStates });
+  const deletion = rt.defer('delete_persona');
+  const pending = rt.api.deletePersona(card.id);
+  deletion.reject(new Error('delete failed'));
+  await assert.rejects(pending, /delete failed/);
+  assert.equal(state.activePersona, card);
+  assert.equal(sessionStates.a.activePersona, card);
+  assert.equal(rt.calls.notify || 0, 0);
+});
+
+test('deletePersona does not clear a replacement selected while deletion is pending', async () => {
+  const rt = loadPersonasFeature();
+  rt.state.activePersona = { id: 'user-a' };
+  const deletion = rt.defer('delete_persona');
+  const pending = rt.api.deletePersona('user-a');
+  rt.state.activeSessionId = 'chat-b';
+  rt.state.activePersona = { id: 'user-b' };
+  deletion.resolve();
+  await pending;
+  assert.equal(rt.state.activePersona.id, 'user-b');
+});
+
+test('deletePersona blocks a late active-persona read from restoring the deleted card', async () => {
+  const rt = loadPersonasFeature();
+  const get = rt.defer('get_active_persona');
+  const sync = rt.api.syncActivePersona();
+  await rt.api.deletePersona('user-a');
+  get.resolve({ id: 'user-a' });
+  await sync;
+  assert.equal(rt.state.activePersona, null);
+});
+
+test('deletePersona blocks an in-flight equip response for the deleted card', async () => {
+  const rt = loadPersonasFeature();
+  const equip = rt.defer('equip_persona');
+  const pending = rt.api.equipPersona('user-a');
+  await rt.api.deletePersona('user-a');
+  equip.resolve({ id: 'user-a', name: 'Card A' });
+  assert.equal(await pending, null);
+  assert.equal(rt.state.activePersona, null);
+  assert.equal(rt.state.chatItems.length, 0);
+});
+
+
+test('recreated persona IDs can be equipped after deletion', async () => {
+  const rt = loadPersonasFeature();
+  await rt.api.deletePersona('user-a');
+  const create = rt.defer('create_persona');
+  const pending = rt.api.createPersona({ name: 'Card A' });
+  create.resolve({ id: 'user-a', name: 'Card A' });
+  await pending;
+  const equip = rt.defer('equip_persona');
+  const equipped = rt.api.equipPersona('user-a');
+  equip.resolve({ id: 'user-a', name: 'Card A' });
+  await equipped;
+  assert.equal(rt.state.activePersona.id, 'user-a');
 });

--- a/pinvou3-app/tests/memory_personas_race.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race.test.mjs
@@ -396,6 +396,17 @@ test('deletePersona blocks an in-flight equip response for the deleted card', as
   assert.equal(rt.state.chatItems.length, 0);
 });
 
+test('deletePersona blocks an in-flight update response for the deleted card', async () => {
+  const rt = loadPersonasFeature();
+  rt.state.activePersona = { id: 'user-a', name: 'Old card' };
+  const update = rt.defer('update_persona');
+  const pending = rt.api.updatePersona('user-a', { name: 'Updated card' });
+  await rt.api.deletePersona('user-a');
+  update.resolve({ id: 'user-a', name: 'Updated card' });
+  assert.equal(await pending, null);
+  assert.equal(rt.state.activePersona, null);
+});
+
 
 test('recreated persona IDs can be equipped after deletion', async () => {
   const rt = loadPersonasFeature();

--- a/pinvou3-app/tests/memory_personas_race_web.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race_web.test.mjs
@@ -277,3 +277,45 @@ test('web: 会话切回的 presentation-sync 不得被在途旧 sync 覆盖（�
   assert.equal(rt.view().activePersona && rt.view().activePersona.id, 'persona-prime',
     '在途旧 sync 的陈旧快照不得覆盖 presentation-sync 写回的权威挂件');
 });
+
+
+test('web: successful deletion clears the equipped card before pool refresh', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const refresh = rt.defer('list_personas');
+  const pending = rt.personas.deletePersona('persona-prime');
+  await new Promise(resolve => { setTimeout(resolve, 0); });
+  assert.equal(rt.view().activePersona, null);
+  refresh.resolve([]);
+  await pending;
+});
+
+test('web: failed deletion leaves the equipped card intact', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  rt.setHandler('delete_persona', () => Promise.reject(new Error('delete failed')));
+  await assert.rejects(rt.personas.deletePersona('persona-prime'), /delete failed/);
+  assert.equal(rt.view().activePersona.id, 'persona-prime');
+});
+
+test('web: late persona read cannot restore a deleted card', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const get = rt.defer('get_active_persona');
+  rt.emit('session:persona_changed', { id: 'chat-a' });
+  await rt.personas.deletePersona('persona-prime');
+  get.resolve({ id: 'persona-prime', name: 'Card A' });
+  await new Promise(resolve => { setTimeout(resolve, 0); });
+  assert.equal(rt.view().activePersona, null);
+});
+
+
+test('web: recreated persona IDs can be equipped after deletion', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  await rt.personas.deletePersona('persona-prime');
+  rt.setHandler('create_persona', async () => ({ id: 'persona-prime', name: 'Card A' }));
+  await rt.personas.createPersona({ name: 'Card A' });
+  await rt.personas.equipPersona('persona-prime');
+  assert.equal(rt.view().activePersona.id, 'persona-prime');
+});

--- a/pinvou3-app/tests/memory_personas_race_web.test.mjs
+++ b/pinvou3-app/tests/memory_personas_race_web.test.mjs
@@ -290,6 +290,16 @@ test('web: successful deletion clears the equipped card before pool refresh', as
   await pending;
 });
 
+test('web: successful deletion clears the cached session selection', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  rt.leave();
+  await rt.personas.deletePersona('persona-prime');
+  const switching = rt.sessions.switchToSession('chat-a');
+  assert.equal(rt.view().activePersona, null, 'cached presentation must be clear before backend sync');
+  await switching;
+});
+
 test('web: failed deletion leaves the equipped card intact', async () => {
   const rt = bootWebBridge();
   await primeSessionA(rt);
@@ -306,6 +316,28 @@ test('web: late persona read cannot restore a deleted card', async () => {
   await rt.personas.deletePersona('persona-prime');
   get.resolve({ id: 'persona-prime', name: 'Card A' });
   await new Promise(resolve => { setTimeout(resolve, 0); });
+  assert.equal(rt.view().activePersona, null);
+});
+
+test('web: in-flight equip cannot restore a deleted card', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const equip = rt.defer('equip_persona');
+  const pending = rt.personas.equipPersona('persona-prime');
+  await rt.personas.deletePersona('persona-prime');
+  equip.resolve({ id: 'persona-prime', name: 'Card A' });
+  assert.equal(await pending, null);
+  assert.equal(rt.view().activePersona, null);
+});
+
+test('web: in-flight update cannot restore a deleted card', async () => {
+  const rt = bootWebBridge();
+  await primeSessionA(rt);
+  const update = rt.defer('update_persona');
+  const pending = rt.personas.updatePersona('persona-prime', { name: 'Updated card' });
+  await rt.personas.deletePersona('persona-prime');
+  update.resolve({ id: 'persona-prime', name: 'Updated card' });
+  assert.equal(await pending, null);
   assert.equal(rt.view().activePersona, null);
 });
 


### PR DESCRIPTION
Deleting an equipped custom card refreshed the pool but left its current and cached chat selections visible. Clear matching selections after successful deletion in the desktop and Web bridges, and reject late reads/equip responses for deleted cards. Recreated IDs remain usable. Historical equip events are preserved.

Propagate filesystem deletion failures instead of reporting success; the editor keeps the card and displays the existing localized failure message.

Validation: 34 memory/persona regression tests, two bridge contract suites, ESLint, UI build, architecture guard, Rust formatting and diff checks passed. A temporary standalone Cargo harness loaded the unchanged production personas module directly, with an isolated paths adapter, and all nine module tests passed, including filesystem deletion failures and missing-file idempotency. Independent review found the deletion-error boundary; it was fixed and the second review approved the final code and scoped validation.

Limitation: full application Rust tests did not complete. The first attempt hit a thin-LTO compiler stack overflow in the unchanged CodeWhale TUI dependency. A retry with increased compiler stack was stopped after the focused production-module tests passed. The standalone harness does not cover full application integration; required CI still applies before merge. No engine, protocol, or localized copy changes.