### PR TITLE
chore(deps): repo-wide dependency audit and refresh

### DIFF
--- a/pinvou-cli/Cargo.lock
+++ b/pinvou-cli/Cargo.lock
@@ -20,7 +20,6 @@ dependencies = [
  "serde_json",
  "sha1 0.10.6",
  "sha2 0.10.9",
- "thiserror 2.0.20",
  "ureq",
  "windows-sys 0.61.2",
 ]
@@ -1314,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1954,6 +1953,12 @@ dependencies = [
  "core-foundation 0.10.1",
  "libc",
 ]
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -2672,11 +2677,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -5285,6 +5296,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6953,7 +6991,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -7658,9 +7696,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9106,7 +9144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/pinvou-cli/Cargo.toml
+++ b/pinvou-cli/Cargo.toml
@@ -8,6 +8,15 @@ rust-version = "1.89"
 license = "MIT"
 
 [workspace.dependencies]
+anyhow = "1.0"
 async-trait = "0.1.89"
+futures = "0.3"
+fs2 = "0.4"
+parquet = { version = "=59.1.0", default-features = false }
+rand = "0.9.4"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10.9"
 thiserror = "2.0"
+tokio = { version = "1.49", default-features = false }
+windows-sys = "0.61.2"

--- a/pinvou-cli/crates/adapter-gaia/Cargo.toml
+++ b/pinvou-cli/crates/adapter-gaia/Cargo.toml
@@ -12,25 +12,24 @@ test-support = []
 agent-backend-api = { path = "../agent-backend-api" }
 benchmark-core = { path = "../benchmark-core" }
 hf-hub = { version = "0.4.3", default-features = false, features = ["ureq", "rustls-tls"] }
-parquet = { version = "=59.1.0", default-features = false, features = ["snap", "flate2-rust_backend", "zstd"] }
-rand = "0.9"
+parquet = { workspace = true, features = ["snap", "flate2-rust_backend", "zstd"] }
+rand.workspace = true
 serde.workspace = true
-serde_json = "1"
+serde_json.workspace = true
 sha1 = "=0.10.6"
-sha2 = "0.10.9"
-thiserror.workspace = true
+sha2.workspace = true
 ureq = { version = "=2.12.1", default-features = false, features = ["tls"] }
-fs2 = "0.4"
+fs2.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
 
 [dev-dependencies]
 async-trait.workspace = true
 arrow-array = "=59.1.0"
 arrow-schema = "=59.1.0"
-futures = "0.3"
-parquet = { version = "=59.1.0", default-features = false, features = ["arrow", "snap", "flate2-rust_backend", "zstd"] }
+futures.workspace = true
+parquet = { workspace = true, features = ["arrow", "snap", "flate2-rust_backend", "zstd"] }
 
 [[test]]
 name = "dataset_contract"

--- a/pinvou-cli/crates/adapter-smoke/Cargo.toml
+++ b/pinvou-cli/crates/adapter-smoke/Cargo.toml
@@ -11,4 +11,4 @@ benchmark-core = { path = "../benchmark-core" }
 serde.workspace = true
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true

--- a/pinvou-cli/crates/agent-backend-api/Cargo.toml
+++ b/pinvou-cli/crates/agent-backend-api/Cargo.toml
@@ -11,5 +11,5 @@ serde.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-futures = "0.3"
-serde_json = "1.0"
+futures.workspace = true
+serde_json.workspace = true

--- a/pinvou-cli/crates/benchmark-core/Cargo.toml
+++ b/pinvou-cli/crates/benchmark-core/Cargo.toml
@@ -9,17 +9,17 @@ license.workspace = true
 agent-backend-api = { path = "../agent-backend-api" }
 async-trait.workspace = true
 serde.workspace = true
-serde_json = "1.0"
+serde_json.workspace = true
 thiserror.workspace = true
-tokio = { version = "1.49", features = ["time"] }
-rand = "0.9.4"
-sha2 = "0.10.9"
+tokio = { workspace = true, features = ["time"] }
+rand.workspace = true
+sha2.workspace = true
 zeroize = "1.9.0"
-fs2 = "0.4"
+fs2.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
 
 [dev-dependencies]
-futures = "0.3"
-tokio = { version = "1.49", features = ["macros", "rt", "time"] }
+futures.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/pinvou-cli/crates/cli/Cargo.toml
+++ b/pinvou-cli/crates/cli/Cargo.toml
@@ -14,8 +14,8 @@ adapter-gaia = { path = "../adapter-gaia" }
 adapter-smoke = { path = "../adapter-smoke" }
 agent-backend-api = { path = "../agent-backend-api" }
 benchmark-core = { path = "../benchmark-core" }
-serde_json = "1"
-anyhow = { version = "1.0", optional = true }
+serde_json.workspace = true
+anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 pinvou-product-backend = { path = "../pinvou-product-backend", optional = true }
 

--- a/pinvou-cli/crates/pinvou-product-backend/Cargo.toml
+++ b/pinvou-cli/crates/pinvou-product-backend/Cargo.toml
@@ -7,5 +7,5 @@ license.workspace = true
 
 [dependencies]
 agent-backend-api = { path = "../agent-backend-api" }
-anyhow = "1.0"
+anyhow.workspace = true
 pinvou3-lib = { package = "pinvou3-tauri", path = "../../../pinvou3-app/src-tauri", default-features = false, features = ["benchmark-hooks", "local-embed"] }

--- a/pinvou-knowledge/Cargo.lock
+++ b/pinvou-knowledge/Cargo.lock
@@ -824,6 +824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,11 +1164,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -2581,6 +2593,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,7 +3022,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.7.1",
  "url",
  "wait-timeout",
 ]
@@ -3544,7 +3583,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3585,7 +3624,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3713,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4475,13 +4514,30 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
  "uuid",
 ]
 

--- a/pinvou-knowledge/Cargo.lock
+++ b/pinvou-knowledge/Cargo.lock
@@ -4538,7 +4538,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -4717,17 +4716,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "v_frame"

--- a/pinvou-knowledge/Cargo.toml
+++ b/pinvou-knowledge/Cargo.toml
@@ -71,7 +71,7 @@ rcgen = { version = "=0.14.9", features = ["x509-parser"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "multipart", "stream"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"], optional = true }
 tar = { version = "0.4", optional = true }
-tower-http = { version = "0.6", features = ["catch-panic", "limit", "request-id", "trace"], optional = true }
+tower-http = { version = "0.7", features = ["catch-panic", "limit", "request-id", "trace"], optional = true }
 wait-timeout = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/pinvou-knowledge/Cargo.toml
+++ b/pinvou-knowledge/Cargo.toml
@@ -71,7 +71,7 @@ rcgen = { version = "=0.14.9", features = ["x509-parser"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "multipart", "stream"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"], optional = true }
 tar = { version = "0.4", optional = true }
-tower-http = { version = "0.7", features = ["catch-panic", "limit", "request-id", "trace"], optional = true }
+tower-http = { version = "0.7", features = ["catch-panic", "trace"], optional = true }
 wait-timeout = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/pinvou3-app/eslint.config.mjs
+++ b/pinvou3-app/eslint.config.mjs
@@ -159,7 +159,7 @@ export default defineConfig([
       'unicorn/prefer-dom-node-append': 'error',
       'unicorn/prefer-dom-node-remove': 'error',
       'unicorn/prefer-dom-node-text-content': 'error',
-      'unicorn/prefer-dom-node-dataset': 'error',
+      'unicorn/dom-node-dataset': 'error',
       'unicorn/prefer-query-selector': 'error',
       'unicorn/require-array-sort-compare': 'error',
       'unicorn/throw-new-error': 'error',

--- a/pinvou3-app/eslint.config.mjs
+++ b/pinvou3-app/eslint.config.mjs
@@ -46,7 +46,7 @@ export default defineConfig([
       ecmaVersion: 2021,
       sourceType: 'module',
       parserOptions: { ecmaFeatures: { jsx: true } },
-      globals: { ...globals.browser, DOMPurify: 'readonly', marked: 'readonly' },
+      globals: { ...globals.browser },
     },
     plugins: { compat, 'import-x': importX, jsdoc, unicorn, sonarjs },
     settings: { 'import-x/resolver': { node: { extensions: ['.js', '.jsx'] } } },

--- a/pinvou3-app/package-lock.json
+++ b/pinvou3-app/package-lock.json
@@ -33,7 +33,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-sonarjs": "^4.2.0",
-        "eslint-plugin-unicorn": "^73.0.0",
+        "eslint-plugin-unicorn": "^74.0.0",
         "globals": "^17.11.0",
         "jscpd": "^5.0.16",
         "knip": "^6.32.2",
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.10.tgz",
-      "integrity": "sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+      "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -321,20 +321,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.10",
-        "@biomejs/cli-darwin-x64": "2.5.10",
-        "@biomejs/cli-linux-arm64": "2.5.10",
-        "@biomejs/cli-linux-arm64-musl": "2.5.10",
-        "@biomejs/cli-linux-x64": "2.5.10",
-        "@biomejs/cli-linux-x64-musl": "2.5.10",
-        "@biomejs/cli-win32-arm64": "2.5.10",
-        "@biomejs/cli-win32-x64": "2.5.10"
+        "@biomejs/cli-darwin-arm64": "2.5.12",
+        "@biomejs/cli-darwin-x64": "2.5.12",
+        "@biomejs/cli-linux-arm64": "2.5.12",
+        "@biomejs/cli-linux-arm64-musl": "2.5.12",
+        "@biomejs/cli-linux-x64": "2.5.12",
+        "@biomejs/cli-linux-x64-musl": "2.5.12",
+        "@biomejs/cli-win32-arm64": "2.5.12",
+        "@biomejs/cli-win32-x64": "2.5.12"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.10.tgz",
-      "integrity": "sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+      "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
       "cpu": [
         "arm64"
       ],
@@ -349,9 +349,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.10.tgz",
-      "integrity": "sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+      "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
       "cpu": [
         "x64"
       ],
@@ -366,13 +366,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.10.tgz",
-      "integrity": "sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+      "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -383,13 +386,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.10.tgz",
-      "integrity": "sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+      "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -400,13 +406,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.10.tgz",
-      "integrity": "sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+      "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -417,13 +426,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.10.tgz",
-      "integrity": "sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+      "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -434,9 +446,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.10.tgz",
-      "integrity": "sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+      "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
       "cpu": [
         "arm64"
       ],
@@ -451,9 +463,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.10",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.10.tgz",
-      "integrity": "sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+      "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
       "cpu": [
         "x64"
       ],
@@ -465,6 +477,30 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
       }
     },
     "node_modules/@dependents/detective-less": {
@@ -526,17 +562,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.95.1",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.95.1.tgz",
-      "integrity": "sha512-LO/RI08Fo9bhXwB7Od9G+1j3eSNq63+ZS5CQO8YLXHbDg6kx6S/DhTeY0+Fc9uZrjK1zZSyTx8Sg5gv5DIoCnA==",
+      "version": "0.97.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.97.0.tgz",
+      "integrity": "sha512-EP8uoFfh6+GsdGCduYtmWAW0h7AO+Ayik9Vh5YbA2r/3N6lmJKkCNZX+q3QBXC1K6ixjQ/9igF2b7WVvLm063g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.67.0",
+        "@typescript-eslint/types": "^8.69.0",
         "comment-parser": "1.4.8",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~9.1.2"
+        "jsdoc-type-pratt-parser": "~9.2.1"
       },
       "engines": {
         "node": "^22.22.2 || >=24.15.0"
@@ -595,15 +631,15 @@
       }
     },
     "node_modules/@eslint-react/ast": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/ast/-/ast-5.18.6.tgz",
-      "integrity": "sha512-okgOez6L9onvcdU0lyLOykKQSaj2hMtVV2ucx2iqmTsfKDGyhVlMuNLnfyOkgQyHdgfROTVtAAYnQ6KPf7PggQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.19.0.tgz",
+      "integrity": "sha512-6d9UY/CVz+zGMi6+aext7HSOVAj2Fa9eL7okBRnjBeMrRhmRAqtbm1oK7J+VlWrmUNLsiNXpyklhq36BsmYddg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/typescript-estree": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/typescript-estree": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "string-ts": "^2.3.1"
       },
       "engines": {
@@ -615,19 +651,19 @@
       }
     },
     "node_modules/@eslint-react/core": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/core/-/core-5.18.6.tgz",
-      "integrity": "sha512-utvjmfgy/lMSMt4QSU5QK2coHk6tkRChxLmkW6z8sthgmB6138CYzC3cPR9kze5pOgYJouF95xiaPnHKnXx21A==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.19.0.tgz",
+      "integrity": "sha512-PFhetWfvG6ZhLiJomkzjKKCLu6DVbKdyeYZ7HE7/rvAvmfsNi9iCGBqxkgXWfWpWEf24KrRUVpS3wLGJpPL8+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/scope-manager": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/scope-manager": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -639,13 +675,13 @@
       }
     },
     "node_modules/@eslint-react/eslint": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/eslint/-/eslint-5.18.6.tgz",
-      "integrity": "sha512-8BzLB6mtIDmAIwAt1u4g6Yp+1LSGAnqm8SGNHbyZG1sQikWW9Fskv3fx5Zy6CGMV9D7gafcHTiVTcuBYNE+87w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.19.0.tgz",
+      "integrity": "sha512-wod1Yd/atJbUD36naGirzztZ9w4BAWSxwIxF8/6qT7PaN/Q9r/vTB/T5rmmgvMa3C/hp0yI3uqr4zbO2mRPBOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.67.0"
+        "@typescript-eslint/utils": "^8.69.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -656,19 +692,19 @@
       }
     },
     "node_modules/@eslint-react/eslint-plugin": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/eslint-plugin/-/eslint-plugin-5.18.6.tgz",
-      "integrity": "sha512-qBZXKx05CPNrvdNydM958rZt2hgVhhriU/8LUeS5s/5gdpuekflrfF+y3yT4NT8Ej3J37h7e50RdH6Lu1r0KPg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.19.0.tgz",
+      "integrity": "sha512-SA3+Iz87sH3pq8hFHb+QhYrOpOyzut+k9YCx2WCJsapK3fu7odk73GRXB6J/W5f8tz0J0ARj1r+DsaSdGtF/zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/shared": "5.18.6",
-        "eslint-plugin-react-dom": "5.18.6",
-        "eslint-plugin-react-jsx": "5.18.6",
-        "eslint-plugin-react-naming-convention": "5.18.6",
-        "eslint-plugin-react-rsc": "5.18.6",
-        "eslint-plugin-react-web-api": "5.18.6",
-        "eslint-plugin-react-x": "5.18.6"
+        "@eslint-react/shared": "5.19.0",
+        "eslint-plugin-react-dom": "5.19.0",
+        "eslint-plugin-react-jsx": "5.19.0",
+        "eslint-plugin-react-naming-convention": "5.19.0",
+        "eslint-plugin-react-rsc": "5.19.0",
+        "eslint-plugin-react-web-api": "5.19.0",
+        "eslint-plugin-react-x": "5.19.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -679,18 +715,18 @@
       }
     },
     "node_modules/@eslint-react/jsx": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/jsx/-/jsx-5.18.6.tgz",
-      "integrity": "sha512-oAbG2pW6XhiROZotfSjLU19A84/AxYHiiKjim5USHH5xtYfYjO7skFSM6LztuPggqn/wccSxLgmKIFGUKM/95g==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.19.0.tgz",
+      "integrity": "sha512-iqauNb+qeNaEbG7VfDj+8taRLJFbEkptzdPx+YnIbyxhCVAnMaB3s/yeVyi4nszja7YwE/FccFInPZ4Qv8fVZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -702,14 +738,14 @@
       }
     },
     "node_modules/@eslint-react/shared": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/shared/-/shared-5.18.6.tgz",
-      "integrity": "sha512-zCzb/W1xwG412BWVTjqhDznsJEHdyZVkVJz4jbAebHLpKxygK5XeG+vShdYbIFC7OcJU8hYbvEf3P2UNqXVhBw==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.19.0.tgz",
+      "integrity": "sha512-4x56YzT3Gph725Z8x1vMbOYUkOpbqp2v9NuFb9F7GqVmyZq9OxAQPEj5b7o+Fd2C1VIC3mHNCfL3FHVZ1YH8mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eslint": "5.18.6",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "ts-pattern": "^5.9.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -722,17 +758,17 @@
       }
     },
     "node_modules/@eslint-react/var": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/@eslint-react/var/-/var-5.18.6.tgz",
-      "integrity": "sha512-5pxFlOy0Ajx+JUz4I4PwnYtOrqcj/R59Gx9m/WWjukFza/ap3FYnu8vEl2Q0txUQoUPJ7euPnBhkKOE7LhsOWA==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.19.0.tgz",
+      "integrity": "sha512-dRRM/AYqQli1VNijY7n0+q4zUlNCGiOY1wGr1r+c5ajvlv/XwGibhTJjY6zGZWIjL9TUMIbIEH8aOdRaw2iNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@typescript-eslint/scope-manager": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@typescript-eslint/scope-manager": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -830,9 +866,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.3.tgz",
+      "integrity": "sha512-IkO+/KEUvwbVpiURZg+P7zF74z5Jxe0UgJxVni+RtoHQ6IZieXaO02kmadomap/q+l6bc/jdPGGqTjhuZnuz1Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -959,6 +995,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mdn/browser-compat-data": {
       "version": "6.1.5",
       "resolved": "https://registry.npmmirror.com/@mdn/browser-compat-data/-/browser-compat-data-6.1.5.tgz",
@@ -995,9 +1055,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
-      "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.148.0.tgz",
+      "integrity": "sha512-pHASv9g5pASxb7akHERZNSkrEqPhFaUix98o7d9hbTpolnnFWl7UiRrcMhCsV1+iVO4/cJwKsbKRJTFNs2tdBQ==",
       "cpu": [
         "arm"
       ],
@@ -1012,9 +1072,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
-      "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.148.0.tgz",
+      "integrity": "sha512-sg/6Ez0KdAygsu0POELux9wN1Po2CP93WY8eNl4DBKIGprsd4QSHBXOb471Pu9i2OCD5sLkISSb2agZEhVn2Zw==",
       "cpu": [
         "arm64"
       ],
@@ -1029,9 +1089,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
-      "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.148.0.tgz",
+      "integrity": "sha512-yiSJmzGUvCUaJT8X3j40gVcX+ckuHQMuiOtF8DvzTs5+JtB/7XuHFPp4M+vv5u+HlBtDUd4Ks5pyHpWz8mfnkg==",
       "cpu": [
         "arm64"
       ],
@@ -1046,9 +1106,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
-      "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.148.0.tgz",
+      "integrity": "sha512-6ZeklaamrMy4H2JmhvcJg6iip59tYILtuLaILxyAHT3l5FDxnI5ihVievAft5ZmAbqtlWHErOi1OpJK8gy1wcA==",
       "cpu": [
         "x64"
       ],
@@ -1063,9 +1123,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
-      "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.148.0.tgz",
+      "integrity": "sha512-vFsPx+a/qFECPnz/H8nC6x6MDvnWscLTCo/5muojEF54ERUq1kdgbvnWo95YnkhjF9sTIcG/uDxQBh1gffaufQ==",
       "cpu": [
         "x64"
       ],
@@ -1080,9 +1140,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
-      "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.148.0.tgz",
+      "integrity": "sha512-eOr3M+6iGbbxNL4PSS0VtsyQ2eOUxSBh00BqO22SbolDimPSYsBuLr/LCrZBkiqW2BoabhR6V4R8jrRAay7hjg==",
       "cpu": [
         "arm"
       ],
@@ -1097,9 +1157,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
-      "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.148.0.tgz",
+      "integrity": "sha512-58ZKDw0mQRbCNfrd2IDyV4o8T7enzGERJn41BH2tjrZVGyiKiFzcfDicuB7Zcpb/1xIOrObovr8Dja6lZi8dLw==",
       "cpu": [
         "arm"
       ],
@@ -1114,13 +1174,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
-      "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.148.0.tgz",
+      "integrity": "sha512-Fnu95O4eZ5i++GPvIzBEZ8y4ddTLR+D9paYa8JRaRk6ZK7nHQiWP5xtrhcPQsXqgat1d7sU/d5rbbI0p1FTHSQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,13 +1194,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
-      "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.148.0.tgz",
+      "integrity": "sha512-3CQy/BMdx7N7H3qrcPxUL+a2CwUZodUcf6oq8iJuNZ9C6Ol1aq3mcWzsgySJ7CHFLvpX21ZDPp1r1X0QLbu/AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,13 +1214,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
-      "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.148.0.tgz",
+      "integrity": "sha512-9LkaYvfiF8hMOw900csAvkf1oxE8XlmMeGowu5BcastSSwV8mKvKRMNU7HsV+ycyj1dQD8pX5qgOw8ja6SJacg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,13 +1234,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
-      "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.148.0.tgz",
+      "integrity": "sha512-2GBiM9h26dR4WJfhoMvnFMnFLf7m/kYs4UMqjvrOfQG4BV1nuTJDH22Zc2MQr3INZF7nSKYQ6xlhD3hQ7A6gug==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,13 +1254,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
-      "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.148.0.tgz",
+      "integrity": "sha512-uPqZexvKJmEgq4mAu36qe2xTfXZE7oyik1R7KtZ5tl8qKlq1U1fIqTFRUEBZqRGvforoTrGIpatRzcoPKO66RA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,13 +1274,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
-      "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.148.0.tgz",
+      "integrity": "sha512-9oUHvnTbp7ZraFsTC8PN6XhdhPSSxZumYvixWl7Smi353gEULvK6yV0sXNVrdFMHQeaDKFCi8TgDhNK7/A+Y+Q==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,13 +1294,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
-      "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.148.0.tgz",
+      "integrity": "sha512-2qhDSJwKzbSZzF7lDqqk8sr/yXsmwr3PeUa4/nazIF+zFAYz1gVPEfC34GQtGxzJUUmklaYAL63368LEfrMeyw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,13 +1314,16 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
-      "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.148.0.tgz",
+      "integrity": "sha512-qQoPDZUFV0bh9xA09XydmkjMBpgc1ukJuhMvzQ9QeVmFaHTS9W5TE5CoLmSl3QQyUP9OuHO3x/WPZTIIZPWR3Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1334,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
-      "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.148.0.tgz",
+      "integrity": "sha512-1UGbaQWEXUCLqAmaR5kwRDjx/R4S5LQKZkM9CHmaHkuKhriOF32aRLfS0jCRNE2yGQJLMEA1z9UucbBVqjXnDw==",
       "cpu": [
         "arm64"
       ],
@@ -1267,9 +1351,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
-      "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.148.0.tgz",
+      "integrity": "sha512-pWKdzRDNG2+NK4h/V6U/CYERcfYD6u28h5IB/VJVsrZaD3muvE58tUj22lieL5vLZ+XFi1GPv9YXckZbJZ9BLA==",
       "cpu": [
         "arm64"
       ],
@@ -1284,9 +1368,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
-      "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.148.0.tgz",
+      "integrity": "sha512-i3p4x+mvwtjcE1J5HM6V7ggsbXiznExN/4MkNyOy3dfXrVV3bnkSfmZxvo6/84qCVX4ShkpNE1SKt9biIF31GQ==",
       "cpu": [
         "ia32"
       ],
@@ -1301,9 +1385,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
-      "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.148.0.tgz",
+      "integrity": "sha512-Ye6vB7VQulghWYkYkECOBYFRVEizz4XyRTUAv+t8BuyurhKU7uD0P9eowL+mKG5Mf8MSYx+DI3Cm8SKZvYG7bQ==",
       "cpu": [
         "x64"
       ],
@@ -1318,13 +1402,13 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
       "dev": true,
       "license": "MIT",
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
@@ -1599,9 +1683,9 @@
       ]
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.80.0.tgz",
-      "integrity": "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.82.0.tgz",
+      "integrity": "sha512-a3LB+C5Dsj5b/qtmG/mv5WrzuiXEpg1KF5nXWcEvaoN5TYAqkIvxPOwTPp3Jy/FoGpRo8zsTFhMElMXfeoOEzA==",
       "cpu": [
         "arm"
       ],
@@ -1616,9 +1700,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.80.0.tgz",
-      "integrity": "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.82.0.tgz",
+      "integrity": "sha512-OBlhRgNqFblGpGenno/aqOfJLOkQ2B8Ig3iDAalfn0H8hJGZKXPeexCRTDm6uwv6YUjSA9Xnwt1y/Bgj5ZH8uw==",
       "cpu": [
         "arm64"
       ],
@@ -1633,9 +1717,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.80.0.tgz",
-      "integrity": "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.82.0.tgz",
+      "integrity": "sha512-dsopxqtY5ZdyT9uLHyGt1SyiLop6hi7hWI3PKpePodkRQOkLaCm+OE4fR9CAz9qdfjiFO8531tX/QDyP/psjFg==",
       "cpu": [
         "arm64"
       ],
@@ -1650,9 +1734,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.80.0.tgz",
-      "integrity": "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.82.0.tgz",
+      "integrity": "sha512-94Lu0SgTClKColU66g1VDuigV3HkcbkJBnTtZjGYfE8UPugaWDgKrm2icjC6HJVUYler2OXaHP/X0TBy8+CowQ==",
       "cpu": [
         "x64"
       ],
@@ -1667,9 +1751,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.80.0.tgz",
-      "integrity": "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.82.0.tgz",
+      "integrity": "sha512-hne/V06ewhh1i0w8+l7GDNROAGCGPmyFuOwiP7YTRu0JycyStJ4785dmF8xU5p0uUwt2emvIF9vc7Xjis+cJ0g==",
       "cpu": [
         "x64"
       ],
@@ -1684,9 +1768,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.80.0.tgz",
-      "integrity": "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.82.0.tgz",
+      "integrity": "sha512-aWY2xtbZf1LneW9Qsv/n2Sp8gOu74JrlQzEtj4coHX2SHFrCfhmAumaU+sI/A5nr+yoTRTSmI/pL2s6ADlNSkw==",
       "cpu": [
         "arm"
       ],
@@ -1701,9 +1785,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.80.0.tgz",
-      "integrity": "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.82.0.tgz",
+      "integrity": "sha512-Fe+TtXCXMh/5f7kWlZ2VAwsMumZWtraFlKVk1NJlL52/beGwfDE7ov+/8gVirHzWokzGu7X65hSPq0ucPDskWQ==",
       "cpu": [
         "arm"
       ],
@@ -1718,13 +1802,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.80.0.tgz",
-      "integrity": "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.82.0.tgz",
+      "integrity": "sha512-6azCZ6OJudlvipNttXCCQcyeFfcJ/NvUZdSN1z8elo73kCHtyQC7WTiUcSjWYvJ1jaq9KDUyMAoAS/vNzhBomA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1735,13 +1822,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.80.0.tgz",
-      "integrity": "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.82.0.tgz",
+      "integrity": "sha512-PLEaSD8IAIIlwW4dwOd9YaxuxeOpwiXL4J24rcnE4iNtyM5j9Q9/3+gti08oXpx0u2ygNjRDx9xjWWpQonuJEw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1752,13 +1842,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.80.0.tgz",
-      "integrity": "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.82.0.tgz",
+      "integrity": "sha512-D94em/BwknNTn4vqxjHh5wb2oL566eFhArabqKIr0cNZMHOJuiraFp1A8tXpH05bbE5tqwEfLXTI0MWEGtn3Dw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1769,13 +1862,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.80.0.tgz",
-      "integrity": "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.82.0.tgz",
+      "integrity": "sha512-MOprxBaoYU2D4VgxXCl3ghydThWtx7Um1lL51kGYNeQ5Al7WzsH7/tqGdNtbLrIWnjq3bsm13+nz/gRIxjrOXw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1786,13 +1882,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.80.0.tgz",
-      "integrity": "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.82.0.tgz",
+      "integrity": "sha512-5h55QsfJ/luDXZzC20k6SNOY1Az+dCP9WvntKtcUWh2JhckAdwApY2ZusaBTwLENnReXU+A2fJtSrYvZJNKNPg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1803,13 +1902,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.80.0.tgz",
-      "integrity": "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.82.0.tgz",
+      "integrity": "sha512-IE8NJNLlHr0CaXyGJPGVn0eTkUyoj1I2UfA8x7I4PSOYKsQ/6btVC7Pywrj5onk0cMH25r6Z38SoN3AvE5Zuog==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1820,13 +1922,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.80.0.tgz",
-      "integrity": "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.82.0.tgz",
+      "integrity": "sha512-XUUUxaBo9XKl+J1B9EmP1cTGQPddzeURvoGkfwh/94PGnbW+hBprDljneoI2M1jzC1bzrIV3ihc7iM9UXl8+tg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1837,13 +1942,16 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.80.0.tgz",
-      "integrity": "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.82.0.tgz",
+      "integrity": "sha512-SWLSFulX9TDuH6yvbPYp4+VNn6jkkIvvI+KiujDM5rWBRHEfkesCC/pCneIIUr6ovkxZ5fRtpi2v5Cz5FrMJZg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1854,9 +1962,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.80.0.tgz",
-      "integrity": "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.82.0.tgz",
+      "integrity": "sha512-BQy35f6ZUdNr9a6c7B7orxQTcLjByGT2z3WAgmRovpRwmPYAaJ+NTplmMzhdjdJ4qSchfMNZy/Ukg+qRg6zseQ==",
       "cpu": [
         "arm64"
       ],
@@ -1871,9 +1979,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.80.0.tgz",
-      "integrity": "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.82.0.tgz",
+      "integrity": "sha512-V4QhSTg5gctZue8RJjsGi7NpQPThr/p1/HfmiMC5kfe1KFEup9SQRVub4A6kijQjdHfxj7bLL1KO3QO7/5bwMQ==",
       "cpu": [
         "arm64"
       ],
@@ -1888,9 +1996,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.80.0.tgz",
-      "integrity": "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.82.0.tgz",
+      "integrity": "sha512-TUSCLaKB2yktpFAJ/r3HAUYsaV/3DT7JS4iNKyoh3a9YNwD0UG7Ezh4D8m23654vQcU6P/RQrCAjRPKe4peP/A==",
       "cpu": [
         "ia32"
       ],
@@ -1905,9 +2013,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.80.0.tgz",
-      "integrity": "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.82.0.tgz",
+      "integrity": "sha512-VTVoRIWJTb+wvUX8EYoPArfFH02whuR10goFXE/LHRRX33ajRrFgqbcONXZMiF4C5rnattfkm87HqYn8jb8hmQ==",
       "cpu": [
         "x64"
       ],
@@ -1922,13 +2030,13 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmmirror.com/@puppeteer/browsers/-/browsers-3.2.1.tgz",
-      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.2.tgz",
+      "integrity": "sha512-q2BU4YfO9h/Wt7IcWPcggpOOqLk2Tbs1hDwolvKZrweRjy751OJBKMN9zO5bfD0pzU7X/tvKw/exQds4pM/LOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "modern-tar": "^0.8.0",
+        "modern-tar": "^0.8.4",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -2564,6 +2672,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
@@ -2575,9 +2693,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2592,14 +2710,14 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.70.0.tgz",
+      "integrity": "sha512-hFHbTNqhU9G+2eKFXCBVb1tjFT/LceiJ4+HfLO4pTpDI0KHi6iajpcFFkaSQ9gXmCh7n82A0PthaayEdN6mspQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.68.0",
-        "@typescript-eslint/types": "^8.68.0",
+        "@typescript-eslint/tsconfig-utils": "^8.70.0",
+        "@typescript-eslint/types": "^8.70.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2614,14 +2732,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
-      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.70.0.tgz",
+      "integrity": "sha512-8nP3Kwh5hlgZ4FicGvmznAmJe8UL4sdU8tLukrPaMuQmDuk4Y8xYfzu/aYZW4xT2JCgc7H/TpDI5cGlxcWJSqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0"
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2632,9 +2750,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.70.0.tgz",
+      "integrity": "sha512-adnkeeNq9Sq1sUf4+FRVc0KdgYghzsgFpZSQVZVvY0LCuUuN0FnQgyGzCJeC4fW1cdXseBAjU2EOqUIjbNcZUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2649,15 +2767,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
-      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.70.0.tgz",
+      "integrity": "sha512-NUMKIhYVaVIVLnRL9CRt+VVcuLgSHUCpXn4/+K8wql+vdInUzvx8BjUO1oJ7cG9shjFJKtF8F8Hh2kCh3/KBVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0",
+        "@typescript-eslint/utils": "8.70.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2674,9 +2792,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.68.0.tgz",
-      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.70.0.tgz",
+      "integrity": "sha512-asTOIYhDg4zdzOScCyaytrsV3cR6B4ecPQlXw/dJIm7J/MZTtCtfVII9JD8Geh4jTCrK/Xe6cg5UevoleMcoJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2688,16 +2806,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.70.0.tgz",
+      "integrity": "sha512-d9NmHMPEKQ7QCLLm1jI3zmoQBwT5KwFYjXBJ9ymZfKCUU+5rmTRykKAFvH5Qn/ZCds3CEAFS9OC9M/jkl0X2bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.68.0",
-        "@typescript-eslint/tsconfig-utils": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/project-service": "8.70.0",
+        "@typescript-eslint/tsconfig-utils": "8.70.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2716,16 +2834,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.68.0.tgz",
-      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.70.0.tgz",
+      "integrity": "sha512-oZmtKJz/4fufZ2p3+Cn3ijEojcdfR+1zYDH2xKYrEly0dR/Q/1xUPRCOlKGxod78nWlU2UnDe09GZ3TaknBFGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0"
+        "@typescript-eslint/scope-manager": "8.70.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2740,13 +2858,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.70.0.tgz",
+      "integrity": "sha512-BoC8PiO4Hkdo0TVJh9Ntxr5MxPDI7/oFsrygN5ADelFSeXG/qgNuucIGA+L5Z6JpPTE/uRfcTWtscjbUaufepQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/types": "8.70.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3105,9 +3223,9 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmmirror.com/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
-      "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3535,7 +3653,7 @@
     },
     "node_modules/birecord": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmmirror.com/birecord/-/birecord-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.2.tgz",
       "integrity": "sha512-5PAPTTmMpMEb+GuMb5DebfBkipRGyIW9+gtwEBSoDA9xkhHILm04+hZQ702pMksu3d8YAuGkmgTzQWcKqTPScA==",
       "dev": true,
       "license": "(MIT OR Apache-2.0)"
@@ -3645,6 +3763,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
       }
     },
     "node_modules/call-bind": {
@@ -3813,7 +3945,7 @@
     },
     "node_modules/cliui": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dev": true,
       "license": "ISC",
@@ -3841,7 +3973,7 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -3932,7 +4064,7 @@
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmmirror.com/compare-versions/-/compare-versions-6.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true,
       "license": "MIT"
@@ -4356,9 +4488,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.14",
-      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.14.tgz",
-      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.15.tgz",
+      "integrity": "sha512-EUBjM+B+lkDE41iE82DDSCfkoPGfXx8IxFxPMjNzm/Uk4xDet77rTN9wqlxlVg71kK7XGuUMv6wUxJUwwv+Xyw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4388,7 +4520,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
@@ -4408,13 +4540,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -4665,9 +4797,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
-      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.10.0.tgz",
+      "integrity": "sha512-NPXn6r5zl4uET1DAVPaOwzX3rut4c0wcmw3dWJAfOsTM5+TogXo0DDjz8pwm/hL8cyVNpHqeK4JpN0NjnyFFNw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -4679,7 +4811,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
+        "@eslint/plugin-kit": "^0.7.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -4694,7 +4826,7 @@
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "11.1.5 || >11.1.6 <12",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
         "ignore": "^5.2.0",
@@ -4859,14 +4991,15 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "64.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.2.1.tgz",
-      "integrity": "sha512-6GpSYxLPcbMw38S94Cngrgs1Zv8yLinQS1O17OxJVZ6deLbrMRCERUYQKceweSqEuG2kx5Amn4l3aKPkCp4geQ==",
+      "version": "64.3.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.3.8.tgz",
+      "integrity": "sha512-JXLYE2BVfmbqLrrslb9/vg3URg8okW5pMnppM+3EYwvPCbuOiSXGOJWaNK208wDx6xXawkIFGtRYgFgrW23dsg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.95.1",
+        "@es-joy/jsdoccomment": "~0.97.0",
         "@es-joy/resolve.exports": "1.2.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "are-docs-informative": "^0.1.1",
         "comment-parser": "1.4.8",
         "debug": "^4.4.3",
@@ -4983,18 +5116,18 @@
       }
     },
     "node_modules/eslint-plugin-react-dom": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.18.6.tgz",
-      "integrity": "sha512-xco47I0Agu+83QH2ONbgZd1JPLSXJON+gtFGJbOhgfPvetfO7UkcHu8iLpncopwyWekAXfhvomJsDlNLTm26/g==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.19.0.tgz",
+      "integrity": "sha512-QxWdjdPxQUI3SSMYR7WyrLew7pQzlOn5P3R5raWh2PiyavaBUbkfJhSJ307l1AaJOVLy5JeIB2Rl4bivwHAOIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/jsx": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/jsx": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "compare-versions": "^6.1.1"
       },
       "engines": {
@@ -5026,19 +5159,19 @@
       }
     },
     "node_modules/eslint-plugin-react-jsx": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.18.6.tgz",
-      "integrity": "sha512-6EvzS5gZGfQ0byvSxgqV/F0qXTVnNGcCU7wgFZqz8I1IXmcbYyBCyU7gqNlKW1/1ptiZFmuwo57+eW6HyK+wEg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.19.0.tgz",
+      "integrity": "sha512-Upvpe50vpPi5jWvLqtBXoZEwaCz1pzszzoukK7qf0g1A6ZJ+XDJhi3yKmPQWBlp9c4GOwzwPuXGU5C2e8cHMbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/core": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/jsx": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0"
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/core": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/jsx": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -5049,19 +5182,19 @@
       }
     },
     "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.18.6.tgz",
-      "integrity": "sha512-3KZkJN8XDTq6YtaYvyWJt3GQRjW3WhoVuGgLfhf0yO+8H0GW78FkesqGe//+np+pBXwPv6hck4c8ViTEQJ9qIQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.19.0.tgz",
+      "integrity": "sha512-H9ko2t+KYPBDOfr29D5hDAT6CXucHJKGQscI+/ndSmkBl9K/KaGWdhFiCzQPi5S2YwPkjrcuaSXIp/n8+PA5GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/core": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/core": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -5073,19 +5206,19 @@
       }
     },
     "node_modules/eslint-plugin-react-rsc": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.18.6.tgz",
-      "integrity": "sha512-4mzLkRKRpN9Rr5JMeNrxkMFLHce1ikAdsjAiPOSIgYwWSsQWxHwpMTf+UfjXgfB6CcAcyKCyIe5HmOMX2kUoVQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.19.0.tgz",
+      "integrity": "sha512-XdfkB2XRS0b1WBkuxnRsWmhivNaBOLAIohBqWQItQycuket6wVliqSY+Q1NcTst4PdJ1bYzLuMgSXYsgwJMV7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/core": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0"
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/core": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -5096,19 +5229,19 @@
       }
     },
     "node_modules/eslint-plugin-react-web-api": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.18.6.tgz",
-      "integrity": "sha512-r8s39AbHZ0071XcgCMoCdNkSARftqI6U/0bBJXPioVUw+hjp0n4EB27fsc69AHzRl/NJWA1oUJb+kcqxoWMR4w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.19.0.tgz",
+      "integrity": "sha512-wCNdYVHgdLmCikLicH6kfO6EE1SKzi63FlhLLGMGzzEAyvudvyfKI0+ZXDkFyjolvKXLQW6Thb8EeAFbHTZksw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/core": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/core": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "birecord": "^0.1.2",
         "ts-pattern": "^5.9.0"
       },
@@ -5121,23 +5254,23 @@
       }
     },
     "node_modules/eslint-plugin-react-x": {
-      "version": "5.18.6",
-      "resolved": "https://registry.npmmirror.com/eslint-plugin-react-x/-/eslint-plugin-react-x-5.18.6.tgz",
-      "integrity": "sha512-VvxeREksTiY9Q7YnpNvQNrjapUGu43rQJXrtbjT9ADwXX5nZiyUqD7T7fkbUYfH6NPz2bYvnAmGEctIfEGTTfQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.19.0.tgz",
+      "integrity": "sha512-HoweOyYhar8G2QEukOctSaK87Y3AzB3bn4ES+0VVhcNOOqBFphRaWqcvoNN8JE+5AKOhhpuzjVKY6DnGPCcAMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.18.6",
-        "@eslint-react/core": "5.18.6",
-        "@eslint-react/eslint": "5.18.6",
-        "@eslint-react/jsx": "5.18.6",
-        "@eslint-react/shared": "5.18.6",
-        "@eslint-react/var": "5.18.6",
-        "@typescript-eslint/scope-manager": "^8.67.0",
-        "@typescript-eslint/type-utils": "^8.67.0",
-        "@typescript-eslint/types": "^8.67.0",
-        "@typescript-eslint/typescript-estree": "^8.67.0",
-        "@typescript-eslint/utils": "^8.67.0",
+        "@eslint-react/ast": "5.19.0",
+        "@eslint-react/core": "5.19.0",
+        "@eslint-react/eslint": "5.19.0",
+        "@eslint-react/jsx": "5.19.0",
+        "@eslint-react/shared": "5.19.0",
+        "@eslint-react/var": "5.19.0",
+        "@typescript-eslint/scope-manager": "^8.69.0",
+        "@typescript-eslint/type-utils": "^8.69.0",
+        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/typescript-estree": "^8.69.0",
+        "@typescript-eslint/utils": "^8.69.0",
         "compare-versions": "^6.1.1",
         "string-ts": "^2.3.1",
         "ts-api-utils": "^2.5.0",
@@ -5218,22 +5351,22 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "73.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
-      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
+      "version": "74.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-74.0.0.tgz",
+      "integrity": "sha512-AGnsGi2SxHg1HEAXxn9nSnZfyjvTWkxm8E8hpd/9tD6dLjBUdcD7+D6ZN64HmmCXTSXlrwVyUqe20Uyb2CaurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@eslint/css-tree": "^4.0.4",
-        "browserslist": "^4.28.4",
+        "@eslint-community/eslint-utils": "^4.10.1",
+        "@eslint/css-tree": "^4.0.5",
+        "browserslist": "^4.28.8",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
-        "core-js-compat": "^3.49.0",
+        "core-js-compat": "^3.50.0",
         "detect-indent": "^7.0.2",
-        "entities": "^4.5.0",
+        "entities": "^8.0.0",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.7.0",
+        "globals": "^17.11.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "is-identifier": "^1.1.0",
@@ -5422,16 +5555,13 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
+        "flat-cache": "^6.1.23"
       }
     },
     "node_modules/filing-cabinet": {
@@ -5523,17 +5653,15 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/flatted": {
@@ -5560,13 +5688,14 @@
       }
     },
     "node_modules/formatly": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
-      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.7.0.tgz",
+      "integrity": "sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fd-package-json": "^2.0.0"
+        "fd-package-json": "^2.0.0",
+        "package-manager-detector": "^1.8.0"
       },
       "bin": {
         "formatly": "bin/index.mjs"
@@ -5690,7 +5819,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
@@ -5700,7 +5829,7 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
@@ -5802,9 +5931,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5955,6 +6084,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -5993,6 +6135,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-entities": {
       "version": "2.6.0",
@@ -6660,9 +6809,9 @@
       "license": "MIT"
     },
     "node_modules/jscpd": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.0.16.tgz",
-      "integrity": "sha512-TiQ4zKtKeldep6UswXFHjVCDhVdLBaJyQcZjhCSzVOmKpT6HBj0jUZiphP1vK1X3VSSuzwcfifJVNpsOIiwRCg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd/-/jscpd-5.2.0.tgz",
+      "integrity": "sha512-6f4qhJGIeR/ZvAkZByfpPw5H28SNEE4fgJ4GXxVuLMiEg7xWrAlUdm0crIJPY6dmykvgdM83ZRrWJXg11fQlYg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6671,19 +6820,24 @@
       "engines": {
         "node": ">=18"
       },
+      "funding": {
+        "url": "https://opencollective.com/jscpd"
+      },
       "optionalDependencies": {
-        "jscpd-darwin-arm64": "5.0.16",
-        "jscpd-darwin-x64": "5.0.16",
-        "jscpd-linux-arm64-gnu": "5.0.16",
-        "jscpd-linux-x64-gnu": "5.0.16",
-        "jscpd-linux-x64-musl": "5.0.16",
-        "jscpd-windows-x64-msvc": "5.0.16"
+        "jscpd-darwin-arm64": "5.2.0",
+        "jscpd-darwin-x64": "5.2.0",
+        "jscpd-linux-arm64-gnu": "5.2.0",
+        "jscpd-linux-arm64-musl": "5.2.0",
+        "jscpd-linux-x64-gnu": "5.2.0",
+        "jscpd-linux-x64-musl": "5.2.0",
+        "jscpd-windows-arm64-msvc": "5.2.0",
+        "jscpd-windows-x64-msvc": "5.2.0"
       }
     },
     "node_modules/jscpd-darwin-arm64": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-darwin-arm64/-/jscpd-darwin-arm64-5.0.16.tgz",
-      "integrity": "sha512-Tu6OAg3Rp6m7LCZqOtPViJxYGTKXTLrI/xMyjEKe79N9L7GpbI3XhgotGDpoE+PjLRbgJgGhRKbkKK18FPySmQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-arm64/-/jscpd-darwin-arm64-5.2.0.tgz",
+      "integrity": "sha512-QnEDfTH2MymizVHiEQpqfYEj63k1DW7QC0QBZoevh+o/iHQrHxKlgrakMysUIwIJlnmvqPB6iP/G3dBpFmnmeQ==",
       "cpu": [
         "arm64"
       ],
@@ -6695,9 +6849,9 @@
       ]
     },
     "node_modules/jscpd-darwin-x64": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-darwin-x64/-/jscpd-darwin-x64-5.0.16.tgz",
-      "integrity": "sha512-3btQ1aG8K7+9rvJjyaRJRcSBD0DvHgZOUVlecjnyO99FYzMvdFREq67UIl5CAXFeYf5EY8TSorCMZQxL6TBD0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-darwin-x64/-/jscpd-darwin-x64-5.2.0.tgz",
+      "integrity": "sha512-P2lYEK0Yyn+0z7618+9A0NErywjaPrwSYcId3gRSt5l0cyKBwhMmyFLX/2t3G2HRi+GX+OT2A/YpWvvTzLJJ1A==",
       "cpu": [
         "x64"
       ],
@@ -6709,13 +6863,33 @@
       ]
     },
     "node_modules/jscpd-linux-arm64-gnu": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-gnu/-/jscpd-linux-arm64-gnu-5.0.16.tgz",
-      "integrity": "sha512-L1F9CNHxRPqGJCKgGRA4gtZcESACFkS2lgfPgWn9fG+4CkiewLcYyy/oxrafJJL1/PPTQ24sbLuzPaKUxJuvuw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-gnu/-/jscpd-linux-arm64-gnu-5.2.0.tgz",
+      "integrity": "sha512-UhdX9vvCFwoG1cViNqFyvxfqNtJ+xWbGsgZ5PbcgUx2OLWnvjhkjihPw/fOUM9IoxHaT66AE5pipaV/oQE/76A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/jscpd-linux-arm64-musl": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-arm64-musl/-/jscpd-linux-arm64-musl-5.2.0.tgz",
+      "integrity": "sha512-13DsZCQ58fOMUX6mU8DZtiTdIk+9Gp2xLu6mtc6fmqqZRJoRHQSSDvMqRVedCqArquxc0I+tqQtZO4n7/8QJxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6723,13 +6897,16 @@
       ]
     },
     "node_modules/jscpd-linux-x64-gnu": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-5.0.16.tgz",
-      "integrity": "sha512-BruP+sAr0+6QsEQZvOkgcS+xR23y4s1hLA0xfkcO1zFFXdnmQdJ4w23/U8VlPwqO2dFRaAEseYEXjHs5oQQGFw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-5.2.0.tgz",
+      "integrity": "sha512-p88BpA5QzyZzyF8uYeVCz9ZBoZYg8s6AwcDc3NkIDNTbrrF0sKqgGjclGWAoJvYAiGExiFNqV768pVHsE//l0Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6737,23 +6914,40 @@
       ]
     },
     "node_modules/jscpd-linux-x64-musl": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-musl/-/jscpd-linux-x64-musl-5.0.16.tgz",
-      "integrity": "sha512-T36RtMnF695Y1/T3cLEhgvspHdKoiF+oxK/lklGJWriLieImZolSOjGXsecW2bp7MNMMGlqLLRzr2RNgnwy+Hg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-linux-x64-musl/-/jscpd-linux-x64-musl-5.2.0.tgz",
+      "integrity": "sha512-6DgIxJpS7L4bb1DkYrqC0SflMY2/2/3Dl0kZJ1In6SeSENcTaZ12W1zX3kNf7wVUDFgPi94TuSxrw3N2TqRhRg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
+    "node_modules/jscpd-windows-arm64-msvc": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-arm64-msvc/-/jscpd-windows-arm64-msvc-5.2.0.tgz",
+      "integrity": "sha512-DI84oCG+L5sYhmYanXjjydXlFzC194/NJA6F7W8cmOI1rKSnWrgIjUtvTmXumygwTK/eAXkK7rFBqFnyiLEzdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/jscpd-windows-x64-msvc": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/jscpd-windows-x64-msvc/-/jscpd-windows-x64-msvc-5.0.16.tgz",
-      "integrity": "sha512-BcrY18r6uje+TjgBKdFZJz6qfAAh9QT24KZYZk+jk6tuIKOYIm6oRMeQEu3Tzr/len9ZethN2h1bKmv+EfHcGw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jscpd-windows-x64-msvc/-/jscpd-windows-x64-msvc-5.2.0.tgz",
+      "integrity": "sha512-EH4chck2EIehosfy7q6hxaKgzlaZv/dZhUHtjBmBf81d5/ZDfa6BsKw2gM8PSoNC0QXznWXv9uQcFWsV+P9v8A==",
       "cpu": [
         "x64"
       ],
@@ -6765,13 +6959,14 @@
       ]
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.1.2.tgz",
-      "integrity": "sha512-9EXymowgk1mb9RY1VxuwKc+AhaxfBk2CV0dWxgGM+l5RURTtiUoAx7MlKwcsiVcEXK5HEPa7FeH/tsRpqjEPRg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.2.1.tgz",
+      "integrity": "sha512-V4Ww4EHnTcTLSOMoB0FsF72JhQvcAsriCm/LWnxJeGWoxIjEL2l9na11abQok5SYShq8m0Gl02el/xAbTCulvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.9"
+        "@types/estree": "^1.0.9",
+        "@types/node": "^26.4.0"
       },
       "engines": {
         "node": "^22.22.2 || >=24.15.0"
@@ -6789,13 +6984,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6851,19 +7039,19 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/knip": {
-      "version": "6.32.2",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.32.2.tgz",
-      "integrity": "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==",
+      "version": "6.35.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.35.1.tgz",
+      "integrity": "sha512-22wnEnv4do2fvoeJsxpFCG/MBxReNxoCVBccaCl7suUJsG+F0UvxI9ycxZ9YgtLHSSjrZl5tOas0JZ/R1vJ93g==",
       "dev": true,
       "funding": [
         {
@@ -6878,16 +7066,16 @@
       "license": "ISC",
       "dependencies": {
         "fdir": "^6.5.0",
-        "formatly": "^0.3.0",
-        "get-tsconfig": "4.14.1",
+        "formatly": "^0.7.0",
+        "get-tsconfig": "4.14.3",
         "jiti": "^2.7.0",
-        "oxc-parser": "^0.143.0",
+        "oxc-parser": "^0.148.0",
         "oxc-resolver": "11.24.2",
-        "picomatch": "^4.0.5",
-        "smol-toml": "^1.7.1",
+        "picomatch": "^4.0.7",
+        "smol-toml": "^1.8.0",
         "strip-json-comments": "5.0.3",
         "tinyglobby": "^0.2.17",
-        "unbash": "^4.0.9",
+        "unbash": "^4.0.11",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -6897,19 +7085,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/knip/node_modules/get-tsconfig": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
-      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/levn": {
@@ -7326,7 +7501,7 @@
     },
     "node_modules/marked": {
       "version": "14.1.4",
-      "resolved": "https://registry.npmmirror.com/marked/-/marked-14.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
       "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
       "license": "MIT",
       "bin": {
@@ -7397,9 +7572,9 @@
       "license": "MIT"
     },
     "node_modules/modern-tar": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmmirror.com/modern-tar/-/modern-tar-0.8.4.tgz",
-      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.5.tgz",
+      "integrity": "sha512-snEhs+6G5Tjd4I7tLCDOaoln2RgE0bD19RzEKgvgK2hZ5VKy3MpLhLTZ2fWpXSTg4K2cyPwp+VHATFJhxfnOeA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7745,40 +7920,40 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.143.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
-      "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.148.0.tgz",
+      "integrity": "sha512-syxUKHeUll89RIABQADcI7sikYrwyssvA6gj4phSSIPezKVM8yMaLAiLLSc7fmzVvrwybfFGFbW5zme9sX87rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.143.0"
+        "@oxc-project/types": "^0.148.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.143.0",
-        "@oxc-parser/binding-android-arm64": "0.143.0",
-        "@oxc-parser/binding-darwin-arm64": "0.143.0",
-        "@oxc-parser/binding-darwin-x64": "0.143.0",
-        "@oxc-parser/binding-freebsd-x64": "0.143.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.143.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.143.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.148.0",
+        "@oxc-parser/binding-android-arm64": "0.148.0",
+        "@oxc-parser/binding-darwin-arm64": "0.148.0",
+        "@oxc-parser/binding-darwin-x64": "0.148.0",
+        "@oxc-parser/binding-freebsd-x64": "0.148.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.148.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.148.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.148.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.148.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.148.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.148.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.148.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.148.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.148.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.148.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.148.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.148.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.148.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.148.0"
       }
     },
     "node_modules/oxc-resolver": {
@@ -7813,9 +7988,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.80.0.tgz",
-      "integrity": "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.82.0.tgz",
+      "integrity": "sha512-+iFM1BGw1ntYJt3QngbJmjbrGxPaKMUADOXOijpWGnYcBPq8YZnQftSS1C+pVcDYy9YxqDVJKQqQkTazTQMboQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7825,28 +8000,28 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.80.0",
-        "@oxlint/binding-android-arm64": "1.80.0",
-        "@oxlint/binding-darwin-arm64": "1.80.0",
-        "@oxlint/binding-darwin-x64": "1.80.0",
-        "@oxlint/binding-freebsd-x64": "1.80.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.80.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.80.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.80.0",
-        "@oxlint/binding-linux-arm64-musl": "1.80.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.80.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.80.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.80.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.80.0",
-        "@oxlint/binding-linux-x64-gnu": "1.80.0",
-        "@oxlint/binding-linux-x64-musl": "1.80.0",
-        "@oxlint/binding-openharmony-arm64": "1.80.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.80.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.80.0",
-        "@oxlint/binding-win32-x64-msvc": "1.80.0"
+        "@oxlint/binding-android-arm-eabi": "1.82.0",
+        "@oxlint/binding-android-arm64": "1.82.0",
+        "@oxlint/binding-darwin-arm64": "1.82.0",
+        "@oxlint/binding-darwin-x64": "1.82.0",
+        "@oxlint/binding-freebsd-x64": "1.82.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.82.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.82.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.82.0",
+        "@oxlint/binding-linux-arm64-musl": "1.82.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.82.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.82.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.82.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.82.0",
+        "@oxlint/binding-linux-x64-gnu": "1.82.0",
+        "@oxlint/binding-linux-x64-musl": "1.82.0",
+        "@oxlint/binding-openharmony-arm64": "1.82.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.82.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.82.0",
+        "@oxlint/binding-win32-x64-msvc": "1.82.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -7921,6 +8096,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-imports-exports": {
       "version": "0.2.4",
@@ -8152,22 +8334,42 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.8.0",
-      "resolved": "https://registry.npmmirror.com/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
-      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
+      "version": "25.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.10.0.tgz",
+      "integrity": "sha512-Hy5eMQshOEMil4JUUx03h5pw1HYkYCso1RG/gcpPlFSd4cYPOcopxcXEAxpLPOkOPJb9LIJtwxuj66bSdvknFg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.2.1",
+        "@puppeteer/browsers": "3.2.2",
         "chromium-bidi": "17.0.2",
         "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.2",
-        "ws": "^8.21.1"
+        "webdriver-bidi-protocol": "0.4.3",
+        "ws": "^8.21.3"
       },
       "engines": {
         "node": ">=22.12.0"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/quote-js-string": {
       "version": "0.1.0",
@@ -8882,14 +9084,14 @@
     },
     "node_modules/string-ts": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmmirror.com/string-ts/-/string-ts-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
       "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.2.2",
-      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-8.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
       "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
       "dev": true,
       "license": "MIT",
@@ -9271,7 +9473,7 @@
     },
     "node_modules/ts-pattern": {
       "version": "5.9.0",
-      "resolved": "https://registry.npmmirror.com/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
       "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
       "dev": true,
       "license": "MIT"
@@ -9444,9 +9646,9 @@
       }
     },
     "node_modules/unbash": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.10.tgz",
-      "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.11.tgz",
+      "integrity": "sha512-FoSOKV7NEofQSkAefMVHam4ZPKYMxjAydxiV72UFEDNV/YofxjGfiZ2A9pZjdL/lRJzTjcu4PABo1JYJX8N5iQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -9471,6 +9673,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
@@ -9674,9 +9883,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
-      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.3.tgz",
+      "integrity": "sha512-uuN0goWfxP22B7J/uAgBpOYNPttC+XVseYE+rSY5+rQ+YBeVz/VORw8WbmLVcqW78zNg5A4qnjNXYUWR3il2ig==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -9797,7 +10006,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
-      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
@@ -9841,7 +10050,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
@@ -9897,7 +10106,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
@@ -9930,7 +10139,7 @@
     },
     "node_modules/yargs": {
       "version": "18.1.0",
-      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-18.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
       "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
       "dev": true,
       "license": "MIT",
@@ -9948,7 +10157,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "dev": true,
       "license": "ISC",

--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -147,7 +147,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-sonarjs": "^4.2.0",
-    "eslint-plugin-unicorn": "^73.0.0",
+    "eslint-plugin-unicorn": "^74.0.0",
     "globals": "^17.11.0",
     "jscpd": "^5.0.16",
     "knip": "^6.32.2",

--- a/pinvou3-app/src-tauri/Cargo.lock
+++ b/pinvou3-app/src-tauri/Cargo.lock
@@ -1350,7 +1350,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
  "tracing",
  "windows-sys 0.61.2",
@@ -1596,7 +1596,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "toml_edit 0.25.13+spec-1.1.0",
  "tower-http 0.7.1",
  "tracing",
@@ -1621,7 +1621,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -1803,6 +1803,12 @@ dependencies = [
  "core-foundation 0.10.1",
  "libc",
 ]
+
+[[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
@@ -2468,7 +2474,7 @@ dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -2487,11 +2493,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.35"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
 dependencies = [
  "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
 ]
 
 [[package]]
@@ -4779,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loop9"
@@ -5077,6 +5089,33 @@ dependencies = [
  "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
 name = "native-tls"
@@ -6221,7 +6260,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "uuid",
  "wait-timeout",
  "walkdir",
@@ -7383,9 +7422,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8599,9 +8638,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -8617,9 +8656,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
 dependencies = [
  "anyhow",
  "dunce",
@@ -8635,15 +8674,15 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-plugin-log"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+checksum = "b4e8861142c21636b03ff6eb9682a073814112e35220435670738a8be7b49896"
 dependencies = [
  "android_logger",
  "fern",
@@ -8662,9 +8701,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-notification"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+checksum = "ad2fd40946aef810c4be9fd33a2d1b9b397cb79042b2d21c81a0a8f204354fd1"
 dependencies = [
  "log",
  "notify-rust",
@@ -8681,9 +8720,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.3"
+version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+checksum = "5cd0cb5c412a5071b69bab6a6df1583cbb89460d4a83b6a24769b08d15b6b1e1"
 dependencies = [
  "serde",
  "serde_json",
@@ -8777,7 +8816,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.20",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -8792,7 +8831,7 @@ checksum = "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6"
 dependencies = [
  "dunce",
  "embed-resource",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -9186,9 +9225,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -9732,9 +9771,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -161,7 +161,7 @@ walkdir = "2"
 # 模型(bge-m3 ONNX)用户本地下载，UserDefinedEmbeddingModel 从目录加载，不走 HF 自动下载。
 # 电子表格解析（file_ingest 用）：读 xlsx/xls/ods 的全部工作表。
 # 0.36 拉入 quick-xml 0.41+,修 RUSTSEC-2026-0194/0195 ReDoS。
-# plist/tauri 传递的 quick-xml 也已统一到 0.41,全图无残留旧版。
+# The quick-xml pulled in transitively by plist/tauri is unified to 0.41 too; no stale version remains in the graph.
 calamine = "0.36"
 # XLSX structure preservation: inspect OOXML cell styles, formulas, and merged
 # ranges that calamine's value-only Range intentionally does not expose.

--- a/pinvou3-app/src-tauri/Cargo.toml
+++ b/pinvou3-app/src-tauri/Cargo.toml
@@ -82,7 +82,8 @@ uuid = { version = "1.11", features = ["v4"] }
 # Codex/Claude/Kimi 各自的 ACP 实现提供，pinvou3 不复制其会话/工具循环。
 # unstable_elicitation is load-bearing (codex_acp CreateElicitation flow);
 # unstable_session_fork only gates the ForkSession API (zero app references), so the phase-4 audit drops it.
-agent-client-protocol = { version = "2", features = ["unstable_elicitation"] }
+# Pinned: 2.1.0 removes the unstable_elicitation feature (and a plain "2" would let cargo update pick it).
+agent-client-protocol = { version = "=2.0.0", features = ["unstable_elicitation"] }
 
 # 底层 Agent —— CodeWhale 提供 LLM 调用 + 工具循环 + 流式事件。
 # 上游 v0.8.45 起 rebrand：库 crate 改名 codewhale-tui。用 Cargo 的 `package`
@@ -160,7 +161,7 @@ walkdir = "2"
 # 模型(bge-m3 ONNX)用户本地下载，UserDefinedEmbeddingModel 从目录加载，不走 HF 自动下载。
 # 电子表格解析（file_ingest 用）：读 xlsx/xls/ods 的全部工作表。
 # 0.36 拉入 quick-xml 0.41+,修 RUSTSEC-2026-0194/0195 ReDoS。
-# 剩余 quick-xml 0.39.4 由 plist/tauri 传递,等上游。
+# plist/tauri 传递的 quick-xml 也已统一到 0.41,全图无残留旧版。
 calamine = "0.36"
 # XLSX structure preservation: inspect OOXML cell styles, formulas, and merged
 # ranges that calamine's value-only Range intentionally does not expose.

--- a/pinvou3-app/src/app/personas-overlay.js
+++ b/pinvou3-app/src/app/personas-overlay.js
@@ -19,7 +19,7 @@ export function ensurePersonaI18nOverlay(onLoaded) {
     return;
   }
   const s = document.createElement('script');
-  s.setAttribute('data-personas-i18n', '1');
+  s.dataset.personasI18n = '1';
   s.src = resolveAppAssetUrl('features/personas/personas-i18n.js');
   s.onload = onLoaded;
   s.onerror = () => s.remove();

--- a/pinvou3-app/src/features/artifacts/design-runtime.js
+++ b/pinvou3-app/src/features/artifacts/design-runtime.js
@@ -148,7 +148,7 @@ function buildDesignRuntimeScript() {
 
     function makeLabel() {
       const label = document.createElement('div');
-      label.setAttribute('data-pinvou-design-label', 'true');
+      label.dataset.pinvouDesignLabel = 'true';
       label.style.cssText = [
         'position:fixed',
         'z-index:2147483647',
@@ -167,7 +167,7 @@ function buildDesignRuntimeScript() {
 
     function makeHandleLayer() {
       const layer = document.createElement('div');
-      layer.setAttribute('data-pinvou-design-handles', 'true');
+      layer.dataset.pinvouDesignHandles = 'true';
       // No inset shorthand: the string reaches the bundle verbatim, Safari 14.0 cannot parse it, and the handle layer would lose its full-screen base.
       layer.style.cssText = 'position:fixed;top:0;right:0;bottom:0;left:0;z-index:2147483647;pointer-events:none;display:none';
       document.documentElement.append(layer);
@@ -273,7 +273,7 @@ function buildDesignRuntimeScript() {
         const dir = item[0], cursor = item[1];
         const p = handlePoint(rect, dir);
         const dot = document.createElement('div');
-        dot.setAttribute('data-pinvou-design-handle', dir);
+        dot.dataset.pinvouDesignHandle = dir;
         dot.style.cssText = [
           'position:fixed',
           'left:' + Math.round(p.x) + 'px',

--- a/pinvou3-app/src/features/conversation/message-clipboard.js
+++ b/pinvou3-app/src/features/conversation/message-clipboard.js
@@ -11,18 +11,19 @@ export { copyClipboardText, fallbackCopyText };
 let legacyHtmlConverter = null;
 let legacyConverterLoading = null;
 
-// turndown 的 node 在 Node/测试下由 domino 解析:domino 的 Element 没有
-// dataset,只有 getAttribute;浏览器下才是真实 Element。这里必须用
-// getAttribute 读 data-*,对 unicorn/dom-node-dataset 逐行豁免。
+// Turndown nodes are parsed by domino under Node/tests: domino's Element has
+// no dataset, only getAttribute; only in the browser is it a real Element.
+// data-* must be read via getAttribute, hence the per-line
+// unicorn/dom-node-dataset exemptions.
 function legacyFencedCodeLanguage(node) {
   const code = node && node.firstChild;
   const className = String((code && code.getAttribute && code.getAttribute('class')) || '');
   const classLanguage = (className.match(/language-(\S+)/) || [null, ''])[1];
-  // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见上
+  // eslint-disable-next-line unicorn/dom-node-dataset -- domino has no dataset, see above
   const dataLanguageId = String((node && node.getAttribute && node.getAttribute('data-language-id')) || '')
     .trim()
     .toLowerCase();
-  // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见上
+  // eslint-disable-next-line unicorn/dom-node-dataset -- domino has no dataset, see above
   const dataLanguage = String((node && node.getAttribute && node.getAttribute('data-language')) || '')
     .trim();
   // renderMarkdown 把无法被 hljs 识别的围栏语言（persona-card / card-question /
@@ -46,7 +47,7 @@ async function ensureLegacyHtmlConverter() {
           && node.nodeName === 'PRE'
           && node.firstChild
           && node.firstChild.nodeName === 'CODE'
-          // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见 legacyFencedCodeLanguage
+          // eslint-disable-next-line unicorn/dom-node-dataset -- domino has no dataset, see legacyFencedCodeLanguage
           && node.getAttribute('data-language')
         ),
         replacement: (_content, node, options) => {

--- a/pinvou3-app/src/features/conversation/message-clipboard.js
+++ b/pinvou3-app/src/features/conversation/message-clipboard.js
@@ -11,13 +11,18 @@ export { copyClipboardText, fallbackCopyText };
 let legacyHtmlConverter = null;
 let legacyConverterLoading = null;
 
+// turndown 的 node 在 Node/测试下由 domino 解析:domino 的 Element 没有
+// dataset,只有 getAttribute;浏览器下才是真实 Element。这里必须用
+// getAttribute 读 data-*,对 unicorn/dom-node-dataset 逐行豁免。
 function legacyFencedCodeLanguage(node) {
   const code = node && node.firstChild;
   const className = String((code && code.getAttribute && code.getAttribute('class')) || '');
   const classLanguage = (className.match(/language-(\S+)/) || [null, ''])[1];
+  // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见上
   const dataLanguageId = String((node && node.getAttribute && node.getAttribute('data-language-id')) || '')
     .trim()
     .toLowerCase();
+  // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见上
   const dataLanguage = String((node && node.getAttribute && node.getAttribute('data-language')) || '')
     .trim();
   // renderMarkdown 把无法被 hljs 识别的围栏语言（persona-card / card-question /
@@ -41,6 +46,7 @@ async function ensureLegacyHtmlConverter() {
           && node.nodeName === 'PRE'
           && node.firstChild
           && node.firstChild.nodeName === 'CODE'
+          // eslint-disable-next-line unicorn/dom-node-dataset -- domino 无 dataset,见 legacyFencedCodeLanguage
           && node.getAttribute('data-language')
         ),
         replacement: (_content, node, options) => {

--- a/pinvou3-app/src/features/pet/pet-markdown.js
+++ b/pinvou3-app/src/features/pet/pet-markdown.js
@@ -1,10 +1,10 @@
 import DOMPurify from 'dompurify';
-// eslint-disable-next-line import-x/namespace -- marked v14's ESM source uses ES2022 class fields, unparseable at this config's ES2021 floor (same as src/shared/markdown-renderer.js); the runtime bundler handles it, no impact
+// eslint-disable-next-line import-x/namespace -- marked's ESM source uses ES2022 class fields, unparseable at this config's ES2021 floor (same as src/shared/markdown-renderer.js); the runtime bundler handles it, no impact
 import { marked } from 'marked';
 
 const DANGEROUS_TAGS_RE = /<(\/?(?:script|style|iframe|object|embed|link|meta)\b[^>]*)>/gi;
 
-marked.setOptions({ gfm: true, breaks: true, headerIds: false, mangle: false });
+marked.setOptions({ gfm: true, breaks: true });
 
 export function renderPetMarkdown(text) {
   const html = marked.parse(String(text || '')).replaceAll(

--- a/pinvou3-app/src/shared/markdown-bridge-fallback.js
+++ b/pinvou3-app/src/shared/markdown-bridge-fallback.js
@@ -40,7 +40,7 @@
   }
 
   if (root.marked) {
-    root.marked.setOptions({ gfm: true, breaks: true, headerIds: false, mangle: false });
+    root.marked.setOptions({ gfm: true, breaks: true });
   }
 
   root.PinvouMarkdownBridgeFallback = Object.freeze({ renderMarkdown });

--- a/pinvou3-app/src/shared/markdown-fences.js
+++ b/pinvou3-app/src/shared/markdown-fences.js
@@ -4,8 +4,6 @@ import { Marked } from 'marked';
 export const MARKDOWN_OPTIONS = Object.freeze({
   gfm: true,
   breaks: true,
-  headerIds: false,
-  mangle: false,
 });
 const markdownLexer = new Marked(MARKDOWN_OPTIONS);
 


### PR DESCRIPTION
## Summary

Repo-wide dependency audit across all parent-repo manifests (`pinvou3-app` JS + `src-tauri` Rust, `pinvou-cli` workspace, `pinvou-knowledge`), executed in three passes per the task brief: (0) remove unused, (1) consolidate duplicated declarations, (2) upgrade in place with **zero net growth in duplicate crate-version families**. The CodeWhale submodule was fully analyzed but deliberately left untouched — dependency changes there are gated by the fork apparatus (upstream PR → new public tag → register/fingerprint updates) and belong in their own PR; findings are listed under Notes.

DCO: all three commits carry `Signed-off-by`.

### P0 — unused

- Removed the unused `thiserror` declaration from `pinvou-cli/crates/adapter-gaia` (its errors are hand-implemented; zero grep hits in src+tests). The `[workspace.dependencies]` entry stays — other members use it.
- Everything else verified used: `knip` reports zero unused files/deps/exports; every pinvou3-app dependency was grep-verified to a real import site; `cargo shear` is clean on both Rust manifests after the change.

### P1 — consolidation

- Hoisted 9 shared declarations into the `pinvou-cli` `[workspace.dependencies]` table (serde_json, anyhow, futures, fs2, sha2, rand, tokio, windows-sys, and parquet version-only), normalizing the diverging `rand` requirement texts. Members keep their own feature lists and the resolved versions are unchanged; the only required lock delta is the dropped `thiserror` edge.
- `pinvou-knowledge`: `tower-http` 0.6 → 0.7, aligning with the version already flowing through the app/cli graphs, and trimmed the unused `limit`/`request-id` features from its declaration (body limiting is a hand-written axum middleware and only `CatchPanicLayer`/`TraceLayer` are used; `uuid` leaves the knowledge lock as its only consumer). Disclosed consequence: the knowledge lock now carries the `tower-http` 0.6.11 (still transitive via reqwest) + 0.7.1 pair — the same dual the app/cli graphs already had.
- Surveyed the multi-version crate families in all three lockfiles: every remaining split is upstream-locked (oauth2 pins the reqwest 0.12/sha2 0.10 chain in the app/cli graphs and hf-hub does in knowledge; rust-i18n-support pins the toml 0.8 chain, the portable-pty/termwiz stack pins the old regex chain). No manifest-level consolidation exists; all documented exact pins and alignment comments (`base64 0.22`, `age =0.12.1`, `tauri-runtime-wry =2.11.4`, `mdns-sd =0.20.3`, …) are preserved.

### P2 — upgrades

- JS in-range refresh (lockfile-only): eslint 10.9.0→10.10.0, oxlint 1.80.0→1.82.0, @biomejs/biome 2.5.10→2.5.12, knip 6.32.2→6.35.1, eslint-plugin-jsdoc 64.2.1→64.3.8, @eslint/react 5.18.6→5.19.0, jscpd 5.0.16→5.2.0, globals 17.11.0→17.12.0, puppeteer-core 25.8.0→25.10.0, dompurify 3.4.14→3.4.15, @types/react-dom 19.2.5→19.2.7, @vitejs/plugin-react 6.1.0→6.1.1; plus one major: eslint-plugin-unicorn ^73→^74 (every allowlisted rule name still exists; the deprecated no-op alias `prefer-dom-node-dataset` is re-pointed to its renamed `dom-node-dataset` form, with the 7 mechanical `.dataset` fixes it re-flags — all behavior-equivalent). Duplicate npm package versions stay flat (23 → 23; `hookified` splits while `get-tsconfig` dedups).
- `src-tauri` targeted lock refresh within existing requirements: toml 1.1.4→1.1.5, log 0.4.33→0.4.34, rustls 0.23.43→0.23.44, uuid 1.24.1→1.26.0, encoding_rs 0.8.35→0.8.41, tauri-plugin-dialog/fs/log/notification/single-instance patch bumps (notification 2.3.3→2.4.0). `encoding_rs` 0.8.41 pulls `multiversion`/`core_detect` as new single-version transitives (no family growth). The `tauri-utils` toml edge stays on 1.1.x.
- `pinvou-cli` targeted lock refresh: rustls 0.23.43→0.23.44, encoding_rs 0.8.35→0.8.41, chacha20 0.10.1→0.10.2 (disclosed in the hoist commit; same targeted method).
- `agent-client-protocol` is now an exact pin `=2.0.0`: 2.1.0 removes the `unstable_elicitation` feature the codex_acp flow requires, and a plain `"2"` would let a future `cargo update` pick the incompatible release.
- Dropped `marked` options that upstream removed years ago (`headerIds`/`mangle`) and two vestigial eslint globals (`marked`/`DOMPurify` — sources only ever read `root.marked` as a property).
- Fixed the stale quick-xml comment in `src-tauri/Cargo.toml` (the lockfile has had a single quick-xml 0.41 since the plist/tauri transitive moved up).

### Evaluated and dropped — each would add a duplicate version family

- `reqwest` 0.13.4→0.13.5: requires `base64` 0.23, adding a 4th base64 version to the src-tauri and pinvou-cli graphs (they still carry 0.13/0.21/0.22 for age/oauth2/plist/reqwest 0.12).
- `flate2` 1.1.9→1.1.10: requires `miniz_oxide` 0.9 alongside 0.8.
- `cc` 1.2.62→1.4.5: requires `shlex` 2 alongside 1.3 (bindgen, codewhale-tui).
- `rcgen` =0.14.9→=0.14.10: pulls `pem` 4, which requires `base64` 0.23 in the pinvou-knowledge graph.

These are deferred until the rest of the graph can move together in one family-wide bump.

### Evaluated and deferred

- **marked 14 → 18**: marked 17 reworked the blockquote tokenizer so a fenced code block inside a list item no longer produces a `code` token, which breaks the token-tree fence scanner in `src/shared/markdown-fences.js` (verified with the token dumps and the `assistant_message_actions` test). Migration needs a dedicated PR.
- **typescript 7**: tooling-only, but `check:types` has documented pre-existing type debt; separate effort.

## Constraints honored

- **macOS 11**: vite `safari14` target, `.browserslistrc`, `src/vendor/**`, `legacy-polyfills.js` untouched; `audit:compat` passes against the Safari 14 baseline; the macOS Rust stack (tauri 2.11.5, `tauri-runtime-wry =2.11.4`, objc2 0.6 family) is unchanged.
- **MSRV 1.89**: every bumped crate's declared `rust-version` checked (max 1.88, incl. `multiversion` 1.86). `agent-client-protocol` stays at 2.0.0 (exact pin above).
- **Duplicate-version families**: verified flat for every upgrade — `pinvou-cli` 89 → 89, `src-tauri` 86 → 86, `pinvou-knowledge` 34 → 35 (the disclosed P1 `tower-http` 0.6/0.7 dual only).
- **`--locked` discipline**: `cargo metadata --locked` passes in all three workspaces.

## Verification

- Rust: the three Cargo.lock files were refreshed with targeted `cargo update -p … --precise …` from the previous lockfiles (no broad re-resolution churn); `cargo metadata --locked --offline` passes in all three workspaces; `cargo check --locked --offline` passes for `pinvou-knowledge --all-features` and the `pinvou-cli` workspace. Full test suites and clippy gates run in CI (rust-test, windows-rust-test, knowledge-rust, fast-gate).
- JS: `npm run lint` (eslint ui+node), `lint:ox`, `lint:biome`, `lint:knip`, `lint:cycles`, `lint:duplicates`, `build:ui`, `audit:compat` — all pass; `npm test` 544 pass / 0 fail; markdown artifact smoke 10/10 (chromium).
- Repo gates: `cargo shear` clean on both manifests; `node scripts/sync-version.mjs --check` consistent; `python3 scripts/architecture-guard.py` passes; `./scripts/fork-guard.sh --fast` passes.

## Notes — CodeWhale submodule findings (not implemented here)

For a follow-up submodule PR (blocked here by the public-tag gate): dead `schemars` dependency in `crates/tui`; dead `tracing-appender` hoisted workspace entry; the root `package.json` is vestigial (a single unused wrangler devDep plus 4 security overrides over its own tree); `web` uses `@eslint/eslintrc` without declaring it; wrangler versions drift across three lockfiles; sharp/axios security-override gaps in telemetry-ingest / wecom-bridge; `eslint-config-next` 15 running against next 16. Worthwhile-but-deliberate upstream upgrades: rmcp 2→3 and keyring 3→4 (both pass through the path-dep crates the parent compiles). One cross-repo caveat: the `[patch.crates-io] unicode-width` CJK fix applies only when CodeWhale's own workspace resolves the graph — parent builds get the crate-internal fallback only.

