### PR TITLE
fix(voice): trigger the shortcut from both Alt keys

### DIFF
--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -69,7 +69,7 @@
     "test:assistant-message-actions": "node tests/assistant_message_actions.test.mjs",
     "test:chat-error-isolation": "node tests/chat_turn_error_isolation.test.mjs",
     "test:attachment-drop": "node tests/attachment_drop_logic.test.mjs && node tests/attachment_drop_bridge.test.mjs && node tests/acp_native_attachment_client.test.mjs && node tests/attachment_bubble_logic.test.mjs",
-    "test:voice-input": "node tests/voice_input_error_logic.test.js && node tests/voice_shortcut_state.test.mjs && node tests/voice_shortcut_settings.test.mjs && node tests/voice_target_registry.test.mjs && node tests/voice_entry_policy.test.mjs",
+    "test:voice-input": "node tests/voice_input_error_logic.test.js && node tests/voice_shortcut_state.test.mjs && node tests/voice_shortcut_router.test.mjs && node tests/voice_shortcut_settings.test.mjs && node tests/voice_target_registry.test.mjs && node tests/voice_entry_policy.test.mjs",
     "eval:voice-normalize": "node scripts/voice-normalize-eval.mjs",
     "test:voice-asr-cancel": "node tests/voice_asr_cancel_logic.test.js",
     "test:bridge-protocol": "node tests/bridge_domain_protocol.test.mjs && node tests/web_bridge_domain_contract.test.mjs && node tests/monitor_bridge_format.test.mjs",

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
@@ -358,14 +358,26 @@ mod tests {
     #[test]
     fn alt_tap_swallows_down_and_up_symmetrically_and_triggers() {
         let mut state = VoiceShortcutState::default();
-        let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        let down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(down.event, None);
         assert!(down.suppress);
         assert!(!down.inject_alt_down);
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
         assert!(up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -374,24 +386,56 @@ mod tests {
     #[test]
     fn alt_autorepeat_stays_swallowed_and_triggers_once() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
-        let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
+        let repeat = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(repeat, VoiceShortcutDecision::suppress(None));
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
 
-        let stray =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let stray = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(stray, VoiceShortcutDecision::pass());
     }
 
     #[test]
     fn alt_combo_injects_alt_down_once_and_forwards_real_up() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
 
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
@@ -409,14 +453,26 @@ mod tests {
 
         // Alt auto-repeat down after a combo is let through, consistent with
         // the synthetic down.
-        let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        let repeat = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(repeat, VoiceShortcutDecision::pass());
 
         // The real up is let through to pair with the synthetic down; no
         // dictation trigger.
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
     }
@@ -424,7 +480,14 @@ mod tests {
     #[test]
     fn alt_escape_combo_forwards_alt_down_once_and_never_triggers() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
 
         // Alt+Esc is treated like a regular combo: swallow and replay
         // [Alt↓, Esc↓] in order, so Esc does not leak through bare.
@@ -435,8 +498,14 @@ mod tests {
 
         // The real Alt up is let through to pair with the synthetic down; no
         // dictation trigger.
-        let alt_up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let alt_up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(alt_up, VoiceShortcutDecision::pass());
         assert!(!alt_up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -449,7 +518,14 @@ mod tests {
         // unforwarded path — no trigger, state reset, no "Alt still held"
         // residue.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
         assert_eq!(combo, VoiceShortcutDecision::forward_combo());
@@ -459,8 +535,14 @@ mod tests {
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, false, true, HWND_A, 0);
         assert_eq!(combo_up, VoiceShortcutDecision::pass());
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::suppress(None));
         assert_eq!(up.event, None);
         assert_eq!(state, VoiceShortcutState::default());
@@ -474,7 +556,14 @@ mod tests {
         // modifier — and no dictation trigger fires. The combo keystroke
         // itself is lost, and no synthetic cleanup key is emitted.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
         assert_eq!(combo, VoiceShortcutDecision::forward_combo());
@@ -483,13 +572,25 @@ mod tests {
 
         // Alt auto-repeat while held is let through, consistent with the
         // injected down being held.
-        let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        let repeat = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(repeat, VoiceShortcutDecision::pass());
 
         // The real up is let through to pair with the injected Alt down.
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert!(!up.suppress);
         assert_eq!(up.event, None);
@@ -503,7 +604,14 @@ mod tests {
         // A later Alt up no longer ghost-triggers dictation, and the next
         // gesture works in full.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1000);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            1000,
+        );
 
         let ghost_up = handle_voice_shortcut_key(
             &mut state,
@@ -522,8 +630,14 @@ mod tests {
 
         // New gesture: down swallowed, up triggers — identical to the first
         // time.
-        let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 90500);
+        let down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            90500,
+        );
         assert!(down.suppress);
         let up = handle_voice_shortcut_key(
             &mut state,
@@ -541,12 +655,31 @@ mod tests {
         // Held normally: OS auto-repeat keeps refreshing the event stream with
         // gaps far below the threshold, so no reset is triggered.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1000);
-        let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1600);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            1000,
+        );
+        let repeat = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            1600,
+        );
         assert_eq!(repeat, VoiceShortcutDecision::suppress(None));
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 1630);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            1630,
+        );
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
     }
 
@@ -601,7 +734,14 @@ mod tests {
     #[test]
     fn alt_space_suppresses_pair_and_never_triggers_or_injects() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
 
         let space_down =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, true, true, HWND_A, 0);
@@ -611,8 +751,14 @@ mod tests {
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, false, true, HWND_A, 0);
         assert_eq!(space_up, VoiceShortcutDecision::suppress(None));
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::suppress(None));
         assert_eq!(up.event, None);
     }
@@ -627,7 +773,14 @@ mod tests {
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, true, true, HWND_A, 0);
         assert_eq!(space_down, VoiceShortcutDecision::pass());
 
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
 
         let space_up =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, false, true, HWND_A, 0);
@@ -650,12 +803,24 @@ mod tests {
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, true, true, HWND_A, 0);
         assert_eq!(space, VoiceShortcutDecision::pass());
 
-        let alt =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        let alt = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(alt, VoiceShortcutDecision::suppress(None));
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
         assert!(up.suppress);
     }
@@ -663,14 +828,26 @@ mod tests {
     #[test]
     fn alt_up_in_another_app_window_does_not_trigger() {
         let mut state = VoiceShortcutState::default();
-        let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        let down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         assert!(down.suppress);
 
         // Hold Alt, switch to another window of the same process, release: no
         // trigger; the down was swallowed, so the up is swallowed in pairs.
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_B, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_B,
+            0,
+        );
         assert_eq!(up.event, None);
         assert!(up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -679,35 +856,74 @@ mod tests {
     #[test]
     fn unknown_foreground_hwnd_still_allows_trigger() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, 0, 0);
-        let up = handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, 0, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            0,
+            0,
+        );
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            0,
+            0,
+        );
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
     }
 
     #[test]
     fn shortcuts_are_ignored_when_no_target_window() {
         let mut state = VoiceShortcutState::default();
-        let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, false, HWND_A, 0);
+        let down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            false,
+            HWND_A,
+            0,
+        );
         assert_eq!(down, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
 
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, false, HWND_A, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            false,
+            HWND_A,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::pass());
     }
 
     #[test]
     fn gesture_state_resets_when_focus_leaves_target_mid_hold() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
         // Hold Alt while focus leaves the target window: keys in between are
         // all let through, and state resets at Alt up.
         let other =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, false, HWND_B, 0);
         assert_eq!(other, VoiceShortcutDecision::pass());
-        let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, false, HWND_B, 0);
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            false,
+            HWND_B,
+            0,
+        );
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
     }

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
@@ -739,6 +739,69 @@ mod tests {
     }
 
     #[test]
+    fn cross_side_hold_resolves_on_first_up_and_rearms_on_repeat() {
+        // Documented cross-side hold: both downs are swallowed (the other side
+        // is a repeat and the arming side sticks), the first up resolves the
+        // gesture and fires once, and the still-held side's auto-repeat
+        // re-arms, so its eventual release fires a second time. Per-side
+        // tracking was deliberately rejected as not worth complicating the
+        // main gesture path — this pins the accepted behavior.
+        let mut state = VoiceShortcutState::default();
+        let left_down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            true,
+            true,
+            HWND_A,
+            1000,
+        );
+        assert!(left_down.suppress);
+
+        let right_down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            true,
+            true,
+            HWND_A,
+            1100,
+        );
+        assert_eq!(right_down, VoiceShortcutDecision::suppress(None));
+        assert_eq!(state.alt_side, AltSide::Left);
+        assert!(state.alt_pending);
+
+        let left_up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Left),
+            false,
+            true,
+            HWND_A,
+            1200,
+        );
+        assert_eq!(left_up.event, Some(VoiceShortcutEvent::TriggerDictation));
+        assert_eq!(state, VoiceShortcutState::default());
+
+        let right_repeat = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            true,
+            true,
+            HWND_A,
+            1300,
+        );
+        assert!(right_repeat.suppress);
+        assert_eq!(state.alt_side, AltSide::Right);
+        let right_up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            false,
+            true,
+            HWND_A,
+            1400,
+        );
+        assert_eq!(right_up.event, Some(VoiceShortcutEvent::TriggerDictation));
+    }
+
+    #[test]
     fn alt_space_suppresses_pair_and_never_triggers_or_injects() {
         let mut state = VoiceShortcutState::default();
         handle_voice_shortcut_key(

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
@@ -2,9 +2,21 @@ use serde::Serialize;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter};
 
+/// Which physical Alt key started the current gesture. The state machine
+/// treats both sides identically; the platform layer only reads this when
+/// replaying a swallowed combo, so the injected modifier keeps the identity of
+/// the key the user actually held (right-Alt combos surface as AltGr rather
+/// than being rewritten to left Alt — see `alt_side_vk`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum AltSide {
+    #[default]
+    Left,
+    Right,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum VoiceShortcutKey {
-    Alt,
+    Alt(AltSide),
     Space,
     Escape,
     Other,
@@ -27,6 +39,9 @@ enum VoiceShortcutEvent {
 struct VoiceShortcutState {
     alt_down: bool,
     alt_pending: bool,
+    /// Which physical Alt key started the current gesture (meaningful only
+    /// while `alt_down`); the platform layer reads it at combo replay time.
+    alt_side: AltSide,
     /// The [Alt↓, combo↓] ordered replay has been issued for a combo key (the
     /// platform layer sets this whenever at least the Alt down was injected,
     /// complete or partial); the real Alt up must be let through to pair with
@@ -118,18 +133,19 @@ fn handle_voice_shortcut_key(
     if !active {
         // Gesture landed on a non-target window: swallow nothing, only reset
         // on Alt up so state cannot leak into the next gesture.
-        if key == VoiceShortcutKey::Alt && !key_down {
+        if matches!(key, VoiceShortcutKey::Alt(_)) && !key_down {
             *state = VoiceShortcutState::default();
         }
         return VoiceShortcutDecision::pass();
     }
 
     match (key, key_down) {
-        (VoiceShortcutKey::Alt, true) => {
+        (VoiceShortcutKey::Alt(side), true) => {
             if state.alt_down {
                 // Long-press auto-repeat: keep swallowing when not forwarded,
                 // let through when forwarded (consistent with the synthetic
-                // down).
+                // down). Covers the other Alt side too: both downs are
+                // swallowed and the first up resolves the gesture.
                 return if state.alt_forwarded {
                     VoiceShortcutDecision::pass()
                 } else {
@@ -138,11 +154,12 @@ fn handle_voice_shortcut_key(
             }
             state.alt_down = true;
             state.alt_pending = true;
+            state.alt_side = side;
             state.alt_forwarded = false;
             state.alt_hwnd = foreground_hwnd;
             VoiceShortcutDecision::suppress(None)
         }
-        (VoiceShortcutKey::Alt, false) => {
+        (VoiceShortcutKey::Alt(_), false) => {
             if !state.alt_down {
                 return VoiceShortcutDecision::pass();
             }
@@ -342,13 +359,13 @@ mod tests {
     fn alt_tap_swallows_down_and_up_symmetrically_and_triggers() {
         let mut state = VoiceShortcutState::default();
         let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert_eq!(down.event, None);
         assert!(down.suppress);
         assert!(!down.inject_alt_down);
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
         assert!(up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -357,24 +374,24 @@ mod tests {
     #[test]
     fn alt_autorepeat_stays_swallowed_and_triggers_once() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert_eq!(repeat, VoiceShortcutDecision::suppress(None));
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
 
         let stray =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(stray, VoiceShortcutDecision::pass());
     }
 
     #[test]
     fn alt_combo_injects_alt_down_once_and_forwards_real_up() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
 
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
@@ -393,13 +410,13 @@ mod tests {
         // Alt auto-repeat down after a combo is let through, consistent with
         // the synthetic down.
         let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert_eq!(repeat, VoiceShortcutDecision::pass());
 
         // The real up is let through to pair with the synthetic down; no
         // dictation trigger.
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
     }
@@ -407,7 +424,7 @@ mod tests {
     #[test]
     fn alt_escape_combo_forwards_alt_down_once_and_never_triggers() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
 
         // Alt+Esc is treated like a regular combo: swallow and replay
         // [Alt↓, Esc↓] in order, so Esc does not leak through bare.
@@ -419,7 +436,7 @@ mod tests {
         // The real Alt up is let through to pair with the synthetic down; no
         // dictation trigger.
         let alt_up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(alt_up, VoiceShortcutDecision::pass());
         assert!(!alt_up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -432,7 +449,7 @@ mod tests {
         // unforwarded path — no trigger, state reset, no "Alt still held"
         // residue.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
         assert_eq!(combo, VoiceShortcutDecision::forward_combo());
@@ -443,7 +460,7 @@ mod tests {
         assert_eq!(combo_up, VoiceShortcutDecision::pass());
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up, VoiceShortcutDecision::suppress(None));
         assert_eq!(up.event, None);
         assert_eq!(state, VoiceShortcutState::default());
@@ -457,7 +474,7 @@ mod tests {
         // modifier — and no dictation trigger fires. The combo keystroke
         // itself is lost, and no synthetic cleanup key is emitted.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         let combo =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
         assert_eq!(combo, VoiceShortcutDecision::forward_combo());
@@ -467,12 +484,12 @@ mod tests {
         // Alt auto-repeat while held is let through, consistent with the
         // injected down being held.
         let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert_eq!(repeat, VoiceShortcutDecision::pass());
 
         // The real up is let through to pair with the injected Alt down.
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert!(!up.suppress);
         assert_eq!(up.event, None);
@@ -486,11 +503,11 @@ mod tests {
         // A later Alt up no longer ghost-triggers dictation, and the next
         // gesture works in full.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 1000);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1000);
 
         let ghost_up = handle_voice_shortcut_key(
             &mut state,
-            VoiceShortcutKey::Alt,
+            VoiceShortcutKey::Alt(AltSide::Left),
             false,
             true,
             HWND_A,
@@ -506,11 +523,11 @@ mod tests {
         // New gesture: down swallowed, up triggers — identical to the first
         // time.
         let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 90500);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 90500);
         assert!(down.suppress);
         let up = handle_voice_shortcut_key(
             &mut state,
-            VoiceShortcutKey::Alt,
+            VoiceShortcutKey::Alt(AltSide::Left),
             false,
             true,
             HWND_A,
@@ -524,19 +541,67 @@ mod tests {
         // Held normally: OS auto-repeat keeps refreshing the event stream with
         // gaps far below the threshold, so no reset is triggered.
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 1000);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1000);
         let repeat =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 1600);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 1600);
         assert_eq!(repeat, VoiceShortcutDecision::suppress(None));
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 1630);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 1630);
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
+    }
+
+    #[test]
+    fn right_alt_tap_triggers_like_left_alt() {
+        let mut state = VoiceShortcutState::default();
+        let down = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
+        assert!(down.suppress);
+        assert!(!down.inject_alt_down);
+
+        let up = handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            false,
+            true,
+            HWND_A,
+            0,
+        );
+        assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
+        assert!(up.suppress);
+        assert_eq!(state, VoiceShortcutState::default());
+    }
+
+    #[test]
+    fn right_alt_combo_records_side_for_platform_replay() {
+        // The state machine treats both sides identically, but the platform
+        // layer must replay the swallowed combo with the VK of the Alt the
+        // user actually held, so the recorded side must survive until the
+        // combo down arrives.
+        let mut state = VoiceShortcutState::default();
+        handle_voice_shortcut_key(
+            &mut state,
+            VoiceShortcutKey::Alt(AltSide::Right),
+            true,
+            true,
+            HWND_A,
+            0,
+        );
+        let combo =
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, true, HWND_A, 0);
+        assert_eq!(combo, VoiceShortcutDecision::forward_combo());
+        assert_eq!(state.alt_side, AltSide::Right);
     }
 
     #[test]
     fn alt_space_suppresses_pair_and_never_triggers_or_injects() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
 
         let space_down =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, true, true, HWND_A, 0);
@@ -547,7 +612,7 @@ mod tests {
         assert_eq!(space_up, VoiceShortcutDecision::suppress(None));
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up, VoiceShortcutDecision::suppress(None));
         assert_eq!(up.event, None);
     }
@@ -562,7 +627,7 @@ mod tests {
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, true, true, HWND_A, 0);
         assert_eq!(space_down, VoiceShortcutDecision::pass());
 
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
 
         let space_up =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Space, false, true, HWND_A, 0);
@@ -586,11 +651,11 @@ mod tests {
         assert_eq!(space, VoiceShortcutDecision::pass());
 
         let alt =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert_eq!(alt, VoiceShortcutDecision::suppress(None));
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_A, 0);
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
         assert!(up.suppress);
     }
@@ -599,13 +664,13 @@ mod tests {
     fn alt_up_in_another_app_window_does_not_trigger() {
         let mut state = VoiceShortcutState::default();
         let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         assert!(down.suppress);
 
         // Hold Alt, switch to another window of the same process, release: no
         // trigger; the down was swallowed, so the up is swallowed in pairs.
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, HWND_B, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, HWND_B, 0);
         assert_eq!(up.event, None);
         assert!(up.suppress);
         assert_eq!(state, VoiceShortcutState::default());
@@ -614,8 +679,8 @@ mod tests {
     #[test]
     fn unknown_foreground_hwnd_still_allows_trigger() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, 0, 0);
-        let up = handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, true, 0, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, 0, 0);
+        let up = handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, true, 0, 0);
         assert_eq!(up.event, Some(VoiceShortcutEvent::TriggerDictation));
     }
 
@@ -623,26 +688,26 @@ mod tests {
     fn shortcuts_are_ignored_when_no_target_window() {
         let mut state = VoiceShortcutState::default();
         let down =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, false, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, false, HWND_A, 0);
         assert_eq!(down, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
 
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, false, HWND_A, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, false, HWND_A, 0);
         assert_eq!(up, VoiceShortcutDecision::pass());
     }
 
     #[test]
     fn gesture_state_resets_when_focus_leaves_target_mid_hold() {
         let mut state = VoiceShortcutState::default();
-        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, true, true, HWND_A, 0);
+        handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), true, true, HWND_A, 0);
         // Hold Alt while focus leaves the target window: keys in between are
         // all let through, and state resets at Alt up.
         let other =
             handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Other, true, false, HWND_B, 0);
         assert_eq!(other, VoiceShortcutDecision::pass());
         let up =
-            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt, false, false, HWND_B, 0);
+            handle_voice_shortcut_key(&mut state, VoiceShortcutKey::Alt(AltSide::Left), false, false, HWND_B, 0);
         assert_eq!(up, VoiceShortcutDecision::pass());
         assert_eq!(state, VoiceShortcutState::default());
     }

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut.rs
@@ -41,6 +41,9 @@ struct VoiceShortcutState {
     alt_pending: bool,
     /// Which physical Alt key started the current gesture (meaningful only
     /// while `alt_down`); the platform layer reads it at combo replay time.
+    /// If the other side is pressed while held, it is swallowed as a repeat
+    /// and the recorded side stays the arming one, so a combo is replayed
+    /// with the side that started the gesture, not the most recent press.
     alt_side: AltSide,
     /// The [Alt↓, combo↓] ordered replay has been issued for a combo key (the
     /// platform layer sets this whenever at least the Alt down was injected,
@@ -145,7 +148,11 @@ fn handle_voice_shortcut_key(
                 // Long-press auto-repeat: keep swallowing when not forwarded,
                 // let through when forwarded (consistent with the synthetic
                 // down). Covers the other Alt side too: both downs are
-                // swallowed and the first up resolves the gesture.
+                // swallowed and the first up resolves the gesture — releasing
+                // the arming side fires dictation while the other side is
+                // still held, whose auto-repeat re-arms and fires once more
+                // on its own release. Holding both Alts is exotic enough that
+                // this double trigger is accepted over per-side tracking.
                 return if state.alt_forwarded {
                     VoiceShortcutDecision::pass()
                 } else {

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut/platform/mod.rs
@@ -584,9 +584,18 @@ mod tests {
     /// Both physical Alt keys start the gesture; only the side differs.
     #[test]
     fn voice_shortcut_key_maps_both_alt_sides() {
-        assert_eq!(voice_shortcut_key(VK_LMENU), VoiceShortcutKey::Alt(AltSide::Left));
-        assert_eq!(voice_shortcut_key(VK_MENU), VoiceShortcutKey::Alt(AltSide::Left));
-        assert_eq!(voice_shortcut_key(VK_RMENU), VoiceShortcutKey::Alt(AltSide::Right));
+        assert_eq!(
+            voice_shortcut_key(VK_LMENU),
+            VoiceShortcutKey::Alt(AltSide::Left)
+        );
+        assert_eq!(
+            voice_shortcut_key(VK_MENU),
+            VoiceShortcutKey::Alt(AltSide::Left)
+        );
+        assert_eq!(
+            voice_shortcut_key(VK_RMENU),
+            VoiceShortcutKey::Alt(AltSide::Right)
+        );
         assert_eq!(voice_shortcut_key(VK_SPACE), VoiceShortcutKey::Space);
         assert_eq!(voice_shortcut_key(VK_ESCAPE), VoiceShortcutKey::Escape);
         assert_eq!(voice_shortcut_key(0x41), VoiceShortcutKey::Other);

--- a/pinvou3-app/src-tauri/src/features/voice_shortcut/platform/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/voice_shortcut/platform/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(target_os = "windows")]
 use super::{
-    VoiceShortcutDecision, VoiceShortcutEvent, VoiceShortcutKey, VoiceShortcutState,
+    AltSide, VoiceShortcutDecision, VoiceShortcutEvent, VoiceShortcutKey, VoiceShortcutState,
     emit_shortcut_event, handle_voice_shortcut_key, is_voice_shortcut_router_window,
     recording_label, resolve_trigger_target,
 };
@@ -250,19 +250,26 @@ unsafe extern "system" fn keyboard_hook_proc(
         if decision.inject_alt_down {
             // The combo down was swallowed: replay [Alt↓, combo↓] in order
             // with a single SendInput, so the system/WebView sees the modifier
-            // order of a real press and Alt+Tab/Alt+F4 keep working. SendInput
-            // reports how many entries were actually injected (not a
-            // transactional boolean), so the outcome is three-valued: a
-            // complete replay confirms alt_forwarded, and a partial replay
-            // (only the leading Alt↓ was injected) must confirm it too — the
-            // synthetic Alt down is already in the system and is paired by the
-            // real Alt up passing through; no synthetic cleanup key is sent
-            // because a cleanup SendInput could itself partially fail, while
-            // the physical Alt release is guaranteed to arrive. Only a
+            // order of a real press and Alt+Tab/Alt+F4 keep working. The Alt↓
+            // uses the VK of the side that started the gesture (left Alt →
+            // VK_LMENU, right Alt → VK_RMENU), so a right-Alt combo keeps the
+            // identity of the held modifier — on AltGr layouts the layout
+            // driver's synthesized left-Ctrl already passed the hook
+            // unswallowed, and the injected RMenu↓ then completes the same
+            // modifier set a real AltGr press produces. SendInput reports how
+            // many entries were actually injected (not a transactional
+            // boolean), so the outcome is three-valued: a complete replay
+            // confirms alt_forwarded, and a partial replay (only the leading
+            // Alt↓ was injected) must confirm it too — the synthetic Alt down
+            // is already in the system and is paired by the real Alt up
+            // passing through; no synthetic cleanup key is sent because a
+            // cleanup SendInput could itself partially fail, while the
+            // physical Alt release is guaranteed to arrive. Only a
             // zero-injection failure leaves alt_forwarded false: the combo is
             // lost, the real Alt up is wrapped up along the unforwarded path,
             // and no state is left behind.
-            if replay_combo_with_alt(info.vkCode as VIRTUAL_KEY).leaves_alt_forwarded() {
+            let alt_vk = alt_side_vk(state.alt_side);
+            if replay_combo_with_alt(alt_vk, info.vkCode as VIRTUAL_KEY).leaves_alt_forwarded() {
                 state.alt_forwarded = true;
             }
         }
@@ -309,6 +316,18 @@ fn focused_router_label(foreground: HWND) -> Option<String> {
         .map(|(_, label)| label.clone())
 }
 
+/// The VK injected for the gesture's Alt side: the replay repeats the physical
+/// key the user held (left Alt replays VK_LMENU, right Alt replays VK_RMENU)
+/// instead of rewriting every gesture to left Alt, so right-Alt combos keep
+/// their modifier identity (AltGr on European layouts; plain Alt elsewhere).
+#[cfg(target_os = "windows")]
+fn alt_side_vk(side: AltSide) -> VIRTUAL_KEY {
+    match side {
+        AltSide::Left => VK_LMENU,
+        AltSide::Right => VK_RMENU,
+    }
+}
+
 /// tap-hold compensation: the combo down was swallowed, so inject the two-entry
 /// [Alt↓, combo↓] sequence with a single SendInput, replayed in order, so the
 /// system and WebView see the same modifier order as a real press (Alt first,
@@ -321,8 +340,8 @@ fn focused_router_label(foreground: HWND) -> Option<String> {
 /// Returns which entries were injected (SendInput reports a count, not a
 /// transactional boolean — see [`ComboReplayOutcome`]).
 #[cfg(target_os = "windows")]
-fn replay_combo_with_alt(combo_vk: VIRTUAL_KEY) -> ComboReplayOutcome {
-    let inputs = combo_replay_inputs(combo_vk);
+fn replay_combo_with_alt(alt_vk: VIRTUAL_KEY, combo_vk: VIRTUAL_KEY) -> ComboReplayOutcome {
+    let inputs = combo_replay_inputs(alt_vk, combo_vk);
     let sent = unsafe {
         SendInput(
             inputs.len() as u32,
@@ -377,13 +396,13 @@ impl ComboReplayOutcome {
 }
 
 #[cfg(target_os = "windows")]
-fn combo_replay_inputs(combo_vk: VIRTUAL_KEY) -> [INPUT; 2] {
+fn combo_replay_inputs(alt_vk: VIRTUAL_KEY, combo_vk: VIRTUAL_KEY) -> [INPUT; 2] {
     [
         INPUT {
             r#type: INPUT_KEYBOARD,
             Anonymous: INPUT_0 {
                 ki: KEYBDINPUT {
-                    wVk: VK_LMENU,
+                    wVk: alt_vk,
                     wScan: 0,
                     dwFlags: 0,
                     time: 0,
@@ -425,10 +444,14 @@ fn call_next_hook(code: i32, w_param: WPARAM, l_param: LPARAM) -> LRESULT {
 #[cfg(target_os = "windows")]
 fn voice_shortcut_key(vk: VIRTUAL_KEY) -> VoiceShortcutKey {
     match vk {
-        VK_MENU | VK_LMENU => VoiceShortcutKey::Alt,
-        // Right Alt / AltGr does not trigger the voice shortcut; it stays with
-        // the input method and combos.
-        VK_RMENU => VoiceShortcutKey::Other,
+        VK_MENU | VK_LMENU => VoiceShortcutKey::Alt(AltSide::Left),
+        // Right Alt (VK_RMENU) triggers too: bare taps are the same gesture as
+        // left Alt. On European layouts right Alt is AltGr, and its character
+        // combos keep working — the layout driver's synthesized left-Ctrl
+        // passes the hook unswallowed, and the swallowed RMenu is replayed as
+        // part of the combo (see alt_side_vk), so the app still sees the
+        // Ctrl+Alt modifier set of a real AltGr press.
+        VK_RMENU => VoiceShortcutKey::Alt(AltSide::Right),
         VK_SPACE => VoiceShortcutKey::Space,
         VK_ESCAPE => VoiceShortcutKey::Escape,
         _ => VoiceShortcutKey::Other,
@@ -464,7 +487,7 @@ fn log_shortcut_decision(
 ) {
     if matches!(
         key,
-        VoiceShortcutKey::Alt | VoiceShortcutKey::Space | VoiceShortcutKey::Escape
+        VoiceShortcutKey::Alt(_) | VoiceShortcutKey::Space | VoiceShortcutKey::Escape
     ) {
         log::debug!(
             "voice shortcut key={:?} down={} target={:?} event={:?} suppress={} inject_alt_down={}",
@@ -523,10 +546,11 @@ mod tests {
     }
 
     /// The replay array is exactly [Alt↓, combo↓] in that order (modifier
-    /// first, so Alt+Tab/Alt+F4 keep working), both as key-down events.
+    /// first, so Alt+Tab/Alt+F4 keep working), both as key-down events, with
+    /// the Alt VK taken from the gesture side.
     #[test]
     fn combo_replay_inputs_are_ordered_alt_down_then_combo_down() {
-        let inputs = combo_replay_inputs(VK_SPACE);
+        let inputs = combo_replay_inputs(VK_LMENU, VK_SPACE);
         assert_eq!(inputs.len(), 2);
         for input in &inputs {
             assert_eq!(input.r#type, INPUT_KEYBOARD);
@@ -539,8 +563,32 @@ mod tests {
         assert_eq!(alt_vk, VK_LMENU);
         assert_eq!(combo_vk, VK_SPACE);
 
-        let inputs = combo_replay_inputs(VK_ESCAPE);
+        let inputs = combo_replay_inputs(VK_LMENU, VK_ESCAPE);
         let combo_vk = unsafe { inputs[1].Anonymous.ki.wVk };
         assert_eq!(combo_vk, VK_ESCAPE);
+    }
+
+    /// Right-Alt gestures replay the right Alt (VK_RMENU), not a rewritten
+    /// left Alt: together with the layout driver's synthesized left-Ctrl that
+    /// passed the hook, the app keeps seeing a real AltGr modifier set.
+    #[test]
+    fn combo_replay_uses_the_gesture_side_alt_vk() {
+        assert_eq!(alt_side_vk(AltSide::Left), VK_LMENU);
+        assert_eq!(alt_side_vk(AltSide::Right), VK_RMENU);
+
+        let inputs = combo_replay_inputs(VK_RMENU, VK_SPACE);
+        let alt_vk = unsafe { inputs[0].Anonymous.ki.wVk };
+        assert_eq!(alt_vk, VK_RMENU);
+    }
+
+    /// Both physical Alt keys start the gesture; only the side differs.
+    #[test]
+    fn voice_shortcut_key_maps_both_alt_sides() {
+        assert_eq!(voice_shortcut_key(VK_LMENU), VoiceShortcutKey::Alt(AltSide::Left));
+        assert_eq!(voice_shortcut_key(VK_MENU), VoiceShortcutKey::Alt(AltSide::Left));
+        assert_eq!(voice_shortcut_key(VK_RMENU), VoiceShortcutKey::Alt(AltSide::Right));
+        assert_eq!(voice_shortcut_key(VK_SPACE), VoiceShortcutKey::Space);
+        assert_eq!(voice_shortcut_key(VK_ESCAPE), VoiceShortcutKey::Escape);
+        assert_eq!(voice_shortcut_key(0x41), VoiceShortcutKey::Other);
     }
 }

--- a/pinvou3-app/src/features/chat/voice-shortcut-state.mjs
+++ b/pinvou3-app/src/features/chat/voice-shortcut-state.mjs
@@ -69,10 +69,13 @@ function voiceShortcutActionForKeyDown(event, current) {
   }
 
   // While an Alt gesture is pending, any other key (including Esc) is a combo member:
-  // clear pending, neither trigger nor cancel. Otherwise the Esc inside the passthrough
-  // batch of Alt+Esc (system window cycling) would cancel an active recording too,
-  // inconsistent with Alt+Tab (Other keys only clear pending).
-  if (state.pendingAlt) return { type: 'clear_pending' };
+  // clear pending, neither trigger nor cancel. swallow:false tells the router to pass
+  // the keydown through unswallowed so it keeps its own behavior (macOS Option
+  // symbols, app menu keys) — the keyup lane already passes combo tails through.
+  // Otherwise the Esc inside the passthrough batch of Alt+Esc (system window
+  // cycling) would cancel an active recording too, inconsistent with Alt+Tab
+  // (Other keys only clear pending).
+  if (state.pendingAlt) return { type: 'clear_pending', swallow: false };
 
   if (event && event.key === 'Escape') {
     return isActiveVoiceShortcutStatus(status) ? { type: 'cancel' } : { type: 'none' };

--- a/pinvou3-app/src/features/chat/voice-shortcut-state.mjs
+++ b/pinvou3-app/src/features/chat/voice-shortcut-state.mjs
@@ -8,11 +8,12 @@ function normalizeVoiceShortcutMode(mode) {
 function isPlainAltKey(event) {
   return event
     && event.key === 'Alt'
-    // Right Alt matches the Rust hook's policy (VK_RMENU classified as Other): reserved for
-    // AltGr/IME, does not trigger the voice shortcut. location 2 = DOM_KEY_LOCATION_RIGHT;
-    // fall back to code in environments where location is missing.
-    && event.location !== 2
-    && event.code !== 'AltRight'
+    // Both physical Alt/Option keys trigger: the Rust hook classifies VK_LMENU
+    // and VK_RMENU as Alt (right Alt kept in sync there), and on macOS this
+    // in-window fallback is the only channel, so right Option must work too.
+    // AltGr (Ctrl+right Alt on European layouts) stays inert via the ctrlKey
+    // guard, matching the hook where the layout-synthesized left-Ctrl passes
+    // unswallowed and no gesture arms.
     && !event.ctrlKey
     && !event.shiftKey
     && !event.metaKey;

--- a/pinvou3-app/src/features/voice-composer/VoiceShortcutRouter.jsx
+++ b/pinvou3-app/src/features/voice-composer/VoiceShortcutRouter.jsx
@@ -115,6 +115,15 @@ function VoiceShortcutRouter({ enabled = true }) {
       // While the intro modal is open, Esc yields to the modal's own close handling
       // (no preventDefault, no voice-start cancel).
       if (action.type === 'cancel' && isVoiceShortcutIntroOpen()) return;
+      // A human combo-member keydown only disarms the pending gesture: pass it
+      // through unswallowed so the key keeps its own behavior (macOS Option
+      // symbols, app menu keys) — mirror of the keyup lane below, which also
+      // returns before preventDefault for clear_pending. Alt+Space carries no
+      // swallow:false and stays suppressed (it opens the window system menu).
+      if (action.type === 'clear_pending' && action.swallow === false) {
+        clearPendingShortcut();
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
       if (action.type === 'clear_pending') {

--- a/pinvou3-app/tests/voice_shortcut_router.test.mjs
+++ b/pinvou3-app/tests/voice_shortcut_router.test.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// The router component has no DOM harness in this repo's node --test setup, so
+// the keydown dispatch order is pinned on the source: the swallow:false early
+// return must precede the preventDefault pair, otherwise human Alt/Option combo
+// keydowns get swallowed again (the #470 regression where right-Option + letter
+// lost the macOS symbol). The keyup lane's clear_pending-before-preventDefault
+// order is pinned too, so the two lanes cannot silently diverge again.
+import assert from 'assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(
+  path.join(testDir, '..', 'src', 'features', 'voice-composer', 'VoiceShortcutRouter.jsx'),
+  'utf8',
+);
+
+const keydownStart = source.indexOf('function handleVoiceShortcutKeyDown');
+const keyupStart = source.indexOf('function handleVoiceShortcutKeyUp');
+const listenersLine = source.indexOf("window.addEventListener('keydown'");
+assert.ok(keydownStart !== -1 && keyupStart !== -1 && listenersLine !== -1, 'router key handlers must exist');
+assert.ok(keydownStart < keyupStart && keyupStart < listenersLine, 'handler layout changed; update this test');
+
+const keydown = source.slice(keydownStart, keyupStart);
+const swallowGuard = keydown.indexOf('action.swallow === false');
+const keydownPreventDefault = keydown.indexOf('event.preventDefault();');
+assert.ok(swallowGuard !== -1, 'keydown lane must keep the swallow:false passthrough guard');
+assert.ok(keydownPreventDefault !== -1, 'keydown lane must keep preventDefault for swallowable actions');
+assert.ok(
+  swallowGuard < keydownPreventDefault,
+  'combo-member keydowns must return before preventDefault so Alt combos keep their own behavior',
+);
+
+const keyup = source.slice(keyupStart, listenersLine);
+const keyupClearPending = keyup.indexOf("action.type === 'clear_pending'");
+const keyupPreventDefault = keyup.indexOf('event.preventDefault();');
+assert.ok(keyupClearPending !== -1 && keyupPreventDefault !== -1, 'keyup lane guards must exist');
+assert.ok(
+  keyupClearPending < keyupPreventDefault,
+  'keyup clear_pending must keep passing combo tails through without preventDefault',
+);
+
+console.log('voice_shortcut_router: ok');

--- a/pinvou3-app/tests/voice_shortcut_state.test.mjs
+++ b/pinvou3-app/tests/voice_shortcut_state.test.mjs
@@ -212,25 +212,45 @@ assert.deepStrictEqual(
   { type: 'trigger', mode: 'dictation' },
 );
 
-// Right Alt shares key === 'Alt' but must never trigger: the Windows hook
-// classifies VK_RMENU as Other ("右 Alt / AltGr 不触发语音快捷键"), so the
-// JS gesture channel must agree — otherwise a bare right-Alt tap would fire
-// dictation through the page lane the hook deliberately passes through.
+// Right Alt triggers the same gesture as left Alt: the Rust hook classifies
+// VK_RMENU as Alt(AltSide::Right) (bare right-Alt taps are swallowed and
+// trigger there, so on Windows-native this lane only matters when the hook is
+// off), and on macOS this JS lane is the only channel — right Option must
+// work. AltGr (Ctrl+right Alt, European layouts) stays inert via the ctrlKey
+// guard, matching the hook where the layout-synthesized left-Ctrl passes
+// unswallowed and no gesture arms.
 const altRight = () => alt({ code: 'AltRight', location: 2 });
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(altRight(), { status: 'idle', pendingAlt: false }),
-  { type: 'none' },
-  'right Alt keydown must not start a pending gesture',
+  { type: 'pending_alt' },
+  'right Alt keydown must arm the gesture like left Alt',
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyUp(altRight(), { status: 'idle', pendingAlt: true }),
-  { type: 'clear_pending' },
-  'right Alt keyup while pending must clear, not trigger (or stop a recording)',
+  { type: 'trigger', mode: 'dictation' },
+  'right Alt keyup while pending must trigger dictation',
+);
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyUp(altRight(), { status: 'idle', pendingAlt: false }),
+  { type: 'none' },
+);
+// A bare right-Alt tap from keydown to keyup is one full gesture.
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyUp(altRight(), { status: 'recording', mode: 'task', pendingAlt: true }),
+  { type: 'trigger', mode: 'task' },
+  'right Alt must also stop an active recording',
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(alt({ code: 'AltRight', location: 2, ctrlKey: true }), { status: 'idle', pendingAlt: false }),
   { type: 'none' },
   'AltGr (ctrl+right Alt) must stay inert',
+);
+// The location/code exclusions were removed, so an AltRight event without a
+// location field must arm as well.
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyDown(alt({ code: 'AltRight' }), { status: 'idle', pendingAlt: false }),
+  { type: 'pending_alt' },
+  'right Alt without a location field must still arm the gesture',
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(alt(), { status: 'idle', pendingAlt: false }),

--- a/pinvou3-app/tests/voice_shortcut_state.test.mjs
+++ b/pinvou3-app/tests/voice_shortcut_state.test.mjs
@@ -65,8 +65,8 @@ assert.deepStrictEqual(
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(key(), { status: 'idle', pendingAlt: true }),
-  { type: 'clear_pending' },
-  'pressing any other key while Alt is pending must cancel the plain-Alt trigger',
+  { type: 'clear_pending', swallow: false },
+  'pressing any other key while Alt is pending must disarm the trigger, unswallowed',
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(alt(), { status: 'idle', pendingSpace: true }),
@@ -144,12 +144,12 @@ assert.deepStrictEqual(
 // still cancels. Same policy as Alt+Tab (Other keys only clear pending).
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown({ key: 'Escape' }, { status: 'recording', mode: 'task', pendingAlt: true }),
-  { type: 'clear_pending' },
+  { type: 'clear_pending', swallow: false },
   'Escape inside an Alt combo passthrough must not cancel an active recording',
 );
 assert.deepStrictEqual(
   voiceShortcutActionForKeyDown({ key: 'Escape' }, { status: 'idle', pendingAlt: true }),
-  { type: 'clear_pending' },
+  { type: 'clear_pending', swallow: false },
   'Escape inside an Alt combo passthrough must clear the pending gesture instead of ignoring it',
 );
 assert.deepStrictEqual(
@@ -319,6 +319,23 @@ assert.deepStrictEqual(
   }),
   { type: 'pending_alt' },
   'an Alt down well after the last combo keydown is a genuine gesture start',
+);
+
+// A human Alt/Option combo member only disarms the pending gesture, and its
+// keydown must stay unswallowed (swallow:false) so the router lets it through:
+// on macOS, right-Option + letter still has to type the symbol (Option+p → π)
+// while merely cancelling the tap — the #470 review regression. Alt+Space keeps
+// no swallow field: it stays swallowed with the gesture cleared (window system
+// menu), pinned by the exact-shape Alt+Space assertions above.
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyDown(key({ key: 'π', code: 'KeyP' }), { status: 'idle', pendingAlt: true }),
+  { type: 'clear_pending', swallow: false },
+  'the symbol keydown of a right-Option combo must disarm without being swallowed',
+);
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyUp(altRight(), { status: 'idle', pendingAlt: false }),
+  { type: 'none' },
+  'the Option up after a cleared combo must stay inert instead of ghost-triggering',
 );
 
 console.log('voice_shortcut_state: ok');

--- a/pinvou3-app/tests/voice_shortcut_state.test.mjs
+++ b/pinvou3-app/tests/voice_shortcut_state.test.mjs
@@ -241,6 +241,33 @@ assert.deepStrictEqual(
   'right Alt must also stop an active recording',
 );
 assert.deepStrictEqual(
+  voiceShortcutActionForKeyUp(altRight(), { status: 'requesting_permission', pendingAlt: true }),
+  { type: 'cancel' },
+  'releasing right Alt while permission is pending must cancel instead of triggering again',
+);
+// The injected-passthrough signature is side-agnostic: a right-Alt down right
+// after a combo keydown is marked injected, and its up clears instead of
+// firing dictation.
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyDown(altRight(), {
+    status: 'idle',
+    pendingAlt: false,
+    now: 1000,
+    lastNonAltKeyDownAt: 990,
+  }),
+  { type: 'pending_alt', injected: true },
+  'an injected right-Alt down must be marked like the left one',
+);
+assert.deepStrictEqual(
+  voiceShortcutActionForKeyUp(altRight(), {
+    status: 'idle',
+    pendingAlt: true,
+    pendingInjected: true,
+  }),
+  { type: 'clear_pending' },
+  'right Alt up of an injected pending must clear instead of firing dictation',
+);
+assert.deepStrictEqual(
   voiceShortcutActionForKeyDown(alt({ code: 'AltRight', location: 2, ctrlKey: true }), { status: 'idle', pendingAlt: false }),
   { type: 'none' },
   'AltGr (ctrl+right Alt) must stay inert',


### PR DESCRIPTION
## Summary

The voice shortcut trigger only worked from the left Alt key. Users reported that the right Alt key does nothing on Windows; macOS right Option was excluded the same way, and the in-window fallback is the only shortcut channel on macOS. Both physical keys now trigger the shortcut.

## Root cause

The right Alt key was deliberately reserved for AltGr/IME in two places:

- `features/voice_shortcut/platform/mod.rs`: the low-level hook classified `VK_RMENU` as `Other`, so right-Alt gestures never armed.
- `src/features/chat/voice-shortcut-state.mjs`: `isPlainAltKey` rejected `location === 2` / `code === 'AltRight'`, and this JS lane is the only shortcut channel on macOS.

## Fix

- The `VoiceShortcutKey::Alt` variant now carries the physical side (`AltSide::Left/Right`), and `VoiceShortcutState` records `alt_side` for the current gesture. The state machine treats both sides identically.
- The Windows combo replay injects the VK of the side that started the gesture (`VK_LMENU` or `VK_RMENU`) instead of always rewriting to left Alt. On AltGr layouts this keeps character combos working: the layout driver's synthesized left-Ctrl passes the hook unswallowed, and the replayed RMenu completes the same modifier set a real AltGr press produces, so `AltGr+key` still inserts the composed character and never ghost-triggers dictation.
- `isPlainAltKey` accepts both sides. AltGr stays inert through the existing `ctrlKey` guard, matching the hook, where the synthesized Ctrl prevents the page lane from arming.
- A human Alt/Option combo-member keydown now disarms the pending gesture without being swallowed (`swallow: false` on the `clear_pending` action; the router returns before `preventDefault`), so right-Option + letter keeps typing its macOS symbol and app menu combos keep working — mirroring the keyup lane, which already passed combo tails through. Alt+Space stays suppressed (window system menu); the injected passthrough is unaffected because its combo keydown arrives while no gesture is pending yet.

## Scope note

The pill animation / stop-hint commit that briefly rode here was split into #475 per review; this PR is keyboard-trigger work only.

## Verification

- `cargo test --lib voice_shortcut`: 24 passed, including right-Alt tap/combo/cancel/injected coverage and a test pinning the documented cross-side hold semantics (arming side sticks, first up resolves, other side re-arms and fires once more).
- `cargo clippy --lib -- -D warnings`, `cargo fmt --check`: clean.
- `npm run test:voice-input` (6 suites, incl. the new `tests/voice_shortcut_router.test.mjs` pinning the keydown dispatch order): pass; the macOS right-Option symbol sequence (arm → symbol keydown disarms unswallowed → Alt up stays inert) is asserted on the state machine, and AltGr (`ctrl+right Alt`) remains asserted inert.
- `npx eslint` on touched files, `python3 scripts/architecture-guard.py`: passed.
- The Windows-only hook code is exercised by the CI `windows-rust-test` lane (compiles and passes there). eslint also runs in CI.
- Still open before merge: a real-Windows AltGr hardware smoke (German/French layout: bare right-Alt tap must start dictation, `AltGr+key` must insert the composed character). CI cannot exercise physical layouts.

Signed-off-by: asto18089 <asto18089@126.com>
