### PR TITLE
feat(build): bundle Linux SenseVoice ASR runtime

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -204,6 +204,9 @@ jobs:
               - 'VERSION'
               - 'scripts/sync-version.mjs'
               - 'scripts/check-linux-glibc-floor.sh'
+              - 'scripts/check-linux-elf-policy.sh'
+              - 'scripts/asr/build-sensevoice-runtime.sh'
+              - 'scripts/asr/sensevoice-source.env'
               - 'scripts/tests/sync-version.test.mjs'
               - 'scripts/tests/test_ci_gate_policy.py'
               - 'scripts/tests/test_release_arm64_policy.py'
@@ -224,6 +227,7 @@ jobs:
               - 'pinvou3-app/tests/knowledge_host_packaging.test.mjs'
               - 'pinvou3-app/tests/codex_acp_windows_*'
               - 'pinvou3-app/tests/windows_runtime_packaging_contract.test.js'
+              - 'pinvou3-app/tests/linux_asr_runtime_packaging.test.js'
               - 'pinvou3-app/tests/macos_phase2_contract.test.js'
             pet:
               - 'pinvou3-app/src/assets/pet/**'
@@ -546,6 +550,7 @@ jobs:
           npm --prefix pinvou3-app run test:tauri-effective-config
           npm --prefix pinvou3-app run test:macos-phase2
           npm --prefix pinvou3-app run test:knowledge-host-packaging
+          npm --prefix pinvou3-app run test:linux-asr-runtime
 
   # pinvou-knowledge 是可单独部署的 crate，必须直接验证自己的默认 feature 图、
   # 测试与部署入口，而不只依赖 Tauri 作为 client-only path dependency 的间接编译。

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -29,6 +29,12 @@ on:
     branches: [main]
     paths:
       - 'VERSION'
+      - 'scripts/asr/build-sensevoice-runtime.sh'
+      - 'scripts/asr/sensevoice-source.env'
+      - 'scripts/check-linux-elf-policy.sh'
+      - 'pinvou3-app/scripts/tauri/linux-asr-runtime.js'
+      - 'pinvou3-app/src-tauri/config/platforms/linux/**'
+      - 'pinvou3-app/tests/linux_asr_runtime_packaging.test.js'
   workflow_dispatch:
 
 permissions:
@@ -198,7 +204,7 @@ jobs:
       # 的 node + knowledge-host 的 pinvou-knowledge-server(asr 是 python、
       # knowledge-host 的 helper 是 shell、连接器 CLI 首用下载)。
       - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
-        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-x64.deb"
+        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-x64.deb" amd64
 
       - name: 上传 deb artifact
         uses: actions/upload-artifact@v7
@@ -309,7 +315,7 @@ jobs:
 
       # glibc 下限守护(同 build-linux-x64,断言全部 ELF 的 GLIBC_ 符号 ≤ 2.35)。
       - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
-        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-arm64.deb"
+        run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-arm64.deb" arm64
 
       - name: 上传 deb artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -29,12 +29,6 @@ on:
     branches: [main]
     paths:
       - 'VERSION'
-      - 'scripts/asr/build-sensevoice-runtime.sh'
-      - 'scripts/asr/sensevoice-source.env'
-      - 'scripts/check-linux-elf-policy.sh'
-      - 'pinvou3-app/scripts/tauri/linux-asr-runtime.js'
-      - 'pinvou3-app/src-tauri/config/platforms/linux/**'
-      - 'pinvou3-app/tests/linux_asr_runtime_packaging.test.js'
   workflow_dispatch:
 
 permissions:
@@ -201,8 +195,8 @@ jobs:
       # glibc 下限守护:解包 deb,对每个 ELF 断言 GLIBC_ 符号版本 ≤ 2.35
       # (Ubuntu 22.04 基线)。runner 被误升或依赖引入新符号时在此挡下,
       # 而不是等 22.04 用户启动崩溃。deb 内 ELF = 主二进制 + codex-bridge
-      # 的 node + knowledge-host 的 pinvou-knowledge-server(asr 是 python、
-      # knowledge-host 的 helper 是 shell、连接器 CLI 首用下载)。
+      # 的 node + knowledge-host 的 pinvou-knowledge-server + ASR 引擎
+      # sense-voice-main(knowledge-host 的 helper 是 shell、连接器 CLI 首用下载)。
       - name: glibc 下限守护 (Ubuntu 22.04 = glibc 2.35)
         run: ./scripts/check-linux-glibc-floor.sh "pinvou3-app/src-tauri/target/release/bundle/deb/pinvou-agent_${VERSION}-linux-x64.deb" amd64
 

--- a/pinvou3-app/package.json
+++ b/pinvou3-app/package.json
@@ -113,6 +113,7 @@
     "test:acp-providers-ui": "node tests/acp_providers_ui_smoke.js",
     "test:kb-smoke": "node tests/kb_smoke.js",
     "test:knowledge-host-packaging": "node --test tests/knowledge_host_packaging.test.mjs",
+    "test:linux-asr-runtime": "node tests/linux_asr_runtime_packaging.test.js",
     "test:composer-tools-smoke": "node tests/composer_tools_smoke.js",
     "test:composer-pending-enable-smoke": "node tests/composer_pending_enable_smoke.js",
     "test:tool-store": "node tests/tool_store_smoke.js",

--- a/pinvou3-app/scripts/tauri/build.js
+++ b/pinvou3-app/scripts/tauri/build.js
@@ -16,6 +16,7 @@ const {
   platformConfigPath,
 } = require("./platform-config.js");
 const { linuxStartupWindowConfigSpec } = require("./startup-window-config.js");
+const { prepareLinuxAsrRuntime } = require("./linux-asr-runtime.js");
 const { prepareKnowledgeHost } = require("./knowledge-host.js");
 const { WRAPPER_ENV } = require("./require-wrapper.js");
 const { stageWindowsInstaller } = require("./windows-installer.js");
@@ -208,6 +209,7 @@ function main() {
     if (developmentHost?.configSpec) additionalConfigs.push(developmentHost.configSpec);
   }
   if (hasTauriBuildCommand) {
+    prepareLinuxAsrRuntime();
     prepareCodexBridge();
     prepareChromeDevtoolsMcpForPlatform();
     prepareWindowsCodexBridge(windowsBridgeOptions);
@@ -253,6 +255,7 @@ module.exports = {
   prepareChromeDevtoolsMcpForPlatform,
   prepareCodexBridge,
   prepareKnowledgeHost,
+  prepareLinuxAsrRuntime,
   prepareWindowsCodexBridge,
   stageWindowsInstaller,
   stageWindowsOnnxRuntime,

--- a/pinvou3-app/scripts/tauri/linux-asr-runtime.js
+++ b/pinvou3-app/scripts/tauri/linux-asr-runtime.js
@@ -1,0 +1,61 @@
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { APP_ROOT } = require("./platform-config.js");
+
+const REPOSITORY_ROOT = path.resolve(APP_ROOT, "..");
+const BUILD_SCRIPT = path.join(
+  REPOSITORY_ROOT,
+  "scripts",
+  "asr",
+  "build-sensevoice-runtime.sh",
+);
+const LINUX_ASR_ARCHITECTURES = {
+  arm64: { directory: "aarch64", scriptArch: "aarch64" },
+  x64: { directory: "x86_64", scriptArch: "x86_64" },
+};
+
+function linuxAsrRuntimeOutput(architecture = process.arch) {
+  const descriptor = LINUX_ASR_ARCHITECTURES[architecture];
+  if (!descriptor) {
+    throw new Error(`Linux SenseVoice runtime 暂不支持 ${architecture} 架构`);
+  }
+  return {
+    ...descriptor,
+    binaryPath: path.join(
+      APP_ROOT,
+      "src-tauri",
+      "target",
+      "linux-asr-runtime",
+      descriptor.directory,
+      "sense-voice-main",
+    ),
+  };
+}
+
+function prepareLinuxAsrRuntime({
+  platform = process.platform,
+  architecture = process.arch,
+  environment = process.env,
+  spawn = spawnSync,
+} = {}) {
+  if (platform !== "linux") return null;
+  const runtime = linuxAsrRuntimeOutput(architecture);
+  const result = spawn(
+    "bash",
+    [BUILD_SCRIPT, "--output", runtime.binaryPath, "--arch", runtime.scriptArch],
+    { cwd: REPOSITORY_ROOT, env: environment, stdio: "inherit" },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Linux SenseVoice runtime 构建失败，退出码：${result.status ?? "unknown"}`);
+  }
+  return runtime;
+}
+
+module.exports = {
+  BUILD_SCRIPT,
+  LINUX_ASR_ARCHITECTURES,
+  linuxAsrRuntimeOutput,
+  prepareLinuxAsrRuntime,
+};

--- a/pinvou3-app/scripts/tauri/platform-config.js
+++ b/pinvou3-app/scripts/tauri/platform-config.js
@@ -6,7 +6,12 @@ const PLATFORM_CONFIG_NAMES = {
   linux: path.join("platforms", "linux", "tauri.conf.json"),
   win32: path.join("platforms", "windows", "tauri.conf.json"),
 };
-const ARCHITECTURE_CONFIG_NAMES = {};
+const ARCHITECTURE_CONFIG_NAMES = {
+  linux: {
+    arm64: path.join("platforms", "linux", "aarch64", "tauri.conf.json"),
+    x64: path.join("platforms", "linux", "x86_64", "tauri.conf.json"),
+  },
+};
 
 function platformConfigPath(platform = process.platform) {
   const configName = PLATFORM_CONFIG_NAMES[platform];

--- a/pinvou3-app/src-tauri/config/README.md
+++ b/pinvou3-app/src-tauri/config/README.md
@@ -5,7 +5,10 @@
 ```text
 config/
 └─ platforms/
-   ├─ linux/tauri.conf.json
+   ├─ linux/
+   │  ├─ tauri.conf.json
+   │  ├─ x86_64/tauri.conf.json
+   │  └─ aarch64/tauri.conf.json
    ├─ macos/tauri.conf.json
    └─ windows/
       ├─ tauri.conf.json
@@ -13,6 +16,8 @@ config/
 ```
 
 - `tauri.conf.json`：对应平台的安装包目标、资源映射和安装器参数；macOS 额外把主窗口覆盖为原生顶栏（`decorations: true` + `titleBarStyle: "Overlay"` + `hiddenTitle`，系统红绿灯替代前端自绘三键）。
+- Linux 的架构 overlay 把统一入口从固定 SenseVoice.cpp commit 构建到
+  `target/linux-asr-runtime/<arch>/` 的当前架构 ELF 映射到 `runtime/asr/`；源码树不存放预编译 ELF。
 - `windows/runtime/x86_64.lock.json`：锁定 Windows 独立 runtime 的 submodule commit、manifest 与目标架构；实际资源映射由 staging 后生成的 overlay 提供。
 
 `--config` overlay 按 JSON Merge Patch 合并：对象合并、**数组整体替换**。

--- a/pinvou3-app/src-tauri/config/platforms/linux/aarch64/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/linux/aarch64/tauri.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": {
+      "target/linux-asr-runtime/aarch64/sense-voice-main": "runtime/asr/sense-voice-main"
+    }
+  }
+}

--- a/pinvou3-app/src-tauri/config/platforms/linux/x86_64/tauri.conf.json
+++ b/pinvou3-app/src-tauri/config/platforms/linux/x86_64/tauri.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../../../../../node_modules/@tauri-apps/cli/config.schema.json",
+  "bundle": {
+    "resources": {
+      "target/linux-asr-runtime/x86_64/sense-voice-main": "runtime/asr/sense-voice-main"
+    }
+  }
+}

--- a/pinvou3-app/tests/linux_asr_runtime_packaging.test.js
+++ b/pinvou3-app/tests/linux_asr_runtime_packaging.test.js
@@ -1,0 +1,102 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const {
+  BUILD_SCRIPT,
+  linuxAsrRuntimeOutput,
+  prepareLinuxAsrRuntime,
+} = require("../scripts/tauri/linux-asr-runtime.js");
+
+const appRoot = path.resolve(__dirname, "..");
+const repoRoot = path.resolve(appRoot, "..");
+const trackedRuntime = "pinvou3-app/src-tauri/resources/platforms/linux/asr/sense-voice-main";
+const senseVoiceLicense = path.join(
+  appRoot,
+  "src-tauri/resources/platforms/linux/asr/LICENSE-SenseVoice.cpp",
+);
+
+const sourceLock = fs.readFileSync(
+  path.join(repoRoot, "scripts/asr/sensevoice-source.env"),
+  "utf8",
+);
+assert.match(
+  sourceLock,
+  /^SENSEVOICE_SOURCE_COMMIT=[0-9a-f]{40}$/mu,
+  "SenseVoice source must be pinned to an immutable commit",
+);
+
+const trackedCheck = spawnSync(
+  "git",
+  ["ls-files", "--error-unmatch", trackedRuntime],
+  { cwd: repoRoot, encoding: "utf8" },
+);
+assert.notEqual(
+  trackedCheck.status,
+  0,
+  "precompiled SenseVoice ELF must not be stored in Git",
+);
+assert.match(fs.readFileSync(senseVoiceLicense, "utf8"), /Copyright \(c\) 2024 lovemefan/u);
+
+const x64 = linuxAsrRuntimeOutput("x64");
+assert.equal(x64.directory, "x86_64");
+assert.match(x64.binaryPath.replaceAll("\\", "/"), /target\/linux-asr-runtime\/x86_64\/sense-voice-main$/u);
+const arm64 = linuxAsrRuntimeOutput("arm64");
+assert.equal(arm64.directory, "aarch64");
+assert.match(arm64.binaryPath.replaceAll("\\", "/"), /target\/linux-asr-runtime\/aarch64\/sense-voice-main$/u);
+assert.throws(() => linuxAsrRuntimeOutput("ia32"), /暂不支持 ia32/);
+
+let invocation = null;
+const prepared = prepareLinuxAsrRuntime({
+  platform: "linux",
+  architecture: "x64",
+  environment: { PINVOU_TEST_ENV: "kept" },
+  spawn: (command, args, options) => {
+    invocation = { command, args, options };
+    return { status: 0 };
+  },
+});
+assert.equal(invocation.command, "bash");
+assert.deepEqual(invocation.args, [
+  BUILD_SCRIPT,
+  "--output",
+  x64.binaryPath,
+  "--arch",
+  "x86_64",
+]);
+assert.equal(invocation.options.cwd, repoRoot);
+assert.equal(invocation.options.env.PINVOU_TEST_ENV, "kept");
+assert.equal(prepared.binaryPath, x64.binaryPath);
+assert.equal(
+  prepareLinuxAsrRuntime({
+    platform: "darwin",
+    spawn: () => { throw new Error("non-Linux must not build SenseVoice"); },
+  }),
+  null,
+);
+assert.throws(
+  () => prepareLinuxAsrRuntime({
+    platform: "linux",
+    architecture: "arm64",
+    spawn: () => ({ status: 9 }),
+  }),
+  /退出码：9/,
+);
+
+for (const [architecture, directory] of [["x64", "x86_64"], ["arm64", "aarch64"]]) {
+  const configPath = path.join(
+    appRoot,
+    "src-tauri/config/platforms/linux",
+    directory,
+    "tauri.conf.json",
+  );
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  assert.equal(
+    config.bundle.resources[`target/linux-asr-runtime/${directory}/sense-voice-main`],
+    "runtime/asr/sense-voice-main",
+    `${architecture} overlay must stage its own SenseVoice ELF`,
+  );
+}
+
+console.log("Linux SenseVoice runtime packaging contract: ok");

--- a/pinvou3-app/tests/linux_asr_runtime_packaging.test.js
+++ b/pinvou3-app/tests/linux_asr_runtime_packaging.test.js
@@ -32,9 +32,9 @@ const trackedCheck = spawnSync(
   ["ls-files", "--error-unmatch", trackedRuntime],
   { cwd: repoRoot, encoding: "utf8" },
 );
-assert.notEqual(
+assert.equal(
   trackedCheck.status,
-  0,
+  1,
   "precompiled SenseVoice ELF must not be stored in Git",
 );
 assert.match(fs.readFileSync(senseVoiceLicense, "utf8"), /Copyright \(c\) 2024 lovemefan/u);

--- a/pinvou3-app/tests/tauri_effective_config.test.js
+++ b/pinvou3-app/tests/tauri_effective_config.test.js
@@ -187,12 +187,13 @@ assert.doesNotThrow(() => requireWrapper({ [WRAPPER_ENV]: "1" }));
 const linuxStartupOverlay = linuxStartupWindowConfigSpec();
 const buildArgs = prepareTauriArgs(
   ["--verbose", "build", "--bundles", "deb"],
-  { platform: "linux" },
+  { platform: "linux", architecture: "x64" },
 );
 assert.equal(tauriCommandIndex(buildArgs), 1, "build command may follow global options");
 assert.deepEqual(configSpecs(buildArgs), [
   platformConfigPath("linux"),
   linuxStartupOverlay,
+  platformArchitectureConfigPath("linux", "x64"),
 ]);
 const linuxArmArgs = prepareTauriArgs(
   ["build", "--bundles", "deb"],
@@ -201,6 +202,7 @@ const linuxArmArgs = prepareTauriArgs(
 assert.deepEqual(configSpecs(linuxArmArgs), [
   platformConfigPath("linux"),
   linuxStartupOverlay,
+  platformArchitectureConfigPath("linux", "arm64"),
 ]);
 
 const explicitOverlay = "custom-signing.json";
@@ -420,7 +422,14 @@ assert.ok(
   "Linux resource manifest must exclude chrome-devtools-mcp",
 );
 
-assert.equal(platformArchitectureConfigPath("linux", "arm64"), null);
+assert.match(
+  platformArchitectureConfigPath("linux", "x64").replaceAll("\\", "/"),
+  /platforms\/linux\/x86_64\/tauri\.conf\.json$/u,
+);
+assert.match(
+  platformArchitectureConfigPath("linux", "arm64").replaceAll("\\", "/"),
+  /platforms\/linux\/aarch64\/tauri\.conf\.json$/u,
+);
 
 const linuxDev = composeEffectiveConfig([linuxStartupOverlay]).effectiveConfig;
 assert.equal(linuxDev.app.windows[0].visible, false);

--- a/pinvou3-app/tests/tauri_platform_layout.test.js
+++ b/pinvou3-app/tests/tauri_platform_layout.test.js
@@ -26,6 +26,8 @@ function assertResourceSourcesExist(config, label) {
 
 const common = readJson("tauri.conf.json");
 const linux = readJson("config/platforms/linux/tauri.conf.json");
+const linuxX64 = readJson("config/platforms/linux/x86_64/tauri.conf.json");
+const linuxArm64 = readJson("config/platforms/linux/aarch64/tauri.conf.json");
 const macos = readJson("config/platforms/macos/tauri.conf.json");
 const windows = readJson("config/platforms/windows/tauri.conf.json");
 
@@ -40,6 +42,12 @@ assert.ok(
   resourceSources(linux).every((source) => source.startsWith("resources/platforms/linux/")),
   "Linux overlay may only package resources/platforms/linux",
 );
+assert.deepEqual(resourceSources(linuxX64), [
+  "target/linux-asr-runtime/x86_64/sense-voice-main",
+]);
+assert.deepEqual(resourceSources(linuxArm64), [
+  "target/linux-asr-runtime/aarch64/sense-voice-main",
+]);
 assert.ok(
   resourceSources(macos).every((source) => source.startsWith("resources/platforms/macos/")),
   "macOS overlay may only package resources/platforms/macos",

--- a/scripts/asr/build-sensevoice-runtime.sh
+++ b/scripts/asr/build-sensevoice-runtime.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# 从固定 SenseVoice.cpp commit 为当前 Linux 主机构建可发布的 ASR 引擎。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=sensevoice-source.env
+source "$SCRIPT_DIR/sensevoice-source.env"
+
+usage() {
+  echo "usage: $0 --output <path> --arch <x86_64|aarch64>" >&2
+  exit 2
+}
+
+output_path=""
+requested_arch=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output)
+      [ "$#" -ge 2 ] || usage
+      output_path="$2"
+      shift 2
+      ;;
+    --arch)
+      [ "$#" -ge 2 ] || usage
+      requested_arch="$2"
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+[ -n "$output_path" ] && [ -n "$requested_arch" ] || usage
+
+case "$(uname -m)" in
+  x86_64|amd64) host_arch="x86_64"; policy_arch="amd64" ;;
+  aarch64|arm64) host_arch="aarch64"; policy_arch="arm64" ;;
+  *) echo "unsupported Linux build architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+[ "$requested_arch" = "$host_arch" ] || {
+  echo "requested SenseVoice architecture $requested_arch does not match build host $host_arch" >&2
+  exit 1
+}
+
+output_path="$(realpath -m "$output_path")"
+output_dir="$(dirname "$output_path")"
+build_root="${PINVOU3_SENSEVOICE_BUILD_ROOT:-$REPO_ROOT/pinvou3-app/src-tauri/target/sensevoice-build/$host_arch}"
+source_dir="$build_root/source"
+build_dir="$build_root/build"
+build_info="$output_path.build-info"
+mkdir -p "$output_dir" "$build_root"
+
+validate_runtime() {
+  "$REPO_ROOT/scripts/check-linux-elf-policy.sh" "$output_path" "$policy_arch"
+}
+
+cached_runtime_matches() {
+  local expected_sha actual_sha
+  expected_sha="$(sed -n 's/^sha256=//p' "$build_info")"
+  [ -n "$expected_sha" ] || return 1
+  actual_sha="$(sha256sum "$output_path" | awk '{print $1}')"
+  [ "$actual_sha" = "$expected_sha" ]
+}
+
+if [ -x "$output_path" ] && [ -f "$build_info" ] \
+  && grep -Fxq "commit=$SENSEVOICE_SOURCE_COMMIT" "$build_info" \
+  && grep -Fxq "architecture=$host_arch" "$build_info" \
+  && cached_runtime_matches \
+  && validate_runtime; then
+  echo "[sensevoice] 复用 $host_arch 运行时: $output_path"
+  exit 0
+fi
+
+for command_name in cmake g++ git make sha256sum strip; do
+  command -v "$command_name" >/dev/null || {
+    echo "missing SenseVoice build dependency: $command_name" >&2
+    exit 1
+  }
+done
+
+source_tmp="$build_root/source.tmp.$$"
+rm -rf -- "$source_tmp"
+trap 'rm -rf -- "${source_tmp:-}" "${output_tmp:-}"' EXIT
+git init --quiet "$source_tmp"
+git -C "$source_tmp" remote add origin "$SENSEVOICE_SOURCE_URL"
+git -C "$source_tmp" fetch --quiet --depth 1 origin "$SENSEVOICE_SOURCE_COMMIT"
+git -C "$source_tmp" checkout --quiet --detach FETCH_HEAD
+git -C "$source_tmp" submodule update --init --recursive --depth 1
+rm -rf -- "$source_dir" "$build_dir"
+mv "$source_tmp" "$source_dir"
+
+cmake -S "$source_dir" -B "$build_dir" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DSENSE_VOICE_BUILD_EXAMPLES=OFF \
+  -DSENSE_VOICE_BUILD_TESTS=OFF \
+  -DSENSE_VOICE_CCACHE=OFF \
+  -DGGML_NATIVE=OFF \
+  -DGGML_CUDA=OFF \
+  -DGGML_VULKAN=OFF \
+  -DGGML_KOMPUTE=OFF
+cmake --build "$build_dir" --target sense-voice-main \
+  --parallel "${PINVOU3_SENSEVOICE_BUILD_JOBS:-4}"
+
+output_tmp="$output_path.tmp.$$"
+cp "$build_dir/bin/sense-voice-main" "$output_tmp"
+strip --strip-unneeded "$output_tmp"
+chmod 0755 "$output_tmp"
+mv "$output_tmp" "$output_path"
+validate_runtime
+
+sha256="$(sha256sum "$output_path" | awk '{print $1}')"
+printf 'source=%s\ncommit=%s\narchitecture=%s\nsha256=%s\n' \
+  "$SENSEVOICE_SOURCE_URL" "$SENSEVOICE_SOURCE_COMMIT" "$host_arch" "$sha256" \
+  > "$build_info"
+echo "[sensevoice] 已构建 $host_arch 运行时: $output_path ($sha256)"

--- a/scripts/asr/build-sensevoice-runtime.sh
+++ b/scripts/asr/build-sensevoice-runtime.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# 从固定 SenseVoice.cpp commit 为当前 Linux 主机构建可发布的 ASR 引擎。
+# Build a shippable ASR engine (sense-voice-main) for the current Linux host
+# from the pinned SenseVoice.cpp commit. Must run on Ubuntu 22.04 or older:
+# the output links the build host's glibc, and the post-build validation
+# rejects symbols above the 22.04 (glibc 2.35) baseline; release CI builds
+# on ubuntu-22.04 runners.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -70,7 +74,9 @@ if [ -x "$output_path" ] && [ -f "$build_info" ] \
   exit 0
 fi
 
-for command_name in cmake g++ git make sha256sum strip; do
+# Pre-check the validation dependencies as well, so a host that cannot run
+# check-linux-elf-policy.sh fails here instead of after a full compile.
+for command_name in cmake g++ git make sha256sum strip dpkg file objdump readelf; do
   command -v "$command_name" >/dev/null || {
     echo "missing SenseVoice build dependency: $command_name" >&2
     exit 1
@@ -88,6 +94,9 @@ git -C "$source_tmp" submodule update --init --recursive --depth 1
 rm -rf -- "$source_dir" "$build_dir"
 mv "$source_tmp" "$source_dir"
 
+# With GGML_NATIVE=OFF the pinned ggml still defaults AVX2/FMA to ON, so the
+# x86_64 engine carries a Haswell+ (AVX2) floor: pre-Haswell CPUs would
+# SIGILL at inference time. Accepted as the release baseline.
 cmake -S "$source_dir" -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \

--- a/scripts/asr/sensevoice-source.env
+++ b/scripts/asr/sensevoice-source.env
@@ -1,0 +1,4 @@
+# SenseVoice.cpp source lock used by Linux packaging and the user setup helper.
+# Keep this file shell-compatible so both build entry points share one immutable source.
+SENSEVOICE_SOURCE_URL=https://github.com/lovemefan/SenseVoice.cpp.git
+SENSEVOICE_SOURCE_COMMIT=6503f51c2357034e1443c86dabeb24ad026c4b45

--- a/scripts/asr/setup-sensevoice.sh
+++ b/scripts/asr/setup-sensevoice.sh
@@ -14,11 +14,12 @@
 set -euo pipefail
 
 QUANT="${1:-q4_k}"
-SENSEVOICE_COMMIT="c78e6919351ac83255e96de46169f518097f1ef3"
 CMAKE_VERSION="4.4.2"
 ASR_DIR="$HOME/.pinvou3/asr"
 MODEL_FILE="sense-voice-small-${QUANT}.gguf"
 HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=sensevoice-source.env
+source "$HERE/sensevoice-source.env"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -51,10 +52,10 @@ fi
 
 echo "[2/5] 克隆 + 构建 SenseVoice.cpp（CUDA=${GGML_CUDA:-OFF}）…"
 git init -q "$WORK/sv"
-git -C "$WORK/sv" remote add origin https://github.com/lovemefan/SenseVoice.cpp
-git -C "$WORK/sv" fetch --depth 1 origin "$SENSEVOICE_COMMIT"
+git -C "$WORK/sv" remote add origin "$SENSEVOICE_SOURCE_URL"
+git -C "$WORK/sv" fetch --depth 1 origin "$SENSEVOICE_SOURCE_COMMIT"
 git -C "$WORK/sv" checkout -q --detach FETCH_HEAD
-test "$(git -C "$WORK/sv" rev-parse HEAD)" = "$SENSEVOICE_COMMIT"
+test "$(git -C "$WORK/sv" rev-parse HEAD)" = "$SENSEVOICE_SOURCE_COMMIT"
 git -C "$WORK/sv" submodule update --init --recursive
 mkdir -p "$WORK/sv/build"
 ( cd "$WORK/sv/build" \

--- a/scripts/check-linux-elf-policy.sh
+++ b/scripts/check-linux-elf-policy.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# 校验文件或目录内全部 ELF 的架构和 Ubuntu 22.04 动态符号版本基线。
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <file-or-directory> <amd64|arm64> [glibc-floor]" >&2
+  exit 2
+}
+
+scan_root="${1:-}"
+expected_arch="${2:-}"
+glibc_floor="${3:-2.35}"
+glibcxx_floor="3.4.30"
+cxxabi_floor="1.3.13"
+
+[ -n "$scan_root" ] && [ -e "$scan_root" ] || usage
+case "$expected_arch" in
+  amd64) expected_machine="Advanced Micro Devices X86-64" ;;
+  arm64) expected_machine="AArch64" ;;
+  *) usage ;;
+esac
+
+for command_name in dpkg file find objdump readelf; do
+  command -v "$command_name" >/dev/null || {
+    echo "missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+display_path() {
+  local elf="$1"
+  if [ -d "$scan_root" ]; then
+    printf '/%s\n' "${elf#"$scan_root"/}"
+  else
+    printf '%s\n' "$elf"
+  fi
+}
+
+dump_dynamic_symbols() {
+  local elf="$1" out
+  out="$(LC_ALL=C objdump -T "$elf" 2>&1)" || {
+    echo "FAIL: $(display_path "$elf") objdump 无法解析(文件损坏或 binutils 不支持?):" >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  }
+  printf '%s\n' "$out"
+}
+
+max_symbol_version() {
+  local dynsyms="$1" prefix="$2"
+  printf '%s\n' "$dynsyms" | grep -o "${prefix}[0-9][0-9.]*" | sort -Vu | tail -n 1 || true
+}
+
+check_prefix() {
+  local dynsyms="$1" elf="$2" prefix="$3" floor="$4" highest version shown
+  highest="$(max_symbol_version "$dynsyms" "$prefix")"
+  [ -n "$highest" ] || return 0
+  version="${highest#"$prefix"}"
+  shown="$(display_path "$elf")"
+  if dpkg --compare-versions "$version" gt "$floor"; then
+    echo "FAIL: $shown requires $highest > baseline $prefix$floor" >&2
+    return 1
+  fi
+  echo "ok: $shown $highest ≤ $prefix$floor"
+}
+
+check_architecture() {
+  local elf="$1" machine shown
+  # LC_ALL=C：readelf 头部字段名随 locale 本地化（如 zh_CN 下输出「系统架构」）。
+  machine="$(LC_ALL=C readelf -h "$elf" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p')"
+  shown="$(display_path "$elf")"
+  if [ "$machine" != "$expected_machine" ]; then
+    echo "FAIL: $shown architecture $machine != expected $expected_machine ($expected_arch)" >&2
+    return 1
+  fi
+  echo "ok: $shown architecture $expected_arch"
+}
+
+elf_count=0
+failed=0
+while IFS= read -r -d '' elf; do
+  file -b "$elf" | grep -q '^ELF' || continue
+  elf_count=$((elf_count + 1))
+  ok=0
+  check_architecture "$elf" || ok=1
+  dynsyms="$(dump_dynamic_symbols "$elf")" || { failed=1; continue; }
+  check_prefix "$dynsyms" "$elf" 'GLIBC_' "$glibc_floor" || ok=1
+  check_prefix "$dynsyms" "$elf" 'GLIBCXX_' "$glibcxx_floor" || ok=1
+  check_prefix "$dynsyms" "$elf" 'CXXABI_' "$cxxabi_floor" || ok=1
+  [ "$ok" -eq 0 ] || failed=1
+done < <(
+  if [ -d "$scan_root" ]; then
+    find "$scan_root" -type f -print0
+  else
+    printf '%s\0' "$scan_root"
+  fi
+)
+
+[ "$elf_count" -gt 0 ] || {
+  echo "FAIL: 未发现任何 ELF: $scan_root" >&2
+  exit 1
+}
+[ "$failed" -eq 0 ] || {
+  echo "FAIL: 存在架构错误或超出 Ubuntu 22.04 基线的 ELF(见上)" >&2
+  exit 1
+}
+echo "PASS: $elf_count 个 ELF 为 $expected_arch，且满足 GLIBC_ ≤ $glibc_floor / GLIBCXX_ ≤ $glibcxx_floor / CXXABI_ ≤ $cxxabi_floor"

--- a/scripts/check-linux-elf-policy.sh
+++ b/scripts/check-linux-elf-policy.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
-# 校验文件或目录内全部 ELF 的架构和 Ubuntu 22.04 动态符号版本基线。
+# Validate the target architecture and the Ubuntu 22.04 dynamic-symbol
+# floors of every ELF under a file or directory:
+#   GLIBC_   <= 2.35   (jammy glibc 2.35; overridable via the third argument)
+#   GLIBCXX_ <= 3.4.30 (jammy libstdc++, gcc 12)
+#   CXXABI_  <= 1.3.13 (jammy libstdc++, gcc 12)
+# Release binaries link the build host's glibc, so a runner upgrade silently
+# raises the baseline; any ELF above the floor fails here in CI instead of
+# crashing on launch for 22.04 users. Runs on the release runner (see the
+# glibc floor guard steps in release-packages.yml) and at the end of
+# build-sensevoice-runtime.sh. Depends on dpkg/file/find/objdump/readelf,
+# all preinstalled on ubuntu runners; meaningful only on Linux, use bash -n
+# for a local syntax check.
 set -euo pipefail
 
 usage() {
@@ -66,7 +77,8 @@ check_prefix() {
 
 check_architecture() {
   local elf="$1" machine shown
-  # LC_ALL=C：readelf 头部字段名随 locale 本地化（如 zh_CN 下输出「系统架构」）。
+  # LC_ALL=C: readelf localizes header field names (e.g. under zh_CN the
+  # "Machine:" header is translated), which would break parsing below.
   machine="$(LC_ALL=C readelf -h "$elf" | sed -n 's/^[[:space:]]*Machine:[[:space:]]*//p')"
   shown="$(display_path "$elf")"
   if [ "$machine" != "$expected_machine" ]; then
@@ -79,9 +91,23 @@ check_architecture() {
 elf_count=0
 failed=0
 while IFS= read -r -d '' elf; do
-  file -b "$elf" | grep -q '^ELF' || continue
+  file_out="$(file -b "$elf")"
+  case "$file_out" in
+    ELF*) ;;
+    *) continue ;;
+  esac
   elf_count=$((elf_count + 1))
   ok=0
+  case "$file_out" in
+    *executable*)
+      # A lost exec bit would otherwise surface late as "Permission denied"
+      # when the engine or host binary is launched.
+      [ -x "$elf" ] || {
+        echo "FAIL: $(display_path "$elf") is an ELF executable without the execute bit" >&2
+        ok=1
+      }
+      ;;
+  esac
   check_architecture "$elf" || ok=1
   dynsyms="$(dump_dynamic_symbols "$elf")" || { failed=1; continue; }
   check_prefix "$dynsyms" "$elf" 'GLIBC_' "$glibc_floor" || ok=1

--- a/scripts/check-linux-glibc-floor.sh
+++ b/scripts/check-linux-glibc-floor.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# 解包 deb 后校验全部 ELF 的目标架构和 Ubuntu 22.04 动态符号版本基线。
+# Extract a release deb and validate the target architecture plus the
+# Ubuntu 22.04 dynamic-symbol floors of every ELF inside; the policy itself
+# lives in check-linux-elf-policy.sh.
 set -euo pipefail
 
 usage() {

--- a/scripts/check-linux-glibc-floor.sh
+++ b/scripts/check-linux-glibc-floor.sh
@@ -1,89 +1,21 @@
 #!/usr/bin/env bash
-# 校验发布 deb 内全部 ELF 的动态符号版本不超过 Ubuntu 22.04 基线:
-#   GLIBC_   ≤ 2.35   (jammy glibc 2.35)
-#   GLIBCXX_ ≤ 3.4.30 (jammy libstdc++,gcc 12)
-#   CXXABI_  ≤ 1.3.13 (同上)
-# 在 release runner 的 deb 产物上运行(见 release-packages.yml 的「glibc 下限守护」
-# 步骤);任一 ELF 超线即非零退出,把「22.04 用户启动即崩」提前挡在 CI,防 runner
-# 被误升级或依赖引入新符号时静默抬高基线。依赖 dpkg-deb/dpkg/file/objdump,
-# 均为 ubuntu runner 自带;脚本本身只在 Linux 上有意义,本地语法检查用 bash -n。
+# 解包 deb 后校验全部 ELF 的目标架构和 Ubuntu 22.04 动态符号版本基线。
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 <deb> [glibc-floor]" >&2
+  echo "usage: $0 <deb> <amd64|arm64> [glibc-floor]" >&2
   exit 2
 }
 
 deb_path="${1:-}"
-[ -n "$deb_path" ] && [ -f "$deb_path" ] || usage
-glibc_floor="${2:-2.35}"
-glibcxx_floor="3.4.30"
-cxxabi_floor="1.3.13"
+expected_arch="${2:-}"
+glibc_floor="${3:-2.35}"
+[ -n "$deb_path" ] && [ -f "$deb_path" ] && [ -n "$expected_arch" ] || usage
 
-for command_name in dpkg-deb dpkg file objdump; do
-  command -v "$command_name" >/dev/null || {
-    echo "missing required command: $command_name" >&2
-    exit 1
-  }
-done
+command -v dpkg-deb >/dev/null || { echo "missing required command: dpkg-deb" >&2; exit 1; }
 
 extract_dir="$(mktemp -d)"
 trap 'rm -rf -- "$extract_dir"' EXIT
 dpkg-deb -x "$deb_path" "$extract_dir"
-
-# 每个 ELF 的动态符号表只解析一次。objdump 自身失败(异架构 ELF/文件损坏/
-# 未来 binutils 不识别的新特性)必须硬失败——静默当成「无符号引用」会把该
-# ELF 的三个前缀全部放行,只有 grep 无匹配才是合法的「无引用」。
-dump_dynamic_symbols() {
-  local elf="$1" out
-  out="$(objdump -T "$elf" 2>&1)" || {
-    echo "FAIL: objdump 无法解析 ${elf#"$extract_dir"}(异架构或损坏?):" >&2
-    printf '%s\n' "$out" >&2
-    return 1
-  }
-  printf '%s\n' "$out"
-}
-
-# 从动态符号表文本提取某前缀的最大符号版本(如 GLIBC_2.38);无引用输出空。
-max_symbol_version() {
-  local dynsyms="$1" prefix="$2"
-  printf '%s\n' "$dynsyms" | grep -o "${prefix}[0-9][0-9.]*" | sort -Vu | tail -n 1 || true
-}
-
-check_prefix() {
-  local dynsyms="$1" elf="$2" prefix="$3" floor="$4" highest version
-  highest="$(max_symbol_version "$dynsyms" "$prefix")"
-  [ -n "$highest" ] || return 0
-  version="${highest#"$prefix"}"
-  if dpkg --compare-versions "$version" gt "$floor"; then
-    echo "FAIL: ${elf#"$extract_dir"} requires $highest > baseline $prefix$floor" >&2
-    return 1
-  fi
-  echo "ok: ${elf#"$extract_dir"} $highest ≤ $prefix$floor"
-  return 0
-}
-
-elf_count=0
-failed=0
-while IFS= read -r -d '' elf; do
-  file -b "$elf" | grep -q '^ELF' || continue
-  elf_count=$((elf_count + 1))
-  dynsyms="$(dump_dynamic_symbols "$elf")" || { failed=1; continue; }
-  ok=0
-  check_prefix "$dynsyms" "$elf" 'GLIBC_' "$glibc_floor" || ok=1
-  check_prefix "$dynsyms" "$elf" 'GLIBCXX_' "$glibcxx_floor" || ok=1
-  check_prefix "$dynsyms" "$elf" 'CXXABI_' "$cxxabi_floor" || ok=1
-  [ "$ok" -eq 0 ] || failed=1
-done < <(find "$extract_dir" -type f -print0)
-
-# deb 至少含主二进制、codex-bridge 的 node、knowledge-host 的
-# pinvou-knowledge-server;一个 ELF 都没有说明解包或打包异常。
-[ "$elf_count" -gt 0 ] || {
-  echo "FAIL: deb 内未发现任何 ELF(解包或打包异常): $deb_path" >&2
-  exit 1
-}
-[ "$failed" -eq 0 ] || {
-  echo "FAIL: 存在超出 Ubuntu 22.04 基线的符号版本引用(见上)" >&2
-  exit 1
-}
-echo "PASS: $elf_count 个 ELF 满足 GLIBC_ ≤ $glibc_floor / GLIBCXX_ ≤ $glibcxx_floor / CXXABI_ ≤ $cxxabi_floor(基线 Ubuntu 22.04)"
+"$(cd "$(dirname "$0")" && pwd)/check-linux-elf-policy.sh" \
+  "$extract_dir" "$expected_arch" "$glibc_floor"

--- a/scripts/tests/test_release_linux_floor_policy.py
+++ b/scripts/tests/test_release_linux_floor_policy.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 RELEASE_WORKFLOW = ROOT / ".github/workflows/release-packages.yml"
 GUARD_SCRIPT = ROOT / "scripts" / "check-linux-glibc-floor.sh"
+ELF_POLICY_SCRIPT = ROOT / "scripts" / "check-linux-elf-policy.sh"
 LINUX_OVERLAY = ROOT / "pinvou3-app/src-tauri/config/platforms/linux/tauri.conf.json"
 
 # Linux 发布基线是 Ubuntu 22.04 (glibc 2.35) x86_64/arm64。发布二进制链接
@@ -82,14 +83,21 @@ class ReleaseLinuxFloorPolicyTests(unittest.TestCase):
             )
 
     def test_guard_script_defaults_to_2204_glibc_floor(self):
-        # 脚本默认 glibc 下限必须与基线一致;workflow 不传参即用默认值。
+        # The wrapper takes the floor as the optional third argument and
+        # delegates to check-linux-elf-policy.sh, which owns the jammy
+        # (gcc 12) GLIBCXX_/CXXABI_ floors; the workflow passes no floor,
+        # so the defaults must match the Ubuntu 22.04 baseline.
         source = GUARD_SCRIPT.read_text(encoding="utf-8")
-        self.assertIn('glibc_floor="${2:-2.35}"', source)
-        self.assertIn('"3.4.30"', source)  # GLIBCXX_ (jammy gcc 12)
-        self.assertIn('"1.3.13"', source)  # CXXABI_ (jammy gcc 12)
+        self.assertIn('glibc_floor="${3:-2.35}"', source)
+        self.assertIn("check-linux-elf-policy.sh", source)
+        policy = ELF_POLICY_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('glibc_floor="${3:-2.35}"', policy)
+        self.assertIn('"3.4.30"', policy)  # GLIBCXX_ (jammy gcc 12)
+        self.assertIn('"1.3.13"', policy)  # CXXABI_ (jammy gcc 12)
 
     def test_guard_script_is_valid_bash(self):
         subprocess.run(["bash", "-n", str(GUARD_SCRIPT)], check=True)
+        subprocess.run(["bash", "-n", str(ELF_POLICY_SCRIPT)], check=True)
 
     def test_deb_declares_webkit_floor(self):
         # tauri-runtime-wry 启用 webkit2gtk v2_40,运行时需要 WebKitGTK ≥ 2.40;


### PR DESCRIPTION
## Problem

On Linux the voice input could never be enabled: the deb shipped only the ASR shim (`pinvou3-asr-shim.py`), while `voice_asr::status()` requires the `sense-voice-main` engine binary plus ffmpeg plus the model before reporting `ready`. Nothing in the build produced the engine, so clicking the mic triggered a silent install loop (`install_asr_runtime` only installs ffmpeg + downloads the model, never the engine) with `ready` stuck at `false`.

Evidence: a 0.9.2 deb built from the internal tree contained `runtime/asr/sense-voice-main`; the open-source baseline never carried the build-time step that produces it (the `.gitignore` entry for `resources/platforms/linux/asr/sense-voice-main` documents the intent, but no script existed here).

## Change

Restore the build-time pipeline:

- `scripts/asr/build-sensevoice-runtime.sh` compiles `sense-voice-main` from the pinned SenseVoice.cpp commit (`scripts/asr/sensevoice-source.env`, now shared with `setup-sensevoice.sh`) into `src-tauri/target/linux-asr-runtime/<arch>/`, stripped and self-validated. No prebuilt ELF enters the source tree.
- `pinvou3-app/scripts/tauri/linux-asr-runtime.js` wires it into `build.js` (no-op off Linux); new per-arch overlays `config/platforms/linux/{x86_64,aarch64}/tauri.conf.json` map the ELF into the bundle as `runtime/asr/sense-voice-main`.
- New `scripts/check-linux-elf-policy.sh` validates ELF architecture and glibc/libstdc++ symbol floors; `check-linux-glibc-floor.sh` delegates to it and gains a required `<amd64|arm64>` argument (both release call sites updated), so an ARM runtime can no longer slip into an x64 deb.
- The added engine adds only ~1.3 MB per architecture to the package; the 182 MB model stays a runtime download as before.
- `tests/linux_asr_runtime_packaging.test.js` locks the packaging contract; the layout test asserts the overlay mappings; CI path filters and the release-contract job cover the new files.
- **Engine pin advance (disclosure).** Sharing one source lock moves `setup-sensevoice.sh` from pin `c78e6919` to `6503f51c` (~96 SenseVoice.cpp commits, including a ggml submodule bump). Nothing in this pipeline strictly requires the newer commit, but it is the pin the end-to-end aarch64 validation below ran on (pinned-source compile + q4_k model transcription), so the setup helper advances to the validated pin rather than keeping a second, unvalidated one.

Also fixes a latent bug in the ported policy script: `readelf`/`objdump` now run under `LC_ALL=C`, because localized output (e.g. zh_CN renders the `Machine:` header as `系统架构:`) silently broke architecture parsing.

## Verification

- `tests/linux_asr_runtime_packaging.test.js`, `tests/tauri_platform_layout.test.js`: pass
- `python3 scripts/architecture-guard.py`, `./scripts/fork-guard.sh --fast`: pass
- End-to-end on aarch64: the pipeline cloned the pinned commit, compiled, stripped and staged a valid engine; the binary loads the q4_k model and transcribes a wav. The ELF policy check correctly flags this Ubuntu 24.04 workstation's build as over the 2.35 floor (expected — release CI builds on ubuntu-22.04).

The full deb build is exercised by the release workflow; I did not run a local `tauri build`.