### PR TITLE
fix(monitor): honor saved context window over endpoint probe

### DIFF
--- a/pinvou3-app/src-tauri/src/core/model_context.rs
+++ b/pinvou3-app/src-tauri/src/core/model_context.rs
@@ -1,9 +1,12 @@
-//! pinvou3 运行状态与 Engine 路由共用的模型上下文窗口解析。
+//! Model context-window resolution shared by pinvou3 runtime state and Engine
+//! routing.
 //!
-//! 已由 CodeWhale 维护的模型事实优先复用底座；这里只补充 pinvou3 设置页已经提供、
-//! 但当前底座尚未覆盖的云端模型。窗口事实（按名解析）与窗口优先级（声明 vs
-//! 探测 vs 推断）都以这里为唯一入口，避免页面显示窗口与 `active_route_limits` /
-//! 压缩阈值 / 监控分母使用不同口径。
+//! Model facts maintained by CodeWhale reuse the base catalog first; this module
+//! only supplements cloud models that the pinvou3 settings page already provides
+//! but the base does not cover yet. Both the window facts (resolved by name) and
+//! the window precedence (declared vs probed vs inferred) have their single entry
+//! point here, so the page display never uses a different scale than
+//! `active_route_limits` / compaction thresholds / the monitor denominator.
 
 /// 精确匹配模型名，并容忍 `-` 分隔的日期、快照或服务档位后缀。
 fn model_name_matches(lower: &str, name: &str) -> bool {
@@ -75,15 +78,19 @@ pub fn resolved_context_window(model: &str) -> Option<u32> {
         .map(|(_, window)| *window)
 }
 
-/// 上下文窗口的统一优先级：宿主 `bridge::route_limits_for_model`（决定推理与
-/// 压缩阈值）与监控展示（`model_probe`）必须共用本函数，禁止各自另写一份
-/// match。优先级为：用户在模型表单显式声明的窗口优先，且与实测探测值取小
-/// （探测值是部署实地事实）；声明缺席时用探测值，再缺席才用调用方解析好的
-/// 推断兜底。第二个返回值标记「推断兜底被真正采用」，供监控页标注
-/// `context_window_inferred` 诊断。
+/// The unified context-window precedence: the host `bridge::route_limits_for_model`
+/// (which decides inference and compaction thresholds) and the monitor display
+/// (`model_probe`) must both call this function; writing a second match elsewhere
+/// is not allowed. Precedence: the window the user explicitly declares in the
+/// model form wins and is min-clamped against the probed value (the probe is
+/// deployment ground truth); without a declaration the probed value applies, and
+/// only when that is absent too does the caller-resolved inferred fallback apply.
+/// The second return value flags "the inferred fallback was actually adopted",
+/// for the monitor page to label the `context_window_inferred` diagnostic.
 ///
-/// 「探测值是否可信/是否参与收紧」由调用方决定：宿主只对可实地内省的本地
-/// vLLM 探测（云端恒为 `probed = None`），监控侧见 `model_probe` 的门控。
+/// "Whether the probed value is trustworthy / participates in clamping" is the
+/// caller's decision: the host only probes locally introspectable vLLM (cloud
+/// is always `probed = None`); the monitor's gate lives in `model_probe`.
 #[must_use]
 pub fn resolve_context_window(
     configured: Option<u32>,
@@ -139,11 +146,13 @@ mod tests {
         assert_eq!(resolved_context_window("unknown-cloud-model"), None);
     }
 
-    /// 窗口优先级表（单一事实源）：声明+探测取小、声明优先于缺席探测、
-    /// 无声明时探测优先于推断、仅推断被真正采用时置标记。
+    /// Window precedence table (single source of truth): declaration+probe →
+    /// min, declaration beats an absent probe, probe beats inference without a
+    /// declaration, and the flag is set only when inference is truly adopted.
     #[test]
     fn context_window_precedence_is_single_sourced() {
-        // 声明 + 探测 → 取小（本地部署实地收紧；under-declare 同理取声明）。
+        // Declaration + probe → min (ground-truth clamping for local deployments;
+        // under-declaring likewise keeps the declaration).
         assert_eq!(
             resolve_context_window(Some(1_048_576), Some(131_072), None),
             (Some(131_072), false)
@@ -152,12 +161,14 @@ mod tests {
             resolve_context_window(Some(32_768), Some(131_072), None),
             (Some(32_768), false)
         );
-        // 声明 + 无探测 → 声明原样生效（云端从不被宿主探测；本地探测失败同此）。
+        // Declaration + no probe → the declaration applies as-is (the host never
+        // probes cloud; a failed local probe lands here too).
         assert_eq!(
             resolve_context_window(Some(1_048_576), None, Some(131_072)),
             (Some(1_048_576), false)
         );
-        // 无声明 → 探测优先；探测缺席才用推断，且仅此时标记推断被采用。
+        // No declaration → probe first; only when the probe is absent does
+        // inference apply, and the adopted flag is set only in that case.
         assert_eq!(
             resolve_context_window(None, Some(262_144), Some(131_072)),
             (Some(262_144), false)

--- a/pinvou3-app/src-tauri/src/core/model_context.rs
+++ b/pinvou3-app/src-tauri/src/core/model_context.rs
@@ -1,8 +1,9 @@
 //! pinvou3 运行状态与 Engine 路由共用的模型上下文窗口解析。
 //!
 //! 已由 CodeWhale 维护的模型事实优先复用底座；这里只补充 pinvou3 设置页已经提供、
-//! 但当前底座尚未覆盖的云端模型。所有消费者必须走这一入口，避免页面显示窗口与
-//! `active_route_limits` / 压缩阈值使用不同口径。
+//! 但当前底座尚未覆盖的云端模型。窗口事实（按名解析）与窗口优先级（声明 vs
+//! 探测 vs 推断）都以这里为唯一入口，避免页面显示窗口与 `active_route_limits` /
+//! 压缩阈值 / 监控分母使用不同口径。
 
 /// 精确匹配模型名，并容忍 `-` 分隔的日期、快照或服务档位后缀。
 fn model_name_matches(lower: &str, name: &str) -> bool {
@@ -74,6 +75,28 @@ pub fn resolved_context_window(model: &str) -> Option<u32> {
         .map(|(_, window)| *window)
 }
 
+/// 上下文窗口的统一优先级：宿主 `bridge::route_limits_for_model`（决定推理与
+/// 压缩阈值）与监控展示（`model_probe`）必须共用本函数，禁止各自另写一份
+/// match。优先级为：用户在模型表单显式声明的窗口优先，且与实测探测值取小
+/// （探测值是部署实地事实）；声明缺席时用探测值，再缺席才用调用方解析好的
+/// 推断兜底。第二个返回值标记「推断兜底被真正采用」，供监控页标注
+/// `context_window_inferred` 诊断。
+///
+/// 「探测值是否可信/是否参与收紧」由调用方决定：宿主只对可实地内省的本地
+/// vLLM 探测（云端恒为 `probed = None`），监控侧见 `model_probe` 的门控。
+#[must_use]
+pub fn resolve_context_window(
+    configured: Option<u32>,
+    probed: Option<u32>,
+    inferred: Option<u32>,
+) -> (Option<u32>, bool) {
+    match (configured, probed) {
+        (Some(configured), Some(probed)) => (Some(configured.min(probed)), false),
+        (Some(configured), None) => (Some(configured), false),
+        (None, probed) => (probed.or(inferred), probed.is_none() && inferred.is_some()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,5 +137,35 @@ mod tests {
             deepseek_tui::models::context_window_for_model("gpt-5.6-sol")
         );
         assert_eq!(resolved_context_window("unknown-cloud-model"), None);
+    }
+
+    /// 窗口优先级表（单一事实源）：声明+探测取小、声明优先于缺席探测、
+    /// 无声明时探测优先于推断、仅推断被真正采用时置标记。
+    #[test]
+    fn context_window_precedence_is_single_sourced() {
+        // 声明 + 探测 → 取小（本地部署实地收紧；under-declare 同理取声明）。
+        assert_eq!(
+            resolve_context_window(Some(1_048_576), Some(131_072), None),
+            (Some(131_072), false)
+        );
+        assert_eq!(
+            resolve_context_window(Some(32_768), Some(131_072), None),
+            (Some(32_768), false)
+        );
+        // 声明 + 无探测 → 声明原样生效（云端从不被宿主探测；本地探测失败同此）。
+        assert_eq!(
+            resolve_context_window(Some(1_048_576), None, Some(131_072)),
+            (Some(1_048_576), false)
+        );
+        // 无声明 → 探测优先；探测缺席才用推断，且仅此时标记推断被采用。
+        assert_eq!(
+            resolve_context_window(None, Some(262_144), Some(131_072)),
+            (Some(262_144), false)
+        );
+        assert_eq!(
+            resolve_context_window(None, None, Some(1_000_000)),
+            (Some(1_000_000), true)
+        );
+        assert_eq!(resolve_context_window(None, None, None), (None, false));
     }
 }

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -1288,10 +1288,12 @@ impl Pinvou3Bridge {
         let configured_context = saved.and_then(|saved| saved.context_window_tokens);
         let inferred_context = crate::core::model_context::resolved_context_window(model);
         let is_local_vllm = self.provider() == "vllm";
-        // 窗口优先级与监控展示共用 core::model_context 的同一函数（声明优先、
-        // 探测取小、推断兜底），防止两条路径各写一份 match 后漂移。探测值只
-        // 对可实地内省的本地 vLLM 存在（云端恒为 None，见 engine_pool 的探测门），
-        // 因此云端声明不会被任何探测值覆盖。
+        // The window precedence shares core::model_context's single function
+        // with the monitor display (declaration wins, probe min-clamps,
+        // inference fills in), so the two paths cannot drift apart by each
+        // keeping their own match. The probed value only exists for locally
+        // introspectable vLLM (cloud is always None, see the probe gate in
+        // engine_pool), so a cloud declaration is never overridden by any probe.
         let (context_tokens, _) = crate::core::model_context::resolve_context_window(
             configured_context,
             self.probed_context_tokens,

--- a/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
+++ b/pinvou3-app/src-tauri/src/features/assistant/platform/bridge.rs
@@ -1288,12 +1288,15 @@ impl Pinvou3Bridge {
         let configured_context = saved.and_then(|saved| saved.context_window_tokens);
         let inferred_context = crate::core::model_context::resolved_context_window(model);
         let is_local_vllm = self.provider() == "vllm";
-        let context_tokens = match (configured_context, self.probed_context_tokens) {
-            (Some(configured), Some(probed)) => Some(configured.min(probed)),
-            (Some(configured), None) => Some(configured),
-            (None, Some(probed)) => Some(probed),
-            (None, None) => inferred_context.or_else(|| is_local_vllm.then_some(128_000)),
-        };
+        // 窗口优先级与监控展示共用 core::model_context 的同一函数（声明优先、
+        // 探测取小、推断兜底），防止两条路径各写一份 match 后漂移。探测值只
+        // 对可实地内省的本地 vLLM 存在（云端恒为 None，见 engine_pool 的探测门），
+        // 因此云端声明不会被任何探测值覆盖。
+        let (context_tokens, _) = crate::core::model_context::resolve_context_window(
+            configured_context,
+            self.probed_context_tokens,
+            inferred_context.or_else(|| is_local_vllm.then_some(128_000)),
+        );
         let configured_output = saved.and_then(|saved| saved.max_output_tokens);
         // User-configured openai-compatible endpoints (the `OpenAI-compatible`
         // preset, or provider_kind == "custom") count as operator-owned: the

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -144,8 +144,10 @@ pub async fn active_model_snapshot() -> Option<VllmSnapshot> {
     let api_key = model.as_ref().and_then(model_api_key);
     let model_id = model.as_ref().map(|m| m.id.clone());
     let provider = preset.as_str().to_string();
-    // 用户在模型表单显式声明的上下文窗口必须参与监控/Live-dot 展示口径，
-    // 否则保存 1M 后聊天页(chat:usage 分母)与监控页/进度条分母各说各话。
+    // The context window the user explicitly declares in the model form must
+    // join the monitor / live-dot display scale; otherwise after saving 1M the
+    // chat page (chat:usage denominator) and the monitor page / progress-bar
+    // denominator each tell their own story.
     let configured_context = model.as_ref().and_then(|m| m.context_window_tokens);
     snapshot_for_model_config(
         &upstream,
@@ -376,10 +378,13 @@ async fn snapshot_for_model_config(
     } else {
         Vec::new()
     };
-    // 展示窗口走统一优先级（见 display_context_window）：用户显式声明优先，
-    // 本地部署的探测值做 min 收紧；云端探测值（常来自代理/网关的列表条目，
-    // 与配置模型无关甚至过时）不得覆盖用户声明，否则保存 1M 后进度条被打回
-    // 131K。探测与目录/预设兜底只在无声明时补位。
+    // The display window goes through the unified precedence (see
+    // display_context_window): an explicit user declaration wins first, a local
+    // deployment's probe value min-clamps; a cloud probe value (usually a list
+    // entry from a proxy/gateway, unrelated to or stale for the configured
+    // model) must not override the user declaration, otherwise saving 1M gets
+    // the progress bar knocked back to 131K. Probe and catalog/preset fallbacks
+    // only fill in when no declaration exists.
     let inferred = infer_context_window(
         preset,
         configured_model.as_deref().or(served_model.as_deref()),
@@ -500,12 +505,17 @@ fn parse_models_response(
     configured: Option<&str>,
 ) -> Option<(Option<String>, Option<u32>)> {
     let entries = crate::core::model_endpoint::parse_models_response_list(v)?;
-    // 云端 /models 往往一次列出全部模型：优先取配置模型自身条目（精确命中，
-    // ASCII 大小写不敏感兜底；配置名先 trim，与 Mismatch 判定的双侧 trim 同口径）。
-    // 首条回退仅供 served 名展示——其 max_model_len 属于别的模型，不得借给配置
-    // 模型（与 `resolve_served_model_from_entries` 的「窗口不借自别的模型」同一
-    // 原则）。两者回退取向不同是有意的：推理路径未命中时保留配置名，让
-    // model_not_found 显式暴露；展示路径回退首条名字仅是诊断信息。
+    // Cloud /models often lists every model at once: prefer the configured
+    // model's own entry (exact hit, ASCII case-insensitive fallback; the
+    // configured name is trimmed first, matching the double-sided trim of the
+    // Mismatch check). The first-entry fallback only serves the served-name
+    // display — its max_model_len belongs to another model and must not be lent
+    // to the configured model (the same "a window is never borrowed from another
+    // model" principle as `resolve_served_model_from_entries`). The two paths
+    // falling back differently is intentional: the inference path keeps the
+    // configured name on a miss so model_not_found surfaces explicitly; the
+    // display path falling back to the first entry's name is diagnostic info
+    // only.
     let configured = configured.map(str::trim).filter(|name| !name.is_empty());
     let matched = configured.and_then(|name| {
         entries.iter().find(|entry| entry.id == name).or_else(|| {
@@ -523,13 +533,17 @@ fn parse_models_response(
     Some((Some(entry.id.clone()), window))
 }
 
-/// 展示侧上下文窗口（监控卡 + `get_backend_status` 的进度条分母）。优先级
-/// 本体在 `core::model_context::resolve_context_window`，与宿主
-/// `bridge::route_limits_for_model`（决定推理与压缩阈值）共用同一函数；本
-/// wrapper 只负责「探测值是否可信」的门控：本地部署（环回/私有 IP，可实地
-/// 内省）的探测值交给统一口径做 min 收紧；云端探测值来自网关/代理的列表
-/// 条目，不是部署实地事实，故在用户已声明窗口时整体不参与（声明优先且无
-/// 收紧依据），仅在无声明时作展示补位。
+/// Display-side context window (the monitor card + the progress-bar denominator
+/// of `get_backend_status`). The precedence itself lives in
+/// `core::model_context::resolve_context_window`, shared with the host
+/// `bridge::route_limits_for_model` (which decides inference and compaction
+/// thresholds); this wrapper only owns the "is the probe trustworthy" gate: a
+/// local deployment's (loopback/private IP, locally introspectable) probe value
+/// is handed to the unified scale for min-clamping; a cloud probe value comes
+/// from gateway/proxy list entries and is not deployment ground truth, so when
+/// the user already declared a window it does not participate at all (the
+/// declaration wins and there is no clamping basis) and only fills the display
+/// when no declaration exists.
 fn display_context_window(
     configured: Option<u32>,
     target_kind: &str,
@@ -543,11 +557,15 @@ fn display_context_window(
     crate::core::model_context::resolve_context_window(configured, probed, inferred)
 }
 
-/// 配置模型名与实际 served 名不一致时降级为 `Mismatch`（仅本地部署调用方启用，
-/// 见 `snapshot_for_model_config`）。抽成纯函数以便单测锁住比较语义：双侧
-/// trim 后精确比较（大小写敏感，与推理路径 `resolve_served_model_from_entries`
-/// 的精确匹配同口径——网关把 id 统一成小写而配置名带大写时，Engine 发送配置
-/// 原名会 model_not_found，监控红点是真实信号而非误报）。
+/// Downgrade to `Mismatch` when the configured model name differs from the
+/// actual served name (only local-deployment callers enable it, see
+/// `snapshot_for_model_config`). Extracted as a pure function so unit tests can
+/// pin the comparison semantics: exact comparison after trimming both sides
+/// (case-sensitive, the same scale as the inference path
+/// `resolve_served_model_from_entries`' exact match — when a gateway normalizes
+/// ids to lowercase while the configured name has uppercase, the Engine sending
+/// the configured original name gets model_not_found, so the monitor red dot is
+/// a real signal, not a false positive).
 fn mismatch_if_served_differs(
     status: VllmStatus,
     configured: Option<&str>,
@@ -560,9 +578,11 @@ fn mismatch_if_served_differs(
 }
 
 fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32> {
-    // 模型名事实经 core::model_context 单一入口解析，宿主 route_limits 的推断
-    // 兜底同源，避免页面显示 1M、实际仍按 128K 压缩。底座与补充表都无法识别时
-    // 按供应商预设兜底（表在 prefs::model_preset）。
+    // Model-name facts resolve through the core::model_context single entry, the
+    // same source as the host route_limits inference fallback, so the page never
+    // displays 1M while compaction still runs on 128K. When neither the base nor
+    // the supplemental table recognizes the name, fall back to the vendor preset
+    // (table in prefs::model_preset).
     if let Some(window) = model.and_then(crate::core::model_context::resolved_context_window) {
         return Some(window);
     }
@@ -837,8 +857,9 @@ mod tests {
         .unwrap()
     }
 
-    /// 云端 /models 一次列出全部模型：max_model_len 必须取配置模型自身的条目，
-    /// 不能借首条（往往是别的模型甚至网关默认 131072）的窗口。
+    /// Cloud /models often lists every model at once: max_model_len must come
+    /// from the configured model's own entry, never borrowed from the first
+    /// entry (often another model, or a gateway default of 131072).
     #[test]
     fn parse_models_response_matches_configured_model_entry() {
         let json = models_list_json(&[
@@ -850,9 +871,11 @@ mod tests {
         assert_eq!(max, Some(131_072));
     }
 
-    /// 配置名不在列表（网关只回部分名单）：首条回退仅供 served 名展示，其
-    /// max_model_len 属于别的模型，不得借给配置模型（与推理路径
-    /// resolve_served_model_from_entries 的「窗口不借自别的模型」同一原则）。
+    /// Configured name not in the list (gateway returns a partial roster): the
+    /// first-entry fallback only serves the served-name display; its
+    /// max_model_len belongs to another model and must not be lent to the
+    /// configured model (the inference path resolve_served_model_from_entries
+    /// follows the same "window never borrowed" principle).
     #[test]
     fn parse_models_response_first_entry_fallback_lends_name_not_window() {
         let json = models_list_json(&[("a", Some(4096)), ("b", Some(8192))]);
@@ -861,8 +884,9 @@ mod tests {
         assert_eq!(max, None);
     }
 
-    /// 大小写不敏感兜底命中时窗口同样归属配置模型（网关把 id 统一成小写是
-    /// 常见形态，窗口确属同一模型）。
+    /// When the case-insensitive fallback hits, the window likewise belongs to
+    /// the configured model (gateways normalizing ids to lowercase are a common
+    /// shape, and the window does belong to the same model).
     #[test]
     fn parse_models_response_matches_case_insensitively_and_keeps_window() {
         let json = models_list_json(&[("other", Some(4096)), ("glm-5.3-flash", Some(131_072))]);
@@ -871,8 +895,9 @@ mod tests {
         assert_eq!(max, Some(131_072));
     }
 
-    /// 配置名先 trim 再匹配（与 Mismatch 判定的双侧 trim 同口径），带首尾
-    /// 空格的配置名不再永远无法命中。
+    /// The configured name is trimmed before matching (the same scale as the
+    /// double-sided trim of the Mismatch check), so a name with leading or
+    /// trailing whitespace can finally match.
     #[test]
     fn parse_models_response_trims_configured_name() {
         let json = models_list_json(&[("glm-5.3-flash", Some(131_072))]);
@@ -881,8 +906,9 @@ mod tests {
         assert_eq!(max, Some(131_072));
     }
 
-    /// 命中条目但服务端未带 max_model_len：窗口保持 None，交由声明/推断兜底，
-    /// 绝不伪造（与 resolve_served_model_from_entries 的同名原则一致）。
+    /// Matched entry but the server carries no max_model_len: the window stays
+    /// None and is left to the declaration/inference fallbacks — never
+    /// fabricated (the same principle as resolve_served_model_from_entries).
     #[test]
     fn parse_models_response_matched_entry_without_window_propagates_none() {
         let json = models_list_json(&[("user-picked", None)]);
@@ -891,8 +917,9 @@ mod tests {
         assert_eq!(max, None);
     }
 
-    /// 用户显式声明的窗口（云端，探测值 131072 来自网关列表）：声明必须原样
-    /// 胜出——回归本次「保存 1048576 后进度条仍显示 131.1K」的根因。
+    /// A user-declared window (cloud; probe value 131072 from a gateway list):
+    /// the declaration must win as-is — regression pin for the reported bug
+    /// (after saving 1048576 the progress bar still showed 131.1K).
     #[test]
     fn display_window_remote_configured_declaration_beats_probe() {
         let (window, inferred) =
@@ -901,20 +928,23 @@ mod tests {
         assert!(!inferred);
     }
 
-    /// 本地部署探测值是实地事实：与宿主 route_limits 同款 min 收紧。
+    /// A local deployment's probe is ground truth: the same min-clamp as the
+    /// host route_limits.
     #[test]
     fn display_window_local_min_clamps_declaration_with_probe() {
         let (window, inferred) =
             display_context_window(Some(1_048_576), "local", Some(131_072), None);
         assert_eq!(window, Some(131_072));
         assert!(!inferred);
-        // 反向：声明 32K、实机 128K → 按声明收紧（与 route_limits 一致）。
+        // Reverse: declared 32K, machine at 128K → clamped to the declaration
+        // (consistent with route_limits).
         let (window, _) = display_context_window(Some(32_768), "local", Some(131_072), None);
         assert_eq!(window, Some(32_768));
     }
 
-    /// 本地声明但探测缺席（/models 解析失败等）：声明原样生效——与宿主
-    /// route_limits 的 (Some, None) 臂一致，探测缺席不产生任何收紧。
+    /// Local declaration but probe absent (/models parse failure etc.): the
+    /// declaration applies as-is — matching the host route_limits (Some, None)
+    /// arm; an absent probe produces no clamping.
     #[test]
     fn display_window_local_declared_without_probe_uses_declaration() {
         let (window, inferred) =
@@ -923,7 +953,8 @@ mod tests {
         assert!(!inferred);
     }
 
-    /// target_kind 异常（URL 解析失败）时有声明仍按声明展示，探测值不覆盖。
+    /// Abnormal target_kind (URL parse failure): a declaration still displays
+    /// as declared, and the probe value does not override it.
     #[test]
     fn display_window_declared_on_nonlocal_target_ignores_probe() {
         let (window, inferred) =
@@ -932,8 +963,9 @@ mod tests {
         assert!(!inferred);
     }
 
-    /// 无声明时保持既有口径：探测值优先，探测缺席才用推断；推断被真正采用时
-    /// 才置诊断标记。
+    /// Without a declaration the existing scale holds: the probe wins first and
+    /// inference only fills in when the probe is absent; the diagnostic flag is
+    /// set only when inference is truly adopted.
     #[test]
     fn display_window_without_declaration_keeps_probe_then_infer() {
         let (window, inferred) =
@@ -948,8 +980,9 @@ mod tests {
         assert!(!inferred);
     }
 
-    /// Mismatch 判定语义（抽出的纯函数）：双侧 trim、精确比较（大小写敏感）、
-    /// 任一侧缺席不降级、原状态非 Ready 时只降级不升级。
+    /// Mismatch detection semantics (extracted pure function): double-sided
+    /// trim, exact comparison (case-sensitive), a missing side never downgrades,
+    /// and a non-Ready original status can only be downgraded, never upgraded.
     #[test]
     fn mismatch_detection_trims_and_is_case_sensitive() {
         use VllmStatus::{Busy, Ready};
@@ -957,8 +990,9 @@ mod tests {
             mismatch_if_served_differs(Ready, Some(" qwen "), Some("qwen")),
             Ready
         );
-        // 大小写不同 → Mismatch：Engine 发送配置原名会 model_not_found，红点是
-        // 真实信号（与 resolve_served_model_from_entries 的精确匹配同口径）。
+        // Case difference → Mismatch: the Engine sending the configured original
+        // name would get model_not_found, so the red dot is a real signal (the
+        // same scale as resolve_served_model_from_entries' exact match).
         assert_eq!(
             mismatch_if_served_differs(Ready, Some("Qwen"), Some("qwen")),
             VllmStatus::Mismatch

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -144,6 +144,9 @@ pub async fn active_model_snapshot() -> Option<VllmSnapshot> {
     let api_key = model.as_ref().and_then(model_api_key);
     let model_id = model.as_ref().map(|m| m.id.clone());
     let provider = preset.as_str().to_string();
+    // 用户在模型表单显式声明的上下文窗口必须参与监控/Live-dot 展示口径，
+    // 否则保存 1M 后聊天页(chat:usage 分母)与监控页/进度条分母各说各话。
+    let configured_context = model.as_ref().and_then(|m| m.context_window_tokens);
     snapshot_for_model_config(
         &upstream,
         configured_model,
@@ -151,6 +154,7 @@ pub async fn active_model_snapshot() -> Option<VllmSnapshot> {
         model_id,
         provider,
         api_key.as_deref(),
+        configured_context,
     )
     .await
 }
@@ -166,6 +170,7 @@ pub async fn vllm_snapshot(
         ModelPreset::LocalVllm,
         None,
         "local_vllm".to_string(),
+        None,
         None,
     )
     .await
@@ -225,6 +230,7 @@ async fn snapshot_for_model_config(
     model_id: Option<String>,
     provider: String,
     api_key: Option<&str>,
+    configured_context: Option<u32>,
 ) -> Option<VllmSnapshot> {
     let client = shared_probe_client()?;
     let target_kind = if preset == ModelPreset::LocalVllm {
@@ -337,7 +343,9 @@ async fn snapshot_for_model_config(
 
     let (served_model, max_model_len) = match models_resp {
         Some(r) => match r.json::<serde_json::Value>().await.ok() {
-            Some(v) => parse_models_response(v).unwrap_or((None, None)),
+            Some(v) => {
+                parse_models_response(v, configured_model.as_deref()).unwrap_or((None, None))
+            }
             None => (None, None),
         },
         None => (None, None),
@@ -368,19 +376,22 @@ async fn snapshot_for_model_config(
     } else {
         Vec::new()
     };
-    let max_model_len = max_model_len.or_else(|| {
-        let inferred = infer_context_window(
-            preset,
-            configured_model.as_deref().or(served_model.as_deref()),
-        );
-        if inferred.is_some() {
-            metric_diagnostics.push(MonitorDiagnostic {
-                code: "context_window_inferred".to_string(),
-                message: "上下文长度由模型名/供应商预设推断，远端模型接口未直接提供".to_string(),
-            });
-        }
-        inferred
-    });
+    // 展示窗口优先级与 Engine `route_limits_for_model` 同口径(用户显式声明
+    // 优先,探测值只对本地部署收紧);云端探测值(常来自代理/网关的列表首条,
+    // 与配置模型无关甚至过时)不得覆盖用户声明,否则保存 1M 后进度条被打回
+    // 131K。探测与目录/预设兜底只在无声明时补位。
+    let inferred = infer_context_window(
+        preset,
+        configured_model.as_deref().or(served_model.as_deref()),
+    );
+    let (max_model_len, window_from_inference) =
+        resolve_display_context_window(target_kind, configured_context, max_model_len, inferred);
+    if window_from_inference {
+        metric_diagnostics.push(MonitorDiagnostic {
+            code: "context_window_inferred".to_string(),
+            message: "上下文长度由模型名/供应商预设推断，远端模型接口未直接提供".to_string(),
+        });
+    }
 
     let running = metrics_text
         .as_deref()
@@ -486,11 +497,43 @@ async fn snapshot_for_model_config(
     Some(snapshot)
 }
 
-fn parse_models_response(v: serde_json::Value) -> Option<(Option<String>, Option<u32>)> {
-    let first = crate::core::model_endpoint::parse_models_response_list(v)?
-        .into_iter()
-        .next()?;
-    Some((Some(first.id), first.max_model_len))
+fn parse_models_response(
+    v: serde_json::Value,
+    configured: Option<&str>,
+) -> Option<(Option<String>, Option<u32>)> {
+    let entries = crate::core::model_endpoint::parse_models_response_list(v)?;
+    // 云端 /models 往往一次列出全部模型，首条的 max_model_len 未必属于配置的
+    // 模型：优先取配置名自身的条目（大小写不敏感兜底），无匹配才退回首条
+    // （与 resolve_served_model_from_entries 的「先匹配、后单条」同一取向）。
+    let matched = configured.and_then(|name| {
+        entries.iter().find(|entry| entry.id == name).or_else(|| {
+            entries
+                .iter()
+                .find(|entry| entry.id.eq_ignore_ascii_case(name))
+        })
+    });
+    let entry = matched.or_else(|| entries.first())?;
+    Some((Some(entry.id.clone()), entry.max_model_len))
+}
+
+/// 展示侧上下文窗口优先级（监控卡 + `get_backend_status` 的进度条分母）。
+/// 与 Engine `route_limits_for_model` 对齐：用户显式声明优先；探测值仅对
+/// 本地部署(可实地内省的 vLLM)做 min 收紧——云端探测值不覆盖声明，避免
+/// 网关/代理的列表首条窗口(常见 131072)打回用户保存的 1M。声明与探测都
+/// 缺席时回落到模型名/供应商预设推断，此时第二个返回值为 true 供诊断标注。
+fn resolve_display_context_window(
+    target_kind: &str,
+    configured: Option<u32>,
+    probed: Option<u32>,
+    inferred: Option<u32>,
+) -> (Option<u32>, bool) {
+    match (configured, probed) {
+        (Some(configured), Some(probed)) if target_kind == "local" => {
+            (Some(configured.min(probed)), false)
+        }
+        (Some(configured), _) => (Some(configured), false),
+        (None, probed) => (probed.or(inferred), probed.is_none() && inferred.is_some()),
+    }
 }
 
 fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32> {
@@ -606,9 +649,11 @@ pub async fn probe_vllm_model_info(
     bearer: Option<&str>,
 ) -> (Option<String>, Option<u32>) {
     // HTTP layer and URL assembly reuse the shared core probe (no /v1/models
-    // semantics drift).
+    // semantics drift). Local single-model probe: no configured name to match,
+    // so the first list entry stays the served-name source (unchanged here;
+    // the configured-name matching lives in `snapshot_for_model_config`).
     match crate::core::model_endpoint::fetch_v1_models(base_url, bearer).await {
-        Some(v) => parse_models_response(v).unwrap_or((None, None)),
+        Some(v) => parse_models_response(v, None).unwrap_or((None, None)),
         None => (None, None),
     }
 }
@@ -748,9 +793,90 @@ mod tests {
             r#"{"object":"list","data":[{"id":"/model","object":"model","max_model_len":65536}]}"#,
         )
         .unwrap();
-        let (id, max) = parse_models_response(json).unwrap();
+        let (id, max) = parse_models_response(json, None).unwrap();
         assert_eq!(id.as_deref(), Some("/model"));
         assert_eq!(max, Some(65536));
+    }
+
+    fn models_list_json(entries: &[(&str, Option<u32>)]) -> serde_json::Value {
+        let data: Vec<String> = entries
+            .iter()
+            .map(|(id, len)| match len {
+                Some(len) => format!(r#"{{"id":"{id}","max_model_len":{len}}}"#),
+                None => format!(r#"{{"id":"{id}"}}"#),
+            })
+            .collect();
+        serde_json::from_str(&format!(
+            r#"{{"object":"list","data":[{}]}}"#,
+            data.join(",")
+        ))
+        .unwrap()
+    }
+
+    /// 云端 /models 一次列出全部模型：max_model_len 必须取配置模型自身的条目，
+    /// 不能借首条（往往是别的模型甚至网关默认 131072）的窗口。
+    #[test]
+    fn parse_models_response_matches_configured_model_entry() {
+        let json = models_list_json(&[
+            ("glm-5.2", Some(1000_000)),
+            ("glm-5.3-flash", Some(131_072)),
+        ]);
+        let (id, max) = parse_models_response(json, Some("glm-5.3-flash")).unwrap();
+        assert_eq!(id.as_deref(), Some("glm-5.3-flash"));
+        assert_eq!(max, Some(131_072));
+    }
+
+    /// 配置名不在列表（网关只回部分名单）：保持首条回退，行为与修复前一致。
+    #[test]
+    fn parse_models_response_falls_back_to_first_entry_when_absent() {
+        let json = models_list_json(&[("a", Some(4096)), ("b", Some(8192))]);
+        let (id, max) = parse_models_response(json, Some("gone")).unwrap();
+        assert_eq!(id.as_deref(), Some("a"));
+        assert_eq!(max, Some(4096));
+    }
+
+    /// 用户显式声明的窗口（云端，探测值 131072 来自网关列表）：声明必须原样
+    /// 胜出——回归本次「保存 1048576 后进度条仍显示 131.1K」的根因。
+    #[test]
+    fn display_window_remote_configured_declaration_beats_probe() {
+        let (window, inferred) = resolve_display_context_window(
+            "remote",
+            Some(1_048_576),
+            Some(131_072),
+            Some(1_000_000),
+        );
+        assert_eq!(window, Some(1_048_576));
+        assert!(!inferred);
+    }
+
+    /// 本地部署探测值是实地事实：与 Engine route_limits 同款 min 收紧。
+    #[test]
+    fn display_window_local_min_clamps_declaration_with_probe() {
+        let (window, inferred) =
+            resolve_display_context_window("local", Some(1_048_576), Some(131_072), None);
+        assert_eq!(window, Some(131_072));
+        assert!(!inferred);
+        // 反向：声明 32K、实机 128K → 按声明收紧（与 route_limits 一致）。
+        let (window, _) =
+            resolve_display_context_window("local", Some(32_768), Some(131_072), None);
+        assert_eq!(window, Some(32_768));
+    }
+
+    /// 无声明时保持既有口径：探测值优先，探测缺席才用推断；推断被真正采用时
+    /// 才置诊断标记。
+    #[test]
+    fn display_window_without_declaration_keeps_probe_then_infer() {
+        let (window, inferred) =
+            resolve_display_context_window("remote", None, Some(262_144), Some(131_072));
+        assert_eq!(window, Some(262_144));
+        assert!(!inferred);
+        let (window, inferred) =
+            resolve_display_context_window("remote", None, None, Some(1_000_000));
+        assert_eq!(window, Some(1_000_000));
+        assert!(inferred);
+        let (window, inferred) = resolve_display_context_window("remote", None, None, None);
+        assert_eq!(window, None);
+        assert!(!inferred);
     }
 
     fn served_entry(

--- a/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
+++ b/pinvou3-app/src-tauri/src/features/monitor/model_probe.rs
@@ -60,7 +60,7 @@ pub struct VllmSnapshot {
     pub prompt_tokens_total: Option<f64>,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum VllmStatus {
     Offline,
@@ -376,16 +376,16 @@ async fn snapshot_for_model_config(
     } else {
         Vec::new()
     };
-    // 展示窗口优先级与 Engine `route_limits_for_model` 同口径(用户显式声明
-    // 优先,探测值只对本地部署收紧);云端探测值(常来自代理/网关的列表首条,
-    // 与配置模型无关甚至过时)不得覆盖用户声明,否则保存 1M 后进度条被打回
+    // 展示窗口走统一优先级（见 display_context_window）：用户显式声明优先，
+    // 本地部署的探测值做 min 收紧；云端探测值（常来自代理/网关的列表条目，
+    // 与配置模型无关甚至过时）不得覆盖用户声明，否则保存 1M 后进度条被打回
     // 131K。探测与目录/预设兜底只在无声明时补位。
     let inferred = infer_context_window(
         preset,
         configured_model.as_deref().or(served_model.as_deref()),
     );
     let (max_model_len, window_from_inference) =
-        resolve_display_context_window(target_kind, configured_context, max_model_len, inferred);
+        display_context_window(configured_context, target_kind, max_model_len, inferred);
     if window_from_inference {
         metric_diagnostics.push(MonitorDiagnostic {
             code: "context_window_inferred".to_string(),
@@ -426,13 +426,11 @@ async fn snapshot_for_model_config(
     // 如果用户配置了模型名，但和 vLLM 实际返回的不一致，降级为 Mismatch。
     // 这样监控台不会显示绿色 READY，聊天 live dot 也会变红。
     if metrics_applicable {
-        if let Some(ref cfg) = configured_model {
-            if let Some(ref actual) = served_model {
-                if cfg.trim() != actual.trim() {
-                    status = VllmStatus::Mismatch;
-                }
-            }
-        }
+        status = mismatch_if_served_differs(
+            status,
+            configured_model.as_deref(),
+            served_model.as_deref(),
+        );
     }
     let health_status = match status {
         VllmStatus::Mismatch => "mismatch",
@@ -502,9 +500,13 @@ fn parse_models_response(
     configured: Option<&str>,
 ) -> Option<(Option<String>, Option<u32>)> {
     let entries = crate::core::model_endpoint::parse_models_response_list(v)?;
-    // 云端 /models 往往一次列出全部模型，首条的 max_model_len 未必属于配置的
-    // 模型：优先取配置名自身的条目（大小写不敏感兜底），无匹配才退回首条
-    // （与 resolve_served_model_from_entries 的「先匹配、后单条」同一取向）。
+    // 云端 /models 往往一次列出全部模型：优先取配置模型自身条目（精确命中，
+    // ASCII 大小写不敏感兜底；配置名先 trim，与 Mismatch 判定的双侧 trim 同口径）。
+    // 首条回退仅供 served 名展示——其 max_model_len 属于别的模型，不得借给配置
+    // 模型（与 `resolve_served_model_from_entries` 的「窗口不借自别的模型」同一
+    // 原则）。两者回退取向不同是有意的：推理路径未命中时保留配置名，让
+    // model_not_found 显式暴露；展示路径回退首条名字仅是诊断信息。
+    let configured = configured.map(str::trim).filter(|name| !name.is_empty());
     let matched = configured.and_then(|name| {
         entries.iter().find(|entry| entry.id == name).or_else(|| {
             entries
@@ -513,32 +515,54 @@ fn parse_models_response(
         })
     });
     let entry = matched.or_else(|| entries.first())?;
-    Some((Some(entry.id.clone()), entry.max_model_len))
+    let window = if matched.is_some() || configured.is_none() {
+        entry.max_model_len
+    } else {
+        None
+    };
+    Some((Some(entry.id.clone()), window))
 }
 
-/// 展示侧上下文窗口优先级（监控卡 + `get_backend_status` 的进度条分母）。
-/// 与 Engine `route_limits_for_model` 对齐：用户显式声明优先；探测值仅对
-/// 本地部署(可实地内省的 vLLM)做 min 收紧——云端探测值不覆盖声明，避免
-/// 网关/代理的列表首条窗口(常见 131072)打回用户保存的 1M。声明与探测都
-/// 缺席时回落到模型名/供应商预设推断，此时第二个返回值为 true 供诊断标注。
-fn resolve_display_context_window(
-    target_kind: &str,
+/// 展示侧上下文窗口（监控卡 + `get_backend_status` 的进度条分母）。优先级
+/// 本体在 `core::model_context::resolve_context_window`，与宿主
+/// `bridge::route_limits_for_model`（决定推理与压缩阈值）共用同一函数；本
+/// wrapper 只负责「探测值是否可信」的门控：本地部署（环回/私有 IP，可实地
+/// 内省）的探测值交给统一口径做 min 收紧；云端探测值来自网关/代理的列表
+/// 条目，不是部署实地事实，故在用户已声明窗口时整体不参与（声明优先且无
+/// 收紧依据），仅在无声明时作展示补位。
+fn display_context_window(
     configured: Option<u32>,
+    target_kind: &str,
     probed: Option<u32>,
     inferred: Option<u32>,
 ) -> (Option<u32>, bool) {
-    match (configured, probed) {
-        (Some(configured), Some(probed)) if target_kind == "local" => {
-            (Some(configured.min(probed)), false)
-        }
-        (Some(configured), _) => (Some(configured), false),
-        (None, probed) => (probed.or(inferred), probed.is_none() && inferred.is_some()),
+    let probed = match (configured, target_kind) {
+        (Some(_), "local") | (None, _) => probed,
+        (Some(_), _) => None,
+    };
+    crate::core::model_context::resolve_context_window(configured, probed, inferred)
+}
+
+/// 配置模型名与实际 served 名不一致时降级为 `Mismatch`（仅本地部署调用方启用，
+/// 见 `snapshot_for_model_config`）。抽成纯函数以便单测锁住比较语义：双侧
+/// trim 后精确比较（大小写敏感，与推理路径 `resolve_served_model_from_entries`
+/// 的精确匹配同口径——网关把 id 统一成小写而配置名带大写时，Engine 发送配置
+/// 原名会 model_not_found，监控红点是真实信号而非误报）。
+fn mismatch_if_served_differs(
+    status: VllmStatus,
+    configured: Option<&str>,
+    served: Option<&str>,
+) -> VllmStatus {
+    match (configured, served) {
+        (Some(cfg), Some(actual)) if cfg.trim() != actual.trim() => VllmStatus::Mismatch,
+        _ => status,
     }
 }
 
 fn infer_context_window(preset: ModelPreset, model: Option<&str>) -> Option<u32> {
-    // 模型名事实与 Engine route_limits 共用同一入口，避免页面显示 1M、实际仍按
-    // 128K 压缩。底座与补充表都无法识别时按供应商预设兜底（表在 prefs::model_preset）。
+    // 模型名事实经 core::model_context 单一入口解析，宿主 route_limits 的推断
+    // 兜底同源，避免页面显示 1M、实际仍按 128K 压缩。底座与补充表都无法识别时
+    // 按供应商预设兜底（表在 prefs::model_preset）。
     if let Some(window) = model.and_then(crate::core::model_context::resolved_context_window) {
         return Some(window);
     }
@@ -826,40 +850,86 @@ mod tests {
         assert_eq!(max, Some(131_072));
     }
 
-    /// 配置名不在列表（网关只回部分名单）：保持首条回退，行为与修复前一致。
+    /// 配置名不在列表（网关只回部分名单）：首条回退仅供 served 名展示，其
+    /// max_model_len 属于别的模型，不得借给配置模型（与推理路径
+    /// resolve_served_model_from_entries 的「窗口不借自别的模型」同一原则）。
     #[test]
-    fn parse_models_response_falls_back_to_first_entry_when_absent() {
+    fn parse_models_response_first_entry_fallback_lends_name_not_window() {
         let json = models_list_json(&[("a", Some(4096)), ("b", Some(8192))]);
         let (id, max) = parse_models_response(json, Some("gone")).unwrap();
         assert_eq!(id.as_deref(), Some("a"));
-        assert_eq!(max, Some(4096));
+        assert_eq!(max, None);
+    }
+
+    /// 大小写不敏感兜底命中时窗口同样归属配置模型（网关把 id 统一成小写是
+    /// 常见形态，窗口确属同一模型）。
+    #[test]
+    fn parse_models_response_matches_case_insensitively_and_keeps_window() {
+        let json = models_list_json(&[("other", Some(4096)), ("glm-5.3-flash", Some(131_072))]);
+        let (id, max) = parse_models_response(json, Some("GLM-5.3-Flash")).unwrap();
+        assert_eq!(id.as_deref(), Some("glm-5.3-flash"));
+        assert_eq!(max, Some(131_072));
+    }
+
+    /// 配置名先 trim 再匹配（与 Mismatch 判定的双侧 trim 同口径），带首尾
+    /// 空格的配置名不再永远无法命中。
+    #[test]
+    fn parse_models_response_trims_configured_name() {
+        let json = models_list_json(&[("glm-5.3-flash", Some(131_072))]);
+        let (id, max) = parse_models_response(json, Some("  glm-5.3-flash\t")).unwrap();
+        assert_eq!(id.as_deref(), Some("glm-5.3-flash"));
+        assert_eq!(max, Some(131_072));
+    }
+
+    /// 命中条目但服务端未带 max_model_len：窗口保持 None，交由声明/推断兜底，
+    /// 绝不伪造（与 resolve_served_model_from_entries 的同名原则一致）。
+    #[test]
+    fn parse_models_response_matched_entry_without_window_propagates_none() {
+        let json = models_list_json(&[("user-picked", None)]);
+        let (id, max) = parse_models_response(json, Some("user-picked")).unwrap();
+        assert_eq!(id.as_deref(), Some("user-picked"));
+        assert_eq!(max, None);
     }
 
     /// 用户显式声明的窗口（云端，探测值 131072 来自网关列表）：声明必须原样
     /// 胜出——回归本次「保存 1048576 后进度条仍显示 131.1K」的根因。
     #[test]
     fn display_window_remote_configured_declaration_beats_probe() {
-        let (window, inferred) = resolve_display_context_window(
-            "remote",
-            Some(1_048_576),
-            Some(131_072),
-            Some(1_000_000),
-        );
+        let (window, inferred) =
+            display_context_window(Some(1_048_576), "remote", Some(131_072), Some(1_000_000));
         assert_eq!(window, Some(1_048_576));
         assert!(!inferred);
     }
 
-    /// 本地部署探测值是实地事实：与 Engine route_limits 同款 min 收紧。
+    /// 本地部署探测值是实地事实：与宿主 route_limits 同款 min 收紧。
     #[test]
     fn display_window_local_min_clamps_declaration_with_probe() {
         let (window, inferred) =
-            resolve_display_context_window("local", Some(1_048_576), Some(131_072), None);
+            display_context_window(Some(1_048_576), "local", Some(131_072), None);
         assert_eq!(window, Some(131_072));
         assert!(!inferred);
         // 反向：声明 32K、实机 128K → 按声明收紧（与 route_limits 一致）。
-        let (window, _) =
-            resolve_display_context_window("local", Some(32_768), Some(131_072), None);
+        let (window, _) = display_context_window(Some(32_768), "local", Some(131_072), None);
         assert_eq!(window, Some(32_768));
+    }
+
+    /// 本地声明但探测缺席（/models 解析失败等）：声明原样生效——与宿主
+    /// route_limits 的 (Some, None) 臂一致，探测缺席不产生任何收紧。
+    #[test]
+    fn display_window_local_declared_without_probe_uses_declaration() {
+        let (window, inferred) =
+            display_context_window(Some(1_048_576), "local", None, Some(131_072));
+        assert_eq!(window, Some(1_048_576));
+        assert!(!inferred);
+    }
+
+    /// target_kind 异常（URL 解析失败）时有声明仍按声明展示，探测值不覆盖。
+    #[test]
+    fn display_window_declared_on_nonlocal_target_ignores_probe() {
+        let (window, inferred) =
+            display_context_window(Some(262_144), "invalid", Some(131_072), None);
+        assert_eq!(window, Some(262_144));
+        assert!(!inferred);
     }
 
     /// 无声明时保持既有口径：探测值优先，探测缺席才用推断；推断被真正采用时
@@ -867,16 +937,39 @@ mod tests {
     #[test]
     fn display_window_without_declaration_keeps_probe_then_infer() {
         let (window, inferred) =
-            resolve_display_context_window("remote", None, Some(262_144), Some(131_072));
+            display_context_window(None, "remote", Some(262_144), Some(131_072));
         assert_eq!(window, Some(262_144));
         assert!(!inferred);
-        let (window, inferred) =
-            resolve_display_context_window("remote", None, None, Some(1_000_000));
+        let (window, inferred) = display_context_window(None, "remote", None, Some(1_000_000));
         assert_eq!(window, Some(1_000_000));
         assert!(inferred);
-        let (window, inferred) = resolve_display_context_window("remote", None, None, None);
+        let (window, inferred) = display_context_window(None, "remote", None, None);
         assert_eq!(window, None);
         assert!(!inferred);
+    }
+
+    /// Mismatch 判定语义（抽出的纯函数）：双侧 trim、精确比较（大小写敏感）、
+    /// 任一侧缺席不降级、原状态非 Ready 时只降级不升级。
+    #[test]
+    fn mismatch_detection_trims_and_is_case_sensitive() {
+        use VllmStatus::{Busy, Ready};
+        assert_eq!(
+            mismatch_if_served_differs(Ready, Some(" qwen "), Some("qwen")),
+            Ready
+        );
+        // 大小写不同 → Mismatch：Engine 发送配置原名会 model_not_found，红点是
+        // 真实信号（与 resolve_served_model_from_entries 的精确匹配同口径）。
+        assert_eq!(
+            mismatch_if_served_differs(Ready, Some("Qwen"), Some("qwen")),
+            VllmStatus::Mismatch
+        );
+        assert_eq!(
+            mismatch_if_served_differs(Busy, Some("a"), Some("b")),
+            VllmStatus::Mismatch
+        );
+        assert_eq!(mismatch_if_served_differs(Ready, None, Some("b")), Ready);
+        assert_eq!(mismatch_if_served_differs(Ready, Some("a"), None), Ready);
+        assert_eq!(mismatch_if_served_differs(Ready, None, None), Ready);
     }
 
     fn served_entry(


### PR DESCRIPTION
## What changed and why

A user-declared context window on a saved model (e.g. `1048576` on a custom `glm-5.3-flash`) kept snapping back to `131.1K` in the chat context meter after saving. The saved value was persisted correctly and the effective path honored it (`route_limits_for_model` in the host bridge reads `SavedModel.context_window_tokens`, and `chat:usage` carries the result as the frontend denominator). The regression came from the parallel display path:

- `get_backend_status` (live-dot poll, every 10s) and the monitor page's `get_monitor_snapshot` (1s while the monitor page is open) both go through `active_model_snapshot()`, which never consulted `context_window_tokens`. It reported whatever `/v1/models` returned — or, when the endpoint reported nothing, the model-name/vendor-preset fallback (the GLM preset fallback is exactly `131_072`).
- The frontend writes that value into `state.tokens.max` on every poll, clobbering the correct `chat:usage` denominator until the session's next turn event.

### Commit 1 — `fix(monitor): honor saved context window over endpoint probe`

1. **Declared window wins.** The display window resolves through the same precedence as the host bridge's `route_limits_for_model`: remote — the user declaration wins outright (the runtime never probes cloud endpoints, so the declaration *is* the runtime window); local — `min(declared, probed)` (the probe is ground-truth deployment introspection, matching the settings-form copy about over-declared values being min-clamped against the runtime probe); neither — fallback to name/vendor-preset inference, with the `context_window_inferred` diagnostic firing only when inference is actually adopted.
2. **Match the configured model in `/models`.** `parse_models_response` previously took the *first* list entry's `max_model_len`, which on multi-model gateways belongs to a different model (often a gateway default of 131072). It now prefers the entry matching the configured model id.

### Commit 2 — `refactor(core): shared context window precedence`

The precedence itself is hoisted into `core::model_context::resolve_context_window`, and both the bridge's `route_limits_for_model` and the monitor display path now call the same function instead of maintaining parallel match blocks (the two copies had already drifted in their "local" gating: `base_url_uses_local_or_private` + provider mapping vs `vllm_target_kind`). Bridge behavior is unchanged; the existing forkguard route/compaction tests pin it. The monitor keeps a thin gate: for a *declared* window on a non-local target the probed value is withheld from the precedence (cloud probe values are gateway list entries, not deployment ground truth).

### Commit 3 — `fix(monitor): adopt shared precedence, no lending`

- The first-entry fallback in `parse_models_response` now lends the served **name** only; a probed `max_model_len` is reported only when the entry provably belongs to the configured model (exact or ASCII case-insensitive match), or when no model name is configured (single-model local servers). An unrelated gateway entry's window is never borrowed — not even to min-clamp a declaration, matching `resolve_served_model_from_entries`' established principle.
- The configured model name is trimmed before matching, mirroring the mismatch comparison.
- The served-vs-configured mismatch downgrade is extracted into a pure `mismatch_if_served_differs` helper with tests pinning its trim/case-sensitive semantics (previously inline and untested).

### Commit 4 — `style: translate new code comments to English`

Comment-only: the comments introduced by this PR are translated into English per `CONTRIBUTING.md` ("Use English for … code comments"; existing history is exempt). The only Chinese line remaining in the diff is the pre-existing `context_window_inferred` diagnostic message, moved verbatim.

## Affected features / compatibility / risks

- Monitor card `max_model_len` and `get_backend_status.max_model_len` (chat progress-bar denominator) become consistent with the runtime window for models with an explicit declaration. The bridge-layer `vllmCtxWarn` computation reads the same value (note: it is currently rendered by no component).
- Without a declaration the window source is unchanged **except** one correction in the same no-borrowing spirit: when a model name *is* configured but the endpoint's `/models` list does not contain it, the display now falls back to name/preset inference instead of borrowing the first list entry's window (which could be an unrelated model's or a gateway default 131072).
- Local deployments where the user *under-declares* display the declared (smaller) window instead of the probed one — matching what the engine actually enforces via `route_limits` min-clamping, so display and compaction thresholds stay in sync.
- `probe_vllm_model_info` (voice live probe) and the legacy `vllm_snapshot` wrapper keep their previous first-entry/local semantics by passing no configured name/window.
- Rust-only change; no frontend, config, or data-format changes. No stored-data migration needed (`context_window_tokens` was already persisted).

## Known residual divergences (pre-existing, documented on purpose)

- The monitor's "local" gate (`vllm_target_kind`) and the bridge's probe gate (`base_url_uses_local_or_private` + provider mapping) disagree on Docker/Lima/OrbStack host aliases: the bridge probes and min-clamps there, the monitor classifies them as remote and lets the declaration stand.
- With no declaration and no probe, the monitor falls back to the vendor-preset table (e.g. LocalVllm → 262144) while the bridge's last-resort is 128000 for local vLLM.
- The frontend poll still writes the *global active model's* window, so a session hot-switched to a different model can transiently show the global denominator until the next `chat:usage` event.

## Tests run

- New unit tests: shared-precedence table at `core::model_context`; remote declaration beats probe (regression for this report); local min-clamp both directions; local declared-without-probe; non-local declared ignores probe; probe-then-infer fallback + diagnostic flag; configured-entry matching (exact, case-insensitive, trimmed); first-entry fallback lends the name but not the window; matched entry without window propagates None; mismatch helper semantics.
- `cargo test --lib`: 2066 passed, 0 failed (13 ignored, incl. the live-vLLM probe) on the final tree.
- `cargo fmt --check`, `scripts/architecture-guard.py`: green. `scripts/fork-guard.sh --fast`: all fingerprint checks green (the count step hits the known bash-3.2 full-width-paren crash on macOS hosts; see #432 — same crash on `main`).

## Unverified scenarios / limitations

- Not verified against a live gateway that reports a first-entry `max_model_len` different from the configured model (no such endpoint available locally); covered by unit tests at the parser and precedence level.

