### PR TITLE
fix(voice): close WAV before recognition

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1148,7 +1148,7 @@ jobs:
             'artifact_read_recovers_an_occupied_1177_layout_after_release' \
             'artifact_writes_never_expose_partial_utf8_to_concurrent_readers' \
             'artifact_public_read_' \
-            'features::voice::platform::windows::tests::closed_temp_wav_can_be_reopened_exclusively_by_asr' \
+            'features::voice::platform::windows::tests::closed_temp_wav_can_be_reopened_when_asr_denies_write_sharing' \
             'features::memory::tests::topic_migration_'; do
             "$test_exe" "$filter" --test-threads=1 2>&1 | tee /tmp/windows_regression.log
             grep -qE 'running [1-9][0-9]* tests?' /tmp/windows_regression.log || {

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1148,6 +1148,7 @@ jobs:
             'artifact_read_recovers_an_occupied_1177_layout_after_release' \
             'artifact_writes_never_expose_partial_utf8_to_concurrent_readers' \
             'artifact_public_read_' \
+            'features::voice::platform::windows::tests::closed_temp_wav_can_be_reopened_exclusively_by_asr' \
             'features::memory::tests::topic_migration_'; do
             "$test_exe" "$filter" --test-threads=1 2>&1 | tee /tmp/windows_regression.log
             grep -qE 'running [1-9][0-9]* tests?' /tmp/windows_regression.log || {

--- a/pinvou3-app/src-tauri/src/app/commands/voice.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/voice.rs
@@ -180,8 +180,36 @@ impl VoiceTempWav {
         Ok(Self { file })
     }
 
-    fn path(&self) -> &std::path::Path {
-        self.file.path()
+    /// Finish writing before handing the path to an external recognizer. On
+    /// Windows, keeping the `NamedTempFile` handle alive can prevent a backend
+    /// that requests exclusive access from reopening the WAV file.
+    fn write_and_close(mut self, audio_bytes: &[u8]) -> std::io::Result<tempfile::TempPath> {
+        use std::io::Write;
+
+        self.file.write_all(audio_bytes)?;
+        self.file.flush()?;
+        Ok(self.file.into_temp_path())
+    }
+}
+
+#[cfg(test)]
+mod voice_temp_wav_tests {
+    use super::VoiceTempWav;
+
+    #[test]
+    fn closed_temp_wav_keeps_contents_and_cleans_up_on_drop() {
+        let wav_path = VoiceTempWav::create()
+            .expect("create temporary WAV")
+            .write_and_close(b"RIFF-test-WAVE")
+            .expect("write and close temporary WAV");
+        let path = wav_path.to_path_buf();
+
+        assert_eq!(
+            std::fs::read(&path).expect("read temporary WAV"),
+            b"RIFF-test-WAVE"
+        );
+        drop(wav_path);
+        assert!(!path.exists(), "temporary WAV must be removed on drop");
     }
 }
 
@@ -433,7 +461,7 @@ pub(crate) async fn transcribe_voice_audio_bytes(
                 "Could not create temporary audio file; please retry",
             )
         })?;
-        std::fs::write(wav_file.path(), &audio_bytes).map_err(|e| {
+        let wav_path = wav_file.write_and_close(&audio_bytes).map_err(|e| {
             log::warn!(
                 target: "pinvou.voice",
                 "[voice_transcribe] write temp wav failed: {e}"
@@ -460,7 +488,7 @@ pub(crate) async fn transcribe_voice_audio_bytes(
             let locale_tag = crate::platform::prefs::UserPrefs::load()
                 .language
                 .speech_recognition_locale();
-            let native = crate::features::voice::recognize_native(wav_file.path(), locale_tag);
+            let native = crate::features::voice::recognize_native(&wav_path, locale_tag);
             match native {
                 Some(Ok(text)) => Ok(LocalAsrOutput {
                     text,
@@ -468,7 +496,7 @@ pub(crate) async fn transcribe_voice_audio_bytes(
                 }),
                 Some(Err(e)) => {
                     if has_explicit_asr_cli_fallback() {
-                        run_local_asr_cli(wav_file.path())
+                        run_local_asr_cli(&wav_path)
                     } else {
                         Err(VoiceCommandError::new(
                             "asr_engine_error",
@@ -478,7 +506,7 @@ pub(crate) async fn transcribe_voice_audio_bytes(
                         ))
                     }
                 }
-                None => run_local_asr_cli(wav_file.path()),
+                None => run_local_asr_cli(&wav_path),
             }
         };
         result

--- a/pinvou3-app/src-tauri/src/app/commands/voice.rs
+++ b/pinvou3-app/src-tauri/src/app/commands/voice.rs
@@ -164,55 +164,6 @@ pub(super) fn apply_local_asr_model_env(
     }
 }
 
-/// Temporary WAV file: `NamedTempFile` generates an unpredictable file name
-/// with 0600 permissions on Unix (the old hand-built pid+millisecond name was
-/// predictable and world-readable at 0644); the file is deleted on drop.
-struct VoiceTempWav {
-    file: tempfile::NamedTempFile,
-}
-
-impl VoiceTempWav {
-    fn create() -> std::io::Result<Self> {
-        let file = tempfile::Builder::new()
-            .prefix("pinvou3-voice-")
-            .suffix(".wav")
-            .tempfile()?;
-        Ok(Self { file })
-    }
-
-    /// Finish writing before handing the path to an external recognizer. On
-    /// Windows, keeping the `NamedTempFile` handle alive can prevent a backend
-    /// that requests exclusive access from reopening the WAV file.
-    fn write_and_close(mut self, audio_bytes: &[u8]) -> std::io::Result<tempfile::TempPath> {
-        use std::io::Write;
-
-        self.file.write_all(audio_bytes)?;
-        self.file.flush()?;
-        Ok(self.file.into_temp_path())
-    }
-}
-
-#[cfg(test)]
-mod voice_temp_wav_tests {
-    use super::VoiceTempWav;
-
-    #[test]
-    fn closed_temp_wav_keeps_contents_and_cleans_up_on_drop() {
-        let wav_path = VoiceTempWav::create()
-            .expect("create temporary WAV")
-            .write_and_close(b"RIFF-test-WAVE")
-            .expect("write and close temporary WAV");
-        let path = wav_path.to_path_buf();
-
-        assert_eq!(
-            std::fs::read(&path).expect("read temporary WAV"),
-            b"RIFF-test-WAVE"
-        );
-        drop(wav_path);
-        assert!(!path.exists(), "temporary WAV must be removed on drop");
-    }
-}
-
 struct LocalAsrOutput {
     text: String,
     /// Recognition backend source (system_speech /
@@ -449,7 +400,7 @@ pub(crate) async fn transcribe_voice_audio_bytes(
     }
 
     let asr_output = tokio::task::spawn_blocking(move || {
-        let wav_file = VoiceTempWav::create().map_err(|e| {
+        let wav_file = crate::features::voice::VoiceTempWav::create().map_err(|e| {
             log::warn!(
                 target: "pinvou.voice",
                 "[voice_transcribe] create temp wav failed: {e}"

--- a/pinvou3-app/src-tauri/src/features/voice/mod.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod microphone_permission;
 mod platform;
+mod temp_wav;
 mod transcript;
 pub(crate) mod voice_asr;
 
@@ -7,5 +8,6 @@ pub(crate) use platform::{
     asr_dependency_packages, asr_missing_message, asr_tool_exists, asr_tool_path,
     engine_binary_name, native_recognition_source, recognize_native,
 };
+pub(crate) use temp_wav::VoiceTempWav;
 pub(crate) use transcript::parse_asr_transcript;
 pub(crate) use voice_asr::set_bundled_engine_dir;

--- a/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
@@ -197,18 +197,21 @@ mod tests {
     use std::os::windows::fs::OpenOptionsExt;
 
     use crate::features::voice::VoiceTempWav;
+    use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
 
     #[test]
-    fn closed_temp_wav_can_be_reopened_exclusively_by_asr() {
+    fn closed_temp_wav_can_be_reopened_when_asr_denies_write_sharing() {
         let wav_path = VoiceTempWav::create()
             .expect("create temporary WAV")
             .write_and_close(b"RIFF-test-WAVE")
             .expect("write and close temporary WAV");
         let reopened = std::fs::OpenOptions::new()
             .read(true)
-            .share_mode(0)
+            // Match the bundled ASR backend: concurrent readers are allowed,
+            // but an existing write handle makes this open fail on Windows.
+            .share_mode(FILE_SHARE_READ)
             .open(&wav_path)
-            .expect("ASR backend must be able to reopen the WAV exclusively");
+            .expect("ASR backend must be able to reopen the WAV without write sharing");
 
         drop(reopened);
     }

--- a/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
@@ -191,3 +191,25 @@ pub async fn reset_microphone_permission(window: tauri::WebviewWindow) -> Result
         .map_err(|_| "麦克风权限重置任务被取消".to_string())??;
     Ok(true)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::os::windows::fs::OpenOptionsExt;
+
+    use super::super::temp_wav::VoiceTempWav;
+
+    #[test]
+    fn closed_temp_wav_can_be_reopened_exclusively_by_asr() {
+        let wav_path = VoiceTempWav::create()
+            .expect("create temporary WAV")
+            .write_and_close(b"RIFF-test-WAVE")
+            .expect("write and close temporary WAV");
+        let reopened = std::fs::OpenOptions::new()
+            .read(true)
+            .share_mode(0)
+            .open(&wav_path)
+            .expect("ASR backend must be able to reopen the WAV exclusively");
+
+        drop(reopened);
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/platform/windows.rs
@@ -196,7 +196,7 @@ pub async fn reset_microphone_permission(window: tauri::WebviewWindow) -> Result
 mod tests {
     use std::os::windows::fs::OpenOptionsExt;
 
-    use super::super::temp_wav::VoiceTempWav;
+    use crate::features::voice::VoiceTempWav;
 
     #[test]
     fn closed_temp_wav_can_be_reopened_exclusively_by_asr() {

--- a/pinvou3-app/src-tauri/src/features/voice/temp_wav.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/temp_wav.rs
@@ -1,0 +1,51 @@
+/// Temporary WAV file: `NamedTempFile` generates an unpredictable file name
+/// with 0600 permissions on Unix (the old hand-built pid+millisecond name was
+/// predictable and world-readable at 0644); the file is deleted on drop.
+pub(crate) struct VoiceTempWav {
+    file: tempfile::NamedTempFile,
+}
+
+impl VoiceTempWav {
+    pub(crate) fn create() -> std::io::Result<Self> {
+        let file = tempfile::Builder::new()
+            .prefix("pinvou3-voice-")
+            .suffix(".wav")
+            .tempfile()?;
+        Ok(Self { file })
+    }
+
+    /// Finish writing before handing the path to an external recognizer. On
+    /// Windows, keeping the `NamedTempFile` handle alive can prevent a backend
+    /// that requests exclusive access from reopening the WAV file.
+    pub(crate) fn write_and_close(
+        mut self,
+        audio_bytes: &[u8],
+    ) -> std::io::Result<tempfile::TempPath> {
+        use std::io::Write;
+
+        self.file.write_all(audio_bytes)?;
+        self.file.flush()?;
+        Ok(self.file.into_temp_path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VoiceTempWav;
+
+    #[test]
+    fn closed_temp_wav_keeps_contents_and_cleans_up_on_drop() {
+        let wav_path = VoiceTempWav::create()
+            .expect("create temporary WAV")
+            .write_and_close(b"RIFF-test-WAVE")
+            .expect("write and close temporary WAV");
+        let path = wav_path.to_path_buf();
+
+        assert_eq!(
+            std::fs::read(&path).expect("read temporary WAV"),
+            b"RIFF-test-WAVE"
+        );
+        drop(wav_path);
+        assert!(!path.exists(), "temporary WAV must be removed on drop");
+    }
+}

--- a/pinvou3-app/src-tauri/src/features/voice/temp_wav.rs
+++ b/pinvou3-app/src-tauri/src/features/voice/temp_wav.rs
@@ -15,8 +15,8 @@ impl VoiceTempWav {
     }
 
     /// Finish writing before handing the path to an external recognizer. On
-    /// Windows, keeping the `NamedTempFile` handle alive can prevent a backend
-    /// that requests exclusive access from reopening the WAV file.
+    /// Windows, keeping the `NamedTempFile` write handle alive can prevent a
+    /// backend whose share mode denies write sharing from reopening the WAV.
     pub(crate) fn write_and_close(
         mut self,
         audio_bytes: &[u8],

--- a/pinvou3-app/tests/voice_input_error_logic.test.js
+++ b/pinvou3-app/tests/voice_input_error_logic.test.js
@@ -8,6 +8,8 @@ const bridgePath = path.join(__dirname, "..", "src", "platform", "tauri", "bridg
 const source = fs.readFileSync(bridgePath, "utf8");
 const rustVoicePath = path.join(__dirname, "..", "src-tauri", "src", "app", "commands", "voice.rs");
 const rustVoiceSource = fs.readFileSync(rustVoicePath, "utf8");
+const rustVoiceTempWavPath = path.join(__dirname, "..", "src-tauri", "src", "features", "voice", "temp_wav.rs");
+const rustVoiceTempWavSource = fs.readFileSync(rustVoiceTempWavPath, "utf8");
 const chatPath = path.join(__dirname, "..", "src", "features", "chat", "ChatView.jsx");
 const chatSource = fs.readFileSync(chatPath, "utf8");
 const routerPath = path.join(__dirname, "..", "src", "features", "voice-composer", "VoiceShortcutRouter.jsx");
@@ -573,19 +575,29 @@ assert.doesNotMatch(
   /voiceEdit(?:PreviewTitle|Apply|ApplyAndSend|Cancel|Original|Result)[^;\n]*\|\| '[^']+'/,
   "voice edit preview must not add single-language fallback copy in the component",
 );
-assert.match(rustVoiceSource, /struct VoiceTempWav/);
+assert.match(rustVoiceTempWavSource, /struct VoiceTempWav/);
 // Temp WAVs use tempfile::NamedTempFile: unpredictable name, 0600 perms,
 // deleted on drop; never revert to self-built pid+millisecond names
 // (predictable and world-readable at 0644).
 assert.match(
-  rustVoiceSource,
+  rustVoiceTempWavSource,
   /file: tempfile::NamedTempFile[\s\S]*?tempfile::Builder::new\(\)[\s\S]*?\.tempfile\(\)\?/,
   "temp wav must use tempfile::NamedTempFile",
 );
 assert.doesNotMatch(
-  rustVoiceSource,
+  rustVoiceTempWavSource,
   /std::process::id\(\)/,
   "temp wav name must not be self-built from pid and milliseconds",
+);
+assert.match(
+  rustVoiceTempWavSource,
+  /write_all\(audio_bytes\)\?[\s\S]*?flush\(\)\?[\s\S]*?into_temp_path\(\)/,
+  "temp wav must close its NamedTempFile handle before external ASR reopens the path",
+);
+assert.match(
+  rustVoiceSource,
+  /VoiceTempWav::create\(\)[\s\S]*?write_and_close\(&audio_bytes\)[\s\S]*?recognize_native\(&wav_path/,
+  "voice transcription must close the temp WAV before starting native ASR",
 );
 const committedAudioDir = path.join(__dirname, "fixtures", "voice-audio-samples");
 assert.ok(


### PR DESCRIPTION
## Summary

- write and flush the temporary WAV through its owned file handle
- convert `NamedTempFile` into `TempPath` before native or CLI ASR starts, closing the Windows file handle while preserving automatic cleanup
- keep the temporary-WAV lifecycle in the voice feature
- add a Windows regression that uses the backend-compatible `FILE_SHARE_READ` mode to prove the WAV can be reopened while write sharing is denied
- execute that regression in the Windows CI test lane
- update the existing voice source contract for the new module boundary and enforce the close-before-ASR ordering

## Root cause

Windows kept the `NamedTempFile` write handle open while the external ASR backend attempted to reopen the WAV with a share mode that permits readers but denies write sharing. The incompatible existing write access caused the backend's audio open/decode failure.

## Verification

- `cargo fmt --manifest-path pinvou3-app/src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `python scripts/architecture-guard.py`
- `npm run test:voice-input`
- `$env:RUST_MIN_STACK='67108864'; $env:CARGO_PROFILE_TEST_LTO='false'; cargo test --manifest-path pinvou3-app/src-tauri/Cargo.toml --lib closed_temp_wav -- --nocapture` (2 passed)
- six independent review rounds completed; the latest review found no blocking or non-blocking issue
- [previous Ready PR CI](https://github.com/Pinvou/pinvou-agent/actions/runs/34570522281): frontend, Linux Rust tests, Rust lint, Windows Rust checks, and the explicitly selected Windows reopen regression passed

## Known external gate

`fast-gate` stops at the public CodeWhale mirror reachability check because `pinvou3-clean` currently resolves to `ae7e3fb36f89486f30d41b28ae0eaaa516ae4740` while the parent repository gitlink is `1fafee7e26b60a59457a43bce50c63aa2ad9dbaf`. This repository-level mirror drift is unrelated to this PR; all jobs that reached this PR's code and tests passed.

## Scope and risk

The production change is limited to the temporary WAV lifecycle. Both native recognition and CLI fallback retain the `TempPath` until recognition returns, so automatic cleanup behavior is unchanged. The CI change only adds the regression to the existing Windows test filter list.